### PR TITLE
Add BIP-39 mnemonic and NIP-06 key derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,7 @@ dependencies = [
  "bitcoin_hashes",
  "serde",
  "unicode-normalization",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4179,6 +4179,8 @@ dependencies = [
  "base64 0.22.1",
  "bech32",
  "bincode",
+ "bip39",
+ "bitcoin",
  "blake2",
  "cbc",
  "chacha20 0.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ rand = "0.10"
 frost-secp256k1-tr = "2.2"
 
 # Bitcoin
-bip39 = "2.2"
+bip39 = { version = "2.2", features = ["zeroize"] }
 bitcoin = { version = "0.32", features = ["serde"] }
 
 # Secure memory

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ rand = "0.10"
 frost-secp256k1-tr = "2.2"
 
 # Bitcoin
+bip39 = "2.2"
 bitcoin = { version = "0.32", features = ["serde"] }
 
 # Secure memory

--- a/keep-core/Cargo.toml
+++ b/keep-core/Cargo.toml
@@ -27,6 +27,8 @@ k256 = { version = "0.13", features = ["schnorr", "ecdh"] }
 rand = "0.10"
 frost-secp256k1-tr = "2.2.0"
 
+bip39 = { workspace = true }
+bitcoin = { workspace = true }
 scrypt = "0.11"
 unicode-normalization = "0.1"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }

--- a/keep-core/src/error.rs
+++ b/keep-core/src/error.rs
@@ -486,6 +486,8 @@ pub enum KeepError {
     KeyNotFound(String),
     #[error("Key already exists: {0}")]
     KeyAlreadyExists(String),
+    #[error("Invalid mnemonic: {0}")]
+    InvalidMnemonic(String),
     #[error("Invalid nsec format")]
     InvalidNsec,
     #[error("Invalid npub format")]

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -54,11 +54,11 @@ pub mod hidden;
 pub mod keyring;
 /// Key types and Nostr keypair operations.
 pub mod keys;
+pub mod migration;
 /// BIP-39 mnemonic generation and validation.
 pub mod mnemonic;
 /// NIP-06 key derivation from mnemonic seed phrase.
 pub mod nip06;
-pub mod migration;
 pub(crate) mod rate_limit;
 /// Relay configuration for FROST shares.
 pub mod relay;

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -54,6 +54,10 @@ pub mod hidden;
 pub mod keyring;
 /// Key types and Nostr keypair operations.
 pub mod keys;
+/// BIP-39 mnemonic generation and validation.
+pub mod mnemonic;
+/// NIP-06 key derivation from mnemonic seed phrase.
+pub mod nip06;
 pub mod migration;
 pub(crate) mod rate_limit;
 /// Relay configuration for FROST shares.

--- a/keep-core/src/mnemonic.rs
+++ b/keep-core/src/mnemonic.rs
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+use bip39::Mnemonic;
+use zeroize::Zeroizing;
+
+use crate::error::{KeepError, Result};
+
+/// Generate a BIP-39 mnemonic phrase with the given word count (12 or 24).
+pub fn generate_mnemonic(word_count: u32) -> Result<Zeroizing<String>> {
+    let entropy_len = match word_count {
+        12 => 16,
+        24 => 32,
+        _ => {
+            return Err(KeepError::InvalidMnemonic(
+                "word count must be 12 or 24".into(),
+            ))
+        }
+    };
+
+    let mut entropy = Zeroizing::new(vec![0u8; entropy_len]);
+    let random: Vec<u8> = if entropy_len == 16 {
+        crate::crypto::random_bytes::<16>().to_vec()
+    } else {
+        crate::crypto::random_bytes::<32>().to_vec()
+    };
+    entropy.copy_from_slice(&random);
+
+    let mnemonic = Mnemonic::from_entropy(&entropy)
+        .map_err(|e| KeepError::InvalidMnemonic(e.to_string()))?;
+
+    Ok(Zeroizing::new(mnemonic.to_string()))
+}
+
+/// Validate a BIP-39 mnemonic phrase.
+pub fn validate_mnemonic(phrase: &str) -> Result<()> {
+    phrase
+        .parse::<Mnemonic>()
+        .map_err(|e| KeepError::InvalidMnemonic(e.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_12_word_mnemonic() {
+        let mnemonic = generate_mnemonic(12).unwrap();
+        assert_eq!(mnemonic.split_whitespace().count(), 12);
+        validate_mnemonic(&mnemonic).unwrap();
+    }
+
+    #[test]
+    fn generate_24_word_mnemonic() {
+        let mnemonic = generate_mnemonic(24).unwrap();
+        assert_eq!(mnemonic.split_whitespace().count(), 24);
+        validate_mnemonic(&mnemonic).unwrap();
+    }
+
+    #[test]
+    fn reject_invalid_word_count() {
+        assert!(generate_mnemonic(15).is_err());
+        assert!(generate_mnemonic(0).is_err());
+    }
+
+    #[test]
+    fn validate_known_mnemonic() {
+        validate_mnemonic(
+            "leader monkey parrot ring guide accident before fence cannon height naive bean",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn reject_invalid_mnemonic() {
+        assert!(validate_mnemonic("invalid words that are not a mnemonic phrase").is_err());
+    }
+}

--- a/keep-core/src/mnemonic.rs
+++ b/keep-core/src/mnemonic.rs
@@ -8,22 +8,15 @@ use crate::error::{KeepError, Result};
 
 /// Generate a BIP-39 mnemonic phrase with the given word count (12 or 24).
 pub fn generate_mnemonic(word_count: u32) -> Result<Zeroizing<String>> {
-    let entropy_len = match word_count {
-        12 => 16,
-        24 => 32,
+    let entropy = match word_count {
+        12 => Zeroizing::new(crate::crypto::random_bytes::<16>().to_vec()),
+        24 => Zeroizing::new(crate::crypto::random_bytes::<32>().to_vec()),
         _ => {
             return Err(KeepError::InvalidMnemonic(
                 "word count must be 12 or 24".into(),
             ))
         }
     };
-
-    let mut entropy = Zeroizing::new(vec![0u8; entropy_len]);
-    if entropy_len == 16 {
-        entropy.copy_from_slice(&crate::crypto::random_bytes::<16>());
-    } else {
-        entropy.copy_from_slice(&crate::crypto::random_bytes::<32>());
-    }
 
     let mnemonic = Mnemonic::from_entropy(&entropy)
         .map_err(|e| KeepError::InvalidMnemonic(e.to_string()))?;

--- a/keep-core/src/mnemonic.rs
+++ b/keep-core/src/mnemonic.rs
@@ -19,12 +19,11 @@ pub fn generate_mnemonic(word_count: u32) -> Result<Zeroizing<String>> {
     };
 
     let mut entropy = Zeroizing::new(vec![0u8; entropy_len]);
-    let random: Vec<u8> = if entropy_len == 16 {
-        crate::crypto::random_bytes::<16>().to_vec()
+    if entropy_len == 16 {
+        entropy.copy_from_slice(&crate::crypto::random_bytes::<16>());
     } else {
-        crate::crypto::random_bytes::<32>().to_vec()
-    };
-    entropy.copy_from_slice(&random);
+        entropy.copy_from_slice(&crate::crypto::random_bytes::<32>());
+    }
 
     let mnemonic = Mnemonic::from_entropy(&entropy)
         .map_err(|e| KeepError::InvalidMnemonic(e.to_string()))?;

--- a/keep-core/src/mnemonic.rs
+++ b/keep-core/src/mnemonic.rs
@@ -18,8 +18,8 @@ pub fn generate_mnemonic(word_count: u32) -> Result<Zeroizing<String>> {
         }
     };
 
-    let mnemonic = Mnemonic::from_entropy(&entropy)
-        .map_err(|e| KeepError::InvalidMnemonic(e.to_string()))?;
+    let mnemonic =
+        Mnemonic::from_entropy(&entropy).map_err(|e| KeepError::InvalidMnemonic(e.to_string()))?;
 
     Ok(Zeroizing::new(mnemonic.to_string()))
 }

--- a/keep-core/src/nip06.rs
+++ b/keep-core/src/nip06.rs
@@ -17,27 +17,30 @@ pub fn derive_nostr_key(
         .parse()
         .map_err(|e: bip39::Error| KeepError::InvalidMnemonic(e.to_string()))?;
 
-    let mut seed = Zeroizing::new([0u8; 64]);
-    let seed_bytes = Zeroizing::new(parsed.to_seed(passphrase));
-    seed.copy_from_slice(&*seed_bytes);
+    let seed = Zeroizing::new(parsed.to_seed(passphrase));
 
     let mut master = Xpriv::new_master(Network::Bitcoin, &*seed)
         .map_err(|e| KeepError::InvalidMnemonic(format!("master key derivation failed: {e}")))?;
 
+    let result = derive_from_master(&mut master, account);
+    master.private_key.non_secure_erase();
+    result
+}
+
+fn derive_from_master(master: &mut Xpriv, account: u32) -> Result<Zeroizing<[u8; 32]>> {
     let path: DerivationPath = format!("m/44'/1237'/{account}'/0/0")
         .parse()
         .map_err(|e: bitcoin::bip32::Error| {
             KeepError::InvalidMnemonic(format!("invalid derivation path: {e}"))
         })?;
 
+    let secp = bitcoin::secp256k1::Secp256k1::signing_only();
     let mut derived = master
-        .derive_priv(&bitcoin::secp256k1::Secp256k1::signing_only(), &path)
+        .derive_priv(&secp, &path)
         .map_err(|e| KeepError::InvalidMnemonic(format!("key derivation failed: {e}")))?;
 
     let result = Zeroizing::new(derived.private_key.secret_bytes());
     derived.private_key.non_secure_erase();
-    master.private_key.non_secure_erase();
-
     Ok(result)
 }
 

--- a/keep-core/src/nip06.rs
+++ b/keep-core/src/nip06.rs
@@ -28,11 +28,18 @@ pub fn derive_nostr_key(
 }
 
 fn derive_from_master(master: &mut Xpriv, account: u32) -> Result<Zeroizing<[u8; 32]>> {
-    let path: DerivationPath = format!("m/44'/1237'/{account}'/0/0")
-        .parse()
-        .map_err(|e: bitcoin::bip32::Error| {
-            KeepError::InvalidMnemonic(format!("invalid derivation path: {e}"))
-        })?;
+    if account > 0x7FFF_FFFF {
+        return Err(KeepError::InvalidInput(format!(
+            "account index {account} exceeds maximum hardened child index (2^31 - 1)"
+        )));
+    }
+
+    let path: DerivationPath =
+        format!("m/44'/1237'/{account}'/0/0")
+            .parse()
+            .map_err(|e: bitcoin::bip32::Error| {
+                KeepError::InvalidMnemonic(format!("invalid derivation path: {e}"))
+            })?;
 
     let secp = bitcoin::secp256k1::Secp256k1::signing_only();
     let mut derived = master

--- a/keep-core/src/nip06.rs
+++ b/keep-core/src/nip06.rs
@@ -24,6 +24,8 @@ pub fn derive_nostr_key(
 
     let result = derive_from_master(&mut master, account);
     master.private_key.non_secure_erase();
+    master.chain_code = bitcoin::bip32::ChainCode::from([0u8; 32]);
+    std::hint::black_box(&master);
     result
 }
 
@@ -48,6 +50,8 @@ fn derive_from_master(master: &mut Xpriv, account: u32) -> Result<Zeroizing<[u8;
 
     let result = Zeroizing::new(derived.private_key.secret_bytes());
     derived.private_key.non_secure_erase();
+    derived.chain_code = bitcoin::bip32::ChainCode::from([0u8; 32]);
+    std::hint::black_box(&derived);
     Ok(result)
 }
 
@@ -99,5 +103,29 @@ mod tests {
     #[test]
     fn reject_invalid_mnemonic() {
         assert!(derive_nostr_key("not a valid mnemonic", "", 0).is_err());
+    }
+
+    #[test]
+    fn derive_nonzero_account() {
+        let mnemonic =
+            "leader monkey parrot ring guide accident before fence cannon height naive bean";
+        let key = derive_nostr_key(mnemonic, "", 1).unwrap();
+        assert_eq!(key.len(), 32);
+        let key0 = derive_nostr_key(mnemonic, "", 0).unwrap();
+        assert_ne!(&key[..], &key0[..]);
+    }
+
+    #[test]
+    fn derive_max_valid_account() {
+        let mnemonic =
+            "leader monkey parrot ring guide accident before fence cannon height naive bean";
+        assert!(derive_nostr_key(mnemonic, "", 0x7FFF_FFFF).is_ok());
+    }
+
+    #[test]
+    fn reject_account_exceeding_hardened_limit() {
+        let mnemonic =
+            "leader monkey parrot ring guide accident before fence cannon height naive bean";
+        assert!(derive_nostr_key(mnemonic, "", 0x8000_0000).is_err());
     }
 }

--- a/keep-core/src/nip06.rs
+++ b/keep-core/src/nip06.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2026 PrivKey LLC
 // SPDX-License-Identifier: MIT
 
-use bitcoin::bip32::{DerivationPath, Xpriv};
+use bitcoin::bip32::{ChainCode, DerivationPath, Xpriv};
 use bitcoin::Network;
 use zeroize::Zeroizing;
 
@@ -13,6 +13,12 @@ pub fn derive_nostr_key(
     passphrase: &str,
     account: u32,
 ) -> Result<Zeroizing<[u8; 32]>> {
+    if account > 0x7FFF_FFFF {
+        return Err(KeepError::InvalidInput(format!(
+            "account index {account} exceeds maximum hardened child index (2^31 - 1)"
+        )));
+    }
+
     let parsed: bip39::Mnemonic = mnemonic
         .parse()
         .map_err(|e: bip39::Error| KeepError::InvalidMnemonic(e.to_string()))?;
@@ -21,20 +27,6 @@ pub fn derive_nostr_key(
 
     let mut master = Xpriv::new_master(Network::Bitcoin, &*seed)
         .map_err(|e| KeepError::InvalidMnemonic(format!("master key derivation failed: {e}")))?;
-
-    let result = derive_from_master(&mut master, account);
-    master.private_key.non_secure_erase();
-    master.chain_code = bitcoin::bip32::ChainCode::from([0u8; 32]);
-    std::hint::black_box(&master);
-    result
-}
-
-fn derive_from_master(master: &mut Xpriv, account: u32) -> Result<Zeroizing<[u8; 32]>> {
-    if account > 0x7FFF_FFFF {
-        return Err(KeepError::InvalidInput(format!(
-            "account index {account} exceeds maximum hardened child index (2^31 - 1)"
-        )));
-    }
 
     let path: DerivationPath =
         format!("m/44'/1237'/{account}'/0/0")
@@ -49,10 +41,17 @@ fn derive_from_master(master: &mut Xpriv, account: u32) -> Result<Zeroizing<[u8;
         .map_err(|e| KeepError::InvalidMnemonic(format!("key derivation failed: {e}")))?;
 
     let result = Zeroizing::new(derived.private_key.secret_bytes());
-    derived.private_key.non_secure_erase();
-    derived.chain_code = bitcoin::bip32::ChainCode::from([0u8; 32]);
-    std::hint::black_box(&derived);
+
+    erase_xpriv(&mut master);
+    erase_xpriv(&mut derived);
+
     Ok(result)
+}
+
+fn erase_xpriv(key: &mut Xpriv) {
+    key.private_key.non_secure_erase();
+    key.chain_code = ChainCode::from([0u8; 32]);
+    std::hint::black_box(key);
 }
 
 #[cfg(test)]

--- a/keep-core/src/nip06.rs
+++ b/keep-core/src/nip06.rs
@@ -13,17 +13,15 @@ pub fn derive_nostr_key(
     passphrase: &str,
     account: u32,
 ) -> Result<Zeroizing<[u8; 32]>> {
-    crate::mnemonic::validate_mnemonic(mnemonic)?;
-
     let parsed: bip39::Mnemonic = mnemonic
         .parse()
         .map_err(|e: bip39::Error| KeepError::InvalidMnemonic(e.to_string()))?;
 
     let mut seed = Zeroizing::new([0u8; 64]);
-    let seed_bytes = parsed.to_seed(passphrase);
-    seed.copy_from_slice(&seed_bytes);
+    let seed_bytes = Zeroizing::new(parsed.to_seed(passphrase));
+    seed.copy_from_slice(&*seed_bytes);
 
-    let master = Xpriv::new_master(Network::Bitcoin, &*seed)
+    let mut master = Xpriv::new_master(Network::Bitcoin, &*seed)
         .map_err(|e| KeepError::InvalidMnemonic(format!("master key derivation failed: {e}")))?;
 
     let path: DerivationPath = format!("m/44'/1237'/{account}'/0/0")
@@ -32,11 +30,15 @@ pub fn derive_nostr_key(
             KeepError::InvalidMnemonic(format!("invalid derivation path: {e}"))
         })?;
 
-    let derived = master.derive_priv(&bitcoin::secp256k1::Secp256k1::new(), &path).map_err(
-        |e| KeepError::InvalidMnemonic(format!("key derivation failed: {e}")),
-    )?;
+    let mut derived = master
+        .derive_priv(&bitcoin::secp256k1::Secp256k1::signing_only(), &path)
+        .map_err(|e| KeepError::InvalidMnemonic(format!("key derivation failed: {e}")))?;
 
-    Ok(Zeroizing::new(derived.private_key.secret_bytes()))
+    let result = Zeroizing::new(derived.private_key.secret_bytes());
+    derived.private_key.non_secure_erase();
+    master.private_key.non_secure_erase();
+
+    Ok(result)
 }
 
 #[cfg(test)]

--- a/keep-core/src/nip06.rs
+++ b/keep-core/src/nip06.rs
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+use bitcoin::bip32::{DerivationPath, Xpriv};
+use bitcoin::Network;
+use zeroize::Zeroizing;
+
+use crate::error::{KeepError, Result};
+
+/// Derive a Nostr private key from a BIP-39 mnemonic using the NIP-06 derivation path.
+pub fn derive_nostr_key(
+    mnemonic: &str,
+    passphrase: &str,
+    account: u32,
+) -> Result<Zeroizing<[u8; 32]>> {
+    crate::mnemonic::validate_mnemonic(mnemonic)?;
+
+    let parsed: bip39::Mnemonic = mnemonic
+        .parse()
+        .map_err(|e: bip39::Error| KeepError::InvalidMnemonic(e.to_string()))?;
+
+    let mut seed = Zeroizing::new([0u8; 64]);
+    let seed_bytes = parsed.to_seed(passphrase);
+    seed.copy_from_slice(&seed_bytes);
+
+    let master = Xpriv::new_master(Network::Bitcoin, &*seed)
+        .map_err(|e| KeepError::InvalidMnemonic(format!("master key derivation failed: {e}")))?;
+
+    let path: DerivationPath = format!("m/44'/1237'/{account}'/0/0")
+        .parse()
+        .map_err(|e: bitcoin::bip32::Error| {
+            KeepError::InvalidMnemonic(format!("invalid derivation path: {e}"))
+        })?;
+
+    let derived = master.derive_priv(&bitcoin::secp256k1::Secp256k1::new(), &path).map_err(
+        |e| KeepError::InvalidMnemonic(format!("key derivation failed: {e}")),
+    )?;
+
+    Ok(Zeroizing::new(derived.private_key.secret_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nip06_test_vector_1() {
+        let mnemonic =
+            "leader monkey parrot ring guide accident before fence cannon height naive bean";
+        let key = derive_nostr_key(mnemonic, "", 0).unwrap();
+        let expected =
+            hex::decode("7f7ff03d123792d6ac594bfa67bf6d0c0ab55b6b1fdb6249303fe861f1ccba9a")
+                .unwrap();
+        assert_eq!(&key[..], &expected[..]);
+
+        let signing_key = k256::SecretKey::from_slice(&*key).unwrap();
+        let pubkey = signing_key.public_key();
+        use k256::elliptic_curve::sec1::ToEncodedPoint;
+        let point = pubkey.to_encoded_point(true);
+        let pubkey_bytes = &point.as_bytes()[1..];
+        assert_eq!(
+            hex::encode(pubkey_bytes),
+            "17162c921dc4d2518f9a101db33695df1afb56ab82f5ff3e5da6eec3ca5cd917"
+        );
+    }
+
+    #[test]
+    fn nip06_test_vector_2() {
+        let mnemonic = "what bleak badge arrange retreat wolf trade produce cricket blur garlic valid proud rude strong choose busy staff weather area salt hollow arm fade";
+        let key = derive_nostr_key(mnemonic, "", 0).unwrap();
+        let expected =
+            hex::decode("c15d739894c81a2fcfd3a2df85a0d2c0dbc47a280d092799f144d73d7ae78add")
+                .unwrap();
+        assert_eq!(&key[..], &expected[..]);
+
+        let signing_key = k256::SecretKey::from_slice(&*key).unwrap();
+        let pubkey = signing_key.public_key();
+        use k256::elliptic_curve::sec1::ToEncodedPoint;
+        let point = pubkey.to_encoded_point(true);
+        let pubkey_bytes = &point.as_bytes()[1..];
+        assert_eq!(
+            hex::encode(pubkey_bytes),
+            "d41b22899549e1f3d335a31002cfd382174006e166d3e658e3a5eecdb6463573"
+        );
+    }
+
+    #[test]
+    fn reject_invalid_mnemonic() {
+        assert!(derive_nostr_key("not a valid mnemonic", "", 0).is_err());
+    }
+}

--- a/keep-core/src/nip06.rs
+++ b/keep-core/src/nip06.rs
@@ -101,7 +101,8 @@ mod tests {
 
     #[test]
     fn reject_invalid_mnemonic() {
-        assert!(derive_nostr_key("not a valid mnemonic", "", 0).is_err());
+        let err = derive_nostr_key("not a valid mnemonic", "", 0).unwrap_err();
+        assert!(matches!(err, KeepError::InvalidMnemonic(_)));
     }
 
     #[test]
@@ -125,6 +126,7 @@ mod tests {
     fn reject_account_exceeding_hardened_limit() {
         let mnemonic =
             "leader monkey parrot ring guide accident before fence cannon height naive bean";
-        assert!(derive_nostr_key(mnemonic, "", 0x8000_0000).is_err());
+        let err = derive_nostr_key(mnemonic, "", 0x8000_0000).unwrap_err();
+        assert!(matches!(err, KeepError::InvalidInput(_)));
     }
 }

--- a/keep-mobile/src/keep_mobile.udl
+++ b/keep-mobile/src/keep_mobile.udl
@@ -243,7 +243,7 @@ interface KeepMobile {
     string generate_mnemonic(u32 word_count);
 
     [Throws=KeepMobileError]
-    boolean validate_mnemonic(string mnemonic);
+    void validate_mnemonic(string mnemonic);
 
     [Throws=KeepMobileError]
     ShareInfo create_account_from_mnemonic(string mnemonic, string passphrase, string name);

--- a/keep-mobile/src/keep_mobile.udl
+++ b/keep-mobile/src/keep_mobile.udl
@@ -248,6 +248,9 @@ interface KeepMobile {
     [Throws=KeepMobileError]
     ShareInfo create_account_from_mnemonic(string mnemonic, string passphrase, string name);
 
+    [Throws=KeepMobileError]
+    ShareInfo create_account_from_mnemonic_with_index(string mnemonic, string passphrase, string name, u32 account_index);
+
     sequence<SignRequest> get_pending_requests();
 
     [Throws=KeepMobileError]

--- a/keep-mobile/src/keep_mobile.udl
+++ b/keep-mobile/src/keep_mobile.udl
@@ -239,6 +239,15 @@ interface KeepMobile {
     [Throws=KeepMobileError]
     ShareInfo import_share(string data, string passphrase, string name);
 
+    [Throws=KeepMobileError]
+    string generate_mnemonic(u32 word_count);
+
+    [Throws=KeepMobileError]
+    boolean validate_mnemonic(string mnemonic);
+
+    [Throws=KeepMobileError]
+    ShareInfo create_account_from_mnemonic(string mnemonic, string passphrase, string name);
+
     sequence<SignRequest> get_pending_requests();
 
     [Throws=KeepMobileError]

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -626,8 +626,7 @@ impl KeepMobile {
         mnemonic.zeroize();
         passphrase.zeroize();
         let key = key?;
-        #[allow(clippy::needless_borrows_for_generic_args)]
-        let mut hex_key = hex::encode(&*key);
+        let mut hex_key = hex::encode(*key);
         let result = self.do_import_nsec(&hex_key, name);
         hex_key.zeroize();
         result

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -594,18 +594,13 @@ impl KeepMobile {
 
     pub fn generate_mnemonic(&self, word_count: u32) -> Result<String, KeepMobileError> {
         let mnemonic = keep_core::mnemonic::generate_mnemonic(word_count)
-            .map_err(|e| KeepMobileError::InvalidInput {
-                msg: e.to_string(),
-            })?;
+            .map_err(|e| KeepMobileError::InvalidInput { msg: e.to_string() })?;
         Ok((*mnemonic).clone())
     }
 
     pub fn validate_mnemonic(&self, mut mnemonic: String) -> Result<(), KeepMobileError> {
-        let result = keep_core::mnemonic::validate_mnemonic(&mnemonic).map_err(|e| {
-            KeepMobileError::InvalidInput {
-                msg: e.to_string(),
-            }
-        });
+        let result = keep_core::mnemonic::validate_mnemonic(&mnemonic)
+            .map_err(|e| KeepMobileError::InvalidInput { msg: e.to_string() });
         mnemonic.zeroize();
         result
     }
@@ -616,15 +611,12 @@ impl KeepMobile {
         mut passphrase: String,
         name: String,
     ) -> Result<ShareInfo, KeepMobileError> {
-        let key = keep_core::nip06::derive_nostr_key(&mnemonic, &passphrase, 0).map_err(|e| {
-            KeepMobileError::InvalidInput {
-                msg: e.to_string(),
-            }
-        });
+        let key = keep_core::nip06::derive_nostr_key(&mnemonic, &passphrase, 0)
+            .map_err(|e| KeepMobileError::InvalidInput { msg: e.to_string() });
         mnemonic.zeroize();
         passphrase.zeroize();
         let key = key?;
-        let mut hex_key = hex::encode(*key);
+        let mut hex_key = hex::encode(&*key);
         let result = self.do_import_nsec(&hex_key, name);
         hex_key.zeroize();
         result

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -592,6 +592,38 @@ impl KeepMobile {
         result
     }
 
+    pub fn generate_mnemonic(&self, word_count: u32) -> Result<String, KeepMobileError> {
+        let mnemonic = keep_core::mnemonic::generate_mnemonic(word_count)
+            .map_err(|e| KeepMobileError::InvalidInput {
+                msg: e.to_string(),
+            })?;
+        Ok((*mnemonic).clone())
+    }
+
+    pub fn validate_mnemonic(&self, mnemonic: String) -> Result<bool, KeepMobileError> {
+        keep_core::mnemonic::validate_mnemonic(&mnemonic).map_err(|e| {
+            KeepMobileError::InvalidInput {
+                msg: e.to_string(),
+            }
+        })?;
+        Ok(true)
+    }
+
+    pub fn create_account_from_mnemonic(
+        &self,
+        mnemonic: String,
+        passphrase: String,
+        name: String,
+    ) -> Result<ShareInfo, KeepMobileError> {
+        let key = keep_core::nip06::derive_nostr_key(&mnemonic, &passphrase, 0).map_err(|e| {
+            KeepMobileError::InvalidInput {
+                msg: e.to_string(),
+            }
+        })?;
+        let hex_key = hex::encode(*key);
+        self.do_import_nsec(&hex_key, name)
+    }
+
     pub fn set_signing_pre_approved(&self, message: Vec<u8>) {
         use sha2::{Digest, Sha256};
         let hash: [u8; 32] = Sha256::digest(&message).into();

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -626,6 +626,7 @@ impl KeepMobile {
         mnemonic.zeroize();
         passphrase.zeroize();
         let key = key?;
+        #[allow(clippy::needless_borrows_for_generic_args)]
         let mut hex_key = hex::encode(&*key);
         let result = self.do_import_nsec(&hex_key, name);
         hex_key.zeroize();

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -600,28 +600,34 @@ impl KeepMobile {
         Ok((*mnemonic).clone())
     }
 
-    pub fn validate_mnemonic(&self, mnemonic: String) -> Result<bool, KeepMobileError> {
-        keep_core::mnemonic::validate_mnemonic(&mnemonic).map_err(|e| {
+    pub fn validate_mnemonic(&self, mut mnemonic: String) -> Result<(), KeepMobileError> {
+        let result = keep_core::mnemonic::validate_mnemonic(&mnemonic).map_err(|e| {
             KeepMobileError::InvalidInput {
                 msg: e.to_string(),
             }
-        })?;
-        Ok(true)
+        });
+        mnemonic.zeroize();
+        result
     }
 
     pub fn create_account_from_mnemonic(
         &self,
-        mnemonic: String,
-        passphrase: String,
+        mut mnemonic: String,
+        mut passphrase: String,
         name: String,
     ) -> Result<ShareInfo, KeepMobileError> {
         let key = keep_core::nip06::derive_nostr_key(&mnemonic, &passphrase, 0).map_err(|e| {
             KeepMobileError::InvalidInput {
                 msg: e.to_string(),
             }
-        })?;
-        let hex_key = hex::encode(*key);
-        self.do_import_nsec(&hex_key, name)
+        });
+        mnemonic.zeroize();
+        passphrase.zeroize();
+        let key = key?;
+        let mut hex_key = hex::encode(*key);
+        let result = self.do_import_nsec(&hex_key, name);
+        hex_key.zeroize();
+        result
     }
 
     pub fn set_signing_pre_approved(&self, message: Vec<u8>) {

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -626,7 +626,7 @@ impl KeepMobile {
         mnemonic.zeroize();
         passphrase.zeroize();
         let key = key?;
-        let mut hex_key = hex::encode(*key);
+        let mut hex_key = hex::encode(&*key);
         let result = self.do_import_nsec(&hex_key, name);
         hex_key.zeroize();
         result

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -616,7 +616,7 @@ impl KeepMobile {
         mnemonic.zeroize();
         passphrase.zeroize();
         let key = key?;
-        let mut hex_key = hex::encode(&*key);
+        let mut hex_key = hex::encode(*key);
         let result = self.do_import_nsec(&hex_key, name);
         hex_key.zeroize();
         result

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -607,11 +607,21 @@ impl KeepMobile {
 
     pub fn create_account_from_mnemonic(
         &self,
+        mnemonic: String,
+        passphrase: String,
+        name: String,
+    ) -> Result<ShareInfo, KeepMobileError> {
+        self.create_account_from_mnemonic_with_index(mnemonic, passphrase, name, 0)
+    }
+
+    pub fn create_account_from_mnemonic_with_index(
+        &self,
         mut mnemonic: String,
         mut passphrase: String,
         name: String,
+        account_index: u32,
     ) -> Result<ShareInfo, KeepMobileError> {
-        let key = keep_core::nip06::derive_nostr_key(&mnemonic, &passphrase, 0)
+        let key = keep_core::nip06::derive_nostr_key(&mnemonic, &passphrase, account_index)
             .map_err(|e| KeepMobileError::InvalidInput { msg: e.to_string() });
         mnemonic.zeroize();
         passphrase.zeroize();


### PR DESCRIPTION
## Summary
- Add BIP-39 mnemonic generation (12/24 words) and validation
- Add NIP-06 key derivation from mnemonic seed phrases
- Expose mnemonic APIs through mobile FFI layer
- Zeroize all sensitive key material (entropy, seeds, private keys)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Generate recovery phrases (12 or 24 words) for secure account backup
  * Import recovery phrases to create new accounts with optional passphrase protection
  * Support for multiple account derivation from a single recovery phrase
<!-- end of auto-generated comment: release notes by coderabbit.ai -->