### PR TITLE
Fix stack-allocated secrets with heap-allocated MlockedBox

### DIFF
--- a/keep-agent-py/src/lib.rs
+++ b/keep-agent-py/src/lib.rs
@@ -355,7 +355,7 @@ impl PyAgentSession {
 
         session.check_operation(&Operation::SignPsbt).map_err(to_py_err)?;
 
-        let secret = self.secret_key
+        let mut secret = self.secret_key
             .ok_or_else(|| PyRuntimeError::new_err("No secret key configured. Pass secret_key to constructor."))?;
 
         let network = match network.unwrap_or("testnet") {
@@ -368,7 +368,7 @@ impl PyAgentSession {
         let mut psbt = keep_bitcoin::psbt::parse_psbt_base64(psbt_base64)
             .map_err(|e| PyValueError::new_err(format!("Invalid PSBT: {}", e)))?;
 
-        let signer = keep_bitcoin::BitcoinSigner::new(secret, network)
+        let signer = keep_bitcoin::BitcoinSigner::new(&mut secret, network)
             .map_err(to_py_err)?;
 
         let analysis = signer.analyze_psbt(&psbt).map_err(to_py_err)?;
@@ -426,7 +426,7 @@ impl PyAgentSession {
 
         session.check_operation(&Operation::GetBitcoinAddress).map_err(to_py_err)?;
 
-        let secret = self.secret_key
+        let mut secret = self.secret_key
             .ok_or_else(|| PyRuntimeError::new_err("No secret key configured. Pass secret_key to constructor."))?;
 
         let network = match network.unwrap_or("testnet") {
@@ -436,7 +436,7 @@ impl PyAgentSession {
             _ => keep_bitcoin::Network::Testnet,
         };
 
-        let signer = keep_bitcoin::BitcoinSigner::new(secret, network)
+        let signer = keep_bitcoin::BitcoinSigner::new(&mut secret, network)
             .map_err(to_py_err)?;
 
         signer.get_receive_address(0).map_err(to_py_err)

--- a/keep-agent-ts/src/lib.rs
+++ b/keep-agent-ts/src/lib.rs
@@ -362,7 +362,7 @@ impl KeepAgentSession {
             .check_operation(&Operation::SignPsbt)
             .map_err(|e| Error::from_reason(e.to_string()))?;
 
-        let secret = self
+        let mut secret = self
             .secret_key
             .ok_or_else(|| Error::from_reason("No secret key configured"))?;
 
@@ -376,7 +376,7 @@ impl KeepAgentSession {
         let mut psbt = keep_bitcoin::psbt::parse_psbt_base64(&psbt_base64)
             .map_err(|e| Error::from_reason(format!("Invalid PSBT: {}", e)))?;
 
-        let signer = keep_bitcoin::BitcoinSigner::new(secret, network)
+        let signer = keep_bitcoin::BitcoinSigner::new(&mut secret, network)
             .map_err(|e| Error::from_reason(e.to_string()))?;
 
         let analysis = signer
@@ -446,7 +446,7 @@ impl KeepAgentSession {
             .check_operation(&Operation::GetBitcoinAddress)
             .map_err(|e| Error::from_reason(e.to_string()))?;
 
-        let secret = self
+        let mut secret = self
             .secret_key
             .ok_or_else(|| Error::from_reason("No secret key configured"))?;
 
@@ -457,7 +457,7 @@ impl KeepAgentSession {
             _ => keep_bitcoin::Network::Testnet,
         };
 
-        let signer = keep_bitcoin::BitcoinSigner::new(secret, network)
+        let signer = keep_bitcoin::BitcoinSigner::new(&mut secret, network)
             .map_err(|e| Error::from_reason(e.to_string()))?;
 
         signer

--- a/keep-agent/src/mcp/server.rs
+++ b/keep-agent/src/mcp/server.rs
@@ -317,7 +317,7 @@ impl McpServer {
                     .and_then(|v| v.as_str())
                     .unwrap_or("testnet");
 
-                if let Some(secret) = self.secret_key {
+                if let Some(mut secret) = self.secret_key {
                     let network = match network_str {
                         "mainnet" | "bitcoin" => keep_bitcoin::Network::Bitcoin,
                         "signet" => keep_bitcoin::Network::Signet,
@@ -328,7 +328,7 @@ impl McpServer {
                     let mut psbt = keep_bitcoin::psbt::parse_psbt_base64(psbt_base64)
                         .map_err(|e| AgentError::Other(format!("Invalid PSBT: {}", e)))?;
 
-                    let signer = keep_bitcoin::BitcoinSigner::new(secret, network)
+                    let signer = keep_bitcoin::BitcoinSigner::new(&mut secret, network)
                         .map_err(|e| AgentError::Other(e.to_string()))?;
 
                     let analysis = signer
@@ -411,7 +411,7 @@ impl McpServer {
                     .and_then(|v| v.as_str())
                     .unwrap_or("testnet");
 
-                if let Some(secret) = self.secret_key {
+                if let Some(mut secret) = self.secret_key {
                     let network = match network_str {
                         "mainnet" | "bitcoin" => keep_bitcoin::Network::Bitcoin,
                         "signet" => keep_bitcoin::Network::Signet,
@@ -419,7 +419,7 @@ impl McpServer {
                         _ => keep_bitcoin::Network::Testnet,
                     };
 
-                    let signer = keep_bitcoin::BitcoinSigner::new(secret, network)
+                    let signer = keep_bitcoin::BitcoinSigner::new(&mut secret, network)
                         .map_err(|e| AgentError::Other(e.to_string()))?;
 
                     let address = signer

--- a/keep-bitcoin/src/descriptor.rs
+++ b/keep-bitcoin/src/descriptor.rs
@@ -14,7 +14,7 @@ pub struct DescriptorExport {
 impl DescriptorExport {
     pub fn from_derivation(derivation: &AddressDerivation, account: u32) -> Result<Self> {
         let network = derivation.network();
-        let fingerprint = derivation.master_fingerprint();
+        let fingerprint = derivation.master_fingerprint()?;
         let xpub = derivation.account_xpub(account)?;
 
         let coin_type = if network == Network::Bitcoin { 0 } else { 1 };

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -2586,8 +2586,7 @@ fn cmd_export_outer(out: &Output, path: &Path, name: &str) -> Result<()> {
     let mut secret = [0u8; 32];
     let decrypted = secret_bytes.as_slice()?;
     secret.copy_from_slice(&decrypted);
-    let keypair = NostrKeypair::from_secret_bytes(&secret)?;
-    secret.zeroize();
+    let keypair = NostrKeypair::from_secret_bytes(&mut secret)?;
 
     out.secret_warning();
     out.newline();
@@ -2628,8 +2627,7 @@ fn cmd_export_hidden(out: &Output, path: &Path, name: &str) -> Result<()> {
     let mut secret = [0u8; 32];
     let decrypted = secret_bytes.as_slice()?;
     secret.copy_from_slice(&decrypted);
-    let keypair = NostrKeypair::from_secret_bytes(&secret)?;
-    secret.zeroize();
+    let keypair = NostrKeypair::from_secret_bytes(&mut secret)?;
 
     out.secret_warning();
     out.newline();
@@ -3189,9 +3187,8 @@ fn cmd_bitcoin_address(
     let mut secret = *slot.expose_secret();
     let net = parse_network(network)?;
 
-    let signer = keep_bitcoin::BitcoinSigner::new(secret, net)
+    let signer = keep_bitcoin::BitcoinSigner::new(&mut secret, net)
         .map_err(|e| KeepError::Other(e.to_string()))?;
-    secret.zeroize();
 
     out.newline();
     out.header("Bitcoin Addresses (BIP-86 Taproot)");
@@ -3231,9 +3228,8 @@ fn cmd_bitcoin_descriptor(
     let mut secret = *slot.expose_secret();
     let net = parse_network(network)?;
 
-    let signer = keep_bitcoin::BitcoinSigner::new(secret, net)
+    let signer = keep_bitcoin::BitcoinSigner::new(&mut secret, net)
         .map_err(|e| KeepError::Other(e.to_string()))?;
-    secret.zeroize();
 
     let export = signer
         .export_descriptor(account)
@@ -3281,9 +3277,8 @@ fn cmd_bitcoin_sign(
     let mut secret = *slot.expose_secret();
     let net = parse_network(network)?;
 
-    let signer = keep_bitcoin::BitcoinSigner::new(secret, net)
+    let signer = keep_bitcoin::BitcoinSigner::new(&mut secret, net)
         .map_err(|e| KeepError::Other(e.to_string()))?;
-    secret.zeroize();
 
     let psbt_data = std::fs::read_to_string(psbt_path)
         .map_err(|e| KeepError::Other(format!("Failed to read PSBT: {}", e)))?;
@@ -3323,8 +3318,8 @@ fn cmd_bitcoin_analyze(out: &Output, psbt_path: &str, network: &str) -> Result<(
         .map_err(|e| KeepError::Other(e.to_string()))?;
 
     let net = parse_network(network)?;
-    let dummy_secret = [1u8; 32];
-    let signer = keep_bitcoin::BitcoinSigner::new(dummy_secret, net)
+    let mut dummy_secret = [1u8; 32];
+    let signer = keep_bitcoin::BitcoinSigner::new(&mut dummy_secret, net)
         .map_err(|e| KeepError::Other(e.to_string()))?;
 
     let analysis = signer

--- a/keep-core/src/keyring.rs
+++ b/keep-core/src/keyring.rs
@@ -33,7 +33,8 @@ impl KeySlot {
     }
 
     pub fn to_nostr_keypair(&self) -> Result<NostrKeypair> {
-        NostrKeypair::from_secret_bytes(self.secret.expose_secret())
+        let mut secret_copy = *self.secret.expose_secret();
+        NostrKeypair::from_secret_bytes(&mut secret_copy)
     }
 }
 

--- a/keep-enclave/enclave/src/signer.rs
+++ b/keep-enclave/enclave/src/signer.rs
@@ -151,7 +151,8 @@ mod mlock {
     unsafe impl Sync for MlockedVec {}
 }
 
-use mlock::{MlockedBox, MlockedVec};
+pub use mlock::MlockedBox;
+use mlock::MlockedVec;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PsbtAnalysis {
@@ -241,7 +242,8 @@ impl EnclaveSigner {
     }
 
     pub fn create_kms(&self) -> crate::kms::EnclaveKms {
-        crate::kms::EnclaveKms::new(*self.ephemeral_secret)
+        let mut secret_copy = *self.ephemeral_secret;
+        crate::kms::EnclaveKms::new(&mut secret_copy)
     }
 
     pub fn get_ephemeral_pubkey(&self) -> Result<[u8; 32]> {


### PR DESCRIPTION
Wrap secrets in MlockedBox to prevent stack memory residue from intermediate copies during moves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated signer and keypair constructors to accept mutable secret buffers and adjusted related APIs.
  * Switched several key/secret storage paths to locked memory with lazy key construction.
  * Fingerprint and master-key retrieval now surface errors via Result types.

* **Security / Privacy**
  * Secrets are now stored in locked memory to reduce exposure and handled more carefully in signing flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->