### PR TITLE
Replace external relay tests with mock relay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,6 +1777,7 @@ dependencies = [
  "frost-secp256k1-tr",
  "hex",
  "keep-core",
+ "nostr-relay-builder",
  "nostr-sdk",
  "parking_lot",
  "serde",
@@ -2045,6 +2046,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade30de16869618919c6b5efc8258f47b654a98b51541eb77f85e8ec5e3c83a6"
 dependencies = [
  "nostr",
+]
+
+[[package]]
+name = "nostr-relay-builder"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ba8e48eaadd5644e7317ca2f892b89a394a8cc57e99fea9f624dc081df1a24"
+dependencies = [
+ "async-utility",
+ "async-wsocket",
+ "atomic-destructor",
+ "hex",
+ "negentropy",
+ "nostr",
+ "nostr-database",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/keep-frost-net/Cargo.toml
+++ b/keep-frost-net/Cargo.toml
@@ -27,3 +27,4 @@ sha2 = "0.10.9"
 [dev-dependencies]
 tempfile = "3.10"
 tokio-test = "0.4"
+nostr-relay-builder = "0.44"


### PR DESCRIPTION
Use nostr-relay-builder MockRelay for integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Switched tests to a self-contained mock relay, removing external relay/env dependencies; re-enabled tests, simplified shutdown handling, replaced verbose logs with assertions, and adjusted timings for faster, more reliable runs.
* **Chores**
  * Added a development dependency to support the mock-relay-based testing workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->