### PR TITLE
Add FROST threshold signatures with NIP-46 integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.49"
+version = "1.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
+checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -559,6 +568,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +610,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-crc32-nostd"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +641,12 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossterm"
@@ -719,6 +749,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "debugless-unwrap"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f400d0750c0c069e8493f2256cb4da6f604b6d2eeb69a0ca8863acde352f8400"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +762,17 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
+]
+
+[[package]]
+name = "derive-getters"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -798,6 +845,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +892,18 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -900,6 +968,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "frost-core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2619366c227233c0f817ae01156bd21b8cf74d2bd96cbe0889f4c2e266724e44"
+dependencies = [
+ "byteorder",
+ "const-crc32-nostd",
+ "debugless-unwrap",
+ "derive-getters",
+ "document-features",
+ "hex",
+ "itertools 0.14.0",
+ "postcard",
+ "rand_core 0.6.4",
+ "serde",
+ "serdect",
+ "thiserror 2.0.17",
+ "visibility",
+ "zeroize",
+]
+
+[[package]]
+name = "frost-rerandomized"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c5eb1ea58c0250b7ce834337f7b19e0417686d14ffc7f626137dea9149762d4"
+dependencies = [
+ "derive-getters",
+ "document-features",
+ "frost-core",
+ "hex",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "frost-secp256k1-tr"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff8a25b14bfd5d25deba5edce61ec99c3afb752a1d26630a196bba4cb1c4ca5e"
+dependencies = [
+ "document-features",
+ "frost-core",
+ "frost-rerandomized",
+ "k256",
+ "rand_core 0.6.4",
+ "sha2",
 ]
 
 [[package]]
@@ -1029,6 +1146,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1170,20 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -1422,6 +1562,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,10 +1613,12 @@ dependencies = [
  "ctrlc",
  "dialoguer",
  "dirs",
+ "frost-secp256k1-tr",
  "hex",
  "indicatif",
  "keep-core",
  "nostr-sdk",
+ "rand 0.9.2",
  "ratatui",
  "secrecy",
  "serde",
@@ -1492,13 +1643,15 @@ dependencies = [
  "chacha20poly1305",
  "chrono",
  "dirs",
+ "frost-secp256k1-tr",
  "hex",
  "k256",
  "memsecurity",
- "rand 0.8.5",
+ "rand 0.9.2",
  "redb",
  "secrecy",
  "serde",
+ "serde_json",
  "subtle",
  "tempfile",
  "thiserror 1.0.69",
@@ -1545,6 +1698,12 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lnurl-pay"
@@ -1950,6 +2109,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,7 +2298,7 @@ dependencies = [
  "crossterm",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.13.0",
  "lru",
  "paste",
  "strum",
@@ -2248,6 +2420,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2394,6 +2575,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2446,6 +2633,16 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
  "serde",
 ]
 
@@ -2552,6 +2749,15 @@ checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -2882,9 +3088,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2904,9 +3110,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3000,7 +3206,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]
@@ -3080,6 +3286,17 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "want"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ Controls:
 - `N` - Reject request
 - `Q` - Quit
 
+## Threshold Signatures (FROST)
+
+Split keys into t-of-n shares for distributed signing:
+
+```bash
+keep frost generate --threshold 2 --shares 3    # Create 2-of-3 key
+keep frost split --key main -t 2 -s 3           # Split existing key
+keep frost list                                  # List shares
+keep frost export --share 1 --group npub1...    # Export share
+keep frost import                                # Import share
+keep frost sign --group npub1... --message <hex> # Sign with local shares
+keep frost sign --group npub1... --message <hex> --interactive  # Multi-device
+```
+
+When serving with FROST shares, the NIP-46 signer automatically uses threshold signing:
+
+```bash
+keep serve --headless   # Detects FROST shares and uses threshold signing
+```
+
 ## Hidden Volumes (Plausible Deniability)
 
 Create a vault with a hidden volume that is cryptographically undetectable:
@@ -69,6 +89,7 @@ KEEP_PASSWORD="hiddenpass" keep --hidden list          # Shows real keys
 - Secure memory handling with zeroize
 - Zero unsafe code - enforced via `#![forbid(unsafe_code)]` in all modules
 - VeraCrypt-style hidden volumes with no detectable markers
+- FROST threshold signatures (BIP-340 compatible Schnorr)
 
 ## License
 

--- a/keep-cli/Cargo.toml
+++ b/keep-cli/Cargo.toml
@@ -37,6 +37,10 @@ hex = "0.4"
 urlencoding = "2.1"
 url = "2.5"
 
+# FROST
+frost-secp256k1-tr = "2.2.0"
+rand = "0.9"
+
 # Misc
 bitflags = { version = "2.4", features = ["serde"] }
 ctrlc = { version = "3.4", features = ["termination"] }

--- a/keep-cli/src/signer/audit.rs
+++ b/keep-cli/src/signer/audit.rs
@@ -92,6 +92,7 @@ impl AuditEntry {
     }
 }
 
+#[allow(clippy::type_complexity)]
 pub struct AuditLog {
     entries: VecDeque<AuditEntry>,
     max_entries: usize,

--- a/keep-cli/src/signer/frost_signer.rs
+++ b/keep-cli/src/signer/frost_signer.rs
@@ -1,0 +1,68 @@
+#![forbid(unsafe_code)]
+
+use keep_core::crypto::SecretKey;
+use keep_core::error::{KeepError, Result};
+use keep_core::frost::StoredShare;
+
+#[derive(Clone)]
+pub struct FrostSigner {
+    group_pubkey: [u8; 32],
+    shares: Vec<StoredShare>,
+    data_key: SecretKey,
+    threshold: u16,
+}
+
+impl FrostSigner {
+    pub fn new(
+        group_pubkey: [u8; 32],
+        shares: Vec<StoredShare>,
+        data_key: SecretKey,
+    ) -> Result<Self> {
+        if shares.is_empty() {
+            return Err(KeepError::Frost("No shares provided".into()));
+        }
+
+        let threshold = shares[0].metadata.threshold;
+
+        if shares.len() < threshold as usize {
+            return Err(KeepError::Frost(format!(
+                "Need {} shares, only {} provided",
+                threshold,
+                shares.len()
+            )));
+        }
+
+        for share in &shares {
+            if share.metadata.group_pubkey != group_pubkey {
+                return Err(KeepError::Frost(
+                    "Share group_pubkey mismatch: all shares must belong to the same group".into(),
+                ));
+            }
+            if share.metadata.threshold != threshold {
+                return Err(KeepError::Frost(
+                    "Share threshold mismatch: all shares must have the same threshold".into(),
+                ));
+            }
+        }
+
+        Ok(Self {
+            group_pubkey,
+            shares,
+            data_key,
+            threshold,
+        })
+    }
+
+    pub fn group_pubkey(&self) -> &[u8; 32] {
+        &self.group_pubkey
+    }
+
+    pub fn sign(&self, message: &[u8]) -> Result<[u8; 64]> {
+        let mut decrypted = Vec::new();
+        for stored in self.shares.iter().take(self.threshold as usize) {
+            decrypted.push(stored.decrypt(&self.data_key)?);
+        }
+
+        keep_core::frost::sign_with_local_shares(&decrypted, message)
+    }
+}

--- a/keep-cli/src/signer/mod.rs
+++ b/keep-cli/src/signer/mod.rs
@@ -1,9 +1,11 @@
 #![forbid(unsafe_code)]
 
 pub mod audit;
+pub mod frost_signer;
 pub mod handler;
 pub mod permissions;
 
 pub use audit::AuditLog;
+pub use frost_signer::FrostSigner;
 pub use handler::SignerHandler;
 pub use permissions::PermissionManager;

--- a/keep-cli/src/signer/permissions.rs
+++ b/keep-cli/src/signer/permissions.rs
@@ -80,9 +80,9 @@ impl PermissionManager {
     }
 
     pub fn connect(&mut self, pubkey: PublicKey, name: String) {
-        if !self.apps.contains_key(&pubkey) {
-            self.apps.insert(pubkey, AppPermission::new(pubkey, name));
-        }
+        self.apps
+            .entry(pubkey)
+            .or_insert_with(|| AppPermission::new(pubkey, name));
     }
 
     #[allow(dead_code)]

--- a/keep-core/Cargo.toml
+++ b/keep-core/Cargo.toml
@@ -2,42 +2,31 @@
 name = "keep-core"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.81"
 description = "Core library for Keep - sovereign key management for Nostr and Bitcoin"
 license = "AGPL-3.0-or-later"
 
 [dependencies]
-# Crypto
 argon2 = "0.5"
 chacha20poly1305 = "0.10"
 blake2 = "0.10"
 k256 = { version = "0.13", features = ["schnorr", "ecdh"] }
-rand = "0.8"
+rand = "0.9"
+frost-secp256k1-tr = "2.2.0"
 
-# Secure memory
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
 secrecy = "0.10"
 subtle = "2.5"
 memsecurity = { version = "3", features = ["encryption", "symm_asymm"] }
-
-# Storage
 redb = "2.4"
-
-# Serialization
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 bincode = "1.3"
 bech32 = "0.11"
 hex = "0.4"
-
-# Error handling
 thiserror = "1.0"
-
-# Time
 chrono = { version = "0.4.39", features = ["serde"] }
-
-# Paths
 dirs = "5.0"
-
-# Logging
 tracing = "0.1"
 
 [dev-dependencies]

--- a/keep-core/src/crypto.rs
+++ b/keep-core/src/crypto.rs
@@ -89,7 +89,7 @@ impl SecretKey {
 
     pub fn generate() -> Result<Self> {
         let mut bytes = [0u8; KEY_SIZE];
-        rand::thread_rng().fill_bytes(&mut bytes);
+        rand::rng().fill_bytes(&mut bytes);
         Self::new(bytes)
     }
 
@@ -185,7 +185,7 @@ pub fn encrypt(plaintext: &[u8], key: &SecretKey) -> Result<EncryptedData> {
     let cipher = XChaCha20Poly1305::new(GenericArray::from_slice(decrypted.expose_borrowed()));
 
     let mut nonce = [0u8; NONCE_SIZE];
-    rand::thread_rng().fill_bytes(&mut nonce);
+    rand::rng().fill_bytes(&mut nonce);
     let nonce_ga = GenericArray::from_slice(&nonce);
 
     let ciphertext = cipher
@@ -219,7 +219,7 @@ pub fn blake2b_256(data: &[u8]) -> [u8; 32] {
 
 pub fn random_bytes<const N: usize>() -> [u8; N] {
     let mut bytes = [0u8; N];
-    rand::thread_rng().fill_bytes(&mut bytes);
+    rand::rng().fill_bytes(&mut bytes);
     bytes
 }
 

--- a/keep-core/src/error.rs
+++ b/keep-core/src/error.rs
@@ -37,6 +37,9 @@ pub enum KeepError {
     #[error("Keep not found at {0}")]
     NotFound(String),
 
+    #[error("FROST error: {0}")]
+    Frost(String),
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 

--- a/keep-core/src/frost/coordinator.rs
+++ b/keep-core/src/frost/coordinator.rs
@@ -1,0 +1,210 @@
+#![forbid(unsafe_code)]
+
+use std::collections::BTreeMap;
+
+use frost::{
+    rand_core::OsRng,
+    round1::{SigningCommitments, SigningNonces},
+    round2::SignatureShare,
+    Identifier, Signature, SigningPackage,
+};
+use frost_secp256k1_tr as frost;
+
+use crate::error::{KeepError, Result};
+use crate::frost::{FrostMessage, FrostMessageType, SharePackage};
+
+pub struct Coordinator {
+    session_id: [u8; 32],
+    message: Vec<u8>,
+    threshold: u16,
+    commitments: BTreeMap<Identifier, SigningCommitments>,
+    signature_shares: BTreeMap<Identifier, SignatureShare>,
+    our_nonces: Option<(Identifier, SigningNonces)>,
+}
+
+impl Coordinator {
+    pub fn new(message: Vec<u8>, threshold: u16) -> Self {
+        Self {
+            session_id: crate::crypto::random_bytes(),
+            message,
+            threshold,
+            commitments: BTreeMap::new(),
+            signature_shares: BTreeMap::new(),
+            our_nonces: None,
+        }
+    }
+
+    pub fn session_id(&self) -> &[u8; 32] {
+        &self.session_id
+    }
+
+    pub fn add_local_share(&mut self, share: &SharePackage) -> Result<FrostMessage> {
+        let kp = share.key_package()?;
+        let id = *kp.identifier();
+
+        let (nonces, commitment) = frost::round1::commit(kp.signing_share(), &mut OsRng);
+
+        self.our_nonces = Some((id, nonces));
+        self.commitments.insert(id, commitment);
+
+        let commit_bytes = commitment
+            .serialize()
+            .map_err(|e| KeepError::Frost(format!("Serialize commitment: {}", e)))?;
+
+        Ok(FrostMessage::commitment(
+            &self.session_id,
+            share.metadata.identifier,
+            &commit_bytes,
+        ))
+    }
+
+    pub fn add_remote_commitment(&mut self, msg: &FrostMessage) -> Result<()> {
+        if msg.msg_type != FrostMessageType::Round1Commitment {
+            return Err(KeepError::Frost("Expected commitment message".into()));
+        }
+
+        if msg.session_id != hex::encode(self.session_id) {
+            return Err(KeepError::Frost("Session ID mismatch".into()));
+        }
+
+        let payload = msg.payload_bytes()?;
+        let commitment = SigningCommitments::deserialize(&payload)
+            .map_err(|e| KeepError::Frost(format!("Invalid commitment: {}", e)))?;
+
+        let id = Identifier::try_from(msg.identifier)
+            .map_err(|e| KeepError::Frost(format!("Invalid identifier: {}", e)))?;
+
+        self.commitments.insert(id, commitment);
+        Ok(())
+    }
+
+    pub fn has_enough_commitments(&self) -> bool {
+        self.commitments.len() >= self.threshold as usize
+    }
+
+    pub fn generate_signature_share(&mut self, share: &SharePackage) -> Result<FrostMessage> {
+        if !self.has_enough_commitments() {
+            return Err(KeepError::Frost(format!(
+                "Need {} commitments, have {}",
+                self.threshold,
+                self.commitments.len()
+            )));
+        }
+
+        let kp = share.key_package()?;
+        let (our_id, nonces) = self
+            .our_nonces
+            .take()
+            .ok_or_else(|| KeepError::Frost("No nonces available".into()))?;
+
+        let signing_package = SigningPackage::new(self.commitments.clone(), &self.message);
+
+        let sig_share = frost::round2::sign(&signing_package, &nonces, &kp)
+            .map_err(|e| KeepError::Frost(format!("Sign failed: {}", e)))?;
+
+        self.signature_shares.insert(our_id, sig_share);
+
+        let share_bytes = sig_share.serialize();
+
+        Ok(FrostMessage::signature_share(
+            &self.session_id,
+            share.metadata.identifier,
+            &share_bytes,
+        ))
+    }
+
+    pub fn add_remote_signature_share(&mut self, msg: &FrostMessage) -> Result<()> {
+        if msg.msg_type != FrostMessageType::Round2Share {
+            return Err(KeepError::Frost("Expected signature share message".into()));
+        }
+
+        if msg.session_id != hex::encode(self.session_id) {
+            return Err(KeepError::Frost("Session ID mismatch".into()));
+        }
+
+        let payload = msg.payload_bytes()?;
+        let sig_share = SignatureShare::deserialize(&payload)
+            .map_err(|e| KeepError::Frost(format!("Invalid signature share: {}", e)))?;
+
+        let id = Identifier::try_from(msg.identifier)
+            .map_err(|e| KeepError::Frost(format!("Invalid identifier: {}", e)))?;
+
+        self.signature_shares.insert(id, sig_share);
+        Ok(())
+    }
+
+    pub fn has_enough_shares(&self) -> bool {
+        self.signature_shares.len() >= self.threshold as usize
+    }
+
+    pub fn aggregate(&self, share: &SharePackage) -> Result<Signature> {
+        if !self.has_enough_shares() {
+            return Err(KeepError::Frost(format!(
+                "Need {} shares, have {}",
+                self.threshold,
+                self.signature_shares.len()
+            )));
+        }
+
+        let signing_package = SigningPackage::new(self.commitments.clone(), &self.message);
+        let pubkey_pkg = share.pubkey_package()?;
+
+        frost::aggregate(&signing_package, &self.signature_shares, &pubkey_pkg)
+            .map_err(|e| KeepError::Frost(format!("Aggregation failed: {}", e)))
+    }
+
+    pub fn aggregate_to_bytes(&self, share: &SharePackage) -> Result<[u8; 64]> {
+        let signature = self.aggregate(share)?;
+        let serialized = signature
+            .serialize()
+            .map_err(|e| KeepError::Frost(format!("Serialize signature: {}", e)))?;
+
+        let bytes = serialized.as_slice();
+        if bytes.len() != 64 {
+            return Err(KeepError::Frost("Invalid signature length".into()));
+        }
+
+        let mut result = [0u8; 64];
+        result.copy_from_slice(bytes);
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frost::{ThresholdConfig, TrustedDealer};
+
+    #[test]
+    fn test_coordinator_local_only() {
+        let config = ThresholdConfig::two_of_three();
+        let dealer = TrustedDealer::new(config);
+        let (shares, _) = dealer.generate("test").unwrap();
+
+        let message = b"test message".to_vec();
+        let mut coord = Coordinator::new(message, 2);
+
+        let _msg1 = coord.add_local_share(&shares[0]).unwrap();
+
+        let kp1 = shares[1].key_package().unwrap();
+        let (nonces1, commit1) = frost::round1::commit(kp1.signing_share(), &mut OsRng);
+        let commit1_bytes = commit1.serialize().unwrap();
+        let msg1 = FrostMessage::commitment(coord.session_id(), 2, &commit1_bytes);
+        coord.add_remote_commitment(&msg1).unwrap();
+
+        assert!(coord.has_enough_commitments());
+
+        let _our_share_msg = coord.generate_signature_share(&shares[0]).unwrap();
+
+        let signing_package = SigningPackage::new(coord.commitments.clone(), b"test message");
+        let sig_share1 = frost::round2::sign(&signing_package, &nonces1, &kp1).unwrap();
+        let share1_bytes = sig_share1.serialize();
+        let share_msg1 = FrostMessage::signature_share(coord.session_id(), 2, &share1_bytes);
+        coord.add_remote_signature_share(&share_msg1).unwrap();
+
+        assert!(coord.has_enough_shares());
+
+        let sig_bytes = coord.aggregate_to_bytes(&shares[0]).unwrap();
+        assert_eq!(sig_bytes.len(), 64);
+    }
+}

--- a/keep-core/src/frost/dealer.rs
+++ b/keep-core/src/frost/dealer.rs
@@ -1,0 +1,209 @@
+#![forbid(unsafe_code)]
+
+use frost::keys::{IdentifierList, KeyPackage, PublicKeyPackage};
+use frost::rand_core::OsRng;
+use frost_secp256k1_tr as frost;
+
+use crate::error::{KeepError, Result};
+
+use super::share::{ShareMetadata, SharePackage};
+
+#[derive(Clone, Copy)]
+pub struct ThresholdConfig {
+    pub threshold: u16,
+    pub total_shares: u16,
+}
+
+impl ThresholdConfig {
+    pub fn new(threshold: u16, total_shares: u16) -> Result<Self> {
+        if threshold < 2 {
+            return Err(KeepError::Frost("Threshold must be at least 2".into()));
+        }
+        if total_shares < threshold {
+            return Err(KeepError::Frost("Total shares must be >= threshold".into()));
+        }
+        if total_shares > 255 {
+            return Err(KeepError::Frost("Maximum 255 shares supported".into()));
+        }
+
+        Ok(Self {
+            threshold,
+            total_shares,
+        })
+    }
+
+    pub fn two_of_three() -> Self {
+        Self {
+            threshold: 2,
+            total_shares: 3,
+        }
+    }
+
+    pub fn three_of_five() -> Self {
+        Self {
+            threshold: 3,
+            total_shares: 5,
+        }
+    }
+}
+
+pub struct TrustedDealer {
+    config: ThresholdConfig,
+}
+
+impl TrustedDealer {
+    pub fn new(config: ThresholdConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn generate(&self, name: &str) -> Result<(Vec<SharePackage>, PublicKeyPackage)> {
+        let (shares, pubkey_pkg) = frost::keys::generate_with_dealer(
+            self.config.total_shares,
+            self.config.threshold,
+            IdentifierList::Default,
+            OsRng,
+        )
+        .map_err(|e| KeepError::Frost(format!("Key generation failed: {}", e)))?;
+
+        let group_pubkey = extract_group_pubkey(&pubkey_pkg)?;
+
+        let packages: Result<Vec<SharePackage>> = shares
+            .into_iter()
+            .enumerate()
+            .map(|(idx, (_, secret_share))| {
+                let key_package = KeyPackage::try_from(secret_share).map_err(|e| {
+                    KeepError::Frost(format!("KeyPackage conversion failed: {}", e))
+                })?;
+
+                let identifier = (idx + 1) as u16;
+
+                let metadata = ShareMetadata::new(
+                    identifier,
+                    self.config.threshold,
+                    self.config.total_shares,
+                    group_pubkey,
+                    name.to_string(),
+                );
+
+                SharePackage::new(metadata, &key_package, &pubkey_pkg)
+            })
+            .collect();
+
+        Ok((packages?, pubkey_pkg))
+    }
+
+    pub fn split_existing(
+        &self,
+        secret: &[u8; 32],
+        name: &str,
+    ) -> Result<(Vec<SharePackage>, PublicKeyPackage)> {
+        let signing_key = frost::SigningKey::deserialize(secret)
+            .map_err(|e| KeepError::Frost(format!("Invalid signing key: {}", e)))?;
+
+        let (shares, pubkey_pkg) = frost::keys::split(
+            &signing_key,
+            self.config.total_shares,
+            self.config.threshold,
+            IdentifierList::Default,
+            &mut OsRng,
+        )
+        .map_err(|e| KeepError::Frost(format!("Key split failed: {}", e)))?;
+
+        let group_pubkey = extract_group_pubkey(&pubkey_pkg)?;
+
+        let packages: Result<Vec<SharePackage>> = shares
+            .into_iter()
+            .enumerate()
+            .map(|(idx, (_, secret_share))| {
+                let key_package = KeyPackage::try_from(secret_share).map_err(|e| {
+                    KeepError::Frost(format!("KeyPackage conversion failed: {}", e))
+                })?;
+
+                let identifier = (idx + 1) as u16;
+
+                let metadata = ShareMetadata::new(
+                    identifier,
+                    self.config.threshold,
+                    self.config.total_shares,
+                    group_pubkey,
+                    name.to_string(),
+                );
+
+                SharePackage::new(metadata, &key_package, &pubkey_pkg)
+            })
+            .collect();
+
+        Ok((packages?, pubkey_pkg))
+    }
+}
+
+fn extract_group_pubkey(pubkey_pkg: &PublicKeyPackage) -> Result<[u8; 32]> {
+    let verifying_key = pubkey_pkg.verifying_key();
+    let serialized = verifying_key
+        .serialize()
+        .map_err(|e| KeepError::Frost(format!("Failed to serialize verifying key: {}", e)))?;
+    let bytes = serialized.as_slice();
+
+    let mut pubkey = [0u8; 32];
+    if bytes.len() == 33 {
+        pubkey.copy_from_slice(&bytes[1..33]);
+    } else if bytes.len() == 32 {
+        pubkey.copy_from_slice(&bytes[0..32]);
+    } else {
+        return Err(KeepError::Frost(format!(
+            "Invalid group pubkey length: expected 32 or 33, got {}",
+            bytes.len()
+        )));
+    }
+    Ok(pubkey)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_two_of_three() {
+        let config = ThresholdConfig::two_of_three();
+        let dealer = TrustedDealer::new(config);
+        let (shares, pubkey_pkg) = dealer.generate("test").unwrap();
+
+        assert_eq!(shares.len(), 3);
+        for share in &shares {
+            assert_eq!(share.metadata.threshold, 2);
+            assert_eq!(share.metadata.total_shares, 3);
+            assert_eq!(share.group_pubkey(), shares[0].group_pubkey());
+        }
+
+        let vk = pubkey_pkg.verifying_key();
+        let vk_bytes = vk.serialize().unwrap();
+        assert_eq!(vk_bytes.as_slice().len(), 33);
+    }
+
+    #[test]
+    fn test_split_preserves_pubkey() {
+        use crate::crypto::random_bytes;
+
+        let secret: [u8; 32] = random_bytes();
+        let config = ThresholdConfig::two_of_three();
+        let dealer = TrustedDealer::new(config);
+
+        let (shares, pubkey_pkg) = dealer.split_existing(&secret, "split").unwrap();
+
+        let expected_pubkey = pubkey_pkg.verifying_key().serialize().unwrap();
+        let expected_slice = expected_pubkey.as_slice();
+        assert_eq!(expected_slice.len(), 33);
+
+        let mut expected_bytes = [0u8; 32];
+        expected_bytes.copy_from_slice(&expected_slice[1..33]);
+
+        assert_eq!(shares[0].group_pubkey(), &expected_bytes);
+    }
+
+    #[test]
+    fn test_invalid_config() {
+        assert!(ThresholdConfig::new(1, 3).is_err());
+        assert!(ThresholdConfig::new(3, 2).is_err());
+        assert!(ThresholdConfig::new(2, 256).is_err());
+    }
+}

--- a/keep-core/src/frost/mod.rs
+++ b/keep-core/src/frost/mod.rs
@@ -1,0 +1,13 @@
+#![forbid(unsafe_code)]
+
+mod coordinator;
+mod dealer;
+mod share;
+mod signing;
+mod transport;
+
+pub use coordinator::Coordinator;
+pub use dealer::{ThresholdConfig, TrustedDealer};
+pub use share::{ShareMetadata, SharePackage, StoredShare};
+pub use signing::{sign_with_local_shares, SessionState, SigningSession};
+pub use transport::{FrostMessage, FrostMessageType, ShareExport};

--- a/keep-core/src/frost/share.rs
+++ b/keep-core/src/frost/share.rs
@@ -1,0 +1,135 @@
+#![forbid(unsafe_code)]
+#![allow(unused_assignments)]
+
+use frost_secp256k1_tr::{
+    keys::{KeyPackage, PublicKeyPackage},
+    Identifier,
+};
+use serde::{Deserialize, Serialize};
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use crate::crypto::{self, SecretKey};
+use crate::error::{KeepError, Result};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ShareMetadata {
+    pub identifier: u16,
+    pub threshold: u16,
+    pub total_shares: u16,
+    pub group_pubkey: [u8; 32],
+    pub name: String,
+    pub created_at: i64,
+    pub last_used: Option<i64>,
+    pub sign_count: u64,
+}
+
+impl ShareMetadata {
+    pub fn new(
+        identifier: u16,
+        threshold: u16,
+        total_shares: u16,
+        group_pubkey: [u8; 32],
+        name: String,
+    ) -> Self {
+        Self {
+            identifier,
+            threshold,
+            total_shares,
+            group_pubkey,
+            name,
+            created_at: chrono::Utc::now().timestamp(),
+            last_used: None,
+            sign_count: 0,
+        }
+    }
+
+    pub fn record_usage(&mut self) {
+        self.last_used = Some(chrono::Utc::now().timestamp());
+    }
+
+    pub fn increment_sign_count(&mut self) {
+        self.sign_count += 1;
+        self.record_usage();
+    }
+}
+
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct SharePackage {
+    #[zeroize(skip)]
+    pub metadata: ShareMetadata,
+    key_package_bytes: Vec<u8>,
+    #[zeroize(skip)]
+    pubkey_package_bytes: Vec<u8>,
+}
+
+impl SharePackage {
+    pub fn new(
+        metadata: ShareMetadata,
+        key_package: &KeyPackage,
+        pubkey_package: &PublicKeyPackage,
+    ) -> Result<Self> {
+        let key_package_bytes = key_package
+            .serialize()
+            .map_err(|e| KeepError::Frost(format!("Failed to serialize key package: {}", e)))?;
+
+        let pubkey_package_bytes = pubkey_package
+            .serialize()
+            .map_err(|e| KeepError::Frost(format!("Failed to serialize pubkey package: {}", e)))?;
+
+        Ok(Self {
+            metadata,
+            key_package_bytes,
+            pubkey_package_bytes,
+        })
+    }
+
+    pub fn key_package(&self) -> Result<KeyPackage> {
+        KeyPackage::deserialize(&self.key_package_bytes)
+            .map_err(|e| KeepError::Frost(format!("Failed to deserialize key package: {}", e)))
+    }
+
+    pub fn pubkey_package(&self) -> Result<PublicKeyPackage> {
+        PublicKeyPackage::deserialize(&self.pubkey_package_bytes)
+            .map_err(|e| KeepError::Frost(format!("Failed to deserialize pubkey package: {}", e)))
+    }
+
+    pub fn identifier(&self) -> Result<Identifier> {
+        let kp = self.key_package()?;
+        Ok(*kp.identifier())
+    }
+
+    pub fn group_pubkey(&self) -> &[u8; 32] {
+        &self.metadata.group_pubkey
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct StoredShare {
+    pub metadata: ShareMetadata,
+    pub encrypted_key_package: Vec<u8>,
+    pub pubkey_package: Vec<u8>,
+}
+
+impl StoredShare {
+    pub fn encrypt(share: &SharePackage, data_key: &SecretKey) -> Result<Self> {
+        let encrypted = crypto::encrypt(&share.key_package_bytes, data_key)?;
+
+        Ok(Self {
+            metadata: share.metadata.clone(),
+            encrypted_key_package: encrypted.to_bytes(),
+            pubkey_package: share.pubkey_package_bytes.clone(),
+        })
+    }
+
+    pub fn decrypt(&self, data_key: &SecretKey) -> Result<SharePackage> {
+        let encrypted = crypto::EncryptedData::from_bytes(&self.encrypted_key_package)?;
+        let decrypted = crypto::decrypt(&encrypted, data_key)?;
+        let key_package_bytes = decrypted.as_slice()?;
+
+        Ok(SharePackage {
+            metadata: self.metadata.clone(),
+            key_package_bytes,
+            pubkey_package_bytes: self.pubkey_package.clone(),
+        })
+    }
+}

--- a/keep-core/src/frost/signing.rs
+++ b/keep-core/src/frost/signing.rs
@@ -1,0 +1,362 @@
+#![forbid(unsafe_code)]
+#![allow(unused_assignments)]
+
+use std::collections::BTreeMap;
+
+use frost::{
+    keys::{KeyPackage, PublicKeyPackage},
+    rand_core::OsRng,
+    round1::{SigningCommitments, SigningNonces},
+    round2::SignatureShare,
+    Identifier, Signature, SigningPackage,
+};
+use frost_secp256k1_tr as frost;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use crate::crypto;
+use crate::error::{KeepError, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionState {
+    CollectingCommitments,
+    CollectingShares,
+    Complete,
+    Failed,
+}
+
+#[derive(ZeroizeOnDrop)]
+pub struct SigningSession {
+    #[zeroize(skip)]
+    session_id: [u8; 32],
+    #[zeroize(skip)]
+    message: Vec<u8>,
+    #[zeroize(skip)]
+    threshold: u16,
+    #[zeroize(skip)]
+    state: SessionState,
+
+    #[zeroize(skip)]
+    commitments: BTreeMap<Identifier, SigningCommitments>,
+    #[zeroize(skip)]
+    signature_shares: BTreeMap<Identifier, SignatureShare>,
+
+    our_nonces: Option<NonceWrapper>,
+
+    #[zeroize(skip)]
+    signature: Option<Signature>,
+}
+
+// SECURITY NOTE: NonceWrapper provides no actual zeroization because SigningNonces
+// from frost-secp256k1-tr doesn't implement Zeroize. During normal operation, nonces
+// are consumed via take() ensuring single use. However, if a session is dropped early
+// (e.g., on error paths before signing completes), the nonce data may remain in memory
+// until the allocator reuses that memory. This is a limitation of the upstream FROST
+// library. For high-security applications, consider process isolation.
+struct NonceWrapper(SigningNonces);
+
+impl Zeroize for NonceWrapper {
+    fn zeroize(&mut self) {
+        // SigningNonces doesn't implement Zeroize - see security note above
+    }
+}
+
+impl Drop for NonceWrapper {
+    fn drop(&mut self) {
+        // Nonces should be consumed via take() during signing
+    }
+}
+
+impl SigningSession {
+    pub fn new(message: Vec<u8>, threshold: u16) -> Self {
+        let session_id = Self::compute_session_id(&message);
+
+        Self {
+            session_id,
+            message,
+            threshold,
+            state: SessionState::CollectingCommitments,
+            commitments: BTreeMap::new(),
+            signature_shares: BTreeMap::new(),
+            our_nonces: None,
+            signature: None,
+        }
+    }
+
+    fn compute_session_id(message: &[u8]) -> [u8; 32] {
+        let timestamp = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
+        let random: [u8; 16] = crypto::random_bytes();
+
+        let mut preimage = Vec::with_capacity(message.len() + 24);
+        preimage.extend_from_slice(message);
+        preimage.extend_from_slice(&timestamp.to_le_bytes());
+        preimage.extend_from_slice(&random);
+
+        crypto::blake2b_256(&preimage)
+    }
+
+    pub fn session_id(&self) -> &[u8; 32] {
+        &self.session_id
+    }
+
+    pub fn state(&self) -> SessionState {
+        self.state
+    }
+
+    pub fn generate_commitment(&mut self, key_package: &KeyPackage) -> Result<SigningCommitments> {
+        if self.state != SessionState::CollectingCommitments {
+            return Err(KeepError::Frost(
+                "Invalid session state for commitment".into(),
+            ));
+        }
+
+        if self.our_nonces.is_some() {
+            return Err(KeepError::Frost(
+                "Commitment already generated for this session".into(),
+            ));
+        }
+
+        let (nonces, commitments) = frost::round1::commit(key_package.signing_share(), &mut OsRng);
+
+        self.our_nonces = Some(NonceWrapper(nonces));
+        self.commitments
+            .insert(*key_package.identifier(), commitments);
+
+        Ok(commitments)
+    }
+
+    pub fn add_commitment(&mut self, id: Identifier, commitment: SigningCommitments) -> Result<()> {
+        if self.state != SessionState::CollectingCommitments {
+            return Err(KeepError::Frost("Not collecting commitments".into()));
+        }
+
+        if self.commitments.contains_key(&id) {
+            return Err(KeepError::Frost("Duplicate commitment".into()));
+        }
+
+        self.commitments.insert(id, commitment);
+
+        if self.commitments.len() >= self.threshold as usize {
+            self.state = SessionState::CollectingShares;
+        }
+
+        Ok(())
+    }
+
+    pub fn commitments_needed(&self) -> usize {
+        self.threshold as usize - self.commitments.len()
+    }
+
+    pub fn generate_signature_share(&mut self, key_package: &KeyPackage) -> Result<SignatureShare> {
+        if self.state != SessionState::CollectingShares {
+            return Err(KeepError::Frost(
+                "Not ready to generate signature share".into(),
+            ));
+        }
+
+        let nonces = self
+            .our_nonces
+            .take()
+            .ok_or_else(|| KeepError::Frost("No nonces available - already used?".into()))?;
+
+        let signing_package = SigningPackage::new(self.commitments.clone(), &self.message);
+
+        let share = frost::round2::sign(&signing_package, &nonces.0, key_package)
+            .map_err(|e| KeepError::Frost(format!("Signing failed: {}", e)))?;
+
+        self.signature_shares
+            .insert(*key_package.identifier(), share);
+
+        Ok(share)
+    }
+
+    pub fn add_signature_share(
+        &mut self,
+        id: Identifier,
+        share: SignatureShare,
+        pubkey_pkg: &PublicKeyPackage,
+    ) -> Result<Option<Signature>> {
+        if self.state != SessionState::CollectingShares {
+            return Err(KeepError::Frost("Not collecting signature shares".into()));
+        }
+
+        if self.signature_shares.contains_key(&id) {
+            return Err(KeepError::Frost("Duplicate signature share".into()));
+        }
+
+        self.signature_shares.insert(id, share);
+
+        if self.signature_shares.len() >= self.threshold as usize {
+            let signing_package = SigningPackage::new(self.commitments.clone(), &self.message);
+
+            match frost::aggregate(&signing_package, &self.signature_shares, pubkey_pkg) {
+                Ok(signature) => {
+                    self.signature = Some(signature);
+                    self.state = SessionState::Complete;
+                    return Ok(Some(signature));
+                }
+                Err(e) => {
+                    self.state = SessionState::Failed;
+                    return Err(KeepError::Frost(format!("Aggregation failed: {}", e)));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    pub fn shares_needed(&self) -> usize {
+        self.threshold as usize - self.signature_shares.len()
+    }
+
+    pub fn signature_bytes(&self) -> Result<Option<[u8; 64]>> {
+        match &self.signature {
+            Some(s) => {
+                let serialized = s.serialize().map_err(|e| {
+                    KeepError::Frost(format!("Failed to serialize signature: {}", e))
+                })?;
+                let bytes_slice = serialized.as_slice();
+                if bytes_slice.len() != 64 {
+                    return Err(KeepError::Frost("Invalid signature length".into()));
+                }
+                let mut bytes = [0u8; 64];
+                bytes.copy_from_slice(bytes_slice);
+                Ok(Some(bytes))
+            }
+            None => Ok(None),
+        }
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.state == SessionState::Complete
+    }
+}
+
+pub fn sign_with_local_shares(shares: &[super::SharePackage], message: &[u8]) -> Result<[u8; 64]> {
+    use frost::{keys::PublicKeyPackage, round1, round2};
+
+    if shares.is_empty() {
+        return Err(KeepError::Frost("No shares provided".into()));
+    }
+
+    let threshold = shares[0].metadata.threshold as usize;
+    if shares.len() < threshold {
+        return Err(KeepError::Frost(format!(
+            "Need {} shares to sign, only {} provided",
+            threshold,
+            shares.len()
+        )));
+    }
+
+    let signing_shares = &shares[..threshold];
+
+    let mut nonces_map: BTreeMap<Identifier, round1::SigningNonces> = BTreeMap::new();
+    let mut commitments_map: BTreeMap<Identifier, round1::SigningCommitments> = BTreeMap::new();
+    let mut verifying_shares: BTreeMap<Identifier, frost::keys::VerifyingShare> = BTreeMap::new();
+
+    for share in signing_shares {
+        let kp = share.key_package()?;
+        let (nonces, commitments) = round1::commit(kp.signing_share(), &mut OsRng);
+        nonces_map.insert(*kp.identifier(), nonces);
+        commitments_map.insert(*kp.identifier(), commitments);
+        verifying_shares.insert(*kp.identifier(), *kp.verifying_share());
+    }
+
+    let signing_package = SigningPackage::new(commitments_map, message);
+
+    let mut signature_shares: BTreeMap<Identifier, round2::SignatureShare> = BTreeMap::new();
+
+    for share in signing_shares {
+        let kp = share.key_package()?;
+        let id = *kp.identifier();
+        let nonces = nonces_map
+            .remove(&id)
+            .ok_or_else(|| KeepError::Frost("Missing nonces for share".into()))?;
+        let sig_share = round2::sign(&signing_package, &nonces, &kp)
+            .map_err(|e| KeepError::Frost(format!("Signing failed: {}", e)))?;
+        signature_shares.insert(id, sig_share);
+    }
+
+    let first_kp = signing_shares[0].key_package()?;
+    let pubkey_pkg = PublicKeyPackage::new(verifying_shares, *first_kp.verifying_key());
+    let signature = frost::aggregate(&signing_package, &signature_shares, &pubkey_pkg)
+        .map_err(|e| KeepError::Frost(format!("Aggregation failed: {}", e)))?;
+
+    let serialized = signature
+        .serialize()
+        .map_err(|e| KeepError::Frost(format!("Failed to serialize signature: {}", e)))?;
+    let bytes_slice = serialized.as_slice();
+    if bytes_slice.len() != 64 {
+        return Err(KeepError::Frost("Invalid signature length".into()));
+    }
+
+    let mut sig_bytes = [0u8; 64];
+    sig_bytes.copy_from_slice(bytes_slice);
+    Ok(sig_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frost::{ThresholdConfig, TrustedDealer};
+
+    #[test]
+    fn test_signing_session_two_of_three() {
+        let config = ThresholdConfig::two_of_three();
+        let dealer = TrustedDealer::new(config);
+        let (shares, pubkey_pkg) = dealer.generate("test").unwrap();
+
+        let message = b"test message to sign".to_vec();
+
+        let kp0 = shares[0].key_package().unwrap();
+        let kp1 = shares[1].key_package().unwrap();
+
+        let mut session0 = SigningSession::new(message.clone(), 2);
+        let mut session1 = SigningSession::new(message.clone(), 2);
+        session1.session_id = session0.session_id;
+
+        let commit0 = session0.generate_commitment(&kp0).unwrap();
+        let commit1 = session1.generate_commitment(&kp1).unwrap();
+
+        session0
+            .add_commitment(*kp1.identifier(), commit1.clone())
+            .unwrap();
+        session1
+            .add_commitment(*kp0.identifier(), commit0.clone())
+            .unwrap();
+
+        assert_eq!(session0.state(), SessionState::CollectingShares);
+        assert_eq!(session1.state(), SessionState::CollectingShares);
+
+        let share0 = session0.generate_signature_share(&kp0).unwrap();
+        let share1 = session1.generate_signature_share(&kp1).unwrap();
+
+        session0
+            .add_signature_share(*kp1.identifier(), share1, &pubkey_pkg)
+            .unwrap();
+        let result = session1
+            .add_signature_share(*kp0.identifier(), share0, &pubkey_pkg)
+            .unwrap();
+
+        assert!(session0.is_complete());
+        assert!(result.is_some());
+
+        let sig_bytes = session0.signature_bytes().unwrap().unwrap();
+        assert_eq!(sig_bytes.len(), 64);
+    }
+
+    #[test]
+    fn test_nonce_single_use() {
+        let config = ThresholdConfig::two_of_three();
+        let dealer = TrustedDealer::new(config);
+        let (shares, _) = dealer.generate("test").unwrap();
+
+        let message = b"test message".to_vec();
+        let kp = shares[0].key_package().unwrap();
+
+        let mut session = SigningSession::new(message, 2);
+        let _ = session.generate_commitment(&kp).unwrap();
+
+        let result = session.generate_commitment(&kp);
+        assert!(result.is_err());
+    }
+}

--- a/keep-core/src/frost/transport.rs
+++ b/keep-core/src/frost/transport.rs
@@ -1,0 +1,399 @@
+#![forbid(unsafe_code)]
+
+use bech32::{Bech32m, Hrp};
+use serde::{Deserialize, Serialize};
+
+use crate::crypto;
+use crate::error::{KeepError, Result};
+
+use super::share::SharePackage;
+
+const SHARE_HRP: &str = "kshare";
+
+#[derive(Serialize, Deserialize)]
+pub struct ShareExport {
+    pub version: u8,
+    pub threshold: u16,
+    pub total: u16,
+    pub identifier: u16,
+    pub group_pubkey: String,
+    pub encrypted_share: String,
+    pub nonce: String,
+    pub salt: String,
+}
+
+impl ShareExport {
+    pub fn from_share(share: &SharePackage, passphrase: &str) -> Result<Self> {
+        let salt: [u8; 32] = crypto::random_bytes();
+        let key = crypto::derive_key(passphrase.as_bytes(), &salt, crypto::Argon2Params::DEFAULT)?;
+
+        let key_package = share.key_package()?;
+        let key_bytes = key_package
+            .serialize()
+            .map_err(|e| KeepError::Frost(format!("Serialization failed: {}", e)))?;
+
+        let encrypted = crypto::encrypt(&key_bytes, &key)?;
+
+        Ok(Self {
+            version: 1,
+            threshold: share.metadata.threshold,
+            total: share.metadata.total_shares,
+            identifier: share.metadata.identifier,
+            group_pubkey: hex::encode(share.metadata.group_pubkey),
+            encrypted_share: hex::encode(&encrypted.ciphertext),
+            nonce: hex::encode(encrypted.nonce),
+            salt: hex::encode(salt),
+        })
+    }
+
+    pub fn to_share(&self, passphrase: &str, name: &str) -> Result<SharePackage> {
+        const INVALID_SHARE: &str = "Invalid or corrupted share data";
+
+        if self.version != 1 {
+            return Err(KeepError::Frost(format!(
+                "Unsupported version: {}",
+                self.version
+            )));
+        }
+
+        let salt_bytes =
+            hex::decode(&self.salt).map_err(|_| KeepError::Frost(INVALID_SHARE.into()))?;
+        if salt_bytes.len() != 32 {
+            return Err(KeepError::Frost(INVALID_SHARE.into()));
+        }
+        let mut salt = [0u8; 32];
+        salt.copy_from_slice(&salt_bytes);
+
+        let key = crypto::derive_key(passphrase.as_bytes(), &salt, crypto::Argon2Params::DEFAULT)?;
+
+        let nonce_bytes =
+            hex::decode(&self.nonce).map_err(|_| KeepError::Frost(INVALID_SHARE.into()))?;
+        if nonce_bytes.len() != 24 {
+            return Err(KeepError::Frost(INVALID_SHARE.into()));
+        }
+        let mut nonce = [0u8; 24];
+        nonce.copy_from_slice(&nonce_bytes);
+
+        let ciphertext = hex::decode(&self.encrypted_share)
+            .map_err(|_| KeepError::Frost(INVALID_SHARE.into()))?;
+
+        let encrypted = crypto::EncryptedData { ciphertext, nonce };
+        let decrypted = crypto::decrypt(&encrypted, &key)?;
+        let key_bytes = decrypted.as_slice()?;
+
+        let key_package = frost_secp256k1_tr::keys::KeyPackage::deserialize(&key_bytes)
+            .map_err(|e| KeepError::Frost(format!("Failed to deserialize key package: {}", e)))?;
+
+        let group_pubkey_bytes =
+            hex::decode(&self.group_pubkey).map_err(|_| KeepError::Frost(INVALID_SHARE.into()))?;
+        if group_pubkey_bytes.len() != 32 {
+            return Err(KeepError::Frost(INVALID_SHARE.into()));
+        }
+        let mut group_pubkey = [0u8; 32];
+        group_pubkey.copy_from_slice(&group_pubkey_bytes);
+
+        let pubkey_package = derive_pubkey_package(&key_package)?;
+
+        let metadata = super::share::ShareMetadata::new(
+            self.identifier,
+            self.threshold,
+            self.total,
+            group_pubkey,
+            name.to_string(),
+        );
+
+        SharePackage::new(metadata, &key_package, &pubkey_package)
+    }
+
+    pub fn to_json(&self) -> Result<String> {
+        serde_json::to_string(self)
+            .map_err(|e| KeepError::Frost(format!("JSON serialization failed: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Self> {
+        serde_json::from_str(json)
+            .map_err(|e| KeepError::Frost(format!("JSON deserialization failed: {}", e)))
+    }
+
+    pub fn to_bech32(&self) -> Result<String> {
+        let json = self.to_json()?;
+        let hrp =
+            Hrp::parse(SHARE_HRP).map_err(|e| KeepError::Frost(format!("Invalid HRP: {}", e)))?;
+        bech32::encode::<Bech32m>(hrp, json.as_bytes())
+            .map_err(|e| KeepError::Frost(format!("Bech32 encoding failed: {}", e)))
+    }
+
+    pub fn from_bech32(encoded: &str) -> Result<Self> {
+        let (hrp, data) = bech32::decode(encoded)
+            .map_err(|e| KeepError::Frost(format!("Bech32 decoding failed: {}", e)))?;
+
+        if hrp.as_str() != SHARE_HRP {
+            return Err(KeepError::Frost(format!(
+                "Invalid prefix: expected {}, got {}",
+                SHARE_HRP,
+                hrp.as_str()
+            )));
+        }
+
+        let json = String::from_utf8(data)
+            .map_err(|_| KeepError::Frost("Invalid UTF-8 in share".into()))?;
+
+        Self::from_json(&json)
+    }
+}
+
+fn derive_pubkey_package(
+    key_package: &frost_secp256k1_tr::keys::KeyPackage,
+) -> Result<frost_secp256k1_tr::keys::PublicKeyPackage> {
+    use frost_secp256k1_tr::keys::PublicKeyPackage;
+    use std::collections::BTreeMap;
+
+    let verifying_share = key_package.verifying_share();
+    let verifying_key = key_package.verifying_key();
+
+    let mut verifying_shares = BTreeMap::new();
+    verifying_shares.insert(*key_package.identifier(), *verifying_share);
+
+    Ok(PublicKeyPackage::new(verifying_shares, *verifying_key))
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct FrostMessage {
+    #[serde(rename = "type")]
+    pub msg_type: FrostMessageType,
+    pub session_id: String,
+    pub identifier: u16,
+    pub payload: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FrostMessageType {
+    Round1Commitment,
+    Round2Share,
+}
+
+impl FrostMessage {
+    pub fn commitment(session_id: &[u8; 32], identifier: u16, commitment_bytes: &[u8]) -> Self {
+        Self {
+            msg_type: FrostMessageType::Round1Commitment,
+            session_id: hex::encode(session_id),
+            identifier,
+            payload: hex::encode(commitment_bytes),
+        }
+    }
+
+    pub fn signature_share(session_id: &[u8; 32], identifier: u16, share_bytes: &[u8]) -> Self {
+        Self {
+            msg_type: FrostMessageType::Round2Share,
+            session_id: hex::encode(session_id),
+            identifier,
+            payload: hex::encode(share_bytes),
+        }
+    }
+
+    pub fn to_json(&self) -> Result<String> {
+        serde_json::to_string(self)
+            .map_err(|e| KeepError::Frost(format!("JSON encode failed: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Self> {
+        serde_json::from_str(json)
+            .map_err(|e| KeepError::Frost(format!("JSON decode failed: {}", e)))
+    }
+
+    pub fn payload_bytes(&self) -> Result<Vec<u8>> {
+        hex::decode(&self.payload).map_err(|_| KeepError::Frost("Invalid payload hex".into()))
+    }
+
+    pub fn session_id_bytes(&self) -> Result<[u8; 32]> {
+        let bytes = hex::decode(&self.session_id)
+            .map_err(|_| KeepError::Frost("Invalid session_id hex".into()))?;
+        if bytes.len() != 32 {
+            return Err(KeepError::Frost("Invalid session_id length".into()));
+        }
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&bytes);
+        Ok(arr)
+    }
+}
+
+impl ShareExport {
+    pub fn to_animated_frames(&self, max_bytes: usize) -> Result<Vec<String>> {
+        let full = self.to_json()?;
+
+        if full.len() <= max_bytes {
+            return Ok(vec![full]);
+        }
+
+        let total_frames = full.len().div_ceil(max_bytes);
+        let frames: Vec<String> = full
+            .as_bytes()
+            .chunks(max_bytes)
+            .enumerate()
+            .map(|(i, chunk)| {
+                let chunk_hex = hex::encode(chunk);
+                format!(
+                    "{{\"f\":{},\"t\":{},\"d\":\"{}\"}}",
+                    i, total_frames, chunk_hex
+                )
+            })
+            .collect();
+
+        Ok(frames)
+    }
+
+    pub fn from_animated_frames(frames: &[String]) -> Result<Self> {
+        if frames.is_empty() {
+            return Err(KeepError::Frost("No frames provided".into()));
+        }
+
+        if frames.len() == 1 {
+            if let Ok(export) = Self::from_json(&frames[0]) {
+                return Ok(export);
+            }
+        }
+
+        let mut sorted: Vec<(usize, Vec<u8>)> = Vec::new();
+
+        for frame in frames {
+            let parsed: serde_json::Value = serde_json::from_str(frame)
+                .map_err(|e| KeepError::Frost(format!("Invalid frame JSON: {}", e)))?;
+
+            let idx = parsed["f"]
+                .as_u64()
+                .ok_or_else(|| KeepError::Frost("Missing frame index".into()))?
+                as usize;
+            let data_hex = parsed["d"]
+                .as_str()
+                .ok_or_else(|| KeepError::Frost("Missing frame data".into()))?;
+            let data = hex::decode(data_hex)
+                .map_err(|_| KeepError::Frost("Invalid frame data hex".into()))?;
+
+            sorted.push((idx, data));
+        }
+
+        sorted.sort_by_key(|(idx, _)| *idx);
+
+        let full_bytes: Vec<u8> = sorted.into_iter().flat_map(|(_, data)| data).collect();
+        let full_json = String::from_utf8(full_bytes)
+            .map_err(|_| KeepError::Frost("Invalid UTF-8 in assembled frames".into()))?;
+
+        Self::from_json(&full_json)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frost::{ThresholdConfig, TrustedDealer};
+
+    #[test]
+    fn test_share_export_roundtrip() {
+        let config = ThresholdConfig::two_of_three();
+        let dealer = TrustedDealer::new(config);
+        let (shares, _) = dealer.generate("test").unwrap();
+
+        let passphrase = "test passphrase";
+        let export = ShareExport::from_share(&shares[0], passphrase).unwrap();
+
+        let json = export.to_json().unwrap();
+        let reimported = ShareExport::from_json(&json).unwrap();
+        let share = reimported.to_share(passphrase, "imported").unwrap();
+
+        assert_eq!(share.metadata.threshold, shares[0].metadata.threshold);
+        assert_eq!(share.metadata.identifier, shares[0].metadata.identifier);
+        assert_eq!(share.group_pubkey(), shares[0].group_pubkey());
+    }
+
+    #[test]
+    fn test_bech32_roundtrip() {
+        let config = ThresholdConfig::two_of_three();
+        let dealer = TrustedDealer::new(config);
+        let (shares, _) = dealer.generate("test").unwrap();
+
+        let export = ShareExport::from_share(&shares[0], "pass").unwrap();
+        let encoded = export.to_bech32().unwrap();
+
+        assert!(encoded.starts_with(SHARE_HRP));
+
+        let decoded = ShareExport::from_bech32(&encoded).unwrap();
+        assert_eq!(decoded.identifier, export.identifier);
+        assert_eq!(decoded.threshold, export.threshold);
+    }
+
+    #[test]
+    fn test_wrong_passphrase_fails() {
+        let config = ThresholdConfig::two_of_three();
+        let dealer = TrustedDealer::new(config);
+        let (shares, _) = dealer.generate("test").unwrap();
+
+        let export = ShareExport::from_share(&shares[0], "correct").unwrap();
+        let result = export.to_share("wrong", "imported");
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_animated_frames_roundtrip() {
+        let config = ThresholdConfig::two_of_three();
+        let dealer = TrustedDealer::new(config);
+        let (shares, _) = dealer.generate("test").unwrap();
+
+        let export = ShareExport::from_share(&shares[0], "pass").unwrap();
+
+        let frames = export.to_animated_frames(100).unwrap();
+        assert!(frames.len() > 1);
+
+        let reconstructed = ShareExport::from_animated_frames(&frames).unwrap();
+        assert_eq!(reconstructed.identifier, export.identifier);
+        assert_eq!(reconstructed.threshold, export.threshold);
+        assert_eq!(reconstructed.group_pubkey, export.group_pubkey);
+    }
+
+    #[test]
+    fn test_animated_frames_single() {
+        let config = ThresholdConfig::two_of_three();
+        let dealer = TrustedDealer::new(config);
+        let (shares, _) = dealer.generate("test").unwrap();
+
+        let export = ShareExport::from_share(&shares[0], "pass").unwrap();
+
+        let frames = export.to_animated_frames(10000).unwrap();
+        assert_eq!(frames.len(), 1);
+
+        let reconstructed = ShareExport::from_animated_frames(&frames).unwrap();
+        assert_eq!(reconstructed.identifier, export.identifier);
+    }
+
+    #[test]
+    fn test_frost_message_roundtrip() {
+        let session_id = [42u8; 32];
+        let commitment_data = vec![1, 2, 3, 4, 5];
+
+        let msg = FrostMessage::commitment(&session_id, 1, &commitment_data);
+        assert_eq!(msg.msg_type, FrostMessageType::Round1Commitment);
+        assert_eq!(msg.identifier, 1);
+
+        let json = msg.to_json().unwrap();
+        let parsed = FrostMessage::from_json(&json).unwrap();
+
+        assert_eq!(parsed.msg_type, FrostMessageType::Round1Commitment);
+        assert_eq!(parsed.identifier, 1);
+        assert_eq!(parsed.payload_bytes().unwrap(), commitment_data);
+        assert_eq!(parsed.session_id_bytes().unwrap(), session_id);
+    }
+
+    #[test]
+    fn test_frost_message_signature_share() {
+        let session_id = [99u8; 32];
+        let share_data = vec![10, 20, 30];
+
+        let msg = FrostMessage::signature_share(&session_id, 2, &share_data);
+        assert_eq!(msg.msg_type, FrostMessageType::Round2Share);
+        assert_eq!(msg.identifier, 2);
+
+        let json = msg.to_json().unwrap();
+        assert!(json.contains("round2_share"));
+    }
+}

--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -152,7 +152,7 @@ impl HiddenStorage {
 
         while written < remaining {
             let to_write = ((remaining - written) as usize).min(buffer.len());
-            rand::thread_rng().fill_bytes(&mut buffer[..to_write]);
+            rand::rng().fill_bytes(&mut buffer[..to_write]);
             file.write_all(&buffer[..to_write])?;
             written += to_write as u64;
         }
@@ -465,7 +465,7 @@ impl HiddenStorage {
         let mut written = 0u64;
         while written < remaining {
             let to_write = ((remaining - written) as usize).min(buffer.len());
-            rand::thread_rng().fill_bytes(&mut buffer[..to_write]);
+            rand::rng().fill_bytes(&mut buffer[..to_write]);
             file.write_all(&buffer[..to_write])?;
             written += to_write as u64;
         }


### PR DESCRIPTION
- Trusted dealer for t-of-n key generation
- Share export/import with encrypted transport
- Interactive multi-device signing
- NIP-46 signer auto-detects FROST shares

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FROST threshold signatures: full t-of-n CLI (generate, split, list, export, import, sign — interactive & non-interactive), server/TUI auto-detects threshold signer, persistent encrypted share storage, transport/messaging for multi-party flows, and public APIs to manage and sign with shares.

* **Security**
  * Passphrase-protected share export/import, on-disk encrypted shares, and BIP-340–compatible Schnorr FROST support.

* **Documentation**
  * README updated with FROST workflow, CLI commands, examples, and security notes.

* **Tests**
  * Unit tests covering FROST generation, splitting, signing, export/import, transport, and protocol flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->