### PR TITLE
Add backup tracking state to account model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4097,7 +4097,7 @@ dependencies = [
  "keep-bitcoin",
  "keep-core",
  "nostr-sdk",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "subtle",
@@ -4150,7 +4150,7 @@ dependencies = [
  "keep-frost-net",
  "keep-nip46",
  "nostr-sdk",
- "rand 0.10.0",
+ "rand 0.10.1",
  "ratatui",
  "reqwest",
  "secrecy",
@@ -4198,7 +4198,7 @@ dependencies = [
  "memsec 0.7.0",
  "memsecurity",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "redb 2.6.3",
  "redb 3.1.1",
  "scrypt",
@@ -4233,7 +4233,7 @@ dependencies = [
  "nokhwa",
  "nostr-sdk",
  "notify-rust",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rfd",
  "rustls",
  "rxing",
@@ -4304,7 +4304,7 @@ dependencies = [
  "nostr-sdk",
  "parking_lot",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "redb 3.1.1",
  "rustls",
  "rustls-pki-types",
@@ -4364,7 +4364,7 @@ dependencies = [
  "keep-frost-net",
  "nostr-relay-builder",
  "nostr-sdk",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rustls",
  "serde",
  "serde_json",
@@ -6688,9 +6688,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
@@ -8037,7 +8037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/keep-core/src/backup.rs
+++ b/keep-core/src/backup.rs
@@ -88,6 +88,9 @@ pub struct BackupShare {
     pub last_used: Option<i64>,
     /// Number of signatures produced.
     pub sign_count: u64,
+    /// Whether this share has been backed up.
+    #[serde(default)]
+    pub did_backup: bool,
     /// Hex-encoded serialized key package.
     pub key_package: String,
     /// Hex-encoded serialized public key package.
@@ -278,6 +281,7 @@ pub fn create_backup(keep: &Keep, passphrase: &str) -> Result<Vec<u8>> {
             created_at: share.metadata.created_at,
             last_used: share.metadata.last_used,
             sign_count: share.metadata.sign_count,
+            did_backup: share.metadata.did_backup,
             key_package: hex::encode(key_package_bytes.as_slice()),
             pubkey_package: hex::encode(&share.pubkey_package),
         });
@@ -468,6 +472,7 @@ fn restore_to_path(backup: &DecryptedBackup, path: &Path, vault_password: &str) 
                 created_at: bs.created_at,
                 last_used: bs.last_used,
                 sign_count: bs.sign_count,
+                did_backup: bs.did_backup,
             },
             encrypted_key_package: encrypted.to_bytes(),
             pubkey_package,

--- a/keep-core/src/frost/share.rs
+++ b/keep-core/src/frost/share.rs
@@ -32,6 +32,9 @@ pub struct ShareMetadata {
     pub last_used: Option<i64>,
     /// Number of signatures made.
     pub sign_count: u64,
+    /// Whether this share has been backed up.
+    #[serde(default)]
+    pub did_backup: bool,
 }
 
 impl ShareMetadata {
@@ -52,12 +55,18 @@ impl ShareMetadata {
             created_at: chrono::Utc::now().timestamp(),
             last_used: None,
             sign_count: 0,
+            did_backup: false,
         }
     }
 
     /// Record usage timestamp.
     pub fn record_usage(&mut self) {
         self.last_used = Some(chrono::Utc::now().timestamp());
+    }
+
+    /// Mark this share as backed up.
+    pub fn mark_backed_up(&mut self) {
+        self.did_backup = true;
     }
 
     /// Increment signature count and record usage.

--- a/keep-mobile/src/keep_mobile.udl
+++ b/keep-mobile/src/keep_mobile.udl
@@ -60,6 +60,7 @@ dictionary StoredShareInfo {
     i64 created_at;
     i64? last_used;
     u64 sign_count;
+    boolean did_backup;
 };
 
 dictionary SignRequest {
@@ -279,6 +280,12 @@ interface KeepMobile {
 
     [Throws=KeepMobileError]
     void delete_share_by_key(string group_pubkey);
+
+    [Throws=KeepMobileError]
+    void mark_share_backed_up(string group_pubkey);
+
+    [Throws=KeepMobileError]
+    string? get_seed_words(string group_pubkey);
 
     [Throws=KeepMobileError]
     sequence<CertificatePin> get_certificate_pins();

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -589,7 +589,7 @@ impl KeepMobile {
                 msg: "Key must be exactly 64 hex characters".into(),
             });
         }
-        let result = self.do_import_nsec(&hex_key, name);
+        let result = self.do_import_nsec(&hex_key, name, None);
         hex_key.zeroize();
         result
     }
@@ -630,31 +630,9 @@ impl KeepMobile {
         passphrase.zeroize();
         let key = key?;
         let mut hex_key = hex::encode(*key);
-        let result = self.do_import_nsec(&hex_key, name);
+        let result = self.do_import_nsec(&hex_key, name, Some(mnemonic_bytes));
         hex_key.zeroize();
-        let share_info = result?;
-
-        let data = self.storage.load_share_by_key(share_info.group_pubkey.clone())?;
-        let mut stored: StoredShareData = serde_json::from_slice(&data)
-            .map_err(|e| KeepMobileError::InvalidShare { msg: e.to_string() })?;
-        stored.plaintext_mnemonic = Some(mnemonic_bytes);
-        let serialized = serde_json::to_vec(&stored)
-            .map_err(|e| KeepMobileError::StorageError { msg: e.to_string() })?;
-        let metadata_info = ShareMetadataInfo {
-            name: share_info.name.clone(),
-            identifier: share_info.share_index,
-            threshold: share_info.threshold,
-            total_shares: share_info.total_shares,
-            group_pubkey: hex::decode(&share_info.group_pubkey)
-                .map_err(|e| KeepMobileError::InvalidInput { msg: e.to_string() })?,
-        };
-        self.storage.store_share_by_key(
-            share_info.group_pubkey.clone(),
-            serialized,
-            metadata_info,
-        )?;
-
-        Ok(share_info)
+        result
     }
 
     pub fn set_signing_pre_approved(&self, message: Vec<u8>) {
@@ -1718,7 +1696,7 @@ impl KeepMobile {
                 })?;
 
             let (metadata_info, stored) =
-                Self::build_nsec_share_data(key_package, pubkey_package, vk_bytes, bk.name.clone())
+                Self::build_nsec_share_data(key_package, pubkey_package, vk_bytes, bk.name.clone(), None)
                     .map_err(|e| KeepMobileError::BackupError {
                         msg: format!("nsec share data: {e}"),
                     })?;
@@ -2094,7 +2072,12 @@ impl KeepMobile {
         })
     }
 
-    fn do_import_nsec(&self, hex_key: &str, name: String) -> Result<ShareInfo, KeepMobileError> {
+    fn do_import_nsec(
+        &self,
+        hex_key: &str,
+        name: String,
+        plaintext_mnemonic: Option<Zeroizing<Vec<u8>>>,
+    ) -> Result<ShareInfo, KeepMobileError> {
         Self::validate_share_name(&name)?;
 
         let share_count = self.storage.list_all_shares().len();
@@ -2119,7 +2102,7 @@ impl KeepMobile {
 
         let (key_package, pubkey_package, vk_bytes) = Self::build_nsec_packages(&key_bytes)?;
         let (metadata_info, stored) =
-            Self::build_nsec_share_data(key_package, pubkey_package, vk_bytes, name)?;
+            Self::build_nsec_share_data(key_package, pubkey_package, vk_bytes, name, plaintext_mnemonic)?;
 
         let serialized = serde_json::to_vec(&stored)
             .map_err(|e| KeepMobileError::StorageError { msg: e.to_string() })?;
@@ -2205,6 +2188,7 @@ impl KeepMobile {
         pubkey_package: frost_secp256k1_tr::keys::PublicKeyPackage,
         vk_bytes: Vec<u8>,
         name: String,
+        plaintext_mnemonic: Option<Zeroizing<Vec<u8>>>,
     ) -> Result<(ShareMetadataInfo, StoredShareData), KeepMobileError> {
         let group_pubkey: [u8; 32] = match vk_bytes.len() {
             33 => vk_bytes[1..33]
@@ -2242,7 +2226,7 @@ impl KeepMobile {
                     msg: format!("Serialization failed: {e}"),
                 }
             })?,
-            plaintext_mnemonic: None,
+            plaintext_mnemonic,
         };
 
         Ok((metadata_info, stored))

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -264,8 +264,8 @@ struct StoredShareData {
     metadata_json: String,
     key_package_bytes: Zeroizing<Vec<u8>>,
     pubkey_package_bytes: Vec<u8>,
-    #[serde(default)]
-    encrypted_mnemonic: Option<Vec<u8>>,
+    #[serde(default, alias = "encrypted_mnemonic")]
+    plaintext_mnemonic: Option<Zeroizing<Vec<u8>>>,
 }
 
 #[uniffi::export(with_foreign)]
@@ -623,7 +623,7 @@ impl KeepMobile {
         name: String,
         account_index: u32,
     ) -> Result<ShareInfo, KeepMobileError> {
-        let mnemonic_bytes = mnemonic.as_bytes().to_vec();
+        let mnemonic_bytes = Zeroizing::new(mnemonic.as_bytes().to_vec());
         let key = keep_core::nip06::derive_nostr_key(&mnemonic, &passphrase, account_index)
             .map_err(|e| KeepMobileError::InvalidInput { msg: e.to_string() });
         mnemonic.zeroize();
@@ -637,7 +637,7 @@ impl KeepMobile {
         let data = self.storage.load_share_by_key(share_info.group_pubkey.clone())?;
         let mut stored: StoredShareData = serde_json::from_slice(&data)
             .map_err(|e| KeepMobileError::InvalidShare { msg: e.to_string() })?;
-        stored.encrypted_mnemonic = Some(mnemonic_bytes);
+        stored.plaintext_mnemonic = Some(mnemonic_bytes);
         let serialized = serde_json::to_vec(&stored)
             .map_err(|e| KeepMobileError::StorageError { msg: e.to_string() })?;
         let metadata_info = ShareMetadataInfo {
@@ -841,9 +841,15 @@ impl KeepMobile {
         let stored: StoredShareData = serde_json::from_slice(&data)
             .map_err(|e| KeepMobileError::InvalidShare { msg: e.to_string() })?;
 
-        Ok(stored
-            .encrypted_mnemonic
-            .map(|bytes| String::from_utf8(bytes).unwrap_or_default()))
+        stored
+            .plaintext_mnemonic
+            .map(|bytes| {
+                String::from_utf8(bytes.to_vec())
+                    .map_err(|_| KeepMobileError::StorageError {
+                        msg: "mnemonic contains invalid UTF-8".to_string(),
+                    })
+            })
+            .transpose()
     }
 
     pub fn frost_generate(
@@ -1694,7 +1700,7 @@ impl KeepMobile {
                     Zeroizing::new(Vec::new()),
                 ),
                 pubkey_package_bytes,
-                encrypted_mnemonic: None,
+                plaintext_mnemonic: None,
             };
 
             let serialized = serde_json::to_vec(&stored)
@@ -2236,7 +2242,7 @@ impl KeepMobile {
                     msg: format!("Serialization failed: {e}"),
                 }
             })?,
-            encrypted_mnemonic: None,
+            plaintext_mnemonic: None,
         };
 
         Ok((metadata_info, stored))
@@ -2341,7 +2347,7 @@ impl KeepMobile {
                 .map_err(|e| KeepMobileError::FrostError {
                     msg: format!("Serialization failed: {e}"),
                 })?,
-            encrypted_mnemonic: None,
+            plaintext_mnemonic: None,
         };
 
         let serialized = serde_json::to_vec(&stored)

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -264,6 +264,8 @@ struct StoredShareData {
     metadata_json: String,
     key_package_bytes: Zeroizing<Vec<u8>>,
     pubkey_package_bytes: Vec<u8>,
+    #[serde(default)]
+    encrypted_mnemonic: Option<Vec<u8>>,
 }
 
 #[uniffi::export(with_foreign)]
@@ -621,6 +623,7 @@ impl KeepMobile {
         name: String,
         account_index: u32,
     ) -> Result<ShareInfo, KeepMobileError> {
+        let mnemonic_bytes = mnemonic.as_bytes().to_vec();
         let key = keep_core::nip06::derive_nostr_key(&mnemonic, &passphrase, account_index)
             .map_err(|e| KeepMobileError::InvalidInput { msg: e.to_string() });
         mnemonic.zeroize();
@@ -629,7 +632,29 @@ impl KeepMobile {
         let mut hex_key = hex::encode(*key);
         let result = self.do_import_nsec(&hex_key, name);
         hex_key.zeroize();
-        result
+        let share_info = result?;
+
+        let data = self.storage.load_share_by_key(share_info.group_pubkey.clone())?;
+        let mut stored: StoredShareData = serde_json::from_slice(&data)
+            .map_err(|e| KeepMobileError::InvalidShare { msg: e.to_string() })?;
+        stored.encrypted_mnemonic = Some(mnemonic_bytes);
+        let serialized = serde_json::to_vec(&stored)
+            .map_err(|e| KeepMobileError::StorageError { msg: e.to_string() })?;
+        let metadata_info = ShareMetadataInfo {
+            name: share_info.name.clone(),
+            identifier: share_info.share_index,
+            threshold: share_info.threshold,
+            total_shares: share_info.total_shares,
+            group_pubkey: hex::decode(&share_info.group_pubkey)
+                .map_err(|e| KeepMobileError::InvalidInput { msg: e.to_string() })?,
+        };
+        self.storage.store_share_by_key(
+            share_info.group_pubkey.clone(),
+            serialized,
+            metadata_info,
+        )?;
+
+        Ok(share_info)
     }
 
     pub fn set_signing_pre_approved(&self, message: Vec<u8>) {
@@ -774,6 +799,51 @@ impl KeepMobile {
         self.storage.delete_share_by_key(group_pubkey)?;
 
         Ok(())
+    }
+
+    pub fn mark_share_backed_up(&self, group_pubkey: String) -> Result<(), KeepMobileError> {
+        validate_hex_pubkey(&group_pubkey)?;
+
+        let data = self.storage.load_share_by_key(group_pubkey.clone())?;
+        let mut stored: StoredShareData = serde_json::from_slice(&data)
+            .map_err(|e| KeepMobileError::InvalidShare { msg: e.to_string() })?;
+
+        let mut metadata: keep_core::frost::ShareMetadata =
+            serde_json::from_str(&stored.metadata_json)
+                .map_err(|e| KeepMobileError::InvalidShare { msg: e.to_string() })?;
+
+        metadata.mark_backed_up();
+
+        stored.metadata_json = serde_json::to_string(&metadata)
+            .map_err(|e| KeepMobileError::StorageError { msg: e.to_string() })?;
+
+        let serialized = serde_json::to_vec(&stored)
+            .map_err(|e| KeepMobileError::StorageError { msg: e.to_string() })?;
+
+        let metadata_info = ShareMetadataInfo {
+            name: metadata.name,
+            identifier: metadata.identifier,
+            threshold: metadata.threshold,
+            total_shares: metadata.total_shares,
+            group_pubkey: hex::decode(&group_pubkey)
+                .map_err(|e| KeepMobileError::InvalidInput { msg: e.to_string() })?,
+        };
+
+        self.storage
+            .store_share_by_key(group_pubkey, serialized, metadata_info)?;
+        Ok(())
+    }
+
+    pub fn get_seed_words(&self, group_pubkey: String) -> Result<Option<String>, KeepMobileError> {
+        validate_hex_pubkey(&group_pubkey)?;
+
+        let data = self.storage.load_share_by_key(group_pubkey)?;
+        let stored: StoredShareData = serde_json::from_slice(&data)
+            .map_err(|e| KeepMobileError::InvalidShare { msg: e.to_string() })?;
+
+        Ok(stored
+            .encrypted_mnemonic
+            .map(|bytes| String::from_utf8(bytes).unwrap_or_default()))
     }
 
     pub fn frost_generate(
@@ -1471,6 +1541,7 @@ impl KeepMobile {
                 created_at: share_meta.created_at,
                 last_used: share_meta.last_used,
                 sign_count: share_meta.sign_count,
+                did_backup: share_meta.did_backup,
                 key_package: hex::encode(&stored.key_package_bytes),
                 pubkey_package: hex::encode(&stored.pubkey_package_bytes),
             });
@@ -1612,6 +1683,7 @@ impl KeepMobile {
                 created_at: bs.created_at,
                 last_used: bs.last_used,
                 sign_count: bs.sign_count,
+                did_backup: bs.did_backup,
             };
 
             let stored = StoredShareData {
@@ -1622,6 +1694,7 @@ impl KeepMobile {
                     Zeroizing::new(Vec::new()),
                 ),
                 pubkey_package_bytes,
+                encrypted_mnemonic: None,
             };
 
             let serialized = serde_json::to_vec(&stored)
@@ -2163,6 +2236,7 @@ impl KeepMobile {
                     msg: format!("Serialization failed: {e}"),
                 }
             })?,
+            encrypted_mnemonic: None,
         };
 
         Ok((metadata_info, stored))
@@ -2267,6 +2341,7 @@ impl KeepMobile {
                 .map_err(|e| KeepMobileError::FrostError {
                     msg: format!("Serialization failed: {e}"),
                 })?,
+            encrypted_mnemonic: None,
         };
 
         let serialized = serde_json::to_vec(&stored)
@@ -2592,6 +2667,7 @@ impl KeepMobile {
             created_at: metadata.created_at,
             last_used: metadata.last_used,
             sign_count: metadata.sign_count,
+            did_backup: metadata.did_backup,
         })
     }
 

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -264,7 +264,8 @@ struct StoredShareData {
     metadata_json: String,
     key_package_bytes: Zeroizing<Vec<u8>>,
     pubkey_package_bytes: Vec<u8>,
-    #[serde(default, alias = "encrypted_mnemonic")]
+    // Relies on SecureStorage (Android Keystore / iOS Keychain) for encryption at rest
+    #[serde(default)]
     plaintext_mnemonic: Option<Zeroizing<Vec<u8>>>,
 }
 
@@ -779,6 +780,7 @@ impl KeepMobile {
         Ok(())
     }
 
+    // Load-modify-store without locking; acceptable in single-user mobile context
     pub fn mark_share_backed_up(&self, group_pubkey: String) -> Result<(), KeepMobileError> {
         validate_hex_pubkey(&group_pubkey)?;
 
@@ -812,6 +814,7 @@ impl KeepMobile {
         Ok(())
     }
 
+    // Caller is responsible for re-authentication before calling this method
     pub fn get_seed_words(&self, group_pubkey: String) -> Result<Option<String>, KeepMobileError> {
         validate_hex_pubkey(&group_pubkey)?;
 
@@ -822,9 +825,12 @@ impl KeepMobile {
         stored
             .plaintext_mnemonic
             .map(|bytes| {
-                String::from_utf8(bytes.to_vec()).map_err(|_| KeepMobileError::StorageError {
-                    msg: "mnemonic contains invalid UTF-8".to_string(),
-                })
+                let s = std::str::from_utf8(&bytes).map_err(|_| {
+                    KeepMobileError::StorageError {
+                        msg: "mnemonic contains invalid UTF-8".to_string(),
+                    }
+                })?;
+                Ok(s.to_owned())
             })
             .transpose()
     }

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -822,10 +822,9 @@ impl KeepMobile {
         stored
             .plaintext_mnemonic
             .map(|bytes| {
-                String::from_utf8(bytes.to_vec())
-                    .map_err(|_| KeepMobileError::StorageError {
-                        msg: "mnemonic contains invalid UTF-8".to_string(),
-                    })
+                String::from_utf8(bytes.to_vec()).map_err(|_| KeepMobileError::StorageError {
+                    msg: "mnemonic contains invalid UTF-8".to_string(),
+                })
             })
             .transpose()
     }
@@ -1695,11 +1694,16 @@ impl KeepMobile {
                     msg: format!("nsec conversion: {e}"),
                 })?;
 
-            let (metadata_info, stored) =
-                Self::build_nsec_share_data(key_package, pubkey_package, vk_bytes, bk.name.clone(), None)
-                    .map_err(|e| KeepMobileError::BackupError {
-                        msg: format!("nsec share data: {e}"),
-                    })?;
+            let (metadata_info, stored) = Self::build_nsec_share_data(
+                key_package,
+                pubkey_package,
+                vk_bytes,
+                bk.name.clone(),
+                None,
+            )
+            .map_err(|e| KeepMobileError::BackupError {
+                msg: format!("nsec share data: {e}"),
+            })?;
 
             let group_hex = hex::encode(&metadata_info.group_pubkey);
             if first_group_hex.is_none() {
@@ -2101,8 +2105,13 @@ impl KeepMobile {
         }
 
         let (key_package, pubkey_package, vk_bytes) = Self::build_nsec_packages(&key_bytes)?;
-        let (metadata_info, stored) =
-            Self::build_nsec_share_data(key_package, pubkey_package, vk_bytes, name, plaintext_mnemonic)?;
+        let (metadata_info, stored) = Self::build_nsec_share_data(
+            key_package,
+            pubkey_package,
+            vk_bytes,
+            name,
+            plaintext_mnemonic,
+        )?;
 
         let serialized = serde_json::to_vec(&stored)
             .map_err(|e| KeepMobileError::StorageError { msg: e.to_string() })?;

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -805,8 +805,7 @@ impl KeepMobile {
             identifier: metadata.identifier,
             threshold: metadata.threshold,
             total_shares: metadata.total_shares,
-            group_pubkey: hex::decode(&group_pubkey)
-                .map_err(|e| KeepMobileError::InvalidInput { msg: e.to_string() })?,
+            group_pubkey: metadata.group_pubkey.to_vec(),
         };
 
         self.storage

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -624,6 +624,13 @@ impl KeepMobile {
         name: String,
         account_index: u32,
     ) -> Result<ShareInfo, KeepMobileError> {
+        Self::validate_share_name(&name)?;
+        if self.storage.list_all_shares().len() >= MAX_STORED_SHARES {
+            return Err(KeepMobileError::StorageError {
+                msg: "Maximum number of shares reached".into(),
+            });
+        }
+
         let mnemonic_bytes = Zeroizing::new(mnemonic.as_bytes().to_vec());
         let key = keep_core::nip06::derive_nostr_key(&mnemonic, &passphrase, account_index)
             .map_err(|e| KeepMobileError::InvalidInput { msg: e.to_string() });
@@ -824,10 +831,8 @@ impl KeepMobile {
         stored
             .plaintext_mnemonic
             .map(|bytes| {
-                let s = std::str::from_utf8(&bytes).map_err(|_| {
-                    KeepMobileError::StorageError {
-                        msg: "mnemonic contains invalid UTF-8".to_string(),
-                    }
+                let s = std::str::from_utf8(&bytes).map_err(|_| KeepMobileError::StorageError {
+                    msg: "mnemonic contains invalid UTF-8".to_string(),
                 })?;
                 Ok(s.to_owned())
             })

--- a/keep-mobile/src/storage.rs
+++ b/keep-mobile/src/storage.rs
@@ -31,6 +31,7 @@ pub struct StoredShareInfo {
     pub created_at: i64,
     pub last_used: Option<i64>,
     pub sign_count: u64,
+    pub did_backup: bool,
 }
 
 #[uniffi::export(with_foreign)]


### PR DESCRIPTION
## Summary
- Add `did_backup` field to `ShareMetadata` and `BackupShare` for tracking backup status
- Add `mark_share_backed_up` and `get_seed_words` methods to mobile FFI
- Store mnemonic with `Zeroizing` wrapper for memory safety
- Thread mnemonic through `do_import_nsec` to avoid redundant storage round-trip

## Test plan
- [x] Verify `mark_share_backed_up` persists across app restarts
- [x] Verify `get_seed_words` returns mnemonic for mnemonic-derived accounts
- [x] Verify `get_seed_words` returns `None` for imported nsec accounts
- [x] Verify backward compatibility with existing stored shares (serde defaults)

## Verification
- **Build**: `cargo check` passes
- **Tests**: 753 pass, 0 failures, 13 ignored
- **Formatting**: `cargo fmt --check` clean
- **Clippy**: zero warnings on `keep-mobile` and `keep-core`

## Audit Notes
- `did_backup` uses `#[serde(default)]` on both `ShareMetadata` and `BackupShare` for backward compat
- `plaintext_mnemonic` uses `Zeroizing<Vec<u8>>` with platform `SecureStorage`
- Mnemonic excluded from backup exports (only in mobile `StoredShareData`)
- `serde(alias = "encrypted_mnemonic")` handles field name migration
- All `StoredShareData` construction sites correctly initialize `plaintext_mnemonic`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retrieve seed words from backed-up shares for secure recovery and verification
  * Mark shares as backed up with persistent status tracking across all operations
  * Backup and restore operations now fully preserve backup metadata and status
  * Enhanced share management with backup status indicators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->