### PR TITLE
Add replay protection timestamp validation to sign requests

### DIFF
--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -68,7 +68,7 @@ pub use nonce_store::{FileNonceStore, MemoryNonceStore, NonceStore};
 pub use peer::{Peer, PeerManager, PeerStatus};
 pub use protocol::{
     AnnouncePayload, CommitmentPayload, ErrorPayload, KfpMessage, PingPayload, PongPayload,
-    SignRequestPayload, SignatureCompletePayload, SignatureSharePayload, KFP_EVENT_KIND,
-    KFP_VERSION,
+    SignRequestPayload, SignatureCompletePayload, SignatureSharePayload,
+    DEFAULT_REPLAY_WINDOW_SECS, KFP_EVENT_KIND, KFP_VERSION,
 };
 pub use session::{derive_session_id, NetworkSession, SessionManager, SessionState};


### PR DESCRIPTION
Adds timestamp-based replay protection for FROST signing requests with configurable window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added replay-window validation to reject sign requests outside the allowed time window
  * Made the replay window duration configurable at runtime

* **Breaking Changes**
  * Renamed a field in the sign request payload (client integrations may need updates)

* **Tests**
  * Added tests covering replay window validation and related behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->