### PR TITLE
Add persistent nonce consumption tracking for FROST sessions

### DIFF
--- a/keep-frost-net/src/error.rs
+++ b/keep-frost-net/src/error.rs
@@ -34,6 +34,9 @@ pub enum FrostNetError {
     #[error("Replay detected: {0}")]
     ReplayDetected(String),
 
+    #[error("Nonce already consumed for session: {0}")]
+    NonceConsumed(String),
+
     #[error("Keep error: {0}")]
     Keep(#[from] keep_core::error::KeepError),
 

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -56,6 +56,7 @@
 mod error;
 mod event;
 mod node;
+mod nonce_store;
 mod peer;
 mod protocol;
 mod session;
@@ -63,6 +64,7 @@ mod session;
 pub use error::{FrostNetError, Result};
 pub use event::KfpEventBuilder;
 pub use node::{KfpNode, KfpNodeEvent};
+pub use nonce_store::{FileNonceStore, MemoryNonceStore, NonceStore};
 pub use peer::{Peer, PeerManager, PeerStatus};
 pub use protocol::{
     AnnouncePayload, CommitmentPayload, ErrorPayload, KfpMessage, PingPayload, PongPayload,

--- a/keep-frost-net/src/nonce_store.rs
+++ b/keep-frost-net/src/nonce_store.rs
@@ -1,0 +1,206 @@
+#![forbid(unsafe_code)]
+
+use std::collections::HashSet;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use tracing::{debug, warn};
+
+use crate::error::{FrostNetError, Result};
+
+pub trait NonceStore: Send + Sync {
+    fn record(&self, session_id: &[u8; 32]) -> Result<()>;
+    fn is_consumed(&self, session_id: &[u8; 32]) -> bool;
+    fn count(&self) -> usize;
+}
+
+pub struct FileNonceStore {
+    path: PathBuf,
+    consumed: Arc<RwLock<HashSet<[u8; 32]>>>,
+}
+
+impl FileNonceStore {
+    pub fn new(path: &Path) -> Result<Self> {
+        let consumed = Arc::new(RwLock::new(HashSet::new()));
+
+        if path.exists() {
+            let file = File::open(path).map_err(|e| {
+                FrostNetError::Session(format!("Failed to open nonce store: {}", e))
+            })?;
+            let reader = BufReader::new(file);
+
+            let mut guard = consumed.write();
+            for line in reader.lines() {
+                let line = line.map_err(|e| {
+                    FrostNetError::Session(format!("Failed to read nonce store: {}", e))
+                })?;
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+
+                let bytes = hex::decode(line).map_err(|e| {
+                    FrostNetError::Session(format!("Invalid hex in nonce store: {}", e))
+                })?;
+
+                if bytes.len() != 32 {
+                    warn!(line = %line, "Skipping invalid entry in nonce store");
+                    continue;
+                }
+
+                let mut session_id = [0u8; 32];
+                session_id.copy_from_slice(&bytes);
+                guard.insert(session_id);
+            }
+            debug!(count = guard.len(), path = ?path, "Loaded consumed session IDs");
+        }
+
+        Ok(Self {
+            path: path.to_path_buf(),
+            consumed,
+        })
+    }
+}
+
+impl NonceStore for FileNonceStore {
+    fn record(&self, session_id: &[u8; 32]) -> Result<()> {
+        // Use write lock for entire operation to prevent TOCTOU race
+        let mut guard = self.consumed.write();
+        if guard.contains(session_id) {
+            return Ok(());
+        }
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .map_err(|e| FrostNetError::Session(format!("Failed to open nonce store: {}", e)))?;
+
+        let hex_id = hex::encode(session_id);
+        writeln!(file, "{}", hex_id).map_err(|e| {
+            FrostNetError::Session(format!("Failed to write to nonce store: {}", e))
+        })?;
+
+        file.sync_all()
+            .map_err(|e| FrostNetError::Session(format!("Failed to sync nonce store: {}", e)))?;
+
+        guard.insert(*session_id);
+        debug!(session_id = %hex_id, "Recorded consumed session ID");
+
+        Ok(())
+    }
+
+    fn is_consumed(&self, session_id: &[u8; 32]) -> bool {
+        self.consumed.read().contains(session_id)
+    }
+
+    fn count(&self) -> usize {
+        self.consumed.read().len()
+    }
+}
+
+pub struct MemoryNonceStore {
+    consumed: Arc<RwLock<HashSet<[u8; 32]>>>,
+}
+
+impl MemoryNonceStore {
+    pub fn new() -> Self {
+        Self {
+            consumed: Arc::new(RwLock::new(HashSet::new())),
+        }
+    }
+}
+
+impl Default for MemoryNonceStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NonceStore for MemoryNonceStore {
+    fn record(&self, session_id: &[u8; 32]) -> Result<()> {
+        self.consumed.write().insert(*session_id);
+        Ok(())
+    }
+
+    fn is_consumed(&self, session_id: &[u8; 32]) -> bool {
+        self.consumed.read().contains(session_id)
+    }
+
+    fn count(&self) -> usize {
+        self.consumed.read().len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_memory_store() {
+        let store = MemoryNonceStore::new();
+        let session_id = [1u8; 32];
+
+        assert!(!store.is_consumed(&session_id));
+        store.record(&session_id).unwrap();
+        assert!(store.is_consumed(&session_id));
+        assert_eq!(store.count(), 1);
+    }
+
+    #[test]
+    fn test_file_store_persistence() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nonces.log");
+
+        let session_id1 = [1u8; 32];
+        let session_id2 = [2u8; 32];
+
+        {
+            let store = FileNonceStore::new(&path).unwrap();
+            assert!(!store.is_consumed(&session_id1));
+            store.record(&session_id1).unwrap();
+            store.record(&session_id2).unwrap();
+            assert!(store.is_consumed(&session_id1));
+            assert!(store.is_consumed(&session_id2));
+        }
+
+        {
+            let store = FileNonceStore::new(&path).unwrap();
+            assert!(store.is_consumed(&session_id1));
+            assert!(store.is_consumed(&session_id2));
+            assert_eq!(store.count(), 2);
+        }
+    }
+
+    #[test]
+    fn test_file_store_new_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("new_nonces.log");
+
+        let store = FileNonceStore::new(&path).unwrap();
+        assert_eq!(store.count(), 0);
+
+        let session_id = [42u8; 32];
+        store.record(&session_id).unwrap();
+        assert!(store.is_consumed(&session_id));
+    }
+
+    #[test]
+    fn test_idempotent_record() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nonces.log");
+
+        let store = FileNonceStore::new(&path).unwrap();
+        let session_id = [1u8; 32];
+
+        store.record(&session_id).unwrap();
+        store.record(&session_id).unwrap();
+        store.record(&session_id).unwrap();
+
+        assert_eq!(store.count(), 1);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added nonce storage support with both persistent file-backed and in-memory options; node initialization can opt into a nonce store.

* **Bug Fixes**
  * Improved nonce tracking to avoid nonce reuse across restarts and duplicate signing requests.

* **Error Handling**
  * Introduced an error to indicate when a nonce has already been consumed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->