### PR TITLE
Add JSON export to audit logs

### DIFF
--- a/keep-mobile/src/audit.rs
+++ b/keep-mobile/src/audit.rs
@@ -130,13 +130,13 @@ impl AuditEntry {
 
 #[derive(Serialize, Deserialize)]
 struct AuditEntryExport {
-    pub timestamp: i64,
-    pub event_type: AuditEventType,
-    pub pubkey: Option<String>,
-    pub success: bool,
-    pub details: Option<String>,
-    pub prev_hash: String,
-    pub hash: String,
+    timestamp: i64,
+    event_type: AuditEventType,
+    pubkey: Option<String>,
+    success: bool,
+    details: Option<String>,
+    prev_hash: String,
+    hash: String,
 }
 
 impl From<AuditEntry> for AuditEntryExport {
@@ -147,8 +147,8 @@ impl From<AuditEntry> for AuditEntryExport {
             pubkey: e.pubkey,
             success: e.success,
             details: e.details,
-            prev_hash: hex::encode(&e.prev_hash),
-            hash: hex::encode(&e.hash),
+            prev_hash: hex::encode(e.prev_hash),
+            hash: hex::encode(e.hash),
         }
     }
 }
@@ -257,15 +257,11 @@ impl AuditLog {
     }
 
     pub fn export_json(&self) -> Result<String, KeepMobileError> {
-        let entry_jsons = self.storage.load_entries(None)?;
-        let mut entries = Vec::with_capacity(entry_jsons.len());
-        for json in entry_jsons {
-            let entry: AuditEntry =
-                serde_json::from_str(&json).map_err(|e| KeepMobileError::Serialization {
-                    msg: format!("Invalid audit entry: {e}"),
-                })?;
-            entries.push(AuditEntryExport::from(entry));
-        }
+        let entries: Vec<AuditEntryExport> = self
+            .get_entries(None)?
+            .into_iter()
+            .map(AuditEntryExport::from)
+            .collect();
         serde_json::to_string_pretty(&entries).map_err(|e| KeepMobileError::Serialization {
             msg: format!("Export failed: {e}"),
         })
@@ -460,16 +456,16 @@ impl SigningAuditEntry {
 
 #[derive(Serialize, Deserialize)]
 struct SigningAuditEntryExport {
-    pub timestamp: i64,
-    pub request_type: SigningRequestType,
-    pub decision: SigningDecision,
-    pub was_automatic: bool,
-    pub caller: String,
-    pub caller_name: Option<String>,
-    pub event_kind: Option<u32>,
-    pub reason: Option<String>,
-    pub prev_hash: String,
-    pub hash: String,
+    timestamp: i64,
+    request_type: SigningRequestType,
+    decision: SigningDecision,
+    was_automatic: bool,
+    caller: String,
+    caller_name: Option<String>,
+    event_kind: Option<u32>,
+    reason: Option<String>,
+    prev_hash: String,
+    hash: String,
 }
 
 impl From<SigningAuditEntry> for SigningAuditEntryExport {
@@ -483,8 +479,8 @@ impl From<SigningAuditEntry> for SigningAuditEntryExport {
             caller_name: e.caller_name,
             event_kind: e.event_kind,
             reason: e.reason,
-            prev_hash: hex::encode(&e.prev_hash),
-            hash: hex::encode(&e.hash),
+            prev_hash: hex::encode(e.prev_hash),
+            hash: hex::encode(e.hash),
         }
     }
 }
@@ -515,6 +511,21 @@ pub trait SigningAuditStorage: Send + Sync {
 pub struct SigningAuditLog {
     storage: std::sync::Arc<dyn SigningAuditStorage>,
     last_hash: std::sync::Mutex<[u8; 32]>,
+}
+
+impl SigningAuditLog {
+    fn load_all_entries(&self) -> Result<Vec<SigningAuditEntry>, KeepMobileError> {
+        let entry_jsons = self.storage.load_entries(None)?;
+        let mut entries = Vec::with_capacity(entry_jsons.len());
+        for json in entry_jsons {
+            let entry: SigningAuditEntry =
+                serde_json::from_str(&json).map_err(|e| KeepMobileError::Serialization {
+                    msg: format!("Invalid signing audit entry: {e}"),
+                })?;
+            entries.push(entry);
+        }
+        Ok(entries)
+    }
 }
 
 #[uniffi::export]
@@ -627,7 +638,7 @@ impl SigningAuditLog {
     }
 
     pub fn verify_chain(&self) -> Result<ChainStatus, KeepMobileError> {
-        let entries = self.storage.load_entries(None)?;
+        let entries = self.load_all_entries()?;
 
         if entries.len() > MAX_AUDIT_ENTRIES {
             return Err(KeepMobileError::StorageError {
@@ -635,7 +646,6 @@ impl SigningAuditLog {
             });
         }
 
-        let mut prev_hash = [0u8; 32];
         let count: u32 = entries
             .len()
             .try_into()
@@ -643,11 +653,8 @@ impl SigningAuditLog {
                 msg: "Entry count exceeds u32".into(),
             })?;
 
-        for json in entries {
-            let entry: SigningAuditEntry =
-                serde_json::from_str(&json).map_err(|e| KeepMobileError::Serialization {
-                    msg: format!("Invalid signing audit entry: {e}"),
-                })?;
+        let mut prev_hash = [0u8; 32];
+        for entry in entries {
             if !entry.verify(&prev_hash) {
                 return Ok(ChainStatus {
                     verified: false,
@@ -671,15 +678,11 @@ impl SigningAuditLog {
     }
 
     pub fn export_json(&self) -> Result<String, KeepMobileError> {
-        let entry_jsons = self.storage.load_entries(None)?;
-        let mut entries = Vec::with_capacity(entry_jsons.len());
-        for json in entry_jsons {
-            let entry: SigningAuditEntry =
-                serde_json::from_str(&json).map_err(|e| KeepMobileError::Serialization {
-                    msg: format!("Invalid signing audit entry: {e}"),
-                })?;
-            entries.push(SigningAuditEntryExport::from(entry));
-        }
+        let entries: Vec<SigningAuditEntryExport> = self
+            .load_all_entries()?
+            .into_iter()
+            .map(SigningAuditEntryExport::from)
+            .collect();
         serde_json::to_string_pretty(&entries).map_err(|e| KeepMobileError::Serialization {
             msg: format!("Export failed: {e}"),
         })

--- a/keep-mobile/src/audit.rs
+++ b/keep-mobile/src/audit.rs
@@ -128,7 +128,8 @@ impl AuditEntry {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize)]
+#[cfg_attr(test, derive(serde::Deserialize))]
 struct AuditEntryExport {
     timestamp: i64,
     event_type: AuditEventType,
@@ -256,7 +257,13 @@ impl AuditLog {
     }
 
     pub fn get_entries(&self, limit: Option<u32>) -> Result<Vec<AuditEntry>, KeepMobileError> {
-        let entry_jsons = self.storage.load_entries(limit)?;
+        const _: () = assert!(MAX_AUDIT_ENTRIES < u32::MAX as usize);
+        let capped = Some(
+            limit
+                .unwrap_or(MAX_AUDIT_ENTRIES as u32 + 1)
+                .min(MAX_AUDIT_ENTRIES as u32 + 1),
+        );
+        let entry_jsons = self.storage.load_entries(capped)?;
         let mut entries = Vec::with_capacity(entry_jsons.len());
         for json in entry_jsons {
             let entry: AuditEntry =
@@ -476,7 +483,8 @@ impl SigningAuditEntry {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize)]
+#[cfg_attr(test, derive(serde::Deserialize))]
 struct SigningAuditEntryExport {
     timestamp: i64,
     request_type: SigningRequestType,
@@ -549,7 +557,10 @@ pub struct SigningAuditLog {
 
 impl SigningAuditLog {
     fn load_all_entries(&self) -> Result<Vec<SigningAuditEntry>, KeepMobileError> {
-        let entry_jsons = self.storage.load_entries(None)?;
+        const _: () = assert!(MAX_AUDIT_ENTRIES < u32::MAX as usize);
+        let entry_jsons = self
+            .storage
+            .load_entries(Some(MAX_AUDIT_ENTRIES as u32 + 1))?;
         let mut entries = Vec::with_capacity(entry_jsons.len());
         for json in entry_jsons {
             let entry: SigningAuditEntry =
@@ -863,6 +874,37 @@ mod tests {
     }
 
     #[test]
+    fn test_export_json_chain_linkage() {
+        let storage = Arc::new(MockStorage::new());
+        let log = AuditLog::new(storage).unwrap();
+
+        log.log_event(AuditEventType::Sign, Some("pk1".into()), true, None)
+            .unwrap();
+        log.log_event(AuditEventType::FrostSign, Some("pk2".into()), true, None)
+            .unwrap();
+        log.log_event(
+            AuditEventType::ShareExport,
+            Some("pk1".into()),
+            true,
+            Some("exported".into()),
+        )
+        .unwrap();
+
+        let json = log.export_json().unwrap();
+        let entries: Vec<AuditEntryExport> = serde_json::from_str(&json).unwrap();
+        assert_eq!(entries.len(), 3);
+
+        assert_eq!(entries[0].prev_hash, "0".repeat(64));
+        for i in 1..entries.len() {
+            assert_eq!(
+                entries[i].prev_hash, entries[i - 1].hash,
+                "entry {i} prev_hash should equal entry {} hash",
+                i - 1
+            );
+        }
+    }
+
+    #[test]
     fn test_chain_detects_tampering() {
         let mock = Arc::new(MockStorage::new());
         let storage: Arc<dyn AuditStorage> = Arc::clone(&mock) as Arc<dyn AuditStorage>;
@@ -1093,6 +1135,38 @@ mod tests {
             .prev_hash
             .chars()
             .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+    }
+
+    #[test]
+    fn test_signing_export_json_chain_linkage() {
+        let storage = Arc::new(MockSigningStorage::new());
+        let log = SigningAuditLog::new(storage).unwrap();
+
+        for i in 0..3 {
+            log.log_event(
+                SigningRequestType::SignEvent,
+                SigningDecision::Approved,
+                false,
+                format!("app{i}"),
+                Some(format!("App {i}")),
+                Some(1),
+                None,
+            )
+            .unwrap();
+        }
+
+        let json = log.export_json().unwrap();
+        let entries: Vec<SigningAuditEntryExport> = serde_json::from_str(&json).unwrap();
+        assert_eq!(entries.len(), 3);
+
+        assert_eq!(entries[0].prev_hash, "0".repeat(64));
+        for i in 1..entries.len() {
+            assert_eq!(
+                entries[i].prev_hash, entries[i - 1].hash,
+                "entry {i} prev_hash should equal entry {} hash",
+                i - 1
+            );
+        }
     }
 
     #[test]

--- a/keep-mobile/src/audit.rs
+++ b/keep-mobile/src/audit.rs
@@ -128,6 +128,31 @@ impl AuditEntry {
     }
 }
 
+#[derive(Serialize, Deserialize)]
+struct AuditEntryExport {
+    pub timestamp: i64,
+    pub event_type: AuditEventType,
+    pub pubkey: Option<String>,
+    pub success: bool,
+    pub details: Option<String>,
+    pub prev_hash: String,
+    pub hash: String,
+}
+
+impl From<AuditEntry> for AuditEntryExport {
+    fn from(e: AuditEntry) -> Self {
+        Self {
+            timestamp: e.timestamp,
+            event_type: e.event_type,
+            pubkey: e.pubkey,
+            success: e.success,
+            details: e.details,
+            prev_hash: hex::encode(&e.prev_hash),
+            hash: hex::encode(&e.hash),
+        }
+    }
+}
+
 #[uniffi::export(with_foreign)]
 pub trait AuditStorage: Send + Sync {
     fn store_entry(&self, entry_json: String) -> Result<(), KeepMobileError>;
@@ -220,13 +245,6 @@ impl AuditLog {
 
     pub fn get_entries(&self, limit: Option<u32>) -> Result<Vec<AuditEntry>, KeepMobileError> {
         let entry_jsons = self.storage.load_entries(limit)?;
-
-        if entry_jsons.len() > MAX_AUDIT_ENTRIES {
-            return Err(KeepMobileError::StorageError {
-                msg: format!("Audit log exceeds maximum of {MAX_AUDIT_ENTRIES} entries"),
-            });
-        }
-
         let mut entries = Vec::with_capacity(entry_jsons.len());
         for json in entry_jsons {
             let entry: AuditEntry =
@@ -239,7 +257,15 @@ impl AuditLog {
     }
 
     pub fn export_json(&self) -> Result<String, KeepMobileError> {
-        let entries = self.get_entries(None)?;
+        let entry_jsons = self.storage.load_entries(None)?;
+        let mut entries = Vec::with_capacity(entry_jsons.len());
+        for json in entry_jsons {
+            let entry: AuditEntry =
+                serde_json::from_str(&json).map_err(|e| KeepMobileError::Serialization {
+                    msg: format!("Invalid audit entry: {e}"),
+                })?;
+            entries.push(AuditEntryExport::from(entry));
+        }
         serde_json::to_string_pretty(&entries).map_err(|e| KeepMobileError::Serialization {
             msg: format!("Export failed: {e}"),
         })
@@ -432,6 +458,37 @@ impl SigningAuditEntry {
     }
 }
 
+#[derive(Serialize, Deserialize)]
+struct SigningAuditEntryExport {
+    pub timestamp: i64,
+    pub request_type: SigningRequestType,
+    pub decision: SigningDecision,
+    pub was_automatic: bool,
+    pub caller: String,
+    pub caller_name: Option<String>,
+    pub event_kind: Option<u32>,
+    pub reason: Option<String>,
+    pub prev_hash: String,
+    pub hash: String,
+}
+
+impl From<SigningAuditEntry> for SigningAuditEntryExport {
+    fn from(e: SigningAuditEntry) -> Self {
+        Self {
+            timestamp: e.timestamp,
+            request_type: e.request_type,
+            decision: e.decision,
+            was_automatic: e.was_automatic,
+            caller: e.caller,
+            caller_name: e.caller_name,
+            event_kind: e.event_kind,
+            reason: e.reason,
+            prev_hash: hex::encode(&e.prev_hash),
+            hash: hex::encode(&e.hash),
+        }
+    }
+}
+
 #[derive(uniffi::Record, Clone, Debug)]
 pub struct ChainStatus {
     pub verified: bool,
@@ -615,24 +672,14 @@ impl SigningAuditLog {
 
     pub fn export_json(&self) -> Result<String, KeepMobileError> {
         let entry_jsons = self.storage.load_entries(None)?;
-
-        if entry_jsons.len() > MAX_AUDIT_ENTRIES {
-            return Err(KeepMobileError::StorageError {
-                msg: format!(
-                    "Signing audit log exceeds maximum of {MAX_AUDIT_ENTRIES} entries"
-                ),
-            });
-        }
-
         let mut entries = Vec::with_capacity(entry_jsons.len());
         for json in entry_jsons {
             let entry: SigningAuditEntry =
                 serde_json::from_str(&json).map_err(|e| KeepMobileError::Serialization {
                     msg: format!("Invalid signing audit entry: {e}"),
                 })?;
-            entries.push(entry);
+            entries.push(SigningAuditEntryExport::from(entry));
         }
-
         serde_json::to_string_pretty(&entries).map_err(|e| KeepMobileError::Serialization {
             msg: format!("Export failed: {e}"),
         })
@@ -748,12 +795,21 @@ mod tests {
         let storage = Arc::new(MockStorage::new());
         let log = AuditLog::new(storage).unwrap();
 
+        let json = log.export_json().unwrap();
+        let entries: Vec<AuditEntryExport> = serde_json::from_str(&json).unwrap();
+        assert!(entries.is_empty());
+
         log.log_event(AuditEventType::Sign, Some("pk1".into()), true, None)
             .unwrap();
 
         let json = log.export_json().unwrap();
-        assert!(json.contains("Sign"), "JSON: {json}");
-        assert!(json.contains("pk1"), "JSON: {json}");
+        let entries: Vec<AuditEntryExport> = serde_json::from_str(&json).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].event_type, AuditEventType::Sign);
+        assert_eq!(entries[0].pubkey.as_deref(), Some("pk1"));
+        assert!(entries[0].success);
+        assert_eq!(entries[0].hash.len(), 64);
+        assert!(entries[0].hash.chars().all(|c| c.is_ascii_hexdigit()));
     }
 
     #[test]
@@ -954,6 +1010,10 @@ mod tests {
         let storage = Arc::new(MockSigningStorage::new());
         let log = SigningAuditLog::new(storage).unwrap();
 
+        let json = log.export_json().unwrap();
+        let entries: Vec<SigningAuditEntryExport> = serde_json::from_str(&json).unwrap();
+        assert!(entries.is_empty());
+
         log.log_event(
             SigningRequestType::SignEvent,
             SigningDecision::Approved,
@@ -966,9 +1026,15 @@ mod tests {
         .unwrap();
 
         let json = log.export_json().unwrap();
-        assert!(json.contains("SignEvent"), "JSON: {json}");
-        assert!(json.contains("app1"), "JSON: {json}");
-        assert!(json.contains("Test App"), "JSON: {json}");
+        let entries: Vec<SigningAuditEntryExport> = serde_json::from_str(&json).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].request_type, SigningRequestType::SignEvent);
+        assert_eq!(entries[0].decision, SigningDecision::Approved);
+        assert_eq!(entries[0].caller, "app1");
+        assert_eq!(entries[0].caller_name.as_deref(), Some("Test App"));
+        assert_eq!(entries[0].event_kind, Some(1));
+        assert_eq!(entries[0].hash.len(), 64);
+        assert!(entries[0].hash.chars().all(|c| c.is_ascii_hexdigit()));
     }
 
     #[test]

--- a/keep-mobile/src/audit.rs
+++ b/keep-mobile/src/audit.rs
@@ -550,9 +550,7 @@ impl SigningAuditLog {
             .load_entries(Some(MAX_AUDIT_ENTRIES as u32 + 1))?;
         if entry_jsons.len() > MAX_AUDIT_ENTRIES {
             return Err(KeepMobileError::StorageError {
-                msg: format!(
-                    "Signing audit log exceeds maximum of {MAX_AUDIT_ENTRIES} entries"
-                ),
+                msg: format!("Signing audit log exceeds maximum of {MAX_AUDIT_ENTRIES} entries"),
             });
         }
         let mut entries = Vec::with_capacity(entry_jsons.len());
@@ -739,7 +737,9 @@ mod tests {
 
     fn assert_lowercase_hex(s: &str) {
         assert_eq!(s.len(), 64);
-        assert!(s.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        assert!(s
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
     }
 
     struct MockStorage {
@@ -871,7 +871,8 @@ mod tests {
         assert_eq!(entries[0].prev_hash, "0".repeat(64));
         for i in 1..entries.len() {
             assert_eq!(
-                entries[i].prev_hash, entries[i - 1].hash,
+                entries[i].prev_hash,
+                entries[i - 1].hash,
                 "entry {i} prev_hash should equal entry {} hash",
                 i - 1
             );
@@ -1128,7 +1129,8 @@ mod tests {
         assert_eq!(entries[0].prev_hash, "0".repeat(64));
         for i in 1..entries.len() {
             assert_eq!(
-                entries[i].prev_hash, entries[i - 1].hash,
+                entries[i].prev_hash,
+                entries[i - 1].hash,
                 "entry {i} prev_hash should equal entry {} hash",
                 i - 1
             );

--- a/keep-mobile/src/audit.rs
+++ b/keep-mobile/src/audit.rs
@@ -139,9 +139,21 @@ struct AuditEntryExport {
     hash: String,
 }
 
-impl From<AuditEntry> for AuditEntryExport {
-    fn from(e: AuditEntry) -> Self {
-        Self {
+impl TryFrom<AuditEntry> for AuditEntryExport {
+    type Error = KeepMobileError;
+
+    fn try_from(e: AuditEntry) -> Result<Self, Self::Error> {
+        if e.prev_hash.len() != 32 {
+            return Err(KeepMobileError::InvalidInput {
+                msg: format!("prev_hash length {} != 32", e.prev_hash.len()),
+            });
+        }
+        if e.hash.len() != 32 {
+            return Err(KeepMobileError::InvalidInput {
+                msg: format!("hash length {} != 32", e.hash.len()),
+            });
+        }
+        Ok(Self {
             timestamp: e.timestamp,
             event_type: e.event_type,
             pubkey: e.pubkey,
@@ -149,7 +161,7 @@ impl From<AuditEntry> for AuditEntryExport {
             details: e.details,
             prev_hash: hex::encode(e.prev_hash),
             hash: hex::encode(e.hash),
-        }
+        })
     }
 }
 
@@ -260,8 +272,8 @@ impl AuditLog {
         let entries: Vec<AuditEntryExport> = self
             .get_entries(None)?
             .into_iter()
-            .map(AuditEntryExport::from)
-            .collect();
+            .map(AuditEntryExport::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
         serde_json::to_string_pretty(&entries).map_err(|e| KeepMobileError::Serialization {
             msg: format!("Export failed: {e}"),
         })
@@ -468,9 +480,21 @@ struct SigningAuditEntryExport {
     hash: String,
 }
 
-impl From<SigningAuditEntry> for SigningAuditEntryExport {
-    fn from(e: SigningAuditEntry) -> Self {
-        Self {
+impl TryFrom<SigningAuditEntry> for SigningAuditEntryExport {
+    type Error = KeepMobileError;
+
+    fn try_from(e: SigningAuditEntry) -> Result<Self, Self::Error> {
+        if e.prev_hash.len() != 32 {
+            return Err(KeepMobileError::InvalidInput {
+                msg: format!("prev_hash length {} != 32", e.prev_hash.len()),
+            });
+        }
+        if e.hash.len() != 32 {
+            return Err(KeepMobileError::InvalidInput {
+                msg: format!("hash length {} != 32", e.hash.len()),
+            });
+        }
+        Ok(Self {
             timestamp: e.timestamp,
             request_type: e.request_type,
             decision: e.decision,
@@ -481,7 +505,7 @@ impl From<SigningAuditEntry> for SigningAuditEntryExport {
             reason: e.reason,
             prev_hash: hex::encode(e.prev_hash),
             hash: hex::encode(e.hash),
-        }
+        })
     }
 }
 
@@ -681,8 +705,8 @@ impl SigningAuditLog {
         let entries: Vec<SigningAuditEntryExport> = self
             .load_all_entries()?
             .into_iter()
-            .map(SigningAuditEntryExport::from)
-            .collect();
+            .map(SigningAuditEntryExport::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
         serde_json::to_string_pretty(&entries).map_err(|e| KeepMobileError::Serialization {
             msg: format!("Export failed: {e}"),
         })
@@ -812,7 +836,15 @@ mod tests {
         assert_eq!(entries[0].pubkey.as_deref(), Some("pk1"));
         assert!(entries[0].success);
         assert_eq!(entries[0].hash.len(), 64);
-        assert!(entries[0].hash.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(entries[0]
+            .hash
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        assert_eq!(entries[0].prev_hash.len(), 64);
+        assert!(entries[0]
+            .prev_hash
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
     }
 
     #[test]
@@ -1037,7 +1069,15 @@ mod tests {
         assert_eq!(entries[0].caller_name.as_deref(), Some("Test App"));
         assert_eq!(entries[0].event_kind, Some(1));
         assert_eq!(entries[0].hash.len(), 64);
-        assert!(entries[0].hash.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(entries[0]
+            .hash
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        assert_eq!(entries[0].prev_hash.len(), 64);
+        assert!(entries[0]
+            .prev_hash
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
     }
 
     #[test]

--- a/keep-mobile/src/audit.rs
+++ b/keep-mobile/src/audit.rs
@@ -21,6 +21,26 @@ fn truncate_str(s: &str, max_len: usize) -> &str {
     &s[..end]
 }
 
+fn require_hash_32(hash: &[u8], field: &str) -> Result<(), KeepMobileError> {
+    if hash.len() != 32 {
+        return Err(KeepMobileError::InvalidInput {
+            msg: format!("{field} length {} != 32", hash.len()),
+        });
+    }
+    Ok(())
+}
+
+fn hash_optional_str(data: &mut Vec<u8>, opt: &Option<String>) {
+    match opt {
+        Some(s) => {
+            data.push(1);
+            data.extend_from_slice(&(s.len() as u32).to_le_bytes());
+            data.extend_from_slice(s.as_bytes());
+        }
+        None => data.push(0),
+    }
+}
+
 #[derive(uniffi::Enum, Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AuditEventType {
     Sign = 0,
@@ -94,25 +114,9 @@ impl AuditEntry {
         let mut data = Vec::new();
         data.extend_from_slice(&self.timestamp.to_le_bytes());
         data.push(self.event_type as u8);
-        match &self.pubkey {
-            Some(pk) => {
-                data.push(1);
-                let len = (pk.len() as u32).to_le_bytes();
-                data.extend_from_slice(&len);
-                data.extend_from_slice(pk.as_bytes());
-            }
-            None => data.push(0),
-        }
+        hash_optional_str(&mut data, &self.pubkey);
         data.push(self.success as u8);
-        match &self.details {
-            Some(d) => {
-                data.push(1);
-                let len = (d.len() as u32).to_le_bytes();
-                data.extend_from_slice(&len);
-                data.extend_from_slice(d.as_bytes());
-            }
-            None => data.push(0),
-        }
+        hash_optional_str(&mut data, &self.details);
         data.extend_from_slice(&self.prev_hash);
         blake2b_256(&data)
     }
@@ -144,16 +148,8 @@ impl TryFrom<AuditEntry> for AuditEntryExport {
     type Error = KeepMobileError;
 
     fn try_from(e: AuditEntry) -> Result<Self, Self::Error> {
-        if e.prev_hash.len() != 32 {
-            return Err(KeepMobileError::InvalidInput {
-                msg: format!("prev_hash length {} != 32", e.prev_hash.len()),
-            });
-        }
-        if e.hash.len() != 32 {
-            return Err(KeepMobileError::InvalidInput {
-                msg: format!("hash length {} != 32", e.hash.len()),
-            });
-        }
+        require_hash_32(&e.prev_hash, "prev_hash")?;
+        require_hash_32(&e.hash, "hash")?;
         Ok(Self {
             timestamp: e.timestamp,
             event_type: e.event_type,
@@ -179,6 +175,29 @@ pub trait AuditStorage: Send + Sync {
 pub struct AuditLog {
     storage: std::sync::Arc<dyn AuditStorage>,
     last_hash: std::sync::Mutex<[u8; 32]>,
+}
+
+impl AuditLog {
+    fn load_all_checked(&self) -> Result<Vec<AuditEntry>, KeepMobileError> {
+        const _: () = assert!(MAX_AUDIT_ENTRIES < u32::MAX as usize);
+        let entry_jsons = self
+            .storage
+            .load_entries(Some(MAX_AUDIT_ENTRIES as u32 + 1))?;
+        if entry_jsons.len() > MAX_AUDIT_ENTRIES {
+            return Err(KeepMobileError::StorageError {
+                msg: format!("Audit log exceeds maximum of {MAX_AUDIT_ENTRIES} entries"),
+            });
+        }
+        let mut entries = Vec::with_capacity(entry_jsons.len());
+        for json in entry_jsons {
+            let entry: AuditEntry =
+                serde_json::from_str(&json).map_err(|e| KeepMobileError::Serialization {
+                    msg: format!("Invalid audit entry: {e}"),
+                })?;
+            entries.push(entry);
+        }
+        Ok(entries)
+    }
 }
 
 #[uniffi::export]
@@ -276,12 +295,7 @@ impl AuditLog {
     }
 
     pub fn export_json(&self) -> Result<String, KeepMobileError> {
-        let entries = self.get_entries(Some(MAX_AUDIT_ENTRIES as u32 + 1))?;
-        if entries.len() > MAX_AUDIT_ENTRIES {
-            return Err(KeepMobileError::StorageError {
-                msg: format!("Audit log exceeds maximum of {MAX_AUDIT_ENTRIES} entries"),
-            });
-        }
+        let entries = self.load_all_checked()?;
         let exports: Vec<AuditEntryExport> = entries
             .into_iter()
             .map(AuditEntryExport::try_from)
@@ -292,12 +306,7 @@ impl AuditLog {
     }
 
     pub fn verify_chain(&self) -> Result<bool, KeepMobileError> {
-        let entries = self.get_entries(Some(MAX_AUDIT_ENTRIES as u32 + 1))?;
-        if entries.len() > MAX_AUDIT_ENTRIES {
-            return Err(KeepMobileError::StorageError {
-                msg: format!("Audit log exceeds maximum of {MAX_AUDIT_ENTRIES} entries"),
-            });
-        }
+        let entries = self.load_all_checked()?;
         let mut prev_hash = [0u8; 32];
 
         for entry in entries {
@@ -445,14 +454,7 @@ impl SigningAuditEntry {
         data.push(self.was_automatic as u8);
         data.extend_from_slice(&(self.caller.len() as u32).to_le_bytes());
         data.extend_from_slice(self.caller.as_bytes());
-        match &self.caller_name {
-            Some(s) => {
-                data.push(1);
-                data.extend_from_slice(&(s.len() as u32).to_le_bytes());
-                data.extend_from_slice(s.as_bytes());
-            }
-            None => data.push(0),
-        }
+        hash_optional_str(&mut data, &self.caller_name);
         match self.event_kind {
             Some(kind) => {
                 data.push(1);
@@ -460,14 +462,7 @@ impl SigningAuditEntry {
             }
             None => data.push(0),
         }
-        match &self.reason {
-            Some(s) => {
-                data.push(1);
-                data.extend_from_slice(&(s.len() as u32).to_le_bytes());
-                data.extend_from_slice(s.as_bytes());
-            }
-            None => data.push(0),
-        }
+        hash_optional_str(&mut data, &self.reason);
         data.extend_from_slice(&self.prev_hash);
         blake2b_256(&data)
     }
@@ -502,16 +497,8 @@ impl TryFrom<SigningAuditEntry> for SigningAuditEntryExport {
     type Error = KeepMobileError;
 
     fn try_from(e: SigningAuditEntry) -> Result<Self, Self::Error> {
-        if e.prev_hash.len() != 32 {
-            return Err(KeepMobileError::InvalidInput {
-                msg: format!("prev_hash length {} != 32", e.prev_hash.len()),
-            });
-        }
-        if e.hash.len() != 32 {
-            return Err(KeepMobileError::InvalidInput {
-                msg: format!("hash length {} != 32", e.hash.len()),
-            });
-        }
+        require_hash_32(&e.prev_hash, "prev_hash")?;
+        require_hash_32(&e.hash, "hash")?;
         Ok(Self {
             timestamp: e.timestamp,
             request_type: e.request_type,
@@ -556,11 +543,18 @@ pub struct SigningAuditLog {
 }
 
 impl SigningAuditLog {
-    fn load_all_entries(&self) -> Result<Vec<SigningAuditEntry>, KeepMobileError> {
+    fn load_all_checked(&self) -> Result<Vec<SigningAuditEntry>, KeepMobileError> {
         const _: () = assert!(MAX_AUDIT_ENTRIES < u32::MAX as usize);
         let entry_jsons = self
             .storage
             .load_entries(Some(MAX_AUDIT_ENTRIES as u32 + 1))?;
+        if entry_jsons.len() > MAX_AUDIT_ENTRIES {
+            return Err(KeepMobileError::StorageError {
+                msg: format!(
+                    "Signing audit log exceeds maximum of {MAX_AUDIT_ENTRIES} entries"
+                ),
+            });
+        }
         let mut entries = Vec::with_capacity(entry_jsons.len());
         for json in entry_jsons {
             let entry: SigningAuditEntry =
@@ -683,20 +677,8 @@ impl SigningAuditLog {
     }
 
     pub fn verify_chain(&self) -> Result<ChainStatus, KeepMobileError> {
-        let entries = self.load_all_entries()?;
-
-        if entries.len() > MAX_AUDIT_ENTRIES {
-            return Err(KeepMobileError::StorageError {
-                msg: format!("Signing audit log exceeds maximum of {MAX_AUDIT_ENTRIES} entries"),
-            });
-        }
-
-        let count: u32 = entries
-            .len()
-            .try_into()
-            .map_err(|_| KeepMobileError::StorageError {
-                msg: "Entry count exceeds u32".into(),
-            })?;
+        let entries = self.load_all_checked()?;
+        let count = entries.len() as u32;
 
         let mut prev_hash = [0u8; 32];
         for entry in entries {
@@ -723,12 +705,7 @@ impl SigningAuditLog {
     }
 
     pub fn export_json(&self) -> Result<String, KeepMobileError> {
-        let entries = self.load_all_entries()?;
-        if entries.len() > MAX_AUDIT_ENTRIES {
-            return Err(KeepMobileError::StorageError {
-                msg: format!("Signing audit log exceeds maximum of {MAX_AUDIT_ENTRIES} entries"),
-            });
-        }
+        let entries = self.load_all_checked()?;
         let exports: Vec<SigningAuditEntryExport> = entries
             .into_iter()
             .map(SigningAuditEntryExport::try_from)
@@ -759,6 +736,11 @@ impl SigningAuditLog {
 mod tests {
     use super::*;
     use std::sync::{Arc, Mutex};
+
+    fn assert_lowercase_hex(s: &str) {
+        assert_eq!(s.len(), 64);
+        assert!(s.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+    }
 
     struct MockStorage {
         entries: Mutex<Vec<String>>,
@@ -861,16 +843,8 @@ mod tests {
         assert_eq!(entries[0].event_type, AuditEventType::Sign);
         assert_eq!(entries[0].pubkey.as_deref(), Some("pk1"));
         assert!(entries[0].success);
-        assert_eq!(entries[0].hash.len(), 64);
-        assert!(entries[0]
-            .hash
-            .chars()
-            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
-        assert_eq!(entries[0].prev_hash.len(), 64);
-        assert!(entries[0]
-            .prev_hash
-            .chars()
-            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        assert_lowercase_hex(&entries[0].hash);
+        assert_lowercase_hex(&entries[0].prev_hash);
     }
 
     #[test]
@@ -1125,16 +1099,8 @@ mod tests {
         assert_eq!(entries[0].caller, "app1");
         assert_eq!(entries[0].caller_name.as_deref(), Some("Test App"));
         assert_eq!(entries[0].event_kind, Some(1));
-        assert_eq!(entries[0].hash.len(), 64);
-        assert!(entries[0]
-            .hash
-            .chars()
-            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
-        assert_eq!(entries[0].prev_hash.len(), 64);
-        assert!(entries[0]
-            .prev_hash
-            .chars()
-            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        assert_lowercase_hex(&entries[0].hash);
+        assert_lowercase_hex(&entries[0].prev_hash);
     }
 
     #[test]

--- a/keep-mobile/src/audit.rs
+++ b/keep-mobile/src/audit.rs
@@ -269,18 +269,28 @@ impl AuditLog {
     }
 
     pub fn export_json(&self) -> Result<String, KeepMobileError> {
-        let entries: Vec<AuditEntryExport> = self
-            .get_entries(None)?
+        let entries = self.get_entries(Some(MAX_AUDIT_ENTRIES as u32 + 1))?;
+        if entries.len() > MAX_AUDIT_ENTRIES {
+            return Err(KeepMobileError::StorageError {
+                msg: format!("Audit log exceeds maximum of {MAX_AUDIT_ENTRIES} entries"),
+            });
+        }
+        let exports: Vec<AuditEntryExport> = entries
             .into_iter()
             .map(AuditEntryExport::try_from)
             .collect::<Result<Vec<_>, _>>()?;
-        serde_json::to_string_pretty(&entries).map_err(|e| KeepMobileError::Serialization {
+        serde_json::to_string_pretty(&exports).map_err(|e| KeepMobileError::Serialization {
             msg: format!("Export failed: {e}"),
         })
     }
 
     pub fn verify_chain(&self) -> Result<bool, KeepMobileError> {
-        let entries = self.get_entries(None)?;
+        let entries = self.get_entries(Some(MAX_AUDIT_ENTRIES as u32 + 1))?;
+        if entries.len() > MAX_AUDIT_ENTRIES {
+            return Err(KeepMobileError::StorageError {
+                msg: format!("Audit log exceeds maximum of {MAX_AUDIT_ENTRIES} entries"),
+            });
+        }
         let mut prev_hash = [0u8; 32];
 
         for entry in entries {
@@ -702,12 +712,17 @@ impl SigningAuditLog {
     }
 
     pub fn export_json(&self) -> Result<String, KeepMobileError> {
-        let entries: Vec<SigningAuditEntryExport> = self
-            .load_all_entries()?
+        let entries = self.load_all_entries()?;
+        if entries.len() > MAX_AUDIT_ENTRIES {
+            return Err(KeepMobileError::StorageError {
+                msg: format!("Signing audit log exceeds maximum of {MAX_AUDIT_ENTRIES} entries"),
+            });
+        }
+        let exports: Vec<SigningAuditEntryExport> = entries
             .into_iter()
             .map(SigningAuditEntryExport::try_from)
             .collect::<Result<Vec<_>, _>>()?;
-        serde_json::to_string_pretty(&entries).map_err(|e| KeepMobileError::Serialization {
+        serde_json::to_string_pretty(&exports).map_err(|e| KeepMobileError::Serialization {
             msg: format!("Export failed: {e}"),
         })
     }

--- a/keep-mobile/src/audit.rs
+++ b/keep-mobile/src/audit.rs
@@ -613,6 +613,31 @@ impl SigningAuditLog {
         })
     }
 
+    pub fn export_json(&self) -> Result<String, KeepMobileError> {
+        let entry_jsons = self.storage.load_entries(None)?;
+
+        if entry_jsons.len() > MAX_AUDIT_ENTRIES {
+            return Err(KeepMobileError::StorageError {
+                msg: format!(
+                    "Signing audit log exceeds maximum of {MAX_AUDIT_ENTRIES} entries"
+                ),
+            });
+        }
+
+        let mut entries = Vec::with_capacity(entry_jsons.len());
+        for json in entry_jsons {
+            let entry: SigningAuditEntry =
+                serde_json::from_str(&json).map_err(|e| KeepMobileError::Serialization {
+                    msg: format!("Invalid signing audit entry: {e}"),
+                })?;
+            entries.push(entry);
+        }
+
+        serde_json::to_string_pretty(&entries).map_err(|e| KeepMobileError::Serialization {
+            msg: format!("Export failed: {e}"),
+        })
+    }
+
     pub fn get_entry_count(&self) -> Result<u32, KeepMobileError> {
         self.storage.entry_count()
     }
@@ -922,6 +947,28 @@ mod tests {
 
         let callers = log.get_distinct_callers().unwrap();
         assert_eq!(callers.len(), 3);
+    }
+
+    #[test]
+    fn test_signing_audit_export_json() {
+        let storage = Arc::new(MockSigningStorage::new());
+        let log = SigningAuditLog::new(storage).unwrap();
+
+        log.log_event(
+            SigningRequestType::SignEvent,
+            SigningDecision::Approved,
+            false,
+            "app1".into(),
+            Some("Test App".into()),
+            Some(1),
+            None,
+        )
+        .unwrap();
+
+        let json = log.export_json().unwrap();
+        assert!(json.contains("SignEvent"), "JSON: {json}");
+        assert!(json.contains("app1"), "JSON: {json}");
+        assert!(json.contains("Test App"), "JSON: {json}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `export_json()` to `AuditLog` and `SigningAuditLog` for full audit log export
- Hash fields exported as hex strings via dedicated export structs
- Deduplicated entry loading across `verify_chain` and `export_json`

## Test plan
- [x] Unit tests for JSON round-trip validation
- [x] Empty log export test
- [x] Hex encoding verification (64-char lowercase hex)
- [x] All existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added export support for signing audit logs and a public audit export that emits validated export records.

* **Improvements**
  * Audit exports now serialize hashes as validated lowercase 64-character hex strings.
  * Export and verification now enforce an explicit maximum entry limit before processing.

* **Tests**
  * Added tests for exported audit entries, lowercase-hex hash formatting, chain linkage, and export/verification limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->