### PR TITLE
Add descriptor session persistence across node restarts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies (Linux)
@@ -50,6 +50,18 @@ jobs:
       - run: cargo test -p keep-core --features testing --test integration_tests
       - run: cargo test -p keep-frost-net --test multinode_test
       - run: cargo test -p keep-enclave-host --test integration_tests
+
+  build-windows:
+    runs-on: windows-latest
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: windows-latest
+      - run: cargo build --release
+      - run: cargo test --workspace --lib --bins
 
   msrv:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4302,6 +4302,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand 0.10.0",
+ "redb 3.1.1",
  "rustls",
  "rustls-pki-types",
  "serde",

--- a/keep-desktop/src/frost.rs
+++ b/keep-desktop/src/frost.rs
@@ -279,6 +279,17 @@ pub(crate) async fn setup_frost_node(
     .await
     .map_err(|e| format!("Connection failed: {e}"))?;
 
+    let session_store_path = nonce_store_path.with_file_name("descriptor-sessions.redb");
+    let node = match keep_frost_net::FileDescriptorSessionStore::new(&session_store_path) {
+        Ok(store) => node.with_descriptor_session_store(
+            Arc::new(store) as Arc<dyn keep_frost_net::DescriptorSessionStore>
+        ),
+        Err(e) => {
+            tracing::warn!("Failed to create descriptor session store: {e}");
+            node
+        }
+    };
+
     let peer_policies = {
         let guard = keep_arc
             .lock()

--- a/keep-frost-net/Cargo.toml
+++ b/keep-frost-net/Cargo.toml
@@ -31,6 +31,7 @@ base64 = "0.22"
 rustls = "0.23"
 rustls-pki-types = "1"
 
+redb = "3"
 thiserror = "2.0"
 tokio-rustls = "0.26"
 tracing = "0.1"

--- a/keep-frost-net/src/descriptor_session.rs
+++ b/keep-frost-net/src/descriptor_session.rs
@@ -15,9 +15,11 @@ use tracing::warn;
 
 use crate::error::{FrostNetError, Result};
 use crate::protocol::{
-    KeySlot, WalletPolicy, DESCRIPTOR_ACK_PHASE_TIMEOUT_SECS, DESCRIPTOR_CONTRIBUTION_TIMEOUT_SECS,
+    is_valid_fingerprint, is_valid_xpub, KeySlot, WalletPolicy,
+    DESCRIPTOR_ACK_PHASE_TIMEOUT_SECS, DESCRIPTOR_CONTRIBUTION_TIMEOUT_SECS,
     DESCRIPTOR_FINALIZE_TIMEOUT_SECS, DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS,
-    DESCRIPTOR_SESSION_TIMEOUT_SECS, MAX_FINGERPRINT_LENGTH, MAX_XPUB_LENGTH,
+    DESCRIPTOR_SESSION_TIMEOUT_SECS, MAX_FINGERPRINT_LENGTH, MAX_PARTICIPANTS, MAX_XPUB_LENGTH,
+    VALID_NETWORKS,
 };
 
 const MAX_SESSIONS: usize = 64;
@@ -64,7 +66,7 @@ pub struct PersistedFinalizedDescriptor {
 pub trait DescriptorSessionStore: Send + Sync {
     fn save(&self, session: &PersistedDescriptorSession) -> Result<()>;
     fn load(&self, session_id: &[u8; 32]) -> Result<Option<PersistedDescriptorSession>>;
-    fn load_all(&self) -> Result<Vec<PersistedDescriptorSession>>;
+    fn load_all(&self, limit: usize) -> Result<Vec<PersistedDescriptorSession>>;
     fn delete(&self, session_id: &[u8; 32]) -> Result<()>;
 }
 
@@ -93,11 +95,38 @@ fn validate_session_timeout(timeout: Duration) -> Result<Duration> {
 }
 
 fn clamp_session_timeout(secs: u64) -> Duration {
-    let max = DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS;
-    Duration::from_secs(secs.max(1).min(max))
+    Duration::from_secs(secs.clamp(1, DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS))
+}
+
+fn instant_to_unix(now: u64, instant: Instant) -> u64 {
+    now.saturating_sub(instant.elapsed().as_secs())
+}
+
+fn discard_reason(session: &DescriptorSession, is_terminal: bool) -> Option<&'static str> {
+    if is_terminal || session.is_expired() {
+        return Some("terminal or expired");
+    }
+    if !VALID_NETWORKS.contains(&session.network.as_str()) {
+        return Some("invalid network");
+    }
+    if session.expected_contributors.len() > MAX_PARTICIPANTS {
+        return Some("too many contributors");
+    }
+    let has_invalid_contribution = session.contributions.values().any(|c| {
+        !is_valid_xpub(&c.account_xpub) || !is_valid_fingerprint(&c.fingerprint)
+    });
+    if has_invalid_contribution {
+        return Some("invalid contribution data");
+    }
+    None
 }
 
 fn unix_to_instant(now: u64, ts: u64, field: &str) -> Result<Instant> {
+    if ts > now.saturating_add(crate::protocol::MAX_FUTURE_SKEW_SECS) {
+        return Err(FrostNetError::Session(format!(
+            "persisted {field} is in the future ({ts} > {now})"
+        )));
+    }
     let elapsed = now.saturating_sub(ts);
     Instant::now()
         .checked_sub(Duration::from_secs(elapsed))
@@ -456,24 +485,26 @@ impl DescriptorSession {
 
     pub fn to_persisted(&self) -> PersistedDescriptorSession {
         let now = now_unix();
-        let elapsed = self.created_at.elapsed().as_secs();
-        let created_at_unix = now.saturating_sub(elapsed);
-
-        let contributions_complete_at_unix = self.contributions_complete_at.map(|t| {
-            let e = t.elapsed().as_secs();
-            now.saturating_sub(e)
-        });
-
-        let finalized_at_unix = self.finalized_at.map(|t| {
-            let e = t.elapsed().as_secs();
-            now.saturating_sub(e)
-        });
+        let created_at_unix = instant_to_unix(now, self.created_at);
+        let contributions_complete_at_unix = self.contributions_complete_at.map(|t| instant_to_unix(now, t));
+        let finalized_at_unix = self.finalized_at.map(|t| instant_to_unix(now, t));
 
         let state = match &self.state {
             DescriptorSessionState::Proposed => PersistedSessionState::Proposed,
             DescriptorSessionState::Finalized => PersistedSessionState::Finalized,
             DescriptorSessionState::Complete => PersistedSessionState::Complete,
-            DescriptorSessionState::Failed(r) => PersistedSessionState::Failed(r.clone()),
+            DescriptorSessionState::Failed(r) => {
+                let truncated = if r.len() > 512 {
+                    let mut end = 512;
+                    while !r.is_char_boundary(end) {
+                        end -= 1;
+                    }
+                    format!("{}...", &r[..end])
+                } else {
+                    r.clone()
+                };
+                PersistedSessionState::Failed(truncated)
+            }
         };
 
         let descriptor = self
@@ -616,7 +647,7 @@ impl DescriptorSessionManager {
         let Some(store) = &self.store else {
             return Ok(0);
         };
-        let persisted = store.load_all()?;
+        let persisted = store.load_all(MAX_SESSIONS)?;
         let mut loaded = 0;
         for p in persisted {
             let sid = p.session_id;
@@ -624,26 +655,27 @@ impl DescriptorSessionManager {
                 p.state,
                 PersistedSessionState::Complete | PersistedSessionState::Failed(_)
             );
-            match DescriptorSession::from_persisted(p) {
-                Ok(session) => {
-                    if is_terminal || session.is_expired() {
-                        if let Err(e) = store.delete(&sid) {
-                            warn!(session_id = %hex::encode(sid), "Failed to clean up persisted session: {e}");
-                        }
-                        continue;
-                    }
-                    if self.sessions.len() >= MAX_SESSIONS {
-                        warn!("Skipping persisted session, max sessions reached");
-                        break;
-                    }
-                    self.sessions.insert(sid, session);
-                    loaded += 1;
-                }
+            let session = match DescriptorSession::from_persisted(p) {
+                Ok(s) => s,
                 Err(e) => {
                     warn!(session_id = %hex::encode(sid), "Failed to restore persisted session: {e}");
                     let _ = store.delete(&sid);
+                    continue;
                 }
+            };
+
+            if let Some(reason) = discard_reason(&session, is_terminal) {
+                warn!(session_id = %hex::encode(sid), "Discarding persisted session: {reason}");
+                let _ = store.delete(&sid);
+                continue;
             }
+
+            if self.sessions.len() >= MAX_SESSIONS {
+                warn!("Skipping persisted session, max sessions reached");
+                break;
+            }
+            self.sessions.insert(sid, session);
+            loaded += 1;
         }
         Ok(loaded)
     }
@@ -689,7 +721,7 @@ impl DescriptorSessionManager {
                     "Descriptor session already active".into(),
                 ));
             }
-            self.sessions.remove(&session_id);
+            self.remove_session(&session_id);
         }
 
         self.cleanup_expired();
@@ -1669,8 +1701,8 @@ mod tests {
             Ok(self.sessions.read().get(session_id).cloned())
         }
 
-        fn load_all(&self) -> Result<Vec<PersistedDescriptorSession>> {
-            Ok(self.sessions.read().values().cloned().collect())
+        fn load_all(&self, limit: usize) -> Result<Vec<PersistedDescriptorSession>> {
+            Ok(self.sessions.read().values().take(limit).cloned().collect())
         }
 
         fn delete(&self, session_id: &[u8; 32]) -> Result<()> {

--- a/keep-frost-net/src/descriptor_session.rs
+++ b/keep-frost-net/src/descriptor_session.rs
@@ -92,6 +92,22 @@ fn validate_session_timeout(timeout: Duration) -> Result<Duration> {
     Ok(timeout)
 }
 
+fn clamp_session_timeout(secs: u64) -> Duration {
+    let max = DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS;
+    Duration::from_secs(secs.max(1).min(max))
+}
+
+fn unix_to_instant(now: u64, ts: u64, field: &str) -> Result<Instant> {
+    let elapsed = now.saturating_sub(ts);
+    Instant::now()
+        .checked_sub(Duration::from_secs(elapsed))
+        .ok_or_else(|| {
+            FrostNetError::Session(format!(
+                "persisted {field} too far in the past ({elapsed}s)"
+            ))
+        })
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DescriptorSessionState {
     Proposed,
@@ -494,18 +510,16 @@ impl DescriptorSession {
 
     pub fn from_persisted(p: PersistedDescriptorSession) -> Result<Self> {
         let now = now_unix();
-        let elapsed_since_creation = now.saturating_sub(p.created_at_unix);
-        let created_at = Instant::now() - Duration::from_secs(elapsed_since_creation);
 
-        let contributions_complete_at = p.contributions_complete_at_unix.map(|ts| {
-            let elapsed = now.saturating_sub(ts);
-            Instant::now() - Duration::from_secs(elapsed)
-        });
-
-        let finalized_at = p.finalized_at_unix.map(|ts| {
-            let elapsed = now.saturating_sub(ts);
-            Instant::now() - Duration::from_secs(elapsed)
-        });
+        let created_at = unix_to_instant(now, p.created_at_unix, "created_at")?;
+        let contributions_complete_at = p
+            .contributions_complete_at_unix
+            .map(|ts| unix_to_instant(now, ts, "contributions_complete_at"))
+            .transpose()?;
+        let finalized_at = p
+            .finalized_at_unix
+            .map(|ts| unix_to_instant(now, ts, "finalized_at"))
+            .transpose()?;
 
         let state = match p.state {
             PersistedSessionState::Proposed => DescriptorSessionState::Proposed,
@@ -520,13 +534,13 @@ impl DescriptorSession {
             policy_hash: d.policy_hash,
         });
 
-        let initiator =
-            match p.initiator {
-                Some(hex) => Some(PublicKey::from_hex(&hex).map_err(|e| {
-                    FrostNetError::Session(format!("invalid initiator pubkey: {e}"))
-                })?),
-                None => None,
-            };
+        let initiator = p
+            .initiator
+            .map(|hex| {
+                PublicKey::from_hex(&hex)
+                    .map_err(|e| FrostNetError::Session(format!("invalid initiator pubkey: {e}")))
+            })
+            .transpose()?;
 
         Ok(Self {
             session_id: p.session_id,
@@ -544,10 +558,10 @@ impl DescriptorSession {
             created_at,
             contributions_complete_at,
             finalized_at,
-            timeout: Duration::from_secs(p.timeout_secs),
-            contribution_timeout: Duration::from_secs(p.contribution_timeout_secs),
-            finalize_timeout: Duration::from_secs(p.finalize_timeout_secs),
-            ack_phase_timeout: Duration::from_secs(p.ack_phase_timeout_secs),
+            timeout: clamp_session_timeout(p.timeout_secs),
+            contribution_timeout: clamp_session_timeout(p.contribution_timeout_secs),
+            finalize_timeout: clamp_session_timeout(p.finalize_timeout_secs),
+            ack_phase_timeout: clamp_session_timeout(p.ack_phase_timeout_secs),
         })
     }
 }
@@ -701,7 +715,6 @@ impl DescriptorSessionManager {
         );
 
         self.sessions.insert(session_id, session);
-        self.persist_session(&session_id);
         Ok(self.sessions.get_mut(&session_id).unwrap())
     }
 

--- a/keep-frost-net/src/descriptor_session.rs
+++ b/keep-frost-net/src/descriptor_session.rs
@@ -15,11 +15,10 @@ use tracing::warn;
 
 use crate::error::{FrostNetError, Result};
 use crate::protocol::{
-    is_valid_fingerprint, is_valid_xpub, KeySlot, WalletPolicy,
-    DESCRIPTOR_ACK_PHASE_TIMEOUT_SECS, DESCRIPTOR_CONTRIBUTION_TIMEOUT_SECS,
-    DESCRIPTOR_FINALIZE_TIMEOUT_SECS, DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS,
-    DESCRIPTOR_SESSION_TIMEOUT_SECS, MAX_FINGERPRINT_LENGTH, MAX_PARTICIPANTS, MAX_XPUB_LENGTH,
-    VALID_NETWORKS,
+    is_valid_fingerprint, is_valid_xpub, KeySlot, WalletPolicy, DESCRIPTOR_ACK_PHASE_TIMEOUT_SECS,
+    DESCRIPTOR_CONTRIBUTION_TIMEOUT_SECS, DESCRIPTOR_FINALIZE_TIMEOUT_SECS,
+    DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS, DESCRIPTOR_SESSION_TIMEOUT_SECS, MAX_FINGERPRINT_LENGTH,
+    MAX_PARTICIPANTS, MAX_XPUB_LENGTH, VALID_NETWORKS,
 };
 
 const MAX_SESSIONS: usize = 64;
@@ -112,9 +111,10 @@ fn discard_reason(session: &DescriptorSession, is_terminal: bool) -> Option<&'st
     if session.expected_contributors.len() > MAX_PARTICIPANTS {
         return Some("too many contributors");
     }
-    let has_invalid_contribution = session.contributions.values().any(|c| {
-        !is_valid_xpub(&c.account_xpub) || !is_valid_fingerprint(&c.fingerprint)
-    });
+    let has_invalid_contribution = session
+        .contributions
+        .values()
+        .any(|c| !is_valid_xpub(&c.account_xpub) || !is_valid_fingerprint(&c.fingerprint));
     if has_invalid_contribution {
         return Some("invalid contribution data");
     }
@@ -486,7 +486,9 @@ impl DescriptorSession {
     pub fn to_persisted(&self) -> PersistedDescriptorSession {
         let now = now_unix();
         let created_at_unix = instant_to_unix(now, self.created_at);
-        let contributions_complete_at_unix = self.contributions_complete_at.map(|t| instant_to_unix(now, t));
+        let contributions_complete_at_unix = self
+            .contributions_complete_at
+            .map(|t| instant_to_unix(now, t));
         let finalized_at_unix = self.finalized_at.map(|t| instant_to_unix(now, t));
 
         let state = match &self.state {

--- a/keep-frost-net/src/descriptor_session.rs
+++ b/keep-frost-net/src/descriptor_session.rs
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: MIT
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::str::FromStr;
-use std::time::{Duration, Instant};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use keep_bitcoin::recovery::{RecoveryConfig, RecoveryTier as BitcoinRecoveryTier, SpendingTier};
 use keep_bitcoin::{xpub_to_x_only, DescriptorExport, Network};
 use nostr_sdk::PublicKey;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
+use tracing::warn;
 
 use crate::error::{FrostNetError, Result};
 use crate::protocol::{
@@ -19,6 +22,58 @@ use crate::protocol::{
 
 const MAX_SESSIONS: usize = 64;
 const REAP_GRACE_SECS: u64 = 60;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedDescriptorSession {
+    pub session_id: [u8; 32],
+    pub group_pubkey: [u8; 32],
+    pub policy: WalletPolicy,
+    pub network: String,
+    pub initiator: Option<String>,
+    pub contributions: BTreeMap<u16, XpubContribution>,
+    pub expected_contributors: HashSet<u16>,
+    pub descriptor: Option<PersistedFinalizedDescriptor>,
+    pub acks: HashSet<u16>,
+    pub nacks: HashSet<u16>,
+    pub expected_acks: HashSet<u16>,
+    pub state: PersistedSessionState,
+    pub created_at_unix: u64,
+    pub contributions_complete_at_unix: Option<u64>,
+    pub finalized_at_unix: Option<u64>,
+    pub timeout_secs: u64,
+    pub contribution_timeout_secs: u64,
+    pub finalize_timeout_secs: u64,
+    pub ack_phase_timeout_secs: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum PersistedSessionState {
+    Proposed,
+    Finalized,
+    Complete,
+    Failed(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedFinalizedDescriptor {
+    pub external: String,
+    pub internal: String,
+    pub policy_hash: [u8; 32],
+}
+
+pub trait DescriptorSessionStore: Send + Sync {
+    fn save(&self, session: &PersistedDescriptorSession) -> Result<()>;
+    fn load(&self, session_id: &[u8; 32]) -> Result<Option<PersistedDescriptorSession>>;
+    fn load_all(&self) -> Result<Vec<PersistedDescriptorSession>>;
+    fn delete(&self, session_id: &[u8; 32]) -> Result<()>;
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
 
 fn validate_session_timeout(timeout: Duration) -> Result<Duration> {
     let max = Duration::from_secs(DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS);
@@ -382,11 +437,125 @@ impl DescriptorSession {
             self.state = DescriptorSessionState::Failed(reason);
         }
     }
+
+    pub fn to_persisted(&self) -> PersistedDescriptorSession {
+        let now = now_unix();
+        let elapsed = self.created_at.elapsed().as_secs();
+        let created_at_unix = now.saturating_sub(elapsed);
+
+        let contributions_complete_at_unix = self.contributions_complete_at.map(|t| {
+            let e = t.elapsed().as_secs();
+            now.saturating_sub(e)
+        });
+
+        let finalized_at_unix = self.finalized_at.map(|t| {
+            let e = t.elapsed().as_secs();
+            now.saturating_sub(e)
+        });
+
+        let state = match &self.state {
+            DescriptorSessionState::Proposed => PersistedSessionState::Proposed,
+            DescriptorSessionState::Finalized => PersistedSessionState::Finalized,
+            DescriptorSessionState::Complete => PersistedSessionState::Complete,
+            DescriptorSessionState::Failed(r) => PersistedSessionState::Failed(r.clone()),
+        };
+
+        let descriptor = self
+            .descriptor
+            .as_ref()
+            .map(|d| PersistedFinalizedDescriptor {
+                external: d.external.clone(),
+                internal: d.internal.clone(),
+                policy_hash: d.policy_hash,
+            });
+
+        PersistedDescriptorSession {
+            session_id: self.session_id,
+            group_pubkey: self.group_pubkey,
+            policy: self.policy.clone(),
+            network: self.network.clone(),
+            initiator: self.initiator.map(|pk| pk.to_hex()),
+            contributions: self.contributions.clone(),
+            expected_contributors: self.expected_contributors.clone(),
+            descriptor,
+            acks: self.acks.clone(),
+            nacks: self.nacks.clone(),
+            expected_acks: self.expected_acks.clone(),
+            state,
+            created_at_unix,
+            contributions_complete_at_unix,
+            finalized_at_unix,
+            timeout_secs: self.timeout.as_secs(),
+            contribution_timeout_secs: self.contribution_timeout.as_secs(),
+            finalize_timeout_secs: self.finalize_timeout.as_secs(),
+            ack_phase_timeout_secs: self.ack_phase_timeout.as_secs(),
+        }
+    }
+
+    pub fn from_persisted(p: PersistedDescriptorSession) -> Result<Self> {
+        let now = now_unix();
+        let elapsed_since_creation = now.saturating_sub(p.created_at_unix);
+        let created_at = Instant::now() - Duration::from_secs(elapsed_since_creation);
+
+        let contributions_complete_at = p.contributions_complete_at_unix.map(|ts| {
+            let elapsed = now.saturating_sub(ts);
+            Instant::now() - Duration::from_secs(elapsed)
+        });
+
+        let finalized_at = p.finalized_at_unix.map(|ts| {
+            let elapsed = now.saturating_sub(ts);
+            Instant::now() - Duration::from_secs(elapsed)
+        });
+
+        let state = match p.state {
+            PersistedSessionState::Proposed => DescriptorSessionState::Proposed,
+            PersistedSessionState::Finalized => DescriptorSessionState::Finalized,
+            PersistedSessionState::Complete => DescriptorSessionState::Complete,
+            PersistedSessionState::Failed(r) => DescriptorSessionState::Failed(r),
+        };
+
+        let descriptor = p.descriptor.map(|d| FinalizedDescriptor {
+            external: d.external,
+            internal: d.internal,
+            policy_hash: d.policy_hash,
+        });
+
+        let initiator =
+            match p.initiator {
+                Some(hex) => Some(PublicKey::from_hex(&hex).map_err(|e| {
+                    FrostNetError::Session(format!("invalid initiator pubkey: {e}"))
+                })?),
+                None => None,
+            };
+
+        Ok(Self {
+            session_id: p.session_id,
+            group_pubkey: p.group_pubkey,
+            policy: p.policy,
+            network: p.network,
+            initiator,
+            contributions: p.contributions,
+            expected_contributors: p.expected_contributors,
+            descriptor,
+            acks: p.acks,
+            nacks: p.nacks,
+            expected_acks: p.expected_acks,
+            state,
+            created_at,
+            contributions_complete_at,
+            finalized_at,
+            timeout: Duration::from_secs(p.timeout_secs),
+            contribution_timeout: Duration::from_secs(p.contribution_timeout_secs),
+            finalize_timeout: Duration::from_secs(p.finalize_timeout_secs),
+            ack_phase_timeout: Duration::from_secs(p.ack_phase_timeout_secs),
+        })
+    }
 }
 
 pub struct DescriptorSessionManager {
     sessions: HashMap<[u8; 32], DescriptorSession>,
     default_timeout: Duration,
+    store: Option<Arc<dyn DescriptorSessionStore>>,
 }
 
 impl DescriptorSessionManager {
@@ -394,6 +563,7 @@ impl DescriptorSessionManager {
         Self {
             sessions: HashMap::new(),
             default_timeout: Duration::from_secs(DESCRIPTOR_SESSION_TIMEOUT_SECS),
+            store: None,
         }
     }
 
@@ -402,7 +572,66 @@ impl DescriptorSessionManager {
         Ok(Self {
             sessions: HashMap::new(),
             default_timeout: validated,
+            store: None,
         })
+    }
+
+    pub fn set_store(&mut self, store: Arc<dyn DescriptorSessionStore>) {
+        self.store = Some(store);
+    }
+
+    pub fn persist_session(&self, session_id: &[u8; 32]) {
+        let Some(store) = &self.store else { return };
+        let Some(session) = self.sessions.get(session_id) else {
+            return;
+        };
+        let persisted = session.to_persisted();
+        if let Err(e) = store.save(&persisted) {
+            warn!(session_id = %hex::encode(session_id), "Failed to persist descriptor session: {e}");
+        }
+    }
+
+    pub fn delete_persisted_session(&self, session_id: &[u8; 32]) {
+        let Some(store) = &self.store else { return };
+        if let Err(e) = store.delete(session_id) {
+            warn!(session_id = %hex::encode(session_id), "Failed to delete persisted descriptor session: {e}");
+        }
+    }
+
+    pub fn load_persisted_sessions(&mut self) -> Result<usize> {
+        let Some(store) = &self.store else {
+            return Ok(0);
+        };
+        let persisted = store.load_all()?;
+        let mut loaded = 0;
+        for p in persisted {
+            let sid = p.session_id;
+            let is_terminal = matches!(
+                p.state,
+                PersistedSessionState::Complete | PersistedSessionState::Failed(_)
+            );
+            match DescriptorSession::from_persisted(p) {
+                Ok(session) => {
+                    if is_terminal || session.is_expired() {
+                        if let Err(e) = store.delete(&sid) {
+                            warn!(session_id = %hex::encode(sid), "Failed to clean up persisted session: {e}");
+                        }
+                        continue;
+                    }
+                    if self.sessions.len() >= MAX_SESSIONS {
+                        warn!("Skipping persisted session, max sessions reached");
+                        break;
+                    }
+                    self.sessions.insert(sid, session);
+                    loaded += 1;
+                }
+                Err(e) => {
+                    warn!(session_id = %hex::encode(sid), "Failed to restore persisted session: {e}");
+                    let _ = store.delete(&sid);
+                }
+            }
+        }
+        Ok(loaded)
     }
 
     pub fn session_count(&self) -> usize {
@@ -472,6 +701,7 @@ impl DescriptorSessionManager {
         );
 
         self.sessions.insert(session_id, session);
+        self.persist_session(&session_id);
         Ok(self.sessions.get_mut(&session_id).unwrap())
     }
 
@@ -487,6 +717,7 @@ impl DescriptorSessionManager {
 
     pub fn remove_session(&mut self, session_id: &[u8; 32]) {
         self.sessions.remove(session_id);
+        self.delete_persisted_session(session_id);
     }
 
     pub fn cleanup_expired(&mut self) -> Vec<([u8; 32], String)> {
@@ -499,6 +730,9 @@ impl DescriptorSessionManager {
                 true
             }
         });
+        for (id, _) in &expired {
+            self.delete_persisted_session(id);
+        }
         expired
     }
 }
@@ -1275,5 +1509,160 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("Duplicate xpub"));
+    }
+
+    #[test]
+    fn test_persist_and_restore_proposed_session() {
+        let mut session = test_session();
+        let keys = nostr_sdk::Keys::generate();
+        session.set_initiator(keys.public_key());
+        session
+            .add_contribution(1, "tpub1zzzzzzzzzzzzzzz".into(), "aabbccdd".into())
+            .unwrap();
+
+        let persisted = session.to_persisted();
+        assert_eq!(persisted.session_id, [1u8; 32]);
+        assert_eq!(persisted.state, PersistedSessionState::Proposed);
+        assert_eq!(persisted.contributions.len(), 1);
+        assert!(persisted.initiator.is_some());
+
+        let restored = DescriptorSession::from_persisted(persisted).unwrap();
+        assert_eq!(*restored.state(), DescriptorSessionState::Proposed);
+        assert_eq!(restored.contributions().len(), 1);
+        assert_eq!(restored.initiator(), Some(&keys.public_key()));
+        assert_eq!(restored.network(), "signet");
+    }
+
+    #[test]
+    fn test_persist_and_restore_finalized_session() {
+        let mut session = test_session();
+        session
+            .add_contribution(1, "tpub1zzzzzzzzzzzzzzz".into(), "aabbccdd".into())
+            .unwrap();
+        session
+            .add_contribution(2, "tpub2zzzzzzzzzzzzzzz".into(), "11223344".into())
+            .unwrap();
+        session
+            .add_contribution(3, "tpub3zzzzzzzzzzzzzzz".into(), "55667788".into())
+            .unwrap();
+
+        let finalized = FinalizedDescriptor {
+            external: "tr(frost_key,{pk(xpub1),pk(xpub2)})".into(),
+            internal: "tr(frost_key,{pk(xpub1),pk(xpub2)})/1".into(),
+            policy_hash: [0xAA; 32],
+        };
+        session.set_finalized(finalized).unwrap();
+
+        let persisted = session.to_persisted();
+        assert_eq!(persisted.state, PersistedSessionState::Finalized);
+        assert!(persisted.descriptor.is_some());
+
+        let restored = DescriptorSession::from_persisted(persisted).unwrap();
+        assert_eq!(*restored.state(), DescriptorSessionState::Finalized);
+        let desc = restored.descriptor().unwrap();
+        assert!(desc.external.contains("frost_key"));
+    }
+
+    #[test]
+    fn test_expired_sessions_cleaned_on_load() {
+        let store = Arc::new(MemorySessionStore::new());
+        let mut manager = DescriptorSessionManager::new();
+        manager.set_store(store.clone());
+
+        let persisted = PersistedDescriptorSession {
+            session_id: [1u8; 32],
+            group_pubkey: [2u8; 32],
+            policy: test_policy(),
+            network: "signet".into(),
+            initiator: None,
+            contributions: BTreeMap::new(),
+            expected_contributors: [1u16, 2, 3].into_iter().collect(),
+            descriptor: None,
+            acks: HashSet::new(),
+            nacks: HashSet::new(),
+            expected_acks: [1u16, 2, 3].into_iter().collect(),
+            state: PersistedSessionState::Proposed,
+            created_at_unix: 1000,
+            contributions_complete_at_unix: None,
+            finalized_at_unix: None,
+            timeout_secs: 1,
+            contribution_timeout_secs: 1,
+            finalize_timeout_secs: 1,
+            ack_phase_timeout_secs: 1,
+        };
+        store.save(&persisted).unwrap();
+
+        let loaded = manager.load_persisted_sessions().unwrap();
+        assert_eq!(loaded, 0);
+        assert!(manager.get_session(&[1u8; 32]).is_none());
+        assert!(store.load(&[1u8; 32]).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_completed_sessions_cleaned_on_load() {
+        let store = Arc::new(MemorySessionStore::new());
+        let mut manager = DescriptorSessionManager::new();
+        manager.set_store(store.clone());
+
+        let persisted = PersistedDescriptorSession {
+            session_id: [1u8; 32],
+            group_pubkey: [2u8; 32],
+            policy: test_policy(),
+            network: "signet".into(),
+            initiator: None,
+            contributions: BTreeMap::new(),
+            expected_contributors: [1u16, 2, 3].into_iter().collect(),
+            descriptor: None,
+            acks: HashSet::new(),
+            nacks: HashSet::new(),
+            expected_acks: [1u16, 2, 3].into_iter().collect(),
+            state: PersistedSessionState::Complete,
+            created_at_unix: super::now_unix(),
+            contributions_complete_at_unix: None,
+            finalized_at_unix: None,
+            timeout_secs: 600,
+            contribution_timeout_secs: 300,
+            finalize_timeout_secs: 300,
+            ack_phase_timeout_secs: 300,
+        };
+        store.save(&persisted).unwrap();
+
+        let loaded = manager.load_persisted_sessions().unwrap();
+        assert_eq!(loaded, 0);
+        assert!(store.load(&[1u8; 32]).unwrap().is_none());
+    }
+
+    struct MemorySessionStore {
+        sessions: parking_lot::RwLock<HashMap<[u8; 32], PersistedDescriptorSession>>,
+    }
+
+    impl MemorySessionStore {
+        fn new() -> Self {
+            Self {
+                sessions: parking_lot::RwLock::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl DescriptorSessionStore for MemorySessionStore {
+        fn save(&self, session: &PersistedDescriptorSession) -> Result<()> {
+            self.sessions
+                .write()
+                .insert(session.session_id, session.clone());
+            Ok(())
+        }
+
+        fn load(&self, session_id: &[u8; 32]) -> Result<Option<PersistedDescriptorSession>> {
+            Ok(self.sessions.read().get(session_id).cloned())
+        }
+
+        fn load_all(&self) -> Result<Vec<PersistedDescriptorSession>> {
+            Ok(self.sessions.read().values().cloned().collect())
+        }
+
+        fn delete(&self, session_id: &[u8; 32]) -> Result<()> {
+            self.sessions.write().remove(session_id);
+            Ok(())
+        }
     }
 }

--- a/keep-frost-net/src/descriptor_session_store.rs
+++ b/keep-frost-net/src/descriptor_session_store.rs
@@ -81,6 +81,9 @@ impl DescriptorSessionStore for FileDescriptorSessionStore {
     }
 
     fn load_all(&self, limit: usize) -> Result<Vec<PersistedDescriptorSession>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
         let txn = self
             .db
             .begin_read()
@@ -115,13 +118,27 @@ impl DescriptorSessionStore for FileDescriptorSessionStore {
         if !corrupt_keys.is_empty() {
             match self.db.begin_write() {
                 Ok(txn) => {
-                    if let Ok(mut table) = txn.open_table(TABLE) {
-                        for key in &corrupt_keys {
-                            let _ = table.remove(key.as_slice());
+                    let mut ok = true;
+                    match txn.open_table(TABLE) {
+                        Ok(mut table) => {
+                            for key in &corrupt_keys {
+                                if let Err(e) = table.remove(key.as_slice()) {
+                                    warn!(key = %hex::encode(key), "Failed to remove corrupt entry: {e}");
+                                    ok = false;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            warn!("Failed to open table for corrupt entry cleanup: {e}");
+                            ok = false;
                         }
                     }
-                    if let Err(e) = txn.commit() {
-                        warn!("Failed to commit corrupt entry cleanup: {e}");
+                    if ok {
+                        if let Err(e) = txn.commit() {
+                            warn!("Failed to commit corrupt entry cleanup: {e}");
+                        }
+                    } else {
+                        warn!("Skipping corrupt entry cleanup commit due to prior errors");
                     }
                 }
                 Err(e) => {

--- a/keep-frost-net/src/descriptor_session_store.rs
+++ b/keep-frost-net/src/descriptor_session_store.rs
@@ -5,6 +5,9 @@ use std::path::Path;
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
 use tracing::{debug, warn};
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 use crate::descriptor_session::{DescriptorSessionStore, PersistedDescriptorSession};
 use crate::error::{FrostNetError, Result};
 
@@ -18,6 +21,14 @@ impl FileDescriptorSessionStore {
     pub fn new(path: &Path) -> Result<Self> {
         let db = Database::create(path)
             .map_err(|e| FrostNetError::Session(format!("Failed to open session store: {e}")))?;
+
+        #[cfg(unix)]
+        {
+            let perms = std::fs::Permissions::from_mode(0o600);
+            std::fs::set_permissions(path, perms).map_err(|e| {
+                FrostNetError::Session(format!("Failed to set session store permissions: {e}"))
+            })?;
+        }
 
         let txn = db.begin_write().map_err(|e| {
             FrostNetError::Session(format!("Failed to begin write for table creation: {e}"))
@@ -69,7 +80,7 @@ impl DescriptorSessionStore for FileDescriptorSessionStore {
             .map_err(Into::into)
     }
 
-    fn load_all(&self) -> Result<Vec<PersistedDescriptorSession>> {
+    fn load_all(&self, limit: usize) -> Result<Vec<PersistedDescriptorSession>> {
         let txn = self
             .db
             .begin_read()
@@ -87,7 +98,12 @@ impl DescriptorSessionStore for FileDescriptorSessionStore {
                 FrostNetError::Session(format!("Failed to read session entry: {e}"))
             })?;
             match serde_json::from_slice::<PersistedDescriptorSession>(value.value()) {
-                Ok(session) => sessions.push(session),
+                Ok(session) => {
+                    sessions.push(session);
+                    if sessions.len() >= limit {
+                        break;
+                    }
+                }
                 Err(e) => {
                     warn!("Removing corrupt session entry: {e}");
                     corrupt_keys.push(key.value().to_vec());
@@ -97,13 +113,20 @@ impl DescriptorSessionStore for FileDescriptorSessionStore {
         drop(txn);
 
         if !corrupt_keys.is_empty() {
-            if let Ok(txn) = self.db.begin_write() {
-                if let Ok(mut table) = txn.open_table(TABLE) {
-                    for key in &corrupt_keys {
-                        let _ = table.remove(key.as_slice());
+            match self.db.begin_write() {
+                Ok(txn) => {
+                    if let Ok(mut table) = txn.open_table(TABLE) {
+                        for key in &corrupt_keys {
+                            let _ = table.remove(key.as_slice());
+                        }
+                    }
+                    if let Err(e) = txn.commit() {
+                        warn!("Failed to commit corrupt entry cleanup: {e}");
                     }
                 }
-                let _ = txn.commit();
+                Err(e) => {
+                    warn!("Failed to begin write for corrupt entry cleanup: {e}");
+                }
             }
         }
 
@@ -187,12 +210,12 @@ mod tests {
 
         assert!(store.load(&[99u8; 32]).unwrap().is_none());
 
-        let all = store.load_all().unwrap();
+        let all = store.load_all(100).unwrap();
         assert_eq!(all.len(), 1);
 
         store.delete(&[1u8; 32]).unwrap();
         assert!(store.load(&[1u8; 32]).unwrap().is_none());
-        assert!(store.load_all().unwrap().is_empty());
+        assert!(store.load_all(100).unwrap().is_empty());
     }
 
     #[test]
@@ -208,7 +231,7 @@ mod tests {
 
         {
             let store = FileDescriptorSessionStore::new(&path).unwrap();
-            let all = store.load_all().unwrap();
+            let all = store.load_all(100).unwrap();
             assert_eq!(all.len(), 2);
             assert!(store.load(&[1u8; 32]).unwrap().is_some());
             assert!(store.load(&[2u8; 32]).unwrap().is_some());
@@ -230,6 +253,6 @@ mod tests {
         let loaded = store.load(&[1u8; 32]).unwrap().unwrap();
         assert_eq!(loaded.state, PersistedSessionState::Finalized);
 
-        assert_eq!(store.load_all().unwrap().len(), 1);
+        assert_eq!(store.load_all(100).unwrap().len(), 1);
     }
 }

--- a/keep-frost-net/src/descriptor_session_store.rs
+++ b/keep-frost-net/src/descriptor_session_store.rs
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+use std::path::Path;
+
+use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
+use tracing::debug;
+
+use crate::descriptor_session::{DescriptorSessionStore, PersistedDescriptorSession};
+use crate::error::{FrostNetError, Result};
+
+const TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("descriptor_sessions");
+
+pub struct FileDescriptorSessionStore {
+    db: Database,
+}
+
+impl FileDescriptorSessionStore {
+    pub fn new(path: &Path) -> Result<Self> {
+        let db = Database::create(path)
+            .map_err(|e| FrostNetError::Session(format!("Failed to open session store: {e}")))?;
+
+        let txn = db.begin_write().map_err(|e| {
+            FrostNetError::Session(format!("Failed to begin write for table creation: {e}"))
+        })?;
+        txn.open_table(TABLE)
+            .map_err(|e| FrostNetError::Session(format!("Failed to create sessions table: {e}")))?;
+        txn.commit()
+            .map_err(|e| FrostNetError::Session(format!("Failed to commit table creation: {e}")))?;
+
+        debug!(path = ?path, "Opened descriptor session store");
+        Ok(Self { db })
+    }
+}
+
+impl DescriptorSessionStore for FileDescriptorSessionStore {
+    fn save(&self, session: &PersistedDescriptorSession) -> Result<()> {
+        let json = serde_json::to_vec(session)?;
+        let txn = self
+            .db
+            .begin_write()
+            .map_err(|e| FrostNetError::Session(format!("Failed to begin write: {e}")))?;
+        {
+            let mut table = txn
+                .open_table(TABLE)
+                .map_err(|e| FrostNetError::Session(format!("Failed to open table: {e}")))?;
+            table
+                .insert(session.session_id.as_slice(), json.as_slice())
+                .map_err(|e| FrostNetError::Session(format!("Failed to insert session: {e}")))?;
+        }
+        txn.commit()
+            .map_err(|e| FrostNetError::Session(format!("Failed to commit session: {e}")))?;
+        Ok(())
+    }
+
+    fn load(&self, session_id: &[u8; 32]) -> Result<Option<PersistedDescriptorSession>> {
+        let txn = self
+            .db
+            .begin_read()
+            .map_err(|e| FrostNetError::Session(format!("Failed to begin read: {e}")))?;
+        let table = txn
+            .open_table(TABLE)
+            .map_err(|e| FrostNetError::Session(format!("Failed to open table: {e}")))?;
+        let entry = table
+            .get(session_id.as_slice())
+            .map_err(|e| FrostNetError::Session(format!("Failed to get session: {e}")))?;
+        match entry {
+            Some(data) => {
+                let session: PersistedDescriptorSession = serde_json::from_slice(data.value())?;
+                Ok(Some(session))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn load_all(&self) -> Result<Vec<PersistedDescriptorSession>> {
+        let txn = self
+            .db
+            .begin_read()
+            .map_err(|e| FrostNetError::Session(format!("Failed to begin read: {e}")))?;
+        let table = txn
+            .open_table(TABLE)
+            .map_err(|e| FrostNetError::Session(format!("Failed to open table: {e}")))?;
+        let mut sessions = Vec::new();
+        let iter = table
+            .iter()
+            .map_err(|e| FrostNetError::Session(format!("Failed to iterate sessions: {e}")))?;
+        for entry in iter {
+            let (_, value) = entry.map_err(|e| {
+                FrostNetError::Session(format!("Failed to read session entry: {e}"))
+            })?;
+            match serde_json::from_slice::<PersistedDescriptorSession>(value.value()) {
+                Ok(session) => sessions.push(session),
+                Err(e) => {
+                    debug!("Skipping corrupt session entry: {e}");
+                }
+            }
+        }
+        Ok(sessions)
+    }
+
+    fn delete(&self, session_id: &[u8; 32]) -> Result<()> {
+        let txn = self
+            .db
+            .begin_write()
+            .map_err(|e| FrostNetError::Session(format!("Failed to begin write: {e}")))?;
+        {
+            let mut table = txn
+                .open_table(TABLE)
+                .map_err(|e| FrostNetError::Session(format!("Failed to open table: {e}")))?;
+            table
+                .remove(session_id.as_slice())
+                .map_err(|e| FrostNetError::Session(format!("Failed to delete session: {e}")))?;
+        }
+        txn.commit()
+            .map_err(|e| FrostNetError::Session(format!("Failed to commit delete: {e}")))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::descriptor_session::PersistedSessionState;
+    use crate::protocol::{KeySlot, PolicyTier, WalletPolicy};
+    use std::collections::{BTreeMap, HashSet};
+    use tempfile::tempdir;
+
+    fn test_persisted_session(id: [u8; 32]) -> PersistedDescriptorSession {
+        PersistedDescriptorSession {
+            session_id: id,
+            group_pubkey: [2u8; 32],
+            policy: WalletPolicy {
+                recovery_tiers: vec![PolicyTier {
+                    threshold: 2,
+                    key_slots: vec![
+                        KeySlot::Participant { share_index: 1 },
+                        KeySlot::Participant { share_index: 2 },
+                    ],
+                    timelock_months: 6,
+                }],
+            },
+            network: "signet".into(),
+            initiator: None,
+            contributions: BTreeMap::new(),
+            expected_contributors: [1u16, 2].into_iter().collect(),
+            descriptor: None,
+            acks: HashSet::new(),
+            nacks: HashSet::new(),
+            expected_acks: [1u16, 2].into_iter().collect(),
+            state: PersistedSessionState::Proposed,
+            created_at_unix: 1700000000,
+            contributions_complete_at_unix: None,
+            finalized_at_unix: None,
+            timeout_secs: 600,
+            contribution_timeout_secs: 300,
+            finalize_timeout_secs: 300,
+            ack_phase_timeout_secs: 300,
+        }
+    }
+
+    #[test]
+    fn test_file_store_crud() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sessions.redb");
+        let store = FileDescriptorSessionStore::new(&path).unwrap();
+
+        let session = test_persisted_session([1u8; 32]);
+        store.save(&session).unwrap();
+
+        let loaded = store.load(&[1u8; 32]).unwrap();
+        assert!(loaded.is_some());
+        let loaded = loaded.unwrap();
+        assert_eq!(loaded.session_id, [1u8; 32]);
+        assert_eq!(loaded.network, "signet");
+
+        assert!(store.load(&[99u8; 32]).unwrap().is_none());
+
+        let all = store.load_all().unwrap();
+        assert_eq!(all.len(), 1);
+
+        store.delete(&[1u8; 32]).unwrap();
+        assert!(store.load(&[1u8; 32]).unwrap().is_none());
+        assert!(store.load_all().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_file_store_persistence() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sessions.redb");
+
+        {
+            let store = FileDescriptorSessionStore::new(&path).unwrap();
+            store.save(&test_persisted_session([1u8; 32])).unwrap();
+            store.save(&test_persisted_session([2u8; 32])).unwrap();
+        }
+
+        {
+            let store = FileDescriptorSessionStore::new(&path).unwrap();
+            let all = store.load_all().unwrap();
+            assert_eq!(all.len(), 2);
+            assert!(store.load(&[1u8; 32]).unwrap().is_some());
+            assert!(store.load(&[2u8; 32]).unwrap().is_some());
+        }
+    }
+
+    #[test]
+    fn test_file_store_overwrite() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sessions.redb");
+        let store = FileDescriptorSessionStore::new(&path).unwrap();
+
+        let mut session = test_persisted_session([1u8; 32]);
+        store.save(&session).unwrap();
+
+        session.state = PersistedSessionState::Finalized;
+        store.save(&session).unwrap();
+
+        let loaded = store.load(&[1u8; 32]).unwrap().unwrap();
+        assert_eq!(loaded.state, PersistedSessionState::Finalized);
+
+        assert_eq!(store.load_all().unwrap().len(), 1);
+    }
+}

--- a/keep-frost-net/src/descriptor_session_store.rs
+++ b/keep-frost-net/src/descriptor_session_store.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::descriptor_session::{DescriptorSessionStore, PersistedDescriptorSession};
 use crate::error::{FrostNetError, Result};
@@ -63,13 +63,10 @@ impl DescriptorSessionStore for FileDescriptorSessionStore {
         let entry = table
             .get(session_id.as_slice())
             .map_err(|e| FrostNetError::Session(format!("Failed to get session: {e}")))?;
-        match entry {
-            Some(data) => {
-                let session: PersistedDescriptorSession = serde_json::from_slice(data.value())?;
-                Ok(Some(session))
-            }
-            None => Ok(None),
-        }
+        entry
+            .map(|data| serde_json::from_slice(data.value()))
+            .transpose()
+            .map_err(Into::into)
     }
 
     fn load_all(&self) -> Result<Vec<PersistedDescriptorSession>> {
@@ -81,20 +78,35 @@ impl DescriptorSessionStore for FileDescriptorSessionStore {
             .open_table(TABLE)
             .map_err(|e| FrostNetError::Session(format!("Failed to open table: {e}")))?;
         let mut sessions = Vec::new();
+        let mut corrupt_keys = Vec::new();
         let iter = table
             .iter()
             .map_err(|e| FrostNetError::Session(format!("Failed to iterate sessions: {e}")))?;
         for entry in iter {
-            let (_, value) = entry.map_err(|e| {
+            let (key, value) = entry.map_err(|e| {
                 FrostNetError::Session(format!("Failed to read session entry: {e}"))
             })?;
             match serde_json::from_slice::<PersistedDescriptorSession>(value.value()) {
                 Ok(session) => sessions.push(session),
                 Err(e) => {
-                    debug!("Skipping corrupt session entry: {e}");
+                    warn!("Removing corrupt session entry: {e}");
+                    corrupt_keys.push(key.value().to_vec());
                 }
             }
         }
+        drop(txn);
+
+        if !corrupt_keys.is_empty() {
+            if let Ok(txn) = self.db.begin_write() {
+                if let Ok(mut table) = txn.open_table(TABLE) {
+                    for key in &corrupt_keys {
+                        let _ = table.remove(key.as_slice());
+                    }
+                }
+                let _ = txn.commit();
+            }
+        }
+
         Ok(sessions)
     }
 

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -60,6 +60,7 @@ mod attestation;
 mod audit;
 mod cert_pin;
 mod descriptor_session;
+mod descriptor_session_store;
 mod ecdh;
 mod error;
 mod event;
@@ -75,9 +76,11 @@ pub use audit::{SigningAuditEntry, SigningAuditLog, SigningOperation};
 pub use cert_pin::{verify_relay_certificate, CertificatePinSet, SpkiHash};
 pub use descriptor_session::{
     derive_descriptor_session_id, derive_policy_hash, participant_indices, reconstruct_descriptor,
-    DescriptorSession, DescriptorSessionManager, DescriptorSessionState, FinalizedDescriptor,
-    XpubContribution,
+    DescriptorSession, DescriptorSessionManager, DescriptorSessionState, DescriptorSessionStore,
+    FinalizedDescriptor, PersistedDescriptorSession, PersistedFinalizedDescriptor,
+    PersistedSessionState, XpubContribution,
 };
+pub use descriptor_session_store::FileDescriptorSessionStore;
 pub use ecdh::{
     aggregate_ecdh_shares, compute_partial_ecdh, derive_ecdh_session_id, EcdhSession,
     EcdhSessionManager, EcdhSessionState,

--- a/keep-frost-net/src/node/descriptor.rs
+++ b/keep-frost-net/src/node/descriptor.rs
@@ -89,6 +89,7 @@ impl KfpNode {
                     return Err(e);
                 }
             }
+            sessions.persist_session(&session_id);
         }
 
         let mut payload = DescriptorProposePayload::new(
@@ -244,6 +245,7 @@ impl KfpNode {
                     ) {
                         debug!("Failed to store initiator contribution: {e}");
                     }
+                    sessions.persist_session(&payload.session_id);
                     true
                 }
                 Err(e) => {
@@ -314,6 +316,7 @@ impl KfpNode {
                 account_xpub.to_string(),
                 fingerprint.to_string(),
             )?;
+            sessions.persist_session(&session_id);
         }
 
         let payload = DescriptorContributePayload::new(
@@ -402,7 +405,9 @@ impl KfpNode {
                 share_index: payload.share_index,
             });
 
-            session.has_all_contributions()
+            let all = session.has_all_contributions();
+            sessions.persist_session(&payload.session_id);
+            all
         };
 
         if all_contributions {
@@ -433,7 +438,9 @@ impl KfpNode {
                 policy_hash,
             })?;
 
-            session.contributions().clone()
+            let contribs = session.contributions().clone();
+            sessions.persist_session(&session_id);
+            contribs
         };
 
         let payload = DescriptorFinalizePayload::new(
@@ -716,6 +723,7 @@ impl KfpNode {
                 internal: payload.internal_descriptor.clone(),
                 policy_hash: payload.policy_hash,
             })?;
+            sessions.persist_session(&payload.session_id);
         }
 
         let _ = self.event_tx.send(KfpNodeEvent::DescriptorComplete {
@@ -828,6 +836,7 @@ impl KfpNode {
             session.fail(format!("Peer {share_index} rejected descriptor: {reason}"));
         }
 
+        sessions.persist_session(&payload.session_id);
         drop(sessions);
 
         info!(
@@ -886,12 +895,14 @@ impl KfpNode {
                 payload.descriptor_hash,
                 &payload.key_proof_psbt,
             )?;
-            (
+            let result = (
                 is_new,
                 session.is_complete(),
                 session.ack_count(),
                 session.expected_ack_count(),
-            )
+            );
+            sessions.persist_session(&payload.session_id);
+            result
         };
 
         info!(

--- a/keep-frost-net/src/node/descriptor.rs
+++ b/keep-frost-net/src/node/descriptor.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 
 use nostr_sdk::prelude::*;
 use sha2::{Digest, Sha256};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use zeroize::Zeroizing;
 
 use crate::descriptor_session::{
@@ -243,7 +243,7 @@ impl KfpNode {
                         payload.initiator_xpub.clone(),
                         payload.initiator_fingerprint.clone(),
                     ) {
-                        debug!("Failed to store initiator contribution: {e}");
+                        warn!("Failed to store initiator contribution: {e}");
                     }
                     sessions.persist_session(&payload.session_id);
                     true

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -469,6 +469,26 @@ impl KfpNode {
         })
     }
 
+    pub fn with_descriptor_session_store(
+        self,
+        store: Arc<dyn crate::descriptor_session::DescriptorSessionStore>,
+    ) -> Self {
+        {
+            let mut sessions = self.descriptor_sessions.write();
+            sessions.set_store(store);
+            match sessions.load_persisted_sessions() {
+                Ok(count) if count > 0 => {
+                    info!(count, "Restored persisted descriptor sessions");
+                }
+                Err(e) => {
+                    warn!("Failed to load persisted descriptor sessions: {e}");
+                }
+                _ => {}
+            }
+        }
+        self
+    }
+
     pub fn with_expected_pcrs(mut self, pcrs: ExpectedPcrs) -> Self {
         self.expected_pcrs = Some(pcrs);
         self

--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -48,13 +48,13 @@ fn within_replay_window(created_at: u64, window_secs: u64) -> bool {
     created_at >= min_valid && created_at <= max_valid
 }
 
-fn is_valid_xpub(xpub: &str) -> bool {
+pub(crate) fn is_valid_xpub(xpub: &str) -> bool {
     xpub.len() >= MIN_XPUB_LENGTH
         && xpub.len() <= MAX_XPUB_LENGTH
         && VALID_XPUB_PREFIXES.iter().any(|pfx| xpub.starts_with(pfx))
 }
 
-fn is_valid_fingerprint(fp: &str) -> bool {
+pub(crate) fn is_valid_fingerprint(fp: &str) -> bool {
     fp.len() == MAX_FINGERPRINT_LENGTH && fp.chars().all(|c| c.is_ascii_hexdigit())
 }
 

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -513,17 +513,21 @@ impl KeepMobile {
         })
     }
 
-    pub fn set_session_store_path(&self, path: String) {
+    pub fn set_session_store_path(&self, path: String) -> Result<(), KeepMobileError> {
         if std::path::Path::new(&path)
             .components()
             .any(|c| matches!(c, std::path::Component::ParentDir))
         {
-            tracing::warn!("Rejecting session store path with parent traversal: {path}");
-            return;
+            return Err(KeepMobileError::InvalidInput {
+                msg: format!("Session store path contains parent traversal: {path}"),
+            });
         }
-        if let Ok(mut guard) = self.session_store_path.lock() {
-            *guard = Some(path);
-        }
+        let mut guard = self.session_store_path.lock().unwrap_or_else(|poisoned| {
+            tracing::error!("session_store_path lock poisoned: {poisoned:?}");
+            poisoned.into_inner()
+        });
+        *guard = Some(path);
+        Ok(())
     }
 
     pub fn initialize(&self, relays: Vec<String>) -> Result<(), KeepMobileError> {
@@ -1912,8 +1916,11 @@ impl KeepMobile {
             let node = if let Some(path) = self
                 .session_store_path
                 .lock()
-                .ok()
-                .and_then(|g| g.clone())
+                .unwrap_or_else(|poisoned| {
+                    tracing::error!("session_store_path lock poisoned: {poisoned:?}");
+                    poisoned.into_inner()
+                })
+                .clone()
             {
                 let store_path =
                     std::path::PathBuf::from(path).join("descriptor-sessions.redb");

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -514,6 +514,13 @@ impl KeepMobile {
     }
 
     pub fn set_session_store_path(&self, path: String) {
+        if std::path::Path::new(&path)
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            tracing::warn!("Rejecting session store path with parent traversal: {path}");
+            return;
+        }
         if let Ok(mut guard) = self.session_store_path.lock() {
             *guard = Some(path);
         }

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -384,6 +384,7 @@ pub struct KeepMobile {
     state_callback: Arc<RwLock<Option<Arc<dyn KeepStateCallback>>>>,
     state_rev: Arc<std::sync::atomic::AtomicU64>,
     pre_approved_hash: Arc<std::sync::Mutex<Option<[u8; 32]>>>,
+    session_store_path: Arc<std::sync::Mutex<Option<String>>>,
 }
 
 struct PendingRequest {
@@ -508,7 +509,14 @@ impl KeepMobile {
             state_callback: Arc::new(RwLock::new(None)),
             state_rev: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             pre_approved_hash: Arc::new(std::sync::Mutex::new(None)),
+            session_store_path: Arc::new(std::sync::Mutex::new(None)),
         })
+    }
+
+    pub fn set_session_store_path(&self, path: String) {
+        if let Ok(mut guard) = self.session_store_path.lock() {
+            *guard = Some(path);
+        }
     }
 
     pub fn initialize(&self, relays: Vec<String>) -> Result<(), KeepMobileError> {
@@ -1892,6 +1900,27 @@ impl KeepMobile {
             let node = match proxy {
                 Some(addr) => KfpNode::new_with_proxy(share, verified_relays, addr).await?,
                 None => KfpNode::new(share, verified_relays).await?,
+            };
+
+            let node = if let Some(path) = self
+                .session_store_path
+                .lock()
+                .ok()
+                .and_then(|g| g.clone())
+            {
+                let store_path =
+                    std::path::PathBuf::from(path).join("descriptor-sessions.redb");
+                match keep_frost_net::FileDescriptorSessionStore::new(&store_path) {
+                    Ok(store) => node.with_descriptor_session_store(
+                        Arc::new(store) as Arc<dyn keep_frost_net::DescriptorSessionStore>,
+                    ),
+                    Err(e) => {
+                        tracing::warn!("Failed to create descriptor session store: {e}");
+                        node
+                    }
+                }
+            } else {
+                node
             };
 
             let (request_tx, request_rx) = mpsc::channel(32);

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1917,15 +1917,15 @@ impl KeepMobile {
             {
                 let store_path =
                     std::path::PathBuf::from(path).join("descriptor-sessions.redb");
-                match keep_frost_net::FileDescriptorSessionStore::new(&store_path) {
-                    Ok(store) => node.with_descriptor_session_store(
-                        Arc::new(store) as Arc<dyn keep_frost_net::DescriptorSessionStore>,
-                    ),
-                    Err(e) => {
-                        tracing::warn!("Failed to create descriptor session store: {e}");
-                        node
-                    }
-                }
+                let store = keep_frost_net::FileDescriptorSessionStore::new(&store_path)
+                    .map_err(|e| KeepMobileError::StorageError {
+                        msg: format!(
+                            "Failed to create descriptor session store: {e}"
+                        ),
+                    })?;
+                node.with_descriptor_session_store(
+                    Arc::new(store) as Arc<dyn keep_frost_net::DescriptorSessionStore>,
+                )
             } else {
                 node
             };


### PR DESCRIPTION
## Summary
- Persist descriptor sessions to disk so they survive node restarts
- Harden session restoration: safe Instant arithmetic, timeout clamping, corrupt entry cleanup
- Reject path traversal in mobile session store path

## Test plan
- [x] `cargo check` passes for keep-frost-net, keep-mobile, keep-desktop
- [x] `cargo test -p keep-frost-net` passes
- [x] Security review completed
- [x] PR review completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Descriptor sessions are persisted to disk and automatically restored on restart for improved session resilience.
  * Mobile app can opt in to on-disk session storage via a configurable session store path.

* **Bug Fixes / Reliability**
  * Persistence failures now emit clearer warnings; corrupted persisted entries are cleaned up to avoid restore issues.
  * Session state is consistently persisted throughout workflows so progress survives restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->