### PR TITLE
Add NIP-49 ncryptsec export to keep-mobile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4097,7 +4097,7 @@ dependencies = [
  "keep-bitcoin",
  "keep-core",
  "nostr-sdk",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "subtle",
@@ -4150,7 +4150,7 @@ dependencies = [
  "keep-frost-net",
  "keep-nip46",
  "nostr-sdk",
- "rand 0.10.0",
+ "rand 0.10.1",
  "ratatui",
  "reqwest",
  "secrecy",
@@ -4198,7 +4198,7 @@ dependencies = [
  "memsec 0.7.0",
  "memsecurity",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "redb 2.6.3",
  "redb 3.1.1",
  "scrypt",
@@ -4233,7 +4233,7 @@ dependencies = [
  "nokhwa",
  "nostr-sdk",
  "notify-rust",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rfd",
  "rustls",
  "rxing",
@@ -4304,7 +4304,7 @@ dependencies = [
  "nostr-sdk",
  "parking_lot",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "redb 3.1.1",
  "rustls",
  "rustls-pki-types",
@@ -4364,7 +4364,7 @@ dependencies = [
  "keep-frost-net",
  "nostr-relay-builder",
  "nostr-sdk",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rustls",
  "serde",
  "serde_json",
@@ -6688,9 +6688,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
@@ -8037,7 +8037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/keep-mobile/src/error.rs
+++ b/keep-mobile/src/error.rs
@@ -80,6 +80,9 @@ pub enum KeepMobileError {
     #[error("Backup error: {msg}")]
     BackupError { msg: String },
 
+    #[error("Encryption error: {msg}")]
+    EncryptionError { msg: String },
+
     #[error("Certificate pin mismatch")]
     CertificatePinMismatch {
         hostname: String,

--- a/keep-mobile/src/keep_mobile.udl
+++ b/keep-mobile/src/keep_mobile.udl
@@ -32,6 +32,7 @@ interface KeepMobileError {
     PolicyViolation(string reason);
     InvalidPolicy(string msg);
     PolicySignatureInvalid();
+    EncryptionError(string msg);
     CertificatePinMismatch(string hostname, string expected, string actual);
 };
 

--- a/keep-mobile/src/keep_mobile.udl
+++ b/keep-mobile/src/keep_mobile.udl
@@ -32,6 +32,7 @@ interface KeepMobileError {
     PolicyViolation(string reason);
     InvalidPolicy(string msg);
     PolicySignatureInvalid();
+    BackupError(string msg);
     EncryptionError(string msg);
     CertificatePinMismatch(string hostname, string expected, string actual);
 };

--- a/keep-mobile/src/keep_mobile.udl
+++ b/keep-mobile/src/keep_mobile.udl
@@ -270,6 +270,9 @@ interface KeepMobile {
     [Throws=KeepMobileError]
     string export_share(string passphrase);
 
+    [Throws=KeepMobileError]
+    string export_ncryptsec(string password);
+
     sequence<StoredShareInfo> list_shares();
 
     StoredShareInfo? get_active_share();

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -744,12 +744,12 @@ impl KeepMobile {
             .map_err(|e| KeepMobileError::FrostError { msg: e.to_string() })?;
 
         let share_bytes = Zeroizing::new(key_package.signing_share().serialize());
-        let secret: [u8; 32] = share_bytes
-            .as_slice()
-            .try_into()
-            .map_err(|_| KeepMobileError::EncryptionError {
-                msg: "unexpected signing share length".into(),
-            })?;
+        let secret: Zeroizing<[u8; 32]> =
+            Zeroizing::new(share_bytes.as_slice().try_into().map_err(|_| {
+                KeepMobileError::EncryptionError {
+                    msg: "unexpected signing share length".into(),
+                }
+            })?);
 
         keep_core::keys::nip49::encrypt(&secret, &password, None)
             .map_err(|e| KeepMobileError::EncryptionError { msg: e.to_string() })

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -729,6 +729,32 @@ impl KeepMobile {
             .map_err(|e| KeepMobileError::FrostError { msg: e.to_string() })
     }
 
+    pub fn export_ncryptsec(&self, password: String) -> Result<String, KeepMobileError> {
+        let password = Zeroizing::new(password);
+        let share = self.load_share_package()?;
+
+        if share.metadata.threshold != 1 || share.metadata.total_shares != 1 {
+            return Err(KeepMobileError::InvalidInput {
+                msg: "NIP-49 export is only supported for single-key (nsec) shares".into(),
+            });
+        }
+
+        let key_package = share
+            .key_package()
+            .map_err(|e| KeepMobileError::FrostError { msg: e.to_string() })?;
+
+        let share_bytes = Zeroizing::new(key_package.signing_share().serialize());
+        let secret: [u8; 32] = share_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| KeepMobileError::EncryptionError {
+                msg: "unexpected signing share length".into(),
+            })?;
+
+        keep_core::keys::nip49::encrypt(&secret, &password, None)
+            .map_err(|e| KeepMobileError::EncryptionError { msg: e.to_string() })
+    }
+
     pub fn list_shares(&self) -> Vec<StoredShareInfo> {
         self.storage
             .list_all_shares()

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -751,7 +751,7 @@ impl KeepMobile {
                 }
             })?);
 
-        keep_core::keys::nip49::encrypt(&secret, &password, None)
+        keep_core::keys::nip49::encrypt(&secret, &password, Some(14))
             .map_err(|e| KeepMobileError::EncryptionError { msg: e.to_string() })
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add password-protected export of encrypted credentials in NIP-49 ncryptsec format.
  * Export is restricted to single-key shares; multi-key shares are rejected.

* **Bug Fixes**
  * Improved error reporting for encryption/export and backup-related failures with clearer messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->