### PR TITLE
Optimize crypto crates in debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,3 +97,9 @@ anyhow = "1.0"
 
 # Testing
 tempfile = "3.10"
+
+[profile.dev.package.argon2]
+opt-level = 3
+
+[profile.dev.package.blake2]
+opt-level = 3


### PR DESCRIPTION
## Summary
- Add `[profile.dev.package]` overrides for `argon2` and `blake2` in workspace Cargo.toml
- Unlock drops from ~11s to ~0.7s in debug builds (15x improvement)

## Test plan
- [x] `cargo build -p keep-desktop` compiles
- [x] `test_reopen_keep` (exercises KDF twice) completes in 0.29s

Fixes #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration for faster development compilation performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->