### PR TITLE
Add network failure simulation tests for FROST protocol

### DIFF
--- a/keep-frost-net/tests/network_failure_test.rs
+++ b/keep-frost-net/tests/network_failure_test.rs
@@ -340,7 +340,9 @@ fn test_malicious_share_from_non_participant() {
     // Deserialization accepts any bytes; validation occurs at aggregation time
     let malicious_share =
         frost_secp256k1_tr::round2::SignatureShare::deserialize(&[0u8; 32]).unwrap();
-    let err = session.add_signature_share(99, malicious_share).unwrap_err();
+    let err = session
+        .add_signature_share(99, malicious_share)
+        .unwrap_err();
     assert!(err.to_string().contains("not a participant"));
 }
 


### PR DESCRIPTION
## Summary
- Add configurable fault injection infrastructure for testing
- Add 32 tests covering message reordering, participant dropout, duplicate delivery, network partition, timeout behavior, and malicious data handling
- Verify session cleanup and nonce reuse prevention

## Test plan
- [x] All 32 tests pass
- [x] Clippy clean
- [x] Existing tests unaffected