### PR TITLE
Fix NIP-55 signer compatibility and single-participant FROST signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -4042,10 +4042,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.88"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if 1.0.4",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -7227,9 +7229,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -9137,9 +9139,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.111"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if 1.0.4",
  "once_cell",
@@ -9150,23 +9152,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.61"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if 1.0.4",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.111"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9174,9 +9172,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.111"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -9187,9 +9185,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.111"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -9379,9 +9377,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.88"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -609,10 +609,6 @@ impl KfpNode {
             .is_none_or(|p| p.allow_receive)
     }
 
-    pub(crate) fn cleanup_session_on_hook_failure(&self, session_id: &[u8; 32]) {
-        self.sessions.write().complete_session(session_id);
-    }
-
     pub(crate) fn invoke_post_sign_hook(&self, session_id: &[u8; 32], signature: &[u8; 64]) {
         let info = {
             let mut sessions = self.sessions.write();

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -100,7 +100,9 @@ impl KfpNode {
             .read()
             .get_peer_by_pubkey(&from)
             .map(|p| p.share_index)
-            .unwrap_or(0);
+            .ok_or_else(|| {
+                FrostNetError::UntrustedPeer(format!("Peer {from} not found in peer list"))
+            })?;
 
         let session_info = SessionInfo {
             session_id: request.session_id,
@@ -242,18 +244,11 @@ impl KfpNode {
         };
 
         if let Some(sig) = self_aggregated_sig {
-            let session_message = {
+            let (session_message, session_participants) = {
                 let sessions = self.sessions.read();
                 sessions
                     .get_session(session_id)
-                    .map(|s| s.message().to_vec())
-                    .unwrap_or_default()
-            };
-            let session_participants = {
-                let sessions = self.sessions.read();
-                sessions
-                    .get_session(session_id)
-                    .map(|s| s.participants().to_vec())
+                    .map(|s| (s.message().to_vec(), s.participants().to_vec()))
                     .unwrap_or_default()
             };
 
@@ -395,19 +390,27 @@ impl KfpNode {
     ) -> Result<()> {
         {
             let sessions = self.sessions.read();
-            if let Some(session) = sessions.get_session(&payload.session_id) {
-                let peers = self.peers.read();
-                let is_participant = session.participants().iter().any(|&idx| {
-                    peers
-                        .get_peer(idx)
-                        .map(|p| p.pubkey == from)
-                        .unwrap_or(false)
-                });
-                if !is_participant {
-                    return Err(FrostNetError::UntrustedPeer(
-                        "Sender not a session participant".into(),
-                    ));
+            let session = match sessions.get_session(&payload.session_id) {
+                Some(s) => s,
+                None => {
+                    debug!(
+                        session_id = %hex::encode(payload.session_id),
+                        "Ignoring signature complete for unknown session"
+                    );
+                    return Ok(());
                 }
+            };
+            let peers = self.peers.read();
+            let is_participant = session.participants().iter().any(|&idx| {
+                peers
+                    .get_peer(idx)
+                    .map(|p| p.pubkey == from)
+                    .unwrap_or(false)
+            });
+            if !is_participant {
+                return Err(FrostNetError::UntrustedPeer(
+                    "Sender not a session participant".into(),
+                ));
             }
         }
 
@@ -477,6 +480,16 @@ impl KfpNode {
             participants.clone(),
         );
 
+        let session_info = SessionInfo {
+            session_id,
+            message: message.clone(),
+            threshold: self.share.metadata.threshold,
+            participants: participants.clone(),
+            requester: self.share.metadata.identifier,
+        };
+        let hooks = self.hooks.read().clone();
+        hooks.pre_sign(&session_info)?;
+
         let key_package = self.share.key_package()?;
         let (nonces, our_commitment) =
             frost_secp256k1_tr::round1::commit(key_package.signing_share(), &mut OsRng);
@@ -494,21 +507,7 @@ impl KfpNode {
             session.set_our_commitment(our_commitment);
             session.add_commitment(self.share.metadata.identifier, our_commitment)?;
 
-            // Record consumption AFTER nonces are generated to prevent reuse across restarts
             sessions.record_nonce_consumption(&session_id)?;
-        }
-
-        let session_info = {
-            let sessions = self.sessions.read();
-            sessions
-                .get_session(&session_id)
-                .map(SessionInfo::from)
-                .ok_or_else(|| FrostNetError::SessionNotFound(hex::encode(session_id)))?
-        };
-        let hooks = self.hooks.read().clone();
-        if let Err(e) = hooks.pre_sign(&session_info) {
-            self.cleanup_session_on_hook_failure(&session_id);
-            return Err(e);
         }
 
         let our_commit_bytes = our_commitment

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -547,7 +547,10 @@ impl KfpNode {
                 .unwrap_or(false)
         };
         if all_committed {
-            self.generate_and_send_share(&session_id).await?;
+            if let Err(e) = self.generate_and_send_share(&session_id).await {
+                self.sessions.write().complete_session(&session_id);
+                return Err(e);
+            }
         }
 
         let timeout = Duration::from_secs(30);

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -226,11 +226,59 @@ impl KfpNode {
         let sig_share = frost_secp256k1_tr::round2::sign(&signing_package, &nonces, &key_package)
             .map_err(|e| FrostNetError::Crypto(format!("Signing failed: {e}")))?;
 
-        {
+        let self_aggregated_sig = {
             let mut sessions = self.sessions.write();
             if let Some(session) = sessions.get_session_mut(session_id) {
                 session.add_signature_share(self.share.metadata.identifier, sig_share)?;
+                if session.has_all_shares() {
+                    let pubkey_pkg = self.share.pubkey_package()?;
+                    session.try_aggregate(&pubkey_pkg)?
+                } else {
+                    None
+                }
+            } else {
+                None
             }
+        };
+
+        if let Some(sig) = self_aggregated_sig {
+            let session_message = {
+                let sessions = self.sessions.read();
+                sessions
+                    .get_session(session_id)
+                    .map(|s| s.message().to_vec())
+                    .unwrap_or_default()
+            };
+            let session_participants = {
+                let sessions = self.sessions.read();
+                sessions
+                    .get_session(session_id)
+                    .map(|s| s.participants().to_vec())
+                    .unwrap_or_default()
+            };
+
+            info!(
+                session_id = %hex::encode(session_id),
+                "Signature complete (single-participant)!"
+            );
+
+            self.audit_log.log_signing_operation(
+                *session_id,
+                &session_message,
+                Some(&sig),
+                session_participants,
+                self.share.metadata.identifier,
+                SigningOperation::SignatureCompleted,
+            );
+
+            self.invoke_post_sign_hook(session_id, &sig);
+
+            let _ = self.event_tx.send(KfpNodeEvent::SignatureComplete {
+                session_id: *session_id,
+                signature: sig,
+            });
+
+            return Ok(());
         }
 
         let share_bytes = sig_share.serialize();
@@ -490,6 +538,20 @@ impl KfpNode {
         }
 
         let mut rx = self.event_tx.subscribe();
+
+        // For single-participant (threshold=1), all commitments are already present.
+        // Must subscribe before generating share so we don't miss SignatureComplete.
+        let all_committed = {
+            let sessions = self.sessions.read();
+            sessions
+                .get_session(&session_id)
+                .map(|s| s.has_all_commitments())
+                .unwrap_or(false)
+        };
+        if all_committed {
+            self.generate_and_send_share(&session_id).await?;
+        }
+
         let timeout = Duration::from_secs(30);
 
         let result = tokio::time::timeout(timeout, async {

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -228,13 +228,14 @@ impl KfpNode {
         let sig_share = frost_secp256k1_tr::round2::sign(&signing_package, &nonces, &key_package)
             .map_err(|e| FrostNetError::Crypto(format!("Signing failed: {e}")))?;
 
-        let self_aggregated_sig = {
+        let self_aggregated = {
             let mut sessions = self.sessions.write();
             if let Some(session) = sessions.get_session_mut(session_id) {
                 session.add_signature_share(self.share.metadata.identifier, sig_share)?;
                 if session.has_all_shares() {
                     let pubkey_pkg = self.share.pubkey_package()?;
-                    session.try_aggregate(&pubkey_pkg)?
+                    let sig = session.try_aggregate(&pubkey_pkg)?;
+                    sig.map(|s| (s, session.message().to_vec(), session.participants().to_vec()))
                 } else {
                     None
                 }
@@ -243,15 +244,7 @@ impl KfpNode {
             }
         };
 
-        if let Some(sig) = self_aggregated_sig {
-            let (session_message, session_participants) = {
-                let sessions = self.sessions.read();
-                sessions
-                    .get_session(session_id)
-                    .map(|s| (s.message().to_vec(), s.participants().to_vec()))
-                    .unwrap_or_default()
-            };
-
+        if let Some((sig, session_message, session_participants)) = self_aggregated {
             info!(
                 session_id = %hex::encode(session_id),
                 "Signature complete (single-participant)!"

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -201,7 +201,10 @@ impl KfpNode {
         self.peers.write().update_last_seen(payload.share_index);
 
         if proceed_to_round2 {
-            self.generate_and_send_share(&payload.session_id).await?;
+            if let Err(e) = self.generate_and_send_share(&payload.session_id).await {
+                self.sessions.write().complete_session(&payload.session_id);
+                return Err(e);
+            }
         }
 
         Ok(())
@@ -585,7 +588,10 @@ impl KfpNode {
 
         match result {
             Ok(r) => r,
-            Err(_) => Err(FrostNetError::Timeout("Signing request timed out".into())),
+            Err(_) => {
+                self.sessions.write().complete_session(&session_id);
+                Err(FrostNetError::Timeout("Signing request timed out".into()))
+            }
         }
     }
 }

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -235,7 +235,13 @@ impl KfpNode {
                 if session.has_all_shares() {
                     let pubkey_pkg = self.share.pubkey_package()?;
                     let sig = session.try_aggregate(&pubkey_pkg)?;
-                    sig.map(|s| (s, session.message().to_vec(), session.participants().to_vec()))
+                    sig.map(|s| {
+                        (
+                            s,
+                            session.message().to_vec(),
+                            session.participants().to_vec(),
+                        )
+                    })
                 } else {
                     None
                 }

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -306,11 +306,13 @@ struct MobileSigningHooks {
 
 impl MobileSigningHooks {
     fn set_pre_approved(&self, approved: bool) {
-        self.pre_approved.store(approved, std::sync::atomic::Ordering::Release);
+        self.pre_approved
+            .store(approved, std::sync::atomic::Ordering::Release);
     }
 
     fn consume_pre_approval(&self) -> bool {
-        self.pre_approved.swap(false, std::sync::atomic::Ordering::AcqRel)
+        self.pre_approved
+            .swap(false, std::sync::atomic::Ordering::AcqRel)
     }
 }
 

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -306,7 +306,10 @@ struct MobileSigningHooks {
 
 impl MobileSigningHooks {
     fn consume_pre_approval(&self, message: &[u8]) -> bool {
-        let mut guard = self.pre_approved_hash.lock().unwrap_or_else(|e| e.into_inner());
+        let mut guard = self
+            .pre_approved_hash
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         if let Some(hash) = guard.take() {
             use sha2::{Digest, Sha256};
             let msg_hash: [u8; 32] = Sha256::digest(message).into();
@@ -380,7 +383,6 @@ pub struct KeepMobile {
     pending_contributions: Arc<std::sync::Mutex<HashMap<[u8; 32], PendingContribution>>>,
     state_callback: Arc<RwLock<Option<Arc<dyn KeepStateCallback>>>>,
     state_rev: Arc<std::sync::atomic::AtomicU64>,
-    signing_hooks: Arc<RwLock<Option<Arc<MobileSigningHooks>>>>,
     pre_approved_hash: Arc<std::sync::Mutex<Option<[u8; 32]>>>,
 }
 
@@ -505,7 +507,6 @@ impl KeepMobile {
             pending_contributions: Arc::new(std::sync::Mutex::new(HashMap::new())),
             state_callback: Arc::new(RwLock::new(None)),
             state_rev: Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            signing_hooks: Arc::new(RwLock::new(None)),
             pre_approved_hash: Arc::new(std::sync::Mutex::new(None)),
         })
     }
@@ -575,11 +576,17 @@ impl KeepMobile {
     pub fn set_signing_pre_approved(&self, message: Vec<u8>) {
         use sha2::{Digest, Sha256};
         let hash: [u8; 32] = Sha256::digest(&message).into();
-        *self.pre_approved_hash.lock().unwrap_or_else(|e| e.into_inner()) = Some(hash);
+        *self
+            .pre_approved_hash
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = Some(hash);
     }
 
     pub fn clear_signing_pre_approval(&self) {
-        *self.pre_approved_hash.lock().unwrap_or_else(|e| e.into_inner()) = None;
+        *self
+            .pre_approved_hash
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = None;
     }
 
     pub fn get_pending_requests(&self) -> Vec<SignRequest> {
@@ -1892,8 +1899,7 @@ impl KeepMobile {
                 request_tx,
                 pre_approved_hash: self.pre_approved_hash.clone(),
             });
-            node.set_hooks(hooks.clone());
-            *self.signing_hooks.write().await = Some(hooks);
+            node.set_hooks(hooks);
 
             let event_rx = node.subscribe();
             let node = Arc::new(node);

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -301,10 +301,25 @@ pub trait KeepStateCallback: Send + Sync + 'static {
 
 struct MobileSigningHooks {
     request_tx: mpsc::Sender<(SessionInfo, mpsc::Sender<bool>)>,
+    pre_approved: std::sync::atomic::AtomicBool,
+}
+
+impl MobileSigningHooks {
+    fn set_pre_approved(&self, approved: bool) {
+        self.pre_approved.store(approved, std::sync::atomic::Ordering::Release);
+    }
+
+    fn consume_pre_approval(&self) -> bool {
+        self.pre_approved.swap(false, std::sync::atomic::Ordering::AcqRel)
+    }
 }
 
 impl SigningHooks for MobileSigningHooks {
     fn pre_sign(&self, session: &SessionInfo) -> keep_frost_net::Result<()> {
+        if self.consume_pre_approval() {
+            return Ok(());
+        }
+
         let (response_tx, mut response_rx) = mpsc::channel(1);
         if self
             .request_tx
@@ -360,6 +375,7 @@ pub struct KeepMobile {
     pending_contributions: Arc<std::sync::Mutex<HashMap<[u8; 32], PendingContribution>>>,
     state_callback: Arc<RwLock<Option<Arc<dyn KeepStateCallback>>>>,
     state_rev: Arc<std::sync::atomic::AtomicU64>,
+    signing_hooks: Arc<RwLock<Option<Arc<MobileSigningHooks>>>>,
 }
 
 struct PendingRequest {
@@ -483,6 +499,7 @@ impl KeepMobile {
             pending_contributions: Arc::new(std::sync::Mutex::new(HashMap::new())),
             state_callback: Arc::new(RwLock::new(None)),
             state_rev: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            signing_hooks: Arc::new(RwLock::new(None)),
         })
     }
 
@@ -546,6 +563,14 @@ impl KeepMobile {
         let result = self.do_import_nsec(&hex_key, name);
         hex_key.zeroize();
         result
+    }
+
+    pub fn set_signing_pre_approved(&self, approved: bool) {
+        self.runtime.block_on(async {
+            if let Some(hooks) = self.signing_hooks.read().await.as_ref() {
+                hooks.set_pre_approved(approved);
+            }
+        });
     }
 
     pub fn get_pending_requests(&self) -> Vec<SignRequest> {
@@ -1854,8 +1879,12 @@ impl KeepMobile {
             };
 
             let (request_tx, request_rx) = mpsc::channel(32);
-            let hooks = Arc::new(MobileSigningHooks { request_tx });
-            node.set_hooks(hooks);
+            let hooks = Arc::new(MobileSigningHooks {
+                request_tx,
+                pre_approved: std::sync::atomic::AtomicBool::new(false),
+            });
+            node.set_hooks(hooks.clone());
+            *self.signing_hooks.write().await = Some(hooks);
 
             let event_rx = node.subscribe();
             let node = Arc::new(node);

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -301,24 +301,27 @@ pub trait KeepStateCallback: Send + Sync + 'static {
 
 struct MobileSigningHooks {
     request_tx: mpsc::Sender<(SessionInfo, mpsc::Sender<bool>)>,
-    pre_approved: std::sync::atomic::AtomicBool,
+    pre_approved_hash: Arc<std::sync::Mutex<Option<[u8; 32]>>>,
 }
 
 impl MobileSigningHooks {
-    fn set_pre_approved(&self, approved: bool) {
-        self.pre_approved
-            .store(approved, std::sync::atomic::Ordering::Release);
-    }
-
-    fn consume_pre_approval(&self) -> bool {
-        self.pre_approved
-            .swap(false, std::sync::atomic::Ordering::AcqRel)
+    fn consume_pre_approval(&self, message: &[u8]) -> bool {
+        let mut guard = self.pre_approved_hash.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(hash) = guard.take() {
+            use sha2::{Digest, Sha256};
+            let msg_hash: [u8; 32] = Sha256::digest(message).into();
+            if hash == msg_hash {
+                return true;
+            }
+            *guard = Some(hash);
+        }
+        false
     }
 }
 
 impl SigningHooks for MobileSigningHooks {
     fn pre_sign(&self, session: &SessionInfo) -> keep_frost_net::Result<()> {
-        if self.consume_pre_approval() {
+        if self.consume_pre_approval(&session.message) {
             return Ok(());
         }
 
@@ -378,6 +381,7 @@ pub struct KeepMobile {
     state_callback: Arc<RwLock<Option<Arc<dyn KeepStateCallback>>>>,
     state_rev: Arc<std::sync::atomic::AtomicU64>,
     signing_hooks: Arc<RwLock<Option<Arc<MobileSigningHooks>>>>,
+    pre_approved_hash: Arc<std::sync::Mutex<Option<[u8; 32]>>>,
 }
 
 struct PendingRequest {
@@ -502,6 +506,7 @@ impl KeepMobile {
             state_callback: Arc::new(RwLock::new(None)),
             state_rev: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             signing_hooks: Arc::new(RwLock::new(None)),
+            pre_approved_hash: Arc::new(std::sync::Mutex::new(None)),
         })
     }
 
@@ -567,12 +572,14 @@ impl KeepMobile {
         result
     }
 
-    pub fn set_signing_pre_approved(&self, approved: bool) {
-        self.runtime.block_on(async {
-            if let Some(hooks) = self.signing_hooks.read().await.as_ref() {
-                hooks.set_pre_approved(approved);
-            }
-        });
+    pub fn set_signing_pre_approved(&self, message: Vec<u8>) {
+        use sha2::{Digest, Sha256};
+        let hash: [u8; 32] = Sha256::digest(&message).into();
+        *self.pre_approved_hash.lock().unwrap_or_else(|e| e.into_inner()) = Some(hash);
+    }
+
+    pub fn clear_signing_pre_approval(&self) {
+        *self.pre_approved_hash.lock().unwrap_or_else(|e| e.into_inner()) = None;
     }
 
     pub fn get_pending_requests(&self) -> Vec<SignRequest> {
@@ -1883,7 +1890,7 @@ impl KeepMobile {
             let (request_tx, request_rx) = mpsc::channel(32);
             let hooks = Arc::new(MobileSigningHooks {
                 request_tx,
-                pre_approved: std::sync::atomic::AtomicBool::new(false),
+                pre_approved_hash: self.pre_approved_hash.clone(),
             });
             node.set_hooks(hooks.clone());
             *self.signing_hooks.write().await = Some(hooks);

--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -101,21 +101,24 @@ fn spawn_async_with_timeout<T: Send + 'static>(
     future: impl std::future::Future<Output = Result<T, KeepMobileError>> + Send + 'static,
 ) -> Result<T, KeepMobileError> {
     let (tx, rx) = std::sync::mpsc::sync_channel(1);
-    mobile.runtime.handle().spawn(async move {
+    let handle = mobile.runtime.handle().spawn(async move {
         let _ = tx.send(future.await);
     });
     match rx.recv_timeout(timeout) {
         Ok(result) => result,
-        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Err(KeepMobileError::FrostError {
-            msg: format!("{operation} timed out"),
-        }),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            handle.abort();
+            Err(KeepMobileError::FrostError {
+                msg: format!("{operation} timed out"),
+            })
+        }
         Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => Err(KeepMobileError::FrostError {
             msg: format!("{operation} failed unexpectedly"),
         }),
     }
 }
 
-const FROST_OP_TIMEOUT: Duration = Duration::from_secs(35);
+const FROST_OP_TIMEOUT: Duration = Duration::from_secs(65);
 
 #[derive(uniffi::Object)]
 pub struct Nip55Handler {

--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -287,16 +287,35 @@ impl Nip55Handler {
         &self,
         pubkey_bytes: &[u8; 33],
     ) -> Result<Zeroizing<[u8; 32]>, KeepMobileError> {
-        self.mobile.runtime.block_on(async {
-            let node_guard = self.mobile.node.read().await;
-            let node = node_guard.as_ref().ok_or(KeepMobileError::NotInitialized)?;
-
-            node.request_ecdh(pubkey_bytes)
-                .await
-                .map_err(|_| KeepMobileError::FrostError {
-                    msg: "ECDH failed".into(),
+        let node_arc = self.mobile.node.clone();
+        let rt = self.mobile.runtime.handle().clone();
+        let pubkey_bytes = *pubkey_bytes;
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        rt.spawn(async move {
+            let result: Result<Zeroizing<[u8; 32]>, KeepMobileError> = async {
+                let node_guard = node_arc.read().await;
+                let node = node_guard.as_ref().ok_or(KeepMobileError::NotInitialized)?;
+                node.request_ecdh(&pubkey_bytes)
+                    .await
+                    .map_err(|_| KeepMobileError::FrostError {
+                        msg: "ECDH failed".into(),
+                    })
+            }.await;
+            let _ = tx.send(result);
+        });
+        match rx.recv_timeout(std::time::Duration::from_secs(35)) {
+            Ok(result) => result,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                Err(KeepMobileError::FrostError {
+                    msg: "ECDH request timed out".into(),
                 })
-        })
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                Err(KeepMobileError::FrostError {
+                    msg: "ECDH task failed unexpectedly".into(),
+                })
+            }
+        }
     }
 
     fn handle_nip44_encrypt(
@@ -487,11 +506,19 @@ impl Nip55Handler {
             }.await;
             let _ = tx.send(result);
         });
-        let signature = rx
-            .recv_timeout(std::time::Duration::from_secs(35))
-            .map_err(|e| KeepMobileError::FrostError {
-                msg: format!("Signing channel error: {e}")
-            })??;
+        let signature = match rx.recv_timeout(std::time::Duration::from_secs(35)) {
+            Ok(result) => result?,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                return Err(KeepMobileError::FrostError {
+                    msg: "Signing request timed out".into(),
+                });
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(KeepMobileError::FrostError {
+                    msg: "Signing task failed unexpectedly".into(),
+                });
+            }
+        };
 
         let signature_hex = hex::encode(signature);
 

--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -94,6 +94,31 @@ struct RateLimitState {
     consecutive_failures: u32,
 }
 
+fn spawn_async_with_timeout<T: Send + 'static>(
+    mobile: &KeepMobile,
+    timeout: Duration,
+    operation: &str,
+    future: impl std::future::Future<Output = Result<T, KeepMobileError>> + Send + 'static,
+) -> Result<T, KeepMobileError> {
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+    mobile.runtime.handle().spawn(async move {
+        let _ = tx.send(future.await);
+    });
+    match rx.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Err(KeepMobileError::FrostError {
+            msg: format!("{operation} timed out"),
+        }),
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            Err(KeepMobileError::FrostError {
+                msg: format!("{operation} failed unexpectedly"),
+            })
+        }
+    }
+}
+
+const FROST_OP_TIMEOUT: Duration = Duration::from_secs(35);
+
 #[derive(uniffi::Object)]
 pub struct Nip55Handler {
     mobile: Arc<KeepMobile>,
@@ -288,34 +313,16 @@ impl Nip55Handler {
         pubkey_bytes: &[u8; 33],
     ) -> Result<Zeroizing<[u8; 32]>, KeepMobileError> {
         let node_arc = self.mobile.node.clone();
-        let rt = self.mobile.runtime.handle().clone();
         let pubkey_bytes = *pubkey_bytes;
-        let (tx, rx) = std::sync::mpsc::sync_channel(1);
-        rt.spawn(async move {
-            let result: Result<Zeroizing<[u8; 32]>, KeepMobileError> = async {
-                let node_guard = node_arc.read().await;
-                let node = node_guard.as_ref().ok_or(KeepMobileError::NotInitialized)?;
-                node.request_ecdh(&pubkey_bytes)
-                    .await
-                    .map_err(|_| KeepMobileError::FrostError {
-                        msg: "ECDH failed".into(),
-                    })
-            }.await;
-            let _ = tx.send(result);
-        });
-        match rx.recv_timeout(std::time::Duration::from_secs(35)) {
-            Ok(result) => result,
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                Err(KeepMobileError::FrostError {
-                    msg: "ECDH request timed out".into(),
+        spawn_async_with_timeout(&self.mobile, FROST_OP_TIMEOUT, "ECDH request", async move {
+            let node_guard = node_arc.read().await;
+            let node = node_guard.as_ref().ok_or(KeepMobileError::NotInitialized)?;
+            node.request_ecdh(&pubkey_bytes)
+                .await
+                .map_err(|_| KeepMobileError::FrostError {
+                    msg: "ECDH failed".into(),
                 })
-            }
-            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                Err(KeepMobileError::FrostError {
-                    msg: "ECDH task failed unexpectedly".into(),
-                })
-            }
-        }
+        })
     }
 
     fn handle_nip44_encrypt(
@@ -494,31 +501,18 @@ impl Nip55Handler {
         let event_hash = compute_nostr_event_id(&event)?;
 
         let node_arc = self.mobile.node.clone();
-        let rt = self.mobile.runtime.handle().clone();
-        let (tx, rx) = std::sync::mpsc::sync_channel(1);
-        rt.spawn(async move {
-            let result: Result<[u8; 64], KeepMobileError> = async {
+        let signature = spawn_async_with_timeout(
+            &self.mobile,
+            FROST_OP_TIMEOUT,
+            "Signing request",
+            async move {
                 let node_guard = node_arc.read().await;
                 let node = node_guard.as_ref().ok_or(KeepMobileError::NotInitialized)?;
                 node.request_signature(event_hash.to_vec(), "nostr_event")
                     .await
                     .map_err(|e| KeepMobileError::FrostError { msg: e.to_string() })
-            }.await;
-            let _ = tx.send(result);
-        });
-        let signature = match rx.recv_timeout(std::time::Duration::from_secs(35)) {
-            Ok(result) => result?,
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                return Err(KeepMobileError::FrostError {
-                    msg: "Signing request timed out".into(),
-                });
-            }
-            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                return Err(KeepMobileError::FrostError {
-                    msg: "Signing task failed unexpectedly".into(),
-                });
-            }
-        };
+            },
+        )?;
 
         let signature_hex = hex::encode(signature);
 

--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -474,14 +474,24 @@ impl Nip55Handler {
 
         let event_hash = compute_nostr_event_id(&event)?;
 
-        let signature = self.mobile.runtime.block_on(async {
-            let node_guard = self.mobile.node.read().await;
-            let node = node_guard.as_ref().ok_or(KeepMobileError::NotInitialized)?;
-
-            node.request_signature(event_hash.to_vec(), "nostr_event")
-                .await
-                .map_err(|e| KeepMobileError::FrostError { msg: e.to_string() })
-        })?;
+        let node_arc = self.mobile.node.clone();
+        let rt = self.mobile.runtime.handle().clone();
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        rt.spawn(async move {
+            let result: Result<[u8; 64], KeepMobileError> = async {
+                let node_guard = node_arc.read().await;
+                let node = node_guard.as_ref().ok_or(KeepMobileError::NotInitialized)?;
+                node.request_signature(event_hash.to_vec(), "nostr_event")
+                    .await
+                    .map_err(|e| KeepMobileError::FrostError { msg: e.to_string() })
+            }.await;
+            let _ = tx.send(result);
+        });
+        let signature = rx
+            .recv_timeout(std::time::Duration::from_secs(35))
+            .map_err(|e| KeepMobileError::FrostError {
+                msg: format!("Signing channel error: {e}")
+            })??;
 
         let signature_hex = hex::encode(signature);
 

--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -109,11 +109,9 @@ fn spawn_async_with_timeout<T: Send + 'static>(
         Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Err(KeepMobileError::FrostError {
             msg: format!("{operation} timed out"),
         }),
-        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-            Err(KeepMobileError::FrostError {
-                msg: format!("{operation} failed unexpectedly"),
-            })
-        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => Err(KeepMobileError::FrostError {
+            msg: format!("{operation} failed unexpectedly"),
+        }),
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix NIP-55 signer compatibility and single-participant FROST signing
- Fix security and correctness issues from review
- Simplify async spawn pattern and consolidate session lock scopes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile signing pre-approval with public APIs to set/clear a pre-approved message hash.

* **Bug Fixes**
  * Unrecognized peer now returns a clear untrusted-peer error.
  * Ignore signature-complete messages for unknown sessions.
  * Ensure sessions are completed on errors and timeouts.

* **Improvements**
  * Faster single-participant signing completion (avoids extra broadcasts).
  * Pre-sign hook invoked earlier in the signing flow.
  * Added timeouts and safer async handling for mobile signing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->