### PR TITLE
Install default crypto provider in CLI

### DIFF
--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -60,6 +60,7 @@ fn init_logging() {
 fn main() {
     init_logging();
     panic::install();
+    keep_frost_net::install_default_crypto_provider();
 
     ctrlc::set_handler(|| {
         let _ = crossterm::terminal::disable_raw_mode();


### PR DESCRIPTION
Adds missing rustls crypto provider initialization to CLI startup, matching keep-mobile and keep-desktop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved system initialization at startup to enhance stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->