### PR TITLE
Add NIP-46 register_wallet for hardware signers

### DIFF
--- a/keep-bitcoin/src/descriptor.rs
+++ b/keep-bitcoin/src/descriptor.rs
@@ -144,14 +144,14 @@ impl DescriptorExport {
 
 /// Build a BIP-389 multipath descriptor from a single-path external descriptor.
 ///
-/// Rewrites every trailing `/0/*` key derivation to `/<0;1>/*`. Keys already in
-/// multipath form (`<0;1>` or `<1;0>`) are normalized to `<0;1>` so all keys in
-/// a multisig descriptor agree on the external/change order. Matching is
+/// Rewrites every trailing `/0/*` key derivation to `/<0;1>/*`. Matching is
 /// anchored so only a `/0/*` that terminates a key expression (immediately
 /// followed by `,` or `)`, and preceded by a non-`/` character) is rewritten;
 /// occurrences inside longer paths or origin info are left alone. Descriptors
-/// containing a terminating `/1/*` (internal) path are rejected rather than
-/// silently coerced.
+/// containing a terminating `/1/*` (internal) path, or already holding
+/// `<1;0>` (reverse-order multipath), are rejected rather than silently
+/// coerced: swapping external and change order would produce divergent
+/// receive/change mappings across co-signers.
 pub fn multipath_from_external(external: &str) -> Result<String> {
     let body = external.split('#').next().unwrap_or(external);
 
@@ -160,9 +160,13 @@ pub fn multipath_from_external(external: &str) -> Result<String> {
             "descriptor contains /1/* internal path; expected external /0/* or multipath".into(),
         ));
     }
+    if body.contains("<1;0>") {
+        return Err(BitcoinError::Descriptor(
+            "descriptor uses <1;0> multipath order; reorder to <0;1> before building".into(),
+        ));
+    }
 
     let normalized = keep_core::descriptor::rewrite_trailing_zero_star(body);
-    let normalized = normalized.replace("<1;0>", "<0;1>");
 
     let checksum = compute_checksum(&normalized)?;
     Ok(format!("{normalized}#{checksum}"))
@@ -432,13 +436,12 @@ mod tests {
     }
 
     #[test]
-    fn test_multipath_normalizes_reverse_order_marker() {
+    fn test_multipath_rejects_reverse_order_marker() {
         let xpub = "xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz";
         let input = format!("wsh(sortedmulti(2,{xpub}/<1;0>/*,{xpub}/<0;1>/*))");
-        let out = multipath_from_external(&input).unwrap();
-        let body = out.split('#').next().unwrap();
-        assert!(!body.contains("<1;0>"));
-        assert_eq!(body.matches("<0;1>").count(), 2);
+        let err = multipath_from_external(&input).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("<1;0>"), "unexpected error: {msg}");
     }
 
     #[test]

--- a/keep-bitcoin/src/descriptor.rs
+++ b/keep-bitcoin/src/descriptor.rs
@@ -430,6 +430,17 @@ mod tests {
     }
 
     #[test]
+    fn test_multipath_no_derivation_tail_unchanged() {
+        // Bare descriptor with no /0/* tail: body should be unchanged aside
+        // from the appended checksum.
+        let xpub = "xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz";
+        let input = format!("tr({xpub})");
+        let out = multipath_from_external(&input).unwrap();
+        let body = out.split('#').next().unwrap();
+        assert_eq!(body, input);
+    }
+
+    #[test]
     fn test_multipath_rejects_internal_only_descriptor() {
         let err = multipath_from_external("tr(xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz/1/*)");
         assert!(err.is_err());

--- a/keep-bitcoin/src/descriptor.rs
+++ b/keep-bitcoin/src/descriptor.rs
@@ -144,21 +144,18 @@ impl DescriptorExport {
 
 /// Build a BIP-389 multipath descriptor from a single-path external descriptor.
 ///
-/// `tr(.../0/*)#chk` becomes `tr(.../<0;1>/*)#newchk`. Descriptors that contain
-/// no `/0/*` derivation path are returned with a (re)computed checksum.
+/// Rewrites every trailing `/0/*` key derivation to `/<0;1>/*`. Keys already in
+/// multipath form (`<0;1>` or `<1;0>`) are left untouched, so mixed multisig
+/// descriptors where some keys are single-path and some are multipath are
+/// normalized to fully multipath. Matching is anchored to `,` and `)` so
+/// occurrences inside origin info (bracketed `[fp/path]`) cannot be rewritten.
 pub fn multipath_from_external(external: &str) -> Result<String> {
     let body = external.split('#').next().unwrap_or(external);
-    if body.contains("<0;1>") || body.contains("<1;0>") {
-        let checksum = compute_checksum(body)?;
-        return Ok(format!("{body}#{checksum}"));
-    }
-    if !body.contains("/0/*") {
-        let checksum = compute_checksum(body)?;
-        return Ok(format!("{body}#{checksum}"));
-    }
-    let multipath = body.replace("/0/*", "/<0;1>/*");
-    let checksum = compute_checksum(&multipath)?;
-    Ok(format!("{multipath}#{checksum}"))
+    let normalized = body
+        .replace("/0/*)", "/<0;1>/*)")
+        .replace("/0/*,", "/<0;1>/*,");
+    let checksum = compute_checksum(&normalized)?;
+    Ok(format!("{normalized}#{checksum}"))
 }
 
 fn compute_checksum(descriptor: &str) -> Result<String> {
@@ -366,6 +363,47 @@ mod tests {
         let xpub_str = xpub.to_string();
 
         assert!(xpub_to_x_only(&xpub_str, Network::Bitcoin).is_err());
+    }
+
+    #[test]
+    fn test_multipath_rewrites_single_key() {
+        let out = multipath_from_external("tr(xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz/0/*)").unwrap();
+        let body = out.split('#').next().unwrap();
+        assert!(body.ends_with("/<0;1>/*)"));
+        assert!(!body.contains("/0/*)"));
+    }
+
+    #[test]
+    fn test_multipath_preserves_already_multipath() {
+        let out = multipath_from_external(
+            "tr(xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz/<0;1>/*)",
+        )
+        .unwrap();
+        let body = out.split('#').next().unwrap();
+        assert!(body.ends_with("/<0;1>/*)"));
+        assert_eq!(body.matches("<0;1>").count(), 1);
+    }
+
+    #[test]
+    fn test_multipath_normalizes_mixed_multisig() {
+        let xpub = "xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz";
+        let input = format!("wsh(sortedmulti(2,{xpub}/<0;1>/*,{xpub}/0/*))");
+        let out = multipath_from_external(&input).unwrap();
+        let body = out.split('#').next().unwrap();
+        assert_eq!(body.matches("<0;1>").count(), 2);
+        assert!(!body.contains("/0/*,"));
+        assert!(!body.contains("/0/*)"));
+    }
+
+    #[test]
+    fn test_multipath_leaves_origin_info_alone() {
+        let out = multipath_from_external(
+            "tr([deadbeef/86'/0'/0']xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz/0/*)",
+        )
+        .unwrap();
+        let body = out.split('#').next().unwrap();
+        assert!(body.contains("[deadbeef/86'/0'/0']"));
+        assert!(body.ends_with("/<0;1>/*)"));
     }
 
     #[test]

--- a/keep-bitcoin/src/descriptor.rs
+++ b/keep-bitcoin/src/descriptor.rs
@@ -145,15 +145,25 @@ impl DescriptorExport {
 /// Build a BIP-389 multipath descriptor from a single-path external descriptor.
 ///
 /// Rewrites every trailing `/0/*` key derivation to `/<0;1>/*`. Keys already in
-/// multipath form (`<0;1>` or `<1;0>`) are left untouched, so mixed multisig
-/// descriptors where some keys are single-path and some are multipath are
-/// normalized to fully multipath. Matching is anchored to `,` and `)` so
-/// occurrences inside origin info (bracketed `[fp/path]`) cannot be rewritten.
+/// multipath form (`<0;1>` or `<1;0>`) are normalized to `<0;1>` so all keys in
+/// a multisig descriptor agree on the external/change order. Matching is
+/// anchored so only a `/0/*` that terminates a key expression (immediately
+/// followed by `,` or `)`, and preceded by a non-`/` character) is rewritten;
+/// occurrences inside longer paths or origin info are left alone. Descriptors
+/// containing a terminating `/1/*` (internal) path are rejected rather than
+/// silently coerced.
 pub fn multipath_from_external(external: &str) -> Result<String> {
     let body = external.split('#').next().unwrap_or(external);
-    let normalized = body
-        .replace("/0/*)", "/<0;1>/*)")
-        .replace("/0/*,", "/<0;1>/*,");
+
+    if keep_core::descriptor::contains_tail(body, '1') {
+        return Err(BitcoinError::Descriptor(
+            "descriptor contains /1/* internal path; expected external /0/* or multipath".into(),
+        ));
+    }
+
+    let normalized = keep_core::descriptor::rewrite_trailing_zero_star(body);
+    let normalized = normalized.replace("<1;0>", "<0;1>");
+
     let checksum = compute_checksum(&normalized)?;
     Ok(format!("{normalized}#{checksum}"))
 }
@@ -404,6 +414,31 @@ mod tests {
         let body = out.split('#').next().unwrap();
         assert!(body.contains("[deadbeef/86'/0'/0']"));
         assert!(body.ends_with("/<0;1>/*)"));
+    }
+
+    #[test]
+    fn test_multipath_does_not_mangle_nested_paths() {
+        // xpub/0/0/*) must become xpub/0/<0;1>/*), not xpub/<0;1>/*.
+        let input = "tr(xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz/0/0/*)";
+        let out = multipath_from_external(input).unwrap();
+        let body = out.split('#').next().unwrap();
+        assert!(body.ends_with("/0/<0;1>/*)"));
+    }
+
+    #[test]
+    fn test_multipath_rejects_internal_only_descriptor() {
+        let err = multipath_from_external("tr(xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz/1/*)");
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn test_multipath_normalizes_reverse_order_marker() {
+        let xpub = "xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz";
+        let input = format!("wsh(sortedmulti(2,{xpub}/<1;0>/*,{xpub}/<0;1>/*))");
+        let out = multipath_from_external(&input).unwrap();
+        let body = out.split('#').next().unwrap();
+        assert!(!body.contains("<1;0>"));
+        assert_eq!(body.matches("<0;1>").count(), 2);
     }
 
     #[test]

--- a/keep-bitcoin/src/descriptor.rs
+++ b/keep-bitcoin/src/descriptor.rs
@@ -114,6 +114,10 @@ impl DescriptorExport {
         Ok(format!("{internal}#{checksum}"))
     }
 
+    pub fn multipath_descriptor(&self) -> Result<String> {
+        multipath_from_external(&self.descriptor)
+    }
+
     pub fn to_sparrow_json(&self, name: &str) -> Result<String> {
         let internal = self.internal_descriptor()?;
 
@@ -136,6 +140,25 @@ impl DescriptorExport {
 
         serde_json::to_string_pretty(&json).map_err(|e| BitcoinError::Descriptor(e.to_string()))
     }
+}
+
+/// Build a BIP-389 multipath descriptor from a single-path external descriptor.
+///
+/// `tr(.../0/*)#chk` becomes `tr(.../<0;1>/*)#newchk`. Descriptors that contain
+/// no `/0/*` derivation path are returned with a (re)computed checksum.
+pub fn multipath_from_external(external: &str) -> Result<String> {
+    let body = external.split('#').next().unwrap_or(external);
+    if body.contains("<0;1>") || body.contains("<1;0>") {
+        let checksum = compute_checksum(body)?;
+        return Ok(format!("{body}#{checksum}"));
+    }
+    if !body.contains("/0/*") {
+        let checksum = compute_checksum(body)?;
+        return Ok(format!("{body}#{checksum}"));
+    }
+    let multipath = body.replace("/0/*", "/<0;1>/*");
+    let checksum = compute_checksum(&multipath)?;
+    Ok(format!("{multipath}#{checksum}"))
 }
 
 fn compute_checksum(descriptor: &str) -> Result<String> {

--- a/keep-bitcoin/src/lib.rs
+++ b/keep-bitcoin/src/lib.rs
@@ -13,7 +13,7 @@ pub mod recovery_tx;
 mod signer;
 
 pub use address::{AddressDerivation, DerivedAddress};
-pub use descriptor::{xpub_to_x_only, DescriptorExport};
+pub use descriptor::{multipath_from_external, xpub_to_x_only, DescriptorExport};
 pub use error::{BitcoinError, Result};
 pub use key_proof::{build_key_proof_psbt, sign_key_proof, verify_key_proof};
 pub use psbt::{PsbtAnalysis, PsbtSigner};

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -210,6 +210,11 @@ pub(crate) enum WalletCommands {
         #[arg(long, help = "Wallet display name sent to the signer")]
         name: Option<String>,
     },
+    /// List hardware signers that have registered a stored wallet
+    Registrations {
+        #[arg(short, long, help = "FROST group npub or hex")]
+        group: String,
+    },
     /// Propose a wallet descriptor via Nostr descriptor coordination
     Propose {
         #[arg(short, long, help = "FROST group npub or hex")]

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -209,11 +209,15 @@ pub(crate) enum WalletCommands {
         device: String,
         #[arg(long, help = "Wallet display name sent to the signer")]
         name: Option<String>,
+        #[arg(long, help = "Print the registration token (HMAC) to the terminal")]
+        show_token: bool,
     },
     /// List hardware signers that have registered a stored wallet
     Registrations {
         #[arg(short, long, help = "FROST group npub or hex")]
         group: String,
+        #[arg(long, help = "Print the registration tokens (HMACs) to the terminal")]
+        show_token: bool,
     },
     /// Propose a wallet descriptor via Nostr descriptor coordination
     Propose {

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -197,6 +197,19 @@ pub(crate) enum WalletCommands {
         )]
         xpub: Vec<String>,
     },
+    /// Register a stored wallet descriptor on a NIP-46 hardware signer
+    Register {
+        #[arg(short, long, help = "FROST group npub or hex")]
+        group: String,
+        #[arg(
+            short,
+            long,
+            help = "NIP-46 bunker URI (bunker://<pubkey>?relay=...&secret=...)"
+        )]
+        device: String,
+        #[arg(long, help = "Wallet display name sent to the signer")]
+        name: Option<String>,
+    },
     /// Propose a wallet descriptor via Nostr descriptor coordination
     Propose {
         #[arg(short, long, help = "FROST group npub or hex")]

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -173,6 +173,7 @@ pub fn cmd_frost_network_serve(
                                 internal_descriptor,
                                 network,
                                 created_at: now,
+                                device_registrations: Vec::new(),
                             };
                             let guard = keep.lock().expect("keep mutex poisoned");
                             match guard.store_wallet_descriptor(&descriptor) {

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -313,16 +313,9 @@ pub fn cmd_wallet_register(
 
     out.success("Wallet registered on device!");
     out.field("Signer pubkey", &hex::encode(signer_bytes));
-    match (&response.hmac, show_token) {
-        (Some(hmac), true) => out.field("Registration token", &hex::encode(hmac.as_slice())),
-        (Some(hmac), false) => out.field(
-            "Registration token",
-            &format!(
-                "[redacted; {} bytes] (use --show-token to reveal)",
-                hmac.len()
-            ),
-        ),
-        (None, _) => out.info("Device did not return a registration token."),
+    match response.hmac.as_deref() {
+        Some(hmac) => out.field("Registration token", &format_token(hmac, show_token)),
+        None => out.info("Device did not return a registration token."),
     }
     out.info("Registration saved to wallet descriptor.");
 
@@ -362,16 +355,8 @@ pub fn cmd_wallet_registrations(
         out.field("Signer pubkey", &hex::encode(reg.signer_pubkey));
         out.field("Wallet name", &reg.wallet_name);
         out.field("Registered at", &format_registered_at(reg.registered_at));
-        if let Some(hmac) = &reg.hmac {
-            let value = if show_token {
-                hex::encode(hmac.as_slice())
-            } else {
-                format!(
-                    "[redacted; {} bytes] (use --show-token to reveal)",
-                    hmac.len()
-                )
-            };
-            out.field("Registration token", &value);
+        if let Some(hmac) = reg.hmac.as_deref() {
+            out.field("Registration token", &format_token(hmac, show_token));
         }
     }
 
@@ -408,6 +393,17 @@ fn truncate_relay_for_log(relay: &str) -> String {
     }
     let prefix: String = relay.chars().take(PREFIX_LEN).collect();
     format!("{prefix}...")
+}
+
+fn format_token(hmac: &[u8], show_token: bool) -> String {
+    if show_token {
+        hex::encode(hmac)
+    } else {
+        format!(
+            "[redacted; {} bytes] (use --show-token to reveal)",
+            hmac.len()
+        )
+    }
 }
 
 fn format_registered_at(ts: u64) -> String {

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -239,6 +239,9 @@ pub fn cmd_wallet_register(
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
 
+    let multipath = keep_bitcoin::multipath_from_external(&desc.external_descriptor)
+        .map_err(|e| KeepError::Runtime(format!("build multipath descriptor: {e}")))?;
+
     rt.block_on(async {
         let spinner = out.spinner("Connecting to signer...");
         let client = keep_nip46::Nip46Client::connect_to(device_uri)
@@ -246,25 +249,34 @@ pub fn cmd_wallet_register(
             .map_err(|e| KeepError::Runtime(format!("connect: {e}")))?;
         spinner.finish();
 
-        let spinner = out.spinner("Authenticating with signer...");
-        client
-            .connect()
-            .await
-            .map_err(|e| KeepError::Runtime(format!("handshake: {e}")))?;
-        spinner.finish();
+        let outcome = async {
+            let spinner = out.spinner("Authenticating with signer...");
+            client
+                .connect()
+                .await
+                .map_err(|e| KeepError::Runtime(format!("handshake: {e}")))?;
+            spinner.finish();
 
-        let spinner = out.spinner("Registering wallet on device (confirm on device)...");
-        let response = client
-            .register_wallet(&wallet_name, &desc.external_descriptor)
-            .await
-            .map_err(|e| KeepError::Runtime(format!("register_wallet: {e}")))?;
-        spinner.finish();
+            let spinner = out.spinner("Registering wallet on device (confirm on device)...");
+            let response = client
+                .register_wallet(&wallet_name, &multipath)
+                .await
+                .map_err(|e| KeepError::Runtime(format!("register_wallet: {e}")))?;
+            spinner.finish();
+            Ok::<_, KeepError>(response)
+        }
+        .await;
 
         client.disconnect().await;
+
+        let response = outcome?;
 
         out.success("Wallet registered on device!");
         if let Some(hmac) = response.hmac {
             out.field("Registration token", &hex::encode(hmac));
+            // TODO: persist the HMAC in WalletDescriptor per signer pubkey so
+            // subsequent sessions can prove prior registration to the device.
+            out.info("Save this token: it is required for subsequent device sessions.");
         } else {
             out.info("Device did not return a registration token.");
         }

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -297,10 +297,27 @@ pub fn cmd_wallet_register(
     let (signer_pubkey, response) = register_outcome?;
 
     let signer_bytes = signer_pubkey.to_bytes();
+    let signer_hex = hex::encode(signer_bytes);
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
+
+    // Surface the device-side outcome before attempting local persistence so an
+    // operator knows registration already took effect on the signer if the
+    // local save errors below. Re-running register is idempotent.
+    out.success("Device accepted the wallet registration");
+    out.field("Signer pubkey", &signer_hex);
+    match response.hmac.as_deref() {
+        Some(hmac) => out.field("Registration token", &format_token(hmac, show_token)),
+        None => out.info("Device did not return a registration token."),
+    }
+
+    let token_status = if response.hmac.is_some() {
+        "received"
+    } else {
+        "none"
+    };
     keep.upsert_device_registration(
         &group_pubkey,
         keep_core::DeviceRegistration {
@@ -309,14 +326,13 @@ pub fn cmd_wallet_register(
             hmac: response.hmac.clone(),
             registered_at: now,
         },
-    )?;
+    )
+    .map_err(|e| {
+        KeepError::Other(format!(
+            "device registration already succeeded on signer {signer_hex} (token: {token_status}) but saving to local descriptor failed: {e}; re-running register is safe"
+        ))
+    })?;
 
-    out.success("Wallet registered on device!");
-    out.field("Signer pubkey", &hex::encode(signer_bytes));
-    match response.hmac.as_deref() {
-        Some(hmac) => out.field("Registration token", &format_token(hmac, show_token)),
-        None => out.info("Device did not return a registration token."),
-    }
     out.info("Registration saved to wallet descriptor.");
 
     Ok(())

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -203,6 +203,100 @@ pub fn cmd_wallet_descriptor(
     Ok(())
 }
 
+pub fn cmd_wallet_register(
+    out: &Output,
+    path: &Path,
+    group: &str,
+    device_uri: &str,
+    name: Option<&str>,
+) -> Result<()> {
+    debug!(group, device = %mask_secret(device_uri), "wallet register");
+
+    let group_pubkey = parse_group_id(group)?;
+
+    let mut keep = Keep::open(path)?;
+    let password = get_password("Enter password")?;
+
+    let spinner = out.spinner("Unlocking vault...");
+    keep.unlock(password.expose_secret())?;
+    spinner.finish();
+
+    let desc = keep
+        .get_wallet_descriptor(&group_pubkey)?
+        .ok_or_else(|| KeepError::KeyNotFound("no descriptor for this group".into()))?;
+
+    let wallet_name = name
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("keep-{}", hex::encode(&group_pubkey[..4])));
+
+    out.newline();
+    out.header("Register Wallet on Hardware Signer");
+    out.field("Group", &hex::encode(group_pubkey));
+    out.field("Network", &desc.network);
+    out.field("Wallet name", &wallet_name);
+    out.newline();
+
+    let rt =
+        tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
+
+    rt.block_on(async {
+        let spinner = out.spinner("Connecting to signer...");
+        let client = keep_nip46::Nip46Client::connect_to(device_uri)
+            .await
+            .map_err(|e| KeepError::Runtime(format!("connect: {e}")))?;
+        spinner.finish();
+
+        let spinner = out.spinner("Authenticating with signer...");
+        client
+            .connect()
+            .await
+            .map_err(|e| KeepError::Runtime(format!("handshake: {e}")))?;
+        spinner.finish();
+
+        let spinner = out.spinner("Registering wallet on device (confirm on device)...");
+        let response = client
+            .register_wallet(&wallet_name, &desc.external_descriptor)
+            .await
+            .map_err(|e| KeepError::Runtime(format!("register_wallet: {e}")))?;
+        spinner.finish();
+
+        client.disconnect().await;
+
+        out.success("Wallet registered on device!");
+        if let Some(hmac) = response.hmac {
+            out.field("Registration token", &hex::encode(hmac));
+        } else {
+            out.info("Device did not return a registration token.");
+        }
+        Ok::<_, KeepError>(())
+    })?;
+
+    Ok(())
+}
+
+fn mask_secret(uri: &str) -> String {
+    match url::Url::parse(uri) {
+        Ok(mut parsed) => {
+            let pairs: Vec<(String, String)> = parsed
+                .query_pairs()
+                .map(|(k, v)| {
+                    if k == "secret" {
+                        (k.into_owned(), "***".into())
+                    } else {
+                        (k.into_owned(), v.into_owned())
+                    }
+                })
+                .collect();
+            parsed.query_pairs_mut().clear();
+            for (k, v) in pairs {
+                parsed.query_pairs_mut().append_pair(&k, &v);
+            }
+            parsed.to_string()
+        }
+        Err(_) => "<invalid>".into(),
+    }
+}
+
 pub fn cmd_wallet_delete(out: &Output, path: &Path, group_hex: &str) -> Result<()> {
     let group_pubkey = parse_group_hex(group_hex)?;
 
@@ -1000,5 +1094,18 @@ mod tests {
         let err = parse_recovery_policy(&specs, 5);
         assert!(err.is_err());
         assert!(err.unwrap_err().to_string().contains("Duplicate timelock"));
+    }
+
+    #[test]
+    fn test_mask_secret_hides_bunker_secret() {
+        let uri = "bunker://aabbcc?relay=wss%3A%2F%2Frelay.example.com&secret=topsecret";
+        let masked = mask_secret(uri);
+        assert!(!masked.contains("topsecret"));
+        assert!(masked.contains("secret=%2A%2A%2A") || masked.contains("secret=***"));
+    }
+
+    #[test]
+    fn test_mask_secret_passthrough_invalid() {
+        assert_eq!(mask_secret("not a url"), "<invalid>");
     }
 }

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -210,6 +210,7 @@ pub fn cmd_wallet_register(
     group: &str,
     device_uri: &str,
     name: Option<&str>,
+    show_token: bool,
 ) -> Result<()> {
     debug!(group, device = %mask_secret(device_uri), "wallet register");
 
@@ -288,17 +289,28 @@ pub fn cmd_wallet_register(
 
     out.success("Wallet registered on device!");
     out.field("Signer pubkey", &hex::encode(signer_bytes));
-    if let Some(hmac) = &response.hmac {
-        out.field("Registration token", &hex::encode(hmac));
-    } else {
-        out.info("Device did not return a registration token.");
+    match (&response.hmac, show_token) {
+        (Some(hmac), true) => out.field("Registration token", &hex::encode(hmac)),
+        (Some(hmac), false) => out.field(
+            "Registration token",
+            &format!(
+                "[redacted; {} bytes] (use --show-token to reveal)",
+                hmac.len()
+            ),
+        ),
+        (None, _) => out.info("Device did not return a registration token."),
     }
     out.info("Registration saved to wallet descriptor.");
 
     Ok(())
 }
 
-pub fn cmd_wallet_registrations(out: &Output, path: &Path, group: &str) -> Result<()> {
+pub fn cmd_wallet_registrations(
+    out: &Output,
+    path: &Path,
+    group: &str,
+    show_token: bool,
+) -> Result<()> {
     let group_pubkey = parse_group_id(group)?;
 
     let mut keep = Keep::open(path)?;
@@ -327,7 +339,15 @@ pub fn cmd_wallet_registrations(out: &Output, path: &Path, group: &str) -> Resul
         out.field("Wallet name", &reg.wallet_name);
         out.field("Registered at", &reg.registered_at.to_string());
         if let Some(hmac) = &reg.hmac {
-            out.field("Registration token", &hex::encode(hmac));
+            let value = if show_token {
+                hex::encode(hmac)
+            } else {
+                format!(
+                    "[redacted; {} bytes] (use --show-token to reveal)",
+                    hmac.len()
+                )
+            };
+            out.field("Registration token", &value);
         }
     }
 

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -179,6 +179,7 @@ pub fn cmd_wallet_descriptor(
         internal_descriptor: internal.clone(),
         network: canonical_network.clone(),
         created_at: now,
+        device_registrations: Vec::new(),
     };
 
     let mut keep = Keep::open(path)?;
@@ -221,7 +222,7 @@ pub fn cmd_wallet_register(
     keep.unlock(password.expose_secret())?;
     spinner.finish();
 
-    let desc = keep
+    let mut desc = keep
         .get_wallet_descriptor(&group_pubkey)?
         .ok_or_else(|| KeepError::KeyNotFound("no descriptor for this group".into()))?;
 
@@ -242,12 +243,13 @@ pub fn cmd_wallet_register(
     let multipath = keep_bitcoin::multipath_from_external(&desc.external_descriptor)
         .map_err(|e| KeepError::Runtime(format!("build multipath descriptor: {e}")))?;
 
-    rt.block_on(async {
+    let (signer_pubkey, response) = rt.block_on(async {
         let spinner = out.spinner("Connecting to signer...");
         let client = keep_nip46::Nip46Client::connect_to(device_uri)
             .await
             .map_err(|e| KeepError::Runtime(format!("connect: {e}")))?;
         spinner.finish();
+        let signer = client.signer_pubkey();
 
         let outcome = async {
             let spinner = out.spinner("Authenticating with signer...");
@@ -268,20 +270,66 @@ pub fn cmd_wallet_register(
         .await;
 
         client.disconnect().await;
-
-        let response = outcome?;
-
-        out.success("Wallet registered on device!");
-        if let Some(hmac) = response.hmac {
-            out.field("Registration token", &hex::encode(hmac));
-            // TODO: persist the HMAC in WalletDescriptor per signer pubkey so
-            // subsequent sessions can prove prior registration to the device.
-            out.info("Save this token: it is required for subsequent device sessions.");
-        } else {
-            out.info("Device did not return a registration token.");
-        }
-        Ok::<_, KeepError>(())
+        Ok::<_, KeepError>((signer, outcome?))
     })?;
+
+    let signer_bytes = signer_pubkey.to_bytes();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    desc.upsert_device_registration(keep_core::DeviceRegistration {
+        signer_pubkey: signer_bytes,
+        wallet_name: wallet_name.clone(),
+        hmac: response.hmac.clone(),
+        registered_at: now,
+    });
+    keep.store_wallet_descriptor(&desc)?;
+
+    out.success("Wallet registered on device!");
+    out.field("Signer pubkey", &hex::encode(signer_bytes));
+    if let Some(hmac) = &response.hmac {
+        out.field("Registration token", &hex::encode(hmac));
+    } else {
+        out.info("Device did not return a registration token.");
+    }
+    out.info("Registration saved to wallet descriptor.");
+
+    Ok(())
+}
+
+pub fn cmd_wallet_registrations(out: &Output, path: &Path, group: &str) -> Result<()> {
+    let group_pubkey = parse_group_id(group)?;
+
+    let mut keep = Keep::open(path)?;
+    let password = get_password("Enter password")?;
+
+    let spinner = out.spinner("Unlocking vault...");
+    keep.unlock(password.expose_secret())?;
+    spinner.finish();
+
+    let desc = keep
+        .get_wallet_descriptor(&group_pubkey)?
+        .ok_or_else(|| KeepError::KeyNotFound("no descriptor for this group".into()))?;
+
+    out.newline();
+    out.header("Registered Hardware Signers");
+    out.field("Group", &hex::encode(group_pubkey));
+
+    if desc.device_registrations.is_empty() {
+        out.info("No hardware signers have registered this wallet.");
+        return Ok(());
+    }
+
+    for reg in &desc.device_registrations {
+        out.newline();
+        out.field("Signer pubkey", &hex::encode(reg.signer_pubkey));
+        out.field("Wallet name", &reg.wallet_name);
+        out.field("Registered at", &reg.registered_at.to_string());
+        if let Some(hmac) = &reg.hmac {
+            out.field("Registration token", &hex::encode(hmac));
+        }
+    }
 
     Ok(())
 }
@@ -789,6 +837,7 @@ pub fn cmd_wallet_propose(
             internal_descriptor,
             network: network.to_string(),
             created_at: now,
+            device_registrations: Vec::new(),
         };
 
         keep.store_wallet_descriptor(&descriptor)?;

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -223,13 +223,33 @@ pub fn cmd_wallet_register(
     keep.unlock(password.expose_secret())?;
     spinner.finish();
 
-    let mut desc = keep
+    let desc = keep
         .get_wallet_descriptor(&group_pubkey)?
         .ok_or_else(|| KeepError::KeyNotFound("no descriptor for this group".into()))?;
 
     let wallet_name = name
         .map(str::to_string)
         .unwrap_or_else(|| format!("keep-{}", hex::encode(&group_pubkey[..4])));
+    if wallet_name.is_empty() {
+        return Err(KeepError::InvalidInput(
+            "wallet name must not be empty".into(),
+        ));
+    }
+    if wallet_name.len() > keep_nip46::MAX_WALLET_NAME_LEN {
+        return Err(KeepError::InvalidInput(format!(
+            "wallet name exceeds {} bytes",
+            keep_nip46::MAX_WALLET_NAME_LEN
+        )));
+    }
+
+    let multipath = keep_bitcoin::multipath_from_external(&desc.external_descriptor)
+        .map_err(|e| KeepError::Runtime(format!("build multipath descriptor: {e}")))?;
+    if multipath.len() > keep_nip46::MAX_DESCRIPTOR_LEN {
+        return Err(KeepError::InvalidInput(format!(
+            "descriptor exceeds {} bytes",
+            keep_nip46::MAX_DESCRIPTOR_LEN
+        )));
+    }
 
     out.newline();
     out.header("Register Wallet on Hardware Signer");
@@ -241,10 +261,7 @@ pub fn cmd_wallet_register(
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
 
-    let multipath = keep_bitcoin::multipath_from_external(&desc.external_descriptor)
-        .map_err(|e| KeepError::Runtime(format!("build multipath descriptor: {e}")))?;
-
-    let (signer_pubkey, response) = rt.block_on(async {
+    let register_outcome = rt.block_on(async {
         let spinner = out.spinner("Connecting to signer...");
         let client = keep_nip46::Nip46Client::connect_to(device_uri)
             .await
@@ -272,25 +289,32 @@ pub fn cmd_wallet_register(
 
         client.disconnect().await;
         Ok::<_, KeepError>((signer, outcome?))
-    })?;
+    });
+    // Give nostr_sdk background tasks a chance to flush before we tear the
+    // runtime down; avoids aborting in-flight disconnect cleanup.
+    rt.shutdown_timeout(Duration::from_secs(2));
+
+    let (signer_pubkey, response) = register_outcome?;
 
     let signer_bytes = signer_pubkey.to_bytes();
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    desc.upsert_device_registration(keep_core::DeviceRegistration {
-        signer_pubkey: signer_bytes,
-        wallet_name: wallet_name.clone(),
-        hmac: response.hmac.clone(),
-        registered_at: now,
-    });
-    keep.store_wallet_descriptor(&desc)?;
+    keep.upsert_device_registration(
+        &group_pubkey,
+        keep_core::DeviceRegistration {
+            signer_pubkey: signer_bytes,
+            wallet_name: wallet_name.clone(),
+            hmac: response.hmac.clone(),
+            registered_at: now,
+        },
+    )?;
 
     out.success("Wallet registered on device!");
     out.field("Signer pubkey", &hex::encode(signer_bytes));
     match (&response.hmac, show_token) {
-        (Some(hmac), true) => out.field("Registration token", &hex::encode(hmac)),
+        (Some(hmac), true) => out.field("Registration token", &hex::encode(hmac.as_slice())),
         (Some(hmac), false) => out.field(
             "Registration token",
             &format!(
@@ -337,10 +361,10 @@ pub fn cmd_wallet_registrations(
         out.newline();
         out.field("Signer pubkey", &hex::encode(reg.signer_pubkey));
         out.field("Wallet name", &reg.wallet_name);
-        out.field("Registered at", &reg.registered_at.to_string());
+        out.field("Registered at", &format_registered_at(reg.registered_at));
         if let Some(hmac) = &reg.hmac {
             let value = if show_token {
-                hex::encode(hmac)
+                hex::encode(hmac.as_slice())
             } else {
                 format!(
                     "[redacted; {} bytes] (use --show-token to reveal)",
@@ -359,12 +383,12 @@ fn mask_secret(uri: &str) -> String {
         Ok(mut parsed) => {
             let pairs: Vec<(String, String)> = parsed
                 .query_pairs()
-                .map(|(k, v)| {
-                    if k == "secret" {
-                        (k.into_owned(), "***".into())
-                    } else {
-                        (k.into_owned(), v.into_owned())
-                    }
+                .map(|(k, v)| match k.as_ref() {
+                    "secret" => (k.into_owned(), "***".into()),
+                    // relay hostnames may include .onion or internal hosts we
+                    // don't want echoed to logs; truncate to a short prefix.
+                    "relay" => (k.into_owned(), truncate_relay_for_log(&v)),
+                    _ => (k.into_owned(), v.into_owned()),
                 })
                 .collect();
             parsed.query_pairs_mut().clear();
@@ -375,6 +399,22 @@ fn mask_secret(uri: &str) -> String {
         }
         Err(_) => "<invalid>".into(),
     }
+}
+
+fn truncate_relay_for_log(relay: &str) -> String {
+    const PREFIX_LEN: usize = 16;
+    if relay.len() <= PREFIX_LEN {
+        return relay.to_string();
+    }
+    let prefix: String = relay.chars().take(PREFIX_LEN).collect();
+    format!("{prefix}...")
+}
+
+fn format_registered_at(ts: u64) -> String {
+    let signed = i64::try_from(ts).unwrap_or(i64::MAX);
+    chrono::DateTime::<chrono::Utc>::from_timestamp(signed, 0)
+        .map(|dt| dt.to_rfc3339())
+        .unwrap_or_else(|| ts.to_string())
 }
 
 pub fn cmd_wallet_delete(out: &Output, path: &Path, group_hex: &str) -> Result<()> {
@@ -1188,5 +1228,19 @@ mod tests {
     #[test]
     fn test_mask_secret_passthrough_invalid() {
         assert_eq!(mask_secret("not a url"), "<invalid>");
+    }
+
+    #[test]
+    fn test_mask_secret_truncates_relay() {
+        let uri = "bunker://aabbcc?relay=wss%3A%2F%2Fabcdefghijklmnop.onion%2Fpath&secret=x";
+        let masked = mask_secret(uri);
+        assert!(!masked.contains("abcdefghijklmnop.onion/path"));
+        assert!(masked.contains("secret=%2A%2A%2A") || masked.contains("secret=***"));
+    }
+
+    #[test]
+    fn test_format_registered_at_rfc3339() {
+        let formatted = format_registered_at(0);
+        assert_eq!(formatted, "1970-01-01T00:00:00+00:00");
     }
 }

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -475,6 +475,9 @@ fn dispatch_wallet(
             device,
             name,
         } => commands::wallet::cmd_wallet_register(out, path, &group, &device, name.as_deref()),
+        WalletCommands::Registrations { group } => {
+            commands::wallet::cmd_wallet_registrations(out, path, &group)
+        }
     }
 }
 

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -470,6 +470,11 @@ fn dispatch_wallet(
                 out, path, &group, &network, relay, share, &recovery, timeout,
             )
         }
+        WalletCommands::Register {
+            group,
+            device,
+            name,
+        } => commands::wallet::cmd_wallet_register(out, path, &group, &device, name.as_deref()),
     }
 }
 

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -474,9 +474,17 @@ fn dispatch_wallet(
             group,
             device,
             name,
-        } => commands::wallet::cmd_wallet_register(out, path, &group, &device, name.as_deref()),
-        WalletCommands::Registrations { group } => {
-            commands::wallet::cmd_wallet_registrations(out, path, &group)
+            show_token,
+        } => commands::wallet::cmd_wallet_register(
+            out,
+            path,
+            &group,
+            &device,
+            name.as_deref(),
+            show_token,
+        ),
+        WalletCommands::Registrations { group, show_token } => {
+            commands::wallet::cmd_wallet_registrations(out, path, &group, show_token)
         }
     }
 }

--- a/keep-core/src/descriptor.rs
+++ b/keep-core/src/descriptor.rs
@@ -73,8 +73,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn contains_tail_rejects_nested_path() {
-        assert!(!contains_tail("xpub.../0/0/*)", '0'));
+    fn contains_tail_matches_terminating_tail_of_deeper_path() {
+        // Deeper paths like /86'/0'/0'/0/* also terminate in /0/*; the final
+        // segment drives external/change derivation and must be flagged.
+        assert!(contains_tail("xpub.../0/0/*)", '0'));
+    }
+
+    #[test]
+    fn contains_tail_ignores_non_terminating_matches() {
+        // /0/*/ is not a tail (not followed by ')' or ','): do not match.
+        assert!(!contains_tail("xpub.../0/*/0/*)", '1'));
+        // /0 not followed by /* is not a tail.
+        assert!(!contains_tail("xpub.../0/1/*)", '0'));
     }
 
     #[test]
@@ -84,7 +94,7 @@ mod tests {
     }
 
     #[test]
-    fn rewrite_leaves_nested_path_alone() {
+    fn rewrite_targets_the_terminating_segment() {
         let input = "tr(xpub.../0/0/*)";
         let out = rewrite_trailing_zero_star(input);
         assert_eq!(out, "tr(xpub.../0/<0;1>/*)");

--- a/keep-core/src/descriptor.rs
+++ b/keep-core/src/descriptor.rs
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: (C) 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+#![forbid(unsafe_code)]
+
+//! Shared text-level helpers for output descriptor strings.
+//!
+//! These helpers live in `keep-core` so that both `keep-bitcoin` (for
+//! normalization) and `keep-nip46` (for validation) can agree on how a
+//! single-path `/0/*` or `/1/*` tail is detected.
+
+/// Returns true if the descriptor body contains a key-expression-terminating
+/// `/{digit}/*` derivation suffix (anchored so matches inside longer paths or
+/// origin info are ignored).
+pub fn contains_tail(body: &str, digit: char) -> bool {
+    let bytes = body.as_bytes();
+    let digit_byte = digit as u8;
+    let mut i = 0;
+    while i + 4 < bytes.len() {
+        if bytes[i] == b'/'
+            && bytes[i + 1] == digit_byte
+            && bytes[i + 2] == b'/'
+            && bytes[i + 3] == b'*'
+            && matches!(bytes[i + 4], b')' | b',')
+            && (i == 0 || bytes[i - 1] != b'/')
+        {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+/// Rewrite every anchored `/0/*` tail to `/<0;1>/*`. Occurrences inside longer
+/// paths (preceded by `/`) or not followed by `,` or `)` are left alone.
+pub fn rewrite_trailing_zero_star(body: &str) -> String {
+    let bytes = body.as_bytes();
+    let mut out = String::with_capacity(body.len() + 8);
+    let mut i = 0;
+    while i < bytes.len() {
+        if i + 4 < bytes.len()
+            && bytes[i] == b'/'
+            && bytes[i + 1] == b'0'
+            && bytes[i + 2] == b'/'
+            && bytes[i + 3] == b'*'
+            && matches!(bytes[i + 4], b')' | b',')
+            && (i == 0 || bytes[i - 1] != b'/')
+        {
+            out.push_str("/<0;1>/*");
+            i += 4;
+        } else {
+            out.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Returns true if the descriptor body contains any BIP-389 multipath
+/// placeholder (`<0;1>` or `<1;0>`).
+pub fn has_multipath_marker(body: &str) -> bool {
+    body.contains("<0;1>") || body.contains("<1;0>")
+}
+
+/// Returns true if the descriptor body contains a terminating single-path
+/// `/0/*` or `/1/*` derivation suffix on any key expression.
+pub fn has_single_path_tail(body: &str) -> bool {
+    contains_tail(body, '0') || contains_tail(body, '1')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contains_tail_rejects_nested_path() {
+        assert!(!contains_tail("xpub.../0/0/*)", '0'));
+    }
+
+    #[test]
+    fn contains_tail_accepts_trailing() {
+        assert!(contains_tail("xpub.../0/*)", '0'));
+        assert!(contains_tail("xpub.../0/*,", '0'));
+    }
+
+    #[test]
+    fn rewrite_leaves_nested_path_alone() {
+        let input = "tr(xpub.../0/0/*)";
+        let out = rewrite_trailing_zero_star(input);
+        assert_eq!(out, "tr(xpub.../0/<0;1>/*)");
+    }
+
+    #[test]
+    fn rewrite_handles_multiple_keys() {
+        let input = "wsh(sortedmulti(2,xpub1/0/*,xpub2/0/*))";
+        let out = rewrite_trailing_zero_star(input);
+        assert_eq!(out, "wsh(sortedmulti(2,xpub1/<0;1>/*,xpub2/<0;1>/*))");
+    }
+
+    #[test]
+    fn rewrite_ignores_origin_info() {
+        let input = "tr([deadbeef/86'/0'/0']xpub.../0/*)";
+        let out = rewrite_trailing_zero_star(input);
+        assert_eq!(out, "tr([deadbeef/86'/0'/0']xpub.../<0;1>/*)");
+    }
+}

--- a/keep-core/src/descriptor.rs
+++ b/keep-core/src/descriptor.rs
@@ -9,9 +9,11 @@
 //! normalization) and `keep-nip46` (for validation) can agree on how a
 //! single-path `/0/*` or `/1/*` tail is detected.
 
-/// Returns true if the descriptor body contains a key-expression-terminating
-/// `/{digit}/*` derivation suffix (anchored so matches inside longer paths or
-/// origin info are ignored).
+/// Returns true if the descriptor body contains a terminating `/{digit}/*`
+/// derivation suffix, i.e. a `/{digit}/*` immediately followed by `)` or `,`.
+/// The guard `bytes[i - 1] != b'/'` only rejects a doubled slash `//{digit}/*`;
+/// nested paths like `xpub.../0/0/*)` also match at the trailing segment
+/// because that segment drives external/change derivation.
 pub fn contains_tail(body: &str, digit: char) -> bool {
     let bytes = body.as_bytes();
     let digit_byte = digit as u8;
@@ -31,12 +33,15 @@ pub fn contains_tail(body: &str, digit: char) -> bool {
     false
 }
 
-/// Rewrite every anchored `/0/*` tail to `/<0;1>/*`. Occurrences inside longer
-/// paths (preceded by `/`) or not followed by `,` or `)` are left alone.
+/// Rewrite every anchored `/0/*` tail (a `/0/*` followed by `)` or `,`, whose
+/// leading `/` is not itself preceded by another `/`) to `/<0;1>/*`. Works on
+/// byte indices but copies unchanged regions as UTF-8 slices so the output
+/// stays well-formed even if the input contains non-ASCII bytes.
 pub fn rewrite_trailing_zero_star(body: &str) -> String {
     let bytes = body.as_bytes();
     let mut out = String::with_capacity(body.len() + 8);
     let mut i = 0;
+    let mut run_start = 0;
     while i < bytes.len() {
         if i + 4 < bytes.len()
             && bytes[i] == b'/'
@@ -46,12 +51,18 @@ pub fn rewrite_trailing_zero_star(body: &str) -> String {
             && matches!(bytes[i + 4], b')' | b',')
             && (i == 0 || bytes[i - 1] != b'/')
         {
+            if run_start < i {
+                out.push_str(&body[run_start..i]);
+            }
             out.push_str("/<0;1>/*");
             i += 4;
+            run_start = i;
         } else {
-            out.push(bytes[i] as char);
             i += 1;
         }
+    }
+    if run_start < bytes.len() {
+        out.push_str(&body[run_start..]);
     }
     out
 }

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -86,7 +86,7 @@ use crate::keys::{KeyRecord, KeyType, NostrKeypair};
 pub use crate::relay::{PeerPolicyEntry, RelayConfig, GLOBAL_RELAY_KEY};
 pub use crate::storage::ProxyConfig;
 use crate::storage::Storage;
-pub use crate::wallet::WalletDescriptor;
+pub use crate::wallet::{DeviceRegistration, WalletDescriptor};
 
 /// The main Keep type for encrypted key management.
 pub struct Keep {

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -40,6 +40,8 @@ pub mod backend;
 pub mod backup;
 /// Cryptographic primitives for encryption, key derivation, and hashing.
 pub mod crypto;
+/// Shared text-level helpers for output descriptor strings.
+pub mod descriptor;
 /// Display formatting helpers for truncation and timestamps.
 pub mod display;
 /// Multi-source entropy mixing for defense-in-depth randomness.

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -690,6 +690,22 @@ impl Keep {
         self.storage.delete_descriptor(group_pubkey)
     }
 
+    /// Atomically insert or update a device registration on the descriptor for
+    /// the given FROST group. Performs the load-modify-store under the
+    /// storage's descriptor write lock so concurrent callers cannot drop each
+    /// other's updates.
+    pub fn upsert_device_registration(
+        &self,
+        group_pubkey: &[u8; 32],
+        registration: DeviceRegistration,
+    ) -> Result<()> {
+        if !self.is_unlocked() {
+            return Err(KeepError::Locked);
+        }
+        self.storage
+            .upsert_device_registration(group_pubkey, registration)
+    }
+
     /// Store a key health status record.
     pub fn store_health_status(&self, status: &wallet::KeyHealthStatus) -> Result<()> {
         if !self.is_unlocked() {

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -203,6 +203,10 @@ pub struct Storage {
     pub(crate) header: Header,
     pub(crate) data_key: Option<SecretKey>,
     pub(crate) backend: Option<Box<dyn StorageBackend>>,
+    /// Serializes read-modify-write sequences on wallet descriptors so that
+    /// e.g. two concurrent `upsert_device_registration` calls cannot drop
+    /// one another's updates.
+    pub(crate) descriptor_lock: std::sync::Mutex<()>,
 }
 
 fn create_storage_dir(path: &Path) -> Result<()> {
@@ -271,6 +275,7 @@ impl Storage {
             header,
             data_key: Some(data_key),
             backend: Some(backend),
+            descriptor_lock: std::sync::Mutex::new(()),
         })
     }
 
@@ -296,6 +301,7 @@ impl Storage {
             header,
             data_key: None,
             backend: None,
+            descriptor_lock: std::sync::Mutex::new(()),
         })
     }
 
@@ -626,6 +632,28 @@ impl Storage {
         }
 
         Ok(descriptors)
+    }
+
+    /// Atomically insert or update a device registration on the descriptor
+    /// for the given group. Serialized under `descriptor_lock` so concurrent
+    /// callers cannot lose each other's updates across the read-modify-write.
+    pub fn upsert_device_registration(
+        &self,
+        group_pubkey: &[u8; 32],
+        registration: crate::wallet::DeviceRegistration,
+    ) -> Result<()> {
+        let _guard = self
+            .descriptor_lock
+            .lock()
+            .map_err(|_| StorageError::database("descriptor lock poisoned"))?;
+        let mut descriptor = self.get_descriptor(group_pubkey)?.ok_or_else(|| {
+            KeepError::KeyNotFound(format!(
+                "wallet descriptor for group {} not found",
+                hex::encode(group_pubkey)
+            ))
+        })?;
+        descriptor.upsert_device_registration(registration);
+        self.store_descriptor(&descriptor)
     }
 
     /// Delete a wallet descriptor.

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -21,6 +21,7 @@ use crate::wallet::{KeyHealthStatus, WalletDescriptor};
 
 use bincode::Options;
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
 
 /// SOCKS5 proxy configuration stored in the vault.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -582,8 +583,10 @@ impl Storage {
         let data_key = self.data_key.as_ref().ok_or(KeepError::Locked)?;
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
 
-        let serialized = serde_json::to_vec(descriptor)
-            .map_err(|e| KeepError::Other(format!("json serialization failed: {e}")))?;
+        let serialized = Zeroizing::new(
+            serde_json::to_vec(descriptor)
+                .map_err(|e| KeepError::Other(format!("json serialization failed: {e}")))?,
+        );
         let encrypted = crypto::encrypt(&serialized, data_key)?;
         let encrypted_bytes = encrypted.to_bytes();
 

--- a/keep-core/src/wallet.rs
+++ b/keep-core/src/wallet.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
 
 /// Health status of a key share from a liveness check.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -45,11 +46,43 @@ pub struct DeviceRegistration {
     pub signer_pubkey: [u8; 32],
     /// The wallet name sent to the device at registration time.
     pub wallet_name: String,
-    /// The registration token (HMAC) returned by the device, if any.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub hmac: Option<Vec<u8>>,
+    /// Opaque registration token returned by the device, if any.
+    ///
+    /// This value is **not** cryptographically verified by keep-core; it is
+    /// an arbitrary byte string the device returned at registration time and
+    /// must not be treated as an authenticator unless a verification protocol
+    /// is added. The inner `Vec<u8>` is wrapped in `Zeroizing` so in-memory
+    /// copies are wiped on drop even when the enclosing descriptor is cloned.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "zeroizing_vec_opt"
+    )]
+    pub hmac: Option<Zeroizing<Vec<u8>>>,
     /// Unix timestamp of the successful registration.
     pub registered_at: u64,
+}
+
+mod zeroizing_vec_opt {
+    use super::*;
+    use serde::{Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(
+        value: &Option<Zeroizing<Vec<u8>>>,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        match value {
+            Some(v) => serializer.serialize_some(&v[..]),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Option<Zeroizing<Vec<u8>>>, D::Error> {
+        let opt: Option<Vec<u8>> = Option::deserialize(deserializer)?;
+        Ok(opt.map(Zeroizing::new))
+    }
 }
 
 impl std::fmt::Debug for DeviceRegistration {
@@ -140,19 +173,22 @@ mod tests {
         desc.upsert_device_registration(DeviceRegistration {
             signer_pubkey: signer,
             wallet_name: "first".into(),
-            hmac: Some(vec![1, 2, 3]),
+            hmac: Some(Zeroizing::new(vec![1, 2, 3])),
             registered_at: 1,
         });
         desc.upsert_device_registration(DeviceRegistration {
             signer_pubkey: signer,
             wallet_name: "second".into(),
-            hmac: Some(vec![9, 9, 9]),
+            hmac: Some(Zeroizing::new(vec![9, 9, 9])),
             registered_at: 2,
         });
         assert_eq!(desc.device_registrations.len(), 1);
         let reg = desc.device_registration(&signer).unwrap();
         assert_eq!(reg.wallet_name, "second");
-        assert_eq!(reg.hmac.as_deref(), Some(&[9, 9, 9][..]));
+        assert_eq!(
+            reg.hmac.as_ref().map(|v| v.as_slice()),
+            Some(&[9, 9, 9][..])
+        );
     }
 
     #[test]

--- a/keep-core/src/wallet.rs
+++ b/keep-core/src/wallet.rs
@@ -38,6 +38,20 @@ impl KeyHealthStatus {
     }
 }
 
+/// Record of a hardware signer that has registered this wallet via NIP-46.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeviceRegistration {
+    /// The NIP-46 signer pubkey (x-only, 32 bytes).
+    pub signer_pubkey: [u8; 32],
+    /// The wallet name sent to the device at registration time.
+    pub wallet_name: String,
+    /// The registration token (HMAC) returned by the device, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hmac: Option<Vec<u8>>,
+    /// Unix timestamp of the successful registration.
+    pub registered_at: u64,
+}
+
 /// A finalized wallet descriptor associated with a FROST group.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WalletDescriptor {
@@ -51,4 +65,90 @@ pub struct WalletDescriptor {
     pub network: String,
     /// Unix timestamp when the descriptor was created.
     pub created_at: u64,
+    /// Hardware signers that have registered this wallet.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub device_registrations: Vec<DeviceRegistration>,
+}
+
+impl WalletDescriptor {
+    /// Return the registration record for a signer pubkey, if any.
+    pub fn device_registration(&self, signer_pubkey: &[u8; 32]) -> Option<&DeviceRegistration> {
+        self.device_registrations
+            .iter()
+            .find(|r| &r.signer_pubkey == signer_pubkey)
+    }
+
+    /// Insert or update the registration for a signer pubkey.
+    pub fn upsert_device_registration(&mut self, reg: DeviceRegistration) {
+        if let Some(slot) = self
+            .device_registrations
+            .iter_mut()
+            .find(|r| r.signer_pubkey == reg.signer_pubkey)
+        {
+            *slot = reg;
+        } else {
+            self.device_registrations.push(reg);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_descriptor_back_compat_deserializes_without_registrations() {
+        let json = r#"{
+            "group_pubkey": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+            "external_descriptor": "tr(xpub.../0/*)#abc",
+            "internal_descriptor": "tr(xpub.../1/*)#def",
+            "network": "testnet",
+            "created_at": 1700000000
+        }"#;
+        let desc: WalletDescriptor = serde_json::from_str(json).expect("back-compat deserialize");
+        assert!(desc.device_registrations.is_empty());
+    }
+
+    #[test]
+    fn test_upsert_device_registration_inserts_then_replaces() {
+        let mut desc = WalletDescriptor {
+            group_pubkey: [0u8; 32],
+            external_descriptor: String::new(),
+            internal_descriptor: String::new(),
+            network: "testnet".into(),
+            created_at: 0,
+            device_registrations: Vec::new(),
+        };
+        let signer = [7u8; 32];
+        desc.upsert_device_registration(DeviceRegistration {
+            signer_pubkey: signer,
+            wallet_name: "first".into(),
+            hmac: Some(vec![1, 2, 3]),
+            registered_at: 1,
+        });
+        desc.upsert_device_registration(DeviceRegistration {
+            signer_pubkey: signer,
+            wallet_name: "second".into(),
+            hmac: Some(vec![9, 9, 9]),
+            registered_at: 2,
+        });
+        assert_eq!(desc.device_registrations.len(), 1);
+        let reg = desc.device_registration(&signer).unwrap();
+        assert_eq!(reg.wallet_name, "second");
+        assert_eq!(reg.hmac.as_deref(), Some(&[9, 9, 9][..]));
+    }
+
+    #[test]
+    fn test_empty_registrations_roundtrip_omits_field() {
+        let desc = WalletDescriptor {
+            group_pubkey: [0u8; 32],
+            external_descriptor: "a".into(),
+            internal_descriptor: "b".into(),
+            network: "testnet".into(),
+            created_at: 1,
+            device_registrations: Vec::new(),
+        };
+        let json = serde_json::to_string(&desc).unwrap();
+        assert!(!json.contains("device_registrations"));
+    }
 }

--- a/keep-core/src/wallet.rs
+++ b/keep-core/src/wallet.rs
@@ -39,7 +39,7 @@ impl KeyHealthStatus {
 }
 
 /// Record of a hardware signer that has registered this wallet via NIP-46.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeviceRegistration {
     /// The NIP-46 signer pubkey (x-only, 32 bytes).
     pub signer_pubkey: [u8; 32],
@@ -50,6 +50,23 @@ pub struct DeviceRegistration {
     pub hmac: Option<Vec<u8>>,
     /// Unix timestamp of the successful registration.
     pub registered_at: u64,
+}
+
+impl std::fmt::Debug for DeviceRegistration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeviceRegistration")
+            .field("signer_pubkey", &self.signer_pubkey)
+            .field("wallet_name", &self.wallet_name)
+            .field(
+                "hmac",
+                &self
+                    .hmac
+                    .as_ref()
+                    .map(|h| format!("<redacted; {} bytes>", h.len())),
+            )
+            .field("registered_at", &self.registered_at)
+            .finish()
+    }
 }
 
 /// A finalized wallet descriptor associated with a FROST group.

--- a/keep-desktop/src/app/mod.rs
+++ b/keep-desktop/src/app/mod.rs
@@ -307,6 +307,7 @@ impl App {
                 | Message::WalletSessionStarted(..)
                 | Message::WalletDescriptorProgress(..)
                 | Message::WalletAnnounceResult(..)
+                | Message::WalletRegisterResult(..)
                 | Message::ConnectRelayResult(..)
                 | Message::BunkerStartResult(..)
                 | Message::BunkerRevokeResult(..)
@@ -400,7 +401,8 @@ impl App {
             Message::WalletsLoaded(..)
             | Message::WalletSessionStarted(..)
             | Message::WalletDescriptorProgress(..)
-            | Message::WalletAnnounceResult(..) => self.handle_wallet_global_message(message),
+            | Message::WalletAnnounceResult(..)
+            | Message::WalletRegisterResult(..) => self.handle_wallet_global_message(message),
 
             Message::Relay(msg) => self.handle_relay_message(msg),
             Message::ConnectRelayResult(result) => self.handle_connect_relay_result(result),

--- a/keep-desktop/src/app/wallet.rs
+++ b/keep-desktop/src/app/wallet.rs
@@ -4,7 +4,8 @@ use crate::message::Message;
 use crate::screen::wallet::{self, DescriptorProgress, SetupPhase};
 use crate::screen::Screen;
 
-use super::{App, ToastKind, MAX_ACTIVE_COORDINATIONS};
+use super::util::with_keep_blocking;
+use super::{friendly_err, App, ToastKind, MAX_ACTIVE_COORDINATIONS};
 
 impl App {
     pub(crate) fn handle_wallet_message(&mut self, msg: wallet::Message) -> Task<Message> {
@@ -66,6 +67,17 @@ impl App {
                 )
             }
             wallet::Event::CopyDescriptor(desc) => iced::clipboard::write(desc),
+            wallet::Event::SubmitRegister {
+                group_pubkey,
+                external_descriptor,
+                device_uri,
+                wallet_name,
+            } => self.begin_register_on_device(
+                group_pubkey,
+                external_descriptor,
+                device_uri,
+                wallet_name,
+            ),
         }
     }
 
@@ -164,8 +176,103 @@ impl App {
                 }
                 Task::none()
             }
+            Message::WalletRegisterResult(result) => {
+                match result {
+                    Ok(()) => {
+                        if let Screen::Wallet(s) = &mut self.screen {
+                            s.register_submitted();
+                        }
+                        self.set_toast("Wallet registered on device".into(), ToastKind::Success);
+                    }
+                    Err(e) => {
+                        if let Screen::Wallet(s) = &mut self.screen {
+                            s.register_failed(e);
+                        }
+                    }
+                }
+                Task::none()
+            }
             _ => Task::none(),
         }
+    }
+
+    fn begin_register_on_device(
+        &mut self,
+        group_pubkey: [u8; 32],
+        external_descriptor: String,
+        device_uri: String,
+        wallet_name: String,
+    ) -> Task<Message> {
+        let multipath = match keep_bitcoin::multipath_from_external(&external_descriptor) {
+            Ok(m) => m,
+            Err(e) => {
+                if let Screen::Wallet(s) = &mut self.screen {
+                    s.register_failed(format!("build multipath descriptor: {e}"));
+                }
+                return Task::none();
+            }
+        };
+        if multipath.len() > keep_nip46::MAX_DESCRIPTOR_LEN {
+            if let Screen::Wallet(s) = &mut self.screen {
+                s.register_failed(format!(
+                    "descriptor exceeds {} bytes",
+                    keep_nip46::MAX_DESCRIPTOR_LEN
+                ));
+            }
+            return Task::none();
+        }
+
+        let keep_arc = self.keep.clone();
+
+        Task::perform(
+            async move {
+                let client = keep_nip46::Nip46Client::connect_to(&device_uri)
+                    .await
+                    .map_err(|e| format!("connect: {e}"))?;
+                let signer = client.signer_pubkey();
+
+                let register_outcome = async {
+                    client
+                        .connect()
+                        .await
+                        .map_err(|e| format!("handshake: {e}"))?;
+                    client
+                        .register_wallet(&wallet_name, &multipath)
+                        .await
+                        .map_err(|e| format!("register_wallet: {e}"))
+                }
+                .await;
+
+                client.disconnect().await;
+                let response = register_outcome?;
+
+                let signer_bytes = signer.to_bytes();
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+
+                tokio::task::spawn_blocking(move || {
+                    with_keep_blocking(&keep_arc, "Failed to save registration", move |keep| {
+                        keep.upsert_device_registration(
+                            &group_pubkey,
+                            keep_core::DeviceRegistration {
+                                signer_pubkey: signer_bytes,
+                                wallet_name,
+                                hmac: response.hmac.clone(),
+                                registered_at: now,
+                            },
+                        )
+                        .map_err(friendly_err)
+                    })
+                })
+                .await
+                .map_err(|_| "Background task failed".to_string())??;
+
+                Ok::<(), String>(())
+            },
+            Message::WalletRegisterResult,
+        )
     }
 
     pub(crate) fn begin_descriptor_coordination(&mut self) -> Task<Message> {

--- a/keep-desktop/src/app/wallet.rs
+++ b/keep-desktop/src/app/wallet.rs
@@ -1,4 +1,5 @@
 use iced::Task;
+use tracing::{info, warn};
 
 use crate::message::Message;
 use crate::screen::wallet::{self, DescriptorProgress, SetupPhase};
@@ -223,23 +224,39 @@ impl App {
         }
 
         let keep_arc = self.keep.clone();
+        let group_hex = hex::encode(group_pubkey);
 
         Task::perform(
             async move {
                 let client = keep_nip46::Nip46Client::connect_to(&device_uri)
                     .await
-                    .map_err(|e| format!("connect: {e}"))?;
+                    .map_err(|e| {
+                        warn!(group = %group_hex, "NIP-46 connect failed: {e}");
+                        format!("connect: {e}")
+                    })?;
                 let signer = client.signer_pubkey();
+                let signer_hex = hex::encode(signer.to_bytes());
 
                 let register_outcome = async {
-                    client
-                        .connect()
-                        .await
-                        .map_err(|e| format!("handshake: {e}"))?;
+                    client.connect().await.map_err(|e| {
+                        warn!(
+                            group = %group_hex,
+                            signer = %signer_hex,
+                            "NIP-46 handshake failed: {e}",
+                        );
+                        format!("handshake: {e}")
+                    })?;
                     client
                         .register_wallet(&wallet_name, &multipath)
                         .await
-                        .map_err(|e| format!("register_wallet: {e}"))
+                        .map_err(|e| {
+                            warn!(
+                                group = %group_hex,
+                                signer = %signer_hex,
+                                "register_wallet rejected: {e}",
+                            );
+                            format!("register_wallet: {e}")
+                        })
                 }
                 .await;
 
@@ -252,13 +269,16 @@ impl App {
                     .unwrap_or_default()
                     .as_secs();
 
+                let group_hex_for_save = group_hex.clone();
+                let signer_hex_for_save = signer_hex.clone();
+                let wallet_name_saved = wallet_name.clone();
                 tokio::task::spawn_blocking(move || {
                     with_keep_blocking(&keep_arc, "Failed to save registration", move |keep| {
                         keep.upsert_device_registration(
                             &group_pubkey,
                             keep_core::DeviceRegistration {
                                 signer_pubkey: signer_bytes,
-                                wallet_name,
+                                wallet_name: wallet_name_saved,
                                 hmac: response.hmac.clone(),
                                 registered_at: now,
                             },
@@ -267,8 +287,21 @@ impl App {
                     })
                 })
                 .await
-                .map_err(|_| "Background task failed".to_string())??;
+                .map_err(|_| {
+                    warn!(
+                        group = %group_hex_for_save,
+                        signer = %signer_hex_for_save,
+                        "spawn_blocking for upsert_device_registration failed",
+                    );
+                    "Background task failed".to_string()
+                })??;
 
+                info!(
+                    group = %group_hex,
+                    signer = %signer_hex,
+                    wallet_name = %wallet_name,
+                    "wallet registered on device",
+                );
                 Ok::<(), String>(())
             },
             Message::WalletRegisterResult,

--- a/keep-desktop/src/frost.rs
+++ b/keep-desktop/src/frost.rs
@@ -1243,6 +1243,7 @@ impl App {
             internal_descriptor: internal_descriptor.clone(),
             network: network.clone(),
             created_at,
+            device_registrations: Vec::new(),
         };
 
         let store_result = {

--- a/keep-desktop/src/message.rs
+++ b/keep-desktop/src/message.rs
@@ -191,6 +191,7 @@ pub enum Message {
     WalletSessionStarted(Result<([u8; 32], [u8; 32], String, usize), String>),
     WalletDescriptorProgress(DescriptorProgress, Option<[u8; 32]>),
     WalletAnnounceResult(Result<(), String>),
+    WalletRegisterResult(Result<(), String>),
 
     // Relay / FROST
     Relay(crate::screen::relay::Message),
@@ -447,6 +448,10 @@ impl fmt::Debug for Message {
             Self::WalletDescriptorProgress(..) => f.write_str("WalletDescriptorProgress"),
             Self::WalletAnnounceResult(r) => f
                 .debug_tuple("WalletAnnounceResult")
+                .field(&r.as_ref().map(|_| "ok").map_err(|e| e.as_str()))
+                .finish(),
+            Self::WalletRegisterResult(r) => f
+                .debug_tuple("WalletRegisterResult")
                 .field(&r.as_ref().map(|_| "ok").map_err(|e| e.as_str()))
                 .finish(),
             Self::Relay(msg) => f.debug_tuple("Relay").field(msg).finish(),

--- a/keep-desktop/src/screen/wallet.rs
+++ b/keep-desktop/src/screen/wallet.rs
@@ -11,6 +11,8 @@ use keep_frost_net::{MAX_XPUB_LABEL_LENGTH, MAX_XPUB_LENGTH, VALID_XPUB_PREFIXES
 use crate::screen::shares::ShareEntry;
 use crate::theme;
 
+const MAX_DEVICE_URI_LEN: usize = 2048;
+
 #[derive(Debug, Clone)]
 pub struct WalletEntry {
     #[allow(dead_code)]
@@ -79,6 +81,16 @@ pub struct AnnounceState {
     pub submitting: bool,
 }
 
+pub struct RegisterState {
+    pub group_pubkey: [u8; 32],
+    pub external_descriptor: String,
+    pub default_wallet_name: String,
+    pub device_uri: String,
+    pub wallet_name: String,
+    pub error: Option<String>,
+    pub submitting: bool,
+}
+
 #[derive(Clone)]
 pub enum Message {
     ToggleDetails(usize),
@@ -98,6 +110,11 @@ pub enum Message {
     CancelAnnounce,
     SubmitAnnounce,
     CopyDescriptor(String),
+    StartRegister(usize),
+    RegisterDeviceUriChanged(String),
+    RegisterNameChanged(String),
+    CancelRegister,
+    SubmitRegister,
 }
 
 impl std::fmt::Debug for Message {
@@ -120,6 +137,13 @@ impl std::fmt::Debug for Message {
             Self::CancelAnnounce => write!(f, "CancelAnnounce"),
             Self::SubmitAnnounce => write!(f, "SubmitAnnounce"),
             Self::CopyDescriptor(_) => write!(f, "CopyDescriptor(<redacted>)"),
+            Self::StartRegister(i) => f.debug_tuple("StartRegister").field(i).finish(),
+            Self::RegisterDeviceUriChanged(_) => {
+                write!(f, "RegisterDeviceUriChanged(<redacted>)")
+            }
+            Self::RegisterNameChanged(n) => f.debug_tuple("RegisterNameChanged").field(n).finish(),
+            Self::CancelRegister => write!(f, "CancelRegister"),
+            Self::SubmitRegister => write!(f, "SubmitRegister"),
         }
     }
 }
@@ -137,6 +161,12 @@ pub enum Event {
         label: String,
     },
     CopyDescriptor(String),
+    SubmitRegister {
+        group_pubkey: [u8; 32],
+        external_descriptor: String,
+        device_uri: String,
+        wallet_name: String,
+    },
 }
 
 pub struct State {
@@ -144,6 +174,7 @@ pub struct State {
     pub expanded: Option<usize>,
     pub setup: Option<SetupState>,
     pub announce: Option<AnnounceState>,
+    pub register: Option<RegisterState>,
     pub peer_xpubs: HashMap<u16, Vec<AnnouncedXpub>>,
 }
 
@@ -164,6 +195,7 @@ impl State {
             expanded: None,
             setup: None,
             announce: None,
+            register: None,
             peer_xpubs: HashMap::new(),
         }
     }
@@ -270,6 +302,78 @@ impl State {
                 })
             }
             Message::CopyDescriptor(desc) => Some(Event::CopyDescriptor(desc)),
+            Message::StartRegister(i) => {
+                if let Some(entry) = self.descriptors.get(i) {
+                    let default_name = hex::encode(&entry.group_pubkey[..4]);
+                    self.register = Some(RegisterState {
+                        group_pubkey: entry.group_pubkey,
+                        external_descriptor: entry.external_descriptor.clone(),
+                        default_wallet_name: format!("keep-{default_name}"),
+                        device_uri: String::new(),
+                        wallet_name: String::new(),
+                        error: None,
+                        submitting: false,
+                    });
+                }
+                None
+            }
+            Message::RegisterDeviceUriChanged(v) => {
+                if let Some(r) = &mut self.register {
+                    r.device_uri = v.chars().take(MAX_DEVICE_URI_LEN).collect();
+                }
+                None
+            }
+            Message::RegisterNameChanged(v) => {
+                if let Some(r) = &mut self.register {
+                    r.wallet_name = v.chars().take(keep_nip46::MAX_WALLET_NAME_LEN).collect();
+                }
+                None
+            }
+            Message::CancelRegister => {
+                self.register = None;
+                None
+            }
+            Message::SubmitRegister => {
+                let Some(r) = &mut self.register else {
+                    return None;
+                };
+                let device_uri = r.device_uri.trim().to_string();
+                if device_uri.is_empty() {
+                    r.error = Some("Device URI is required".into());
+                    return None;
+                }
+                if !(device_uri.starts_with("bunker://")
+                    || device_uri.starts_with("nostrconnect://"))
+                {
+                    r.error = Some("URI must start with bunker:// or nostrconnect://".into());
+                    return None;
+                }
+                let name_trimmed = r.wallet_name.trim();
+                let wallet_name = if name_trimmed.is_empty() {
+                    r.default_wallet_name.clone()
+                } else {
+                    name_trimmed.to_string()
+                };
+                r.error = None;
+                r.submitting = true;
+                Some(Event::SubmitRegister {
+                    group_pubkey: r.group_pubkey,
+                    external_descriptor: r.external_descriptor.clone(),
+                    device_uri,
+                    wallet_name,
+                })
+            }
+        }
+    }
+
+    pub fn register_submitted(&mut self) {
+        self.register = None;
+    }
+
+    pub fn register_failed(&mut self, error: String) {
+        if let Some(r) = &mut self.register {
+            r.error = Some(error);
+            r.submitting = false;
         }
     }
 
@@ -327,6 +431,10 @@ impl State {
     }
 
     pub fn view(&self) -> Element<'_, Message> {
+        if let Some(register) = &self.register {
+            return self.view_register(register);
+        }
+
         if let Some(announce) = &self.announce {
             return self.view_announce(announce);
         }
@@ -705,13 +813,22 @@ impl State {
                 .size(theme::size::SMALL)
                 .color(theme::color::TEXT_MUTED);
 
+            let register_btn = button(text("Register on Device").size(theme::size::SMALL))
+                .on_press(Message::StartRegister(i))
+                .style(theme::primary_button)
+                .padding([theme::space::XS, theme::space::MD]);
+
+            let actions_row = row![register_btn].spacing(theme::space::SM);
+
             let details = column![
                 ext_row,
                 ext_value,
                 int_row,
                 int_value,
                 hex_full,
-                created_text
+                created_text,
+                Space::new().height(theme::space::SM),
+                actions_row,
             ]
             .spacing(theme::space::XS);
 
@@ -785,6 +902,90 @@ impl State {
             submit_btn,
         ]
         .spacing(theme::space::XS);
+
+        if let Some(err) = &state.error {
+            content = content.push(theme::error_text(err.as_str()));
+        }
+
+        container(scrollable(content))
+            .padding(theme::space::XL)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into()
+    }
+
+    fn view_register<'a>(&self, state: &'a RegisterState) -> Element<'a, Message> {
+        let back_btn = button(text("< Back").size(theme::size::BODY))
+            .on_press_maybe(if state.submitting {
+                None
+            } else {
+                Some(Message::CancelRegister)
+            })
+            .style(theme::text_button)
+            .padding([theme::space::XS, theme::space::SM]);
+
+        let title_text = text("Register on Hardware Signer")
+            .size(theme::size::HEADING)
+            .color(theme::color::TEXT);
+
+        let header = row![back_btn, Space::new().width(theme::space::SM), title_text]
+            .align_y(Alignment::Center);
+
+        let subtitle = text(
+            "Send this descriptor to a NIP-46 capable hardware signer so it can verify addresses",
+        )
+        .size(theme::size::SMALL)
+        .color(theme::color::TEXT_MUTED);
+
+        let group_label = text(format!("Group: {}", hex::encode(&state.group_pubkey[..8])))
+            .size(theme::size::TINY)
+            .color(theme::color::TEXT_DIM);
+
+        let uri_input = text_input("bunker://... or nostrconnect://...", &state.device_uri)
+            .on_input(Message::RegisterDeviceUriChanged)
+            .padding(theme::space::SM)
+            .secure(true);
+
+        let name_placeholder = format!("default: {}", state.default_wallet_name);
+        let name_input = text_input(&name_placeholder, &state.wallet_name)
+            .on_input(Message::RegisterNameChanged)
+            .padding(theme::space::SM);
+
+        let can_submit = !state.submitting && !state.device_uri.trim().is_empty();
+        let submit_label = if state.submitting {
+            "Registering..."
+        } else {
+            "Register"
+        };
+        let mut submit_btn = button(text(submit_label).size(theme::size::BODY))
+            .style(theme::primary_button)
+            .padding([theme::space::SM, theme::space::LG]);
+        if can_submit {
+            submit_btn = submit_btn.on_press(Message::SubmitRegister);
+        }
+
+        let mut content = column![
+            header,
+            subtitle,
+            group_label,
+            Space::new().height(theme::space::SM),
+            theme::label("Device URI"),
+            uri_input,
+            Space::new().height(theme::space::XS),
+            theme::label("Wallet name (optional)"),
+            name_input,
+            Space::new().height(theme::space::MD),
+            submit_btn,
+        ]
+        .spacing(theme::space::XS);
+
+        if state.submitting {
+            content = content.push(
+                text("Confirm the registration on your hardware signer.")
+                    .size(theme::size::SMALL)
+                    .color(theme::color::TEXT_MUTED),
+            );
+        }
 
         if let Some(err) = &state.error {
             content = content.push(theme::error_text(err.as_str()));

--- a/keep-desktop/src/screen/wallet.rs
+++ b/keep-desktop/src/screen/wallet.rs
@@ -13,6 +13,17 @@ use crate::theme;
 
 const MAX_DEVICE_URI_LEN: usize = 2048;
 
+fn truncate_to_bytes(s: &str, max_bytes: usize) -> String {
+    let mut out = String::with_capacity(s.len().min(max_bytes));
+    for c in s.chars() {
+        if out.len() + c.len_utf8() > max_bytes {
+            break;
+        }
+        out.push(c);
+    }
+    out
+}
+
 #[derive(Debug, Clone)]
 pub struct WalletEntry {
     #[allow(dead_code)]
@@ -319,13 +330,13 @@ impl State {
             }
             Message::RegisterDeviceUriChanged(v) => {
                 if let Some(r) = &mut self.register {
-                    r.device_uri = v.chars().take(MAX_DEVICE_URI_LEN).collect();
+                    r.device_uri = truncate_to_bytes(&v, MAX_DEVICE_URI_LEN);
                 }
                 None
             }
             Message::RegisterNameChanged(v) => {
                 if let Some(r) = &mut self.register {
-                    r.wallet_name = v.chars().take(keep_nip46::MAX_WALLET_NAME_LEN).collect();
+                    r.wallet_name = truncate_to_bytes(&v, keep_nip46::MAX_WALLET_NAME_LEN);
                 }
                 None
             }
@@ -941,15 +952,19 @@ impl State {
             .size(theme::size::TINY)
             .color(theme::color::TEXT_DIM);
 
-        let uri_input = text_input("bunker://... or nostrconnect://...", &state.device_uri)
-            .on_input(Message::RegisterDeviceUriChanged)
+        let mut uri_input = text_input("bunker://... or nostrconnect://...", &state.device_uri)
             .padding(theme::space::SM)
             .secure(true);
+        if !state.submitting {
+            uri_input = uri_input.on_input(Message::RegisterDeviceUriChanged);
+        }
 
         let name_placeholder = format!("default: {}", state.default_wallet_name);
-        let name_input = text_input(&name_placeholder, &state.wallet_name)
-            .on_input(Message::RegisterNameChanged)
-            .padding(theme::space::SM);
+        let mut name_input =
+            text_input(&name_placeholder, &state.wallet_name).padding(theme::space::SM);
+        if !state.submitting {
+            name_input = name_input.on_input(Message::RegisterNameChanged);
+        }
 
         let can_submit = !state.submitting && !state.device_uri.trim().is_empty();
         let submit_label = if state.submitting {

--- a/keep-mobile/src/keep_mobile.udl
+++ b/keep-mobile/src/keep_mobile.udl
@@ -155,6 +155,14 @@ dictionary WalletDescriptorInfo {
     string internal_descriptor;
     string network;
     u64 created_at;
+    sequence<DeviceRegistrationInfo> device_registrations;
+};
+
+dictionary DeviceRegistrationInfo {
+    string signer_pubkey;
+    string wallet_name;
+    string? hmac;
+    u64 registered_at;
 };
 
 dictionary RecoveryTierConfig {

--- a/keep-mobile/src/keep_mobile.udl
+++ b/keep-mobile/src/keep_mobile.udl
@@ -312,6 +312,9 @@ interface KeepMobile {
     [Throws=KeepMobileError]
     void wallet_descriptor_delete(string group_pubkey);
 
+    [Throws=KeepMobileError]
+    string? wallet_register_on_device(string group_pubkey, string device_uri, string? wallet_name);
+
     void wallet_descriptor_set_callbacks(DescriptorCallbacks callbacks);
 
     [Throws=KeepMobileError]

--- a/keep-mobile/src/keep_mobile.udl
+++ b/keep-mobile/src/keep_mobile.udl
@@ -320,8 +320,12 @@ interface KeepMobile {
     [Throws=KeepMobileError]
     void wallet_descriptor_delete(string group_pubkey);
 
+    // Register a wallet on a hardware NIP-46 signer. The returned
+    // DeviceRegistrationInfo has its `hmac` field cleared so the raw token
+    // never crosses the UniFFI boundary. The token is persisted internally on
+    // the wallet descriptor in secure storage.
     [Throws=KeepMobileError]
-    string? wallet_register_on_device(string group_pubkey, string device_uri, string? wallet_name);
+    DeviceRegistrationInfo wallet_register_on_device(string group_pubkey, string device_uri, string? wallet_name);
 
     void wallet_descriptor_set_callbacks(DescriptorCallbacks callbacks);
 

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1646,13 +1646,30 @@ impl KeepMobile {
         for d in &descriptors {
             let bytes = decode_hex(&d.group_pubkey, "descriptor group_pubkey")?;
             let group_pubkey = bytes_to_32(&bytes, "descriptor group_pubkey")?;
+            let mut device_registrations = Vec::with_capacity(d.device_registrations.len());
+            for reg in &d.device_registrations {
+                let signer_bytes =
+                    decode_hex(&reg.signer_pubkey, "device_registration signer_pubkey")?;
+                let signer_pubkey =
+                    bytes_to_32(&signer_bytes, "device_registration signer_pubkey")?;
+                let hmac = match reg.hmac.as_deref() {
+                    Some(h) => Some(decode_hex(h, "device_registration hmac")?),
+                    None => None,
+                };
+                device_registrations.push(keep_core::DeviceRegistration {
+                    signer_pubkey,
+                    wallet_name: reg.wallet_name.clone(),
+                    hmac,
+                    registered_at: reg.registered_at,
+                });
+            }
             core_descriptors.push(keep_core::wallet::WalletDescriptor {
                 group_pubkey,
                 external_descriptor: d.external_descriptor.clone(),
                 internal_descriptor: d.internal_descriptor.clone(),
                 network: d.network.clone(),
                 created_at: d.created_at,
-                device_registrations: Vec::new(),
+                device_registrations,
             });
         }
 

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1168,20 +1168,26 @@ impl KeepMobile {
             format!("keep-{tag}")
         });
 
+        let multipath =
+            keep_bitcoin::multipath_from_external(&desc.external_descriptor).map_err(|e| {
+                KeepMobileError::InvalidInput {
+                    msg: format!("build multipath descriptor: {e}"),
+                }
+            })?;
+
+        // TODO: persist the returned HMAC in the stored WalletDescriptor per
+        // signer pubkey so subsequent sessions can prove prior registration.
         self.runtime.block_on(async {
             let client = keep_nip46::Nip46Client::connect_to(&device_uri)
                 .await
-                .map_err(|e| KeepMobileError::NetworkError { msg: e.to_string() })?;
+                .map_err(nip46_to_mobile_error)?;
 
             let outcome: Result<Option<String>, KeepMobileError> = async {
-                client
-                    .connect()
-                    .await
-                    .map_err(|e| KeepMobileError::NetworkError { msg: e.to_string() })?;
+                client.connect().await.map_err(nip46_to_mobile_error)?;
                 let response = client
-                    .register_wallet(&name, &desc.external_descriptor)
+                    .register_wallet(&name, &multipath)
                     .await
-                    .map_err(|e| KeepMobileError::NetworkError { msg: e.to_string() })?;
+                    .map_err(nip46_to_mobile_error)?;
                 Ok(response.hmac.map(hex::encode))
             }
             .await;
@@ -1936,6 +1942,16 @@ fn decode_hex(hex_str: &str, label: &str) -> Result<Vec<u8>, KeepMobileError> {
     hex::decode(hex_str).map_err(|e| KeepMobileError::BackupError {
         msg: format!("hex decode {label}: {e}"),
     })
+}
+
+fn nip46_to_mobile_error(e: keep_core::error::KeepError) -> KeepMobileError {
+    match e {
+        keep_core::error::KeepError::InvalidInput(msg) => KeepMobileError::InvalidInput { msg },
+        keep_core::error::KeepError::Runtime(msg) => KeepMobileError::NetworkError { msg },
+        other => KeepMobileError::NetworkError {
+            msg: other.to_string(),
+        },
+    }
 }
 
 fn bytes_to_32(bytes: &[u8], label: &str) -> Result<[u8; 32], KeepMobileError> {

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -37,10 +37,10 @@ pub use signing_policy::{
 };
 pub use storage::{SecureStorage, ShareInfo, ShareMetadataInfo, StoredShareInfo};
 pub use types::{
-    AnnouncedXpubInfo, BackupInfo, ConnectionStatus, DescriptorProposal, DkgConfig, DkgStatus,
-    FrostGenerationResult, GeneratedShareInfo, KeepLiveState, KeyHealthStatusInfo, PeerInfo,
-    PeerStatus, RecoveryTierConfig, SignRequest, SignRequestMetadata, ThresholdConfig,
-    WalletDescriptorInfo,
+    AnnouncedXpubInfo, BackupInfo, ConnectionStatus, DescriptorProposal, DeviceRegistrationInfo,
+    DkgConfig, DkgStatus, FrostGenerationResult, GeneratedShareInfo, KeepLiveState,
+    KeyHealthStatusInfo, PeerInfo, PeerStatus, RecoveryTierConfig, SignRequest,
+    SignRequestMetadata, ThresholdConfig, WalletDescriptorInfo,
 };
 
 #[uniffi::export]
@@ -1155,7 +1155,7 @@ impl KeepMobile {
     ) -> Result<Option<String>, KeepMobileError> {
         validate_hex_pubkey(&group_pubkey)?;
 
-        let desc = persistence::load_descriptor(&self.storage, &group_pubkey)?;
+        let mut desc = persistence::load_descriptor(&self.storage, &group_pubkey)?;
         let name = wallet_name.unwrap_or_else(|| format!("keep-{}", &group_pubkey[..8]));
 
         let multipath =
@@ -1165,12 +1165,11 @@ impl KeepMobile {
                 }
             })?;
 
-        // TODO: persist the returned HMAC in the stored WalletDescriptor per
-        // signer pubkey so subsequent sessions can prove prior registration.
-        self.runtime.block_on(async {
+        let (signer_hex, hmac_hex) = self.runtime.block_on(async {
             let client = keep_nip46::Nip46Client::connect_to(&device_uri)
                 .await
                 .map_err(nip46_to_mobile_error)?;
+            let signer_hex = hex::encode(client.signer_pubkey().to_bytes());
 
             let outcome: Result<Option<String>, KeepMobileError> = async {
                 client.connect().await.map_err(nip46_to_mobile_error)?;
@@ -1183,8 +1182,31 @@ impl KeepMobile {
             .await;
 
             client.disconnect().await;
-            outcome
-        })
+            outcome.map(|hmac_hex| (signer_hex, hmac_hex))
+        })?;
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let registration = DeviceRegistrationInfo {
+            signer_pubkey: signer_hex,
+            wallet_name: name,
+            hmac: hmac_hex.clone(),
+            registered_at: now,
+        };
+        if let Some(slot) = desc
+            .device_registrations
+            .iter_mut()
+            .find(|r| r.signer_pubkey == registration.signer_pubkey)
+        {
+            *slot = registration;
+        } else {
+            desc.device_registrations.push(registration);
+        }
+        persistence::persist_descriptor(&self.storage, &desc)?;
+
+        Ok(hmac_hex)
     }
 
     pub fn wallet_descriptor_set_callbacks(&self, callbacks: Arc<dyn DescriptorCallbacks>) {
@@ -1630,6 +1652,7 @@ impl KeepMobile {
                 internal_descriptor: d.internal_descriptor.clone(),
                 network: d.network.clone(),
                 created_at: d.created_at,
+                device_registrations: Vec::new(),
             });
         }
 
@@ -1814,6 +1837,16 @@ impl KeepMobile {
                 internal_descriptor: wd.internal_descriptor.clone(),
                 network: wd.network.clone(),
                 created_at: wd.created_at,
+                device_registrations: wd
+                    .device_registrations
+                    .iter()
+                    .map(|r| DeviceRegistrationInfo {
+                        signer_pubkey: hex::encode(r.signer_pubkey),
+                        wallet_name: r.wallet_name.clone(),
+                        hmac: r.hmac.as_deref().map(hex::encode),
+                        registered_at: r.registered_at,
+                    })
+                    .collect(),
             });
         }
 
@@ -2694,6 +2727,7 @@ impl KeepMobile {
             internal_descriptor: internal_descriptor.clone(),
             network,
             created_at,
+            device_registrations: Vec::new(),
         };
 
         if let Err(e) = persistence::persist_descriptor(storage, &info) {

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1691,7 +1691,15 @@ impl KeepMobile {
                 let signer_pubkey =
                     bytes_to_32(&signer_bytes, "device_registration signer_pubkey")?;
                 let hmac = match reg.hmac.as_deref() {
-                    Some(h) => Some(Zeroizing::new(decode_hex(h, "device_registration hmac")?)),
+                    Some(h) => {
+                        if !persistence::is_valid_hmac_hex(h) {
+                            return Err(KeepMobileError::BackupError {
+                                msg: "device_registration hmac has invalid hex length or format"
+                                    .into(),
+                            });
+                        }
+                        Some(Zeroizing::new(decode_hex(h, "device_registration hmac")?))
+                    }
                     None => None,
                 };
                 device_registrations.push(keep_core::DeviceRegistration {
@@ -2029,7 +2037,10 @@ fn nip46_to_mobile_error(e: keep_core::error::KeepError) -> KeepMobileError {
         KeepError::RateLimited(_) => KeepMobileError::RateLimited,
         KeepError::NetworkErr(NetworkError::Timeout { .. }) => KeepMobileError::Timeout,
         KeepError::NetworkErr(e) => KeepMobileError::NetworkError { msg: e.to_string() },
-        KeepError::Runtime(msg) => KeepMobileError::NetworkError { msg },
+        KeepError::StorageErr(e) => KeepMobileError::StorageError { msg: e.to_string() },
+        KeepError::CryptoErr(e) => KeepMobileError::FrostError { msg: e.to_string() },
+        KeepError::Encryption(msg) => KeepMobileError::EncryptionError { msg },
+        KeepError::Runtime(msg) => KeepMobileError::NotSupported { msg },
         other => KeepMobileError::NetworkError {
             msg: other.to_string(),
         },

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1156,17 +1156,7 @@ impl KeepMobile {
         validate_hex_pubkey(&group_pubkey)?;
 
         let desc = persistence::load_descriptor(&self.storage, &group_pubkey)?;
-        let group_bytes =
-            hex::decode(&group_pubkey).map_err(|e| KeepMobileError::InvalidInput {
-                msg: format!("invalid group pubkey hex: {e}"),
-            })?;
-        let name = wallet_name.unwrap_or_else(|| {
-            let tag = group_bytes
-                .get(..4)
-                .map(hex::encode)
-                .unwrap_or_else(|| "keep".into());
-            format!("keep-{tag}")
-        });
+        let name = wallet_name.unwrap_or_else(|| format!("keep-{}", &group_pubkey[..8]));
 
         let multipath =
             keep_bitcoin::multipath_from_external(&desc.external_descriptor).map_err(|e| {
@@ -1945,9 +1935,13 @@ fn decode_hex(hex_str: &str, label: &str) -> Result<Vec<u8>, KeepMobileError> {
 }
 
 fn nip46_to_mobile_error(e: keep_core::error::KeepError) -> KeepMobileError {
+    use keep_core::error::{KeepError, NetworkError};
     match e {
-        keep_core::error::KeepError::InvalidInput(msg) => KeepMobileError::InvalidInput { msg },
-        keep_core::error::KeepError::Runtime(msg) => KeepMobileError::NetworkError { msg },
+        KeepError::InvalidInput(msg) => KeepMobileError::InvalidInput { msg },
+        KeepError::RateLimited(_) => KeepMobileError::RateLimited,
+        KeepError::NetworkErr(NetworkError::Timeout { .. }) => KeepMobileError::Timeout,
+        KeepError::NetworkErr(e) => KeepMobileError::NetworkError { msg: e.to_string() },
+        KeepError::Runtime(msg) => KeepMobileError::NetworkError { msg },
         other => KeepMobileError::NetworkError {
             msg: other.to_string(),
         },

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1147,6 +1147,50 @@ impl KeepMobile {
         persistence::delete_descriptor(&self.storage, &group_pubkey)
     }
 
+    pub fn wallet_register_on_device(
+        &self,
+        group_pubkey: String,
+        device_uri: String,
+        wallet_name: Option<String>,
+    ) -> Result<Option<String>, KeepMobileError> {
+        validate_hex_pubkey(&group_pubkey)?;
+
+        let desc = persistence::load_descriptor(&self.storage, &group_pubkey)?;
+        let group_bytes =
+            hex::decode(&group_pubkey).map_err(|e| KeepMobileError::InvalidInput {
+                msg: format!("invalid group pubkey hex: {e}"),
+            })?;
+        let name = wallet_name.unwrap_or_else(|| {
+            let tag = group_bytes
+                .get(..4)
+                .map(hex::encode)
+                .unwrap_or_else(|| "keep".into());
+            format!("keep-{tag}")
+        });
+
+        self.runtime.block_on(async {
+            let client = keep_nip46::Nip46Client::connect_to(&device_uri)
+                .await
+                .map_err(|e| KeepMobileError::NetworkError { msg: e.to_string() })?;
+
+            let outcome: Result<Option<String>, KeepMobileError> = async {
+                client
+                    .connect()
+                    .await
+                    .map_err(|e| KeepMobileError::NetworkError { msg: e.to_string() })?;
+                let response = client
+                    .register_wallet(&name, &desc.external_descriptor)
+                    .await
+                    .map_err(|e| KeepMobileError::NetworkError { msg: e.to_string() })?;
+                Ok(response.hmac.map(hex::encode))
+            }
+            .await;
+
+            client.disconnect().await;
+            outcome
+        })
+    }
+
     pub fn wallet_descriptor_set_callbacks(&self, callbacks: Arc<dyn DescriptorCallbacks>) {
         self.runtime.block_on(async {
             *self.descriptor_callbacks.write().await = Some(callbacks);

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1242,10 +1242,8 @@ impl KeepMobile {
 
         // Strip the raw token before crossing the UniFFI boundary.
         Ok(DeviceRegistrationInfo {
-            signer_pubkey: persisted.signer_pubkey,
-            wallet_name: persisted.wallet_name,
             hmac: None,
-            registered_at: persisted.registered_at,
+            ..persisted
         })
     }
 

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1214,12 +1214,12 @@ impl KeepMobile {
         // Atomically reload the descriptor under the storage lock so a
         // concurrent register/edit cannot drop our update.
         let persisted = {
-            let _guard = self
-                .descriptor_write_lock
-                .lock()
-                .map_err(|_| KeepMobileError::StorageError {
-                    msg: "descriptor lock poisoned".into(),
-                })?;
+            let _guard =
+                self.descriptor_write_lock
+                    .lock()
+                    .map_err(|_| KeepMobileError::StorageError {
+                        msg: "descriptor lock poisoned".into(),
+                    })?;
             let mut desc = persistence::load_descriptor(&self.storage, &group_pubkey)?;
             let registration = DeviceRegistrationInfo {
                 signer_pubkey: signer_hex,

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -388,6 +388,7 @@ pub struct KeepMobile {
     state_rev: Arc<std::sync::atomic::AtomicU64>,
     pre_approved_hash: Arc<std::sync::Mutex<Option<[u8; 32]>>>,
     session_store_path: Arc<std::sync::Mutex<Option<String>>>,
+    descriptor_write_lock: Arc<std::sync::Mutex<()>>,
 }
 
 struct PendingRequest {
@@ -526,6 +527,7 @@ impl KeepMobile {
             state_rev: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             pre_approved_hash: Arc::new(std::sync::Mutex::new(None)),
             session_store_path: Arc::new(std::sync::Mutex::new(None)),
+            descriptor_write_lock: Arc::new(std::sync::Mutex::new(())),
         })
     }
 
@@ -1147,22 +1149,41 @@ impl KeepMobile {
         persistence::delete_descriptor(&self.storage, &group_pubkey)
     }
 
+    /// Register a wallet on a hardware NIP-46 signer and persist the result.
+    ///
+    /// On success the returned `DeviceRegistrationInfo` has its `hmac` field
+    /// cleared so the raw registration token never crosses the UniFFI boundary
+    /// into foreign code (Kotlin/Swift), where it could be inadvertently
+    /// logged or displayed. The token itself is persisted on the wallet
+    /// descriptor in secure storage.
     pub fn wallet_register_on_device(
         &self,
         group_pubkey: String,
         device_uri: String,
         wallet_name: Option<String>,
-    ) -> Result<Option<String>, KeepMobileError> {
+    ) -> Result<DeviceRegistrationInfo, KeepMobileError> {
         validate_hex_pubkey(&group_pubkey)?;
 
-        let mut desc = persistence::load_descriptor(&self.storage, &group_pubkey)?;
         let name = wallet_name.unwrap_or_else(|| format!("keep-{}", &group_pubkey[..8]));
+        if name.is_empty() {
+            return Err(KeepMobileError::InvalidInput {
+                msg: "wallet name must not be empty".into(),
+            });
+        }
+        if name.len() > keep_nip46::MAX_WALLET_NAME_LEN {
+            return Err(KeepMobileError::InvalidInput {
+                msg: format!(
+                    "wallet name exceeds {} bytes",
+                    keep_nip46::MAX_WALLET_NAME_LEN
+                ),
+            });
+        }
 
-        let multipath =
-            keep_bitcoin::multipath_from_external(&desc.external_descriptor).map_err(|e| {
-                KeepMobileError::InvalidInput {
-                    msg: format!("build multipath descriptor: {e}"),
-                }
+        let desc_initial = persistence::load_descriptor(&self.storage, &group_pubkey)?;
+
+        let multipath = keep_bitcoin::multipath_from_external(&desc_initial.external_descriptor)
+            .map_err(|e| KeepMobileError::InvalidInput {
+                msg: format!("build multipath descriptor: {e}"),
             })?;
 
         let (signer_hex, hmac_hex) = self.runtime.block_on(async {
@@ -1177,7 +1198,7 @@ impl KeepMobile {
                     .register_wallet(&name, &multipath)
                     .await
                     .map_err(nip46_to_mobile_error)?;
-                Ok(response.hmac.map(hex::encode))
+                Ok(response.hmac.as_deref().map(|h| hex::encode(h.as_slice())))
             }
             .await;
 
@@ -1189,24 +1210,43 @@ impl KeepMobile {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
-        let registration = DeviceRegistrationInfo {
-            signer_pubkey: signer_hex,
-            wallet_name: name,
-            hmac: hmac_hex.clone(),
-            registered_at: now,
-        };
-        if let Some(slot) = desc
-            .device_registrations
-            .iter_mut()
-            .find(|r| r.signer_pubkey == registration.signer_pubkey)
-        {
-            *slot = registration;
-        } else {
-            desc.device_registrations.push(registration);
-        }
-        persistence::persist_descriptor(&self.storage, &desc)?;
 
-        Ok(hmac_hex)
+        // Atomically reload the descriptor under the storage lock so a
+        // concurrent register/edit cannot drop our update.
+        let persisted = {
+            let _guard = self
+                .descriptor_write_lock
+                .lock()
+                .map_err(|_| KeepMobileError::StorageError {
+                    msg: "descriptor lock poisoned".into(),
+                })?;
+            let mut desc = persistence::load_descriptor(&self.storage, &group_pubkey)?;
+            let registration = DeviceRegistrationInfo {
+                signer_pubkey: signer_hex,
+                wallet_name: name,
+                hmac: hmac_hex,
+                registered_at: now,
+            };
+            if let Some(slot) = desc
+                .device_registrations
+                .iter_mut()
+                .find(|r| r.signer_pubkey == registration.signer_pubkey)
+            {
+                *slot = registration.clone();
+            } else {
+                desc.device_registrations.push(registration.clone());
+            }
+            persistence::persist_descriptor(&self.storage, &desc)?;
+            registration
+        };
+
+        // Strip the raw token before crossing the UniFFI boundary.
+        Ok(DeviceRegistrationInfo {
+            signer_pubkey: persisted.signer_pubkey,
+            wallet_name: persisted.wallet_name,
+            hmac: None,
+            registered_at: persisted.registered_at,
+        })
     }
 
     pub fn wallet_descriptor_set_callbacks(&self, callbacks: Arc<dyn DescriptorCallbacks>) {
@@ -1653,7 +1693,7 @@ impl KeepMobile {
                 let signer_pubkey =
                     bytes_to_32(&signer_bytes, "device_registration signer_pubkey")?;
                 let hmac = match reg.hmac.as_deref() {
-                    Some(h) => Some(decode_hex(h, "device_registration hmac")?),
+                    Some(h) => Some(Zeroizing::new(decode_hex(h, "device_registration hmac")?)),
                     None => None,
                 };
                 device_registrations.push(keep_core::DeviceRegistration {

--- a/keep-mobile/src/persistence.rs
+++ b/keep-mobile/src/persistence.rs
@@ -337,7 +337,7 @@ pub(crate) fn persist_descriptor(
     Ok(())
 }
 
-fn is_valid_hmac_hex(s: &str) -> bool {
+pub(crate) fn is_valid_hmac_hex(s: &str) -> bool {
     s.len() == HMAC_SHA256_HEX_LEN && s.chars().all(|c| c.is_ascii_hexdigit())
 }
 

--- a/keep-mobile/src/persistence.rs
+++ b/keep-mobile/src/persistence.rs
@@ -337,18 +337,17 @@ pub(crate) fn persist_descriptor(
     Ok(())
 }
 
+fn is_valid_hmac_hex(s: &str) -> bool {
+    s.len() == HMAC_SHA256_HEX_LEN && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
 fn stored_to_info(stored: StoredDescriptor) -> WalletDescriptorInfo {
     let device_registrations = stored
         .device_registrations
         .into_iter()
         .filter_map(|r| {
-            let hmac = match r.hmac {
-                Some(h) if h.len() == HMAC_SHA256_HEX_LEN
-                    && h.chars().all(|c| c.is_ascii_hexdigit()) =>
-                {
-                    Some(h)
-                }
-                Some(h) => {
+            if let Some(h) = r.hmac.as_deref() {
+                if !is_valid_hmac_hex(h) {
                     tracing::warn!(
                         signer = %r.signer_pubkey,
                         hmac_len = h.len(),
@@ -356,12 +355,11 @@ fn stored_to_info(stored: StoredDescriptor) -> WalletDescriptorInfo {
                     );
                     return None;
                 }
-                None => None,
-            };
+            }
             Some(DeviceRegistrationInfo {
                 signer_pubkey: r.signer_pubkey,
                 wallet_name: r.wallet_name,
-                hmac,
+                hmac: r.hmac,
                 registered_at: r.registered_at,
             })
         })

--- a/keep-mobile/src/persistence.rs
+++ b/keep-mobile/src/persistence.rs
@@ -204,7 +204,14 @@ pub(crate) fn persist_cert_pins(
     )
 }
 
+/// At-rest schema for a persisted wallet descriptor.
+///
+/// `SecureStorage` implementations **must** back this record with platform
+/// secure storage (iOS Keychain, Android Keystore-backed) because
+/// `device_registrations` contains device-returned authentication material
+/// (the HMAC/registration token).
 #[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct StoredDescriptor {
     group_pubkey: String,
     external_descriptor: String,
@@ -215,7 +222,13 @@ struct StoredDescriptor {
     device_registrations: Vec<StoredDeviceRegistration>,
 }
 
+/// At-rest schema for a hardware-signer registration record.
+///
+/// See [`StoredDescriptor`] for secure-storage requirements. The `hmac` field,
+/// when present, must be exactly `HMAC_SHA256_HEX_LEN` hex characters; entries
+/// that fail this shape are dropped with a warning at load time.
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct StoredDeviceRegistration {
     pub signer_pubkey: String,
     pub wallet_name: String,
@@ -223,6 +236,8 @@ pub(crate) struct StoredDeviceRegistration {
     pub hmac: Option<String>,
     pub registered_at: u64,
 }
+
+const HMAC_SHA256_HEX_LEN: usize = 64;
 
 fn descriptor_key(group_pubkey_hex: &str) -> String {
     format!("{DESCRIPTOR_KEY_PREFIX}{group_pubkey_hex}")
@@ -326,11 +341,29 @@ fn stored_to_info(stored: StoredDescriptor) -> WalletDescriptorInfo {
     let device_registrations = stored
         .device_registrations
         .into_iter()
-        .map(|r| DeviceRegistrationInfo {
-            signer_pubkey: r.signer_pubkey,
-            wallet_name: r.wallet_name,
-            hmac: r.hmac,
-            registered_at: r.registered_at,
+        .filter_map(|r| {
+            let hmac = match r.hmac {
+                Some(h) if h.len() == HMAC_SHA256_HEX_LEN
+                    && h.chars().all(|c| c.is_ascii_hexdigit()) =>
+                {
+                    Some(h)
+                }
+                Some(h) => {
+                    tracing::warn!(
+                        signer = %r.signer_pubkey,
+                        hmac_len = h.len(),
+                        "dropping device_registration with malformed hmac"
+                    );
+                    return None;
+                }
+                None => None,
+            };
+            Some(DeviceRegistrationInfo {
+                signer_pubkey: r.signer_pubkey,
+                wallet_name: r.wallet_name,
+                hmac,
+                registered_at: r.registered_at,
+            })
         })
         .collect();
     WalletDescriptorInfo {

--- a/keep-mobile/src/persistence.rs
+++ b/keep-mobile/src/persistence.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::KeepMobileError;
 use crate::policy::{PolicyBundle, POLICY_PUBKEY_LEN};
 use crate::storage::{SecureStorage, ShareMetadataInfo};
-use crate::types::{KeyHealthStatusInfo, WalletDescriptorInfo};
+use crate::types::{DeviceRegistrationInfo, KeyHealthStatusInfo, WalletDescriptorInfo};
 use crate::velocity::VelocityTracker;
 use crate::{
     CERT_PINS_STORAGE_KEY, DESCRIPTOR_INDEX_KEY, DESCRIPTOR_KEY_PREFIX, HEALTH_STATUS_INDEX_KEY,
@@ -211,6 +211,17 @@ struct StoredDescriptor {
     internal_descriptor: String,
     network: String,
     created_at: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    device_registrations: Vec<StoredDeviceRegistration>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct StoredDeviceRegistration {
+    pub signer_pubkey: String,
+    pub wallet_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hmac: Option<String>,
+    pub registered_at: u64,
 }
 
 fn descriptor_key(group_pubkey_hex: &str) -> String {
@@ -257,13 +268,7 @@ pub(crate) fn load_descriptors(storage: &Arc<dyn SecureStorage>) -> Vec<WalletDe
         match storage.load_share_by_key(descriptor_key(group_hex)) {
             Ok(data) => match serde_json::from_slice::<StoredDescriptor>(&data) {
                 Ok(stored) => {
-                    result.push(WalletDescriptorInfo {
-                        group_pubkey: stored.group_pubkey,
-                        external_descriptor: stored.external_descriptor,
-                        internal_descriptor: stored.internal_descriptor,
-                        network: stored.network,
-                        created_at: stored.created_at,
-                    });
+                    result.push(stored_to_info(stored));
                 }
                 Err(e) => {
                     tracing::warn!("Corrupt descriptor for {group_hex}: {e}");
@@ -292,26 +297,14 @@ pub(crate) fn load_descriptor(
         serde_json::from_slice(&data).map_err(|e| KeepMobileError::StorageError {
             msg: format!("Failed to deserialize descriptor: {e}"),
         })?;
-    Ok(WalletDescriptorInfo {
-        group_pubkey: stored.group_pubkey,
-        external_descriptor: stored.external_descriptor,
-        internal_descriptor: stored.internal_descriptor,
-        network: stored.network,
-        created_at: stored.created_at,
-    })
+    Ok(stored_to_info(stored))
 }
 
 pub(crate) fn persist_descriptor(
     storage: &Arc<dyn SecureStorage>,
     info: &WalletDescriptorInfo,
 ) -> Result<(), KeepMobileError> {
-    let stored = StoredDescriptor {
-        group_pubkey: info.group_pubkey.clone(),
-        external_descriptor: info.external_descriptor.clone(),
-        internal_descriptor: info.internal_descriptor.clone(),
-        network: info.network.clone(),
-        created_at: info.created_at,
-    };
+    let stored = info_to_stored(info);
     let data = serde_json::to_vec(&stored).map_err(|e| KeepMobileError::StorageError {
         msg: format!("Failed to serialize descriptor: {e}"),
     })?;
@@ -327,6 +320,47 @@ pub(crate) fn persist_descriptor(
         persist_descriptor_index(storage, &index)?;
     }
     Ok(())
+}
+
+fn stored_to_info(stored: StoredDescriptor) -> WalletDescriptorInfo {
+    let device_registrations = stored
+        .device_registrations
+        .into_iter()
+        .map(|r| DeviceRegistrationInfo {
+            signer_pubkey: r.signer_pubkey,
+            wallet_name: r.wallet_name,
+            hmac: r.hmac,
+            registered_at: r.registered_at,
+        })
+        .collect();
+    WalletDescriptorInfo {
+        group_pubkey: stored.group_pubkey,
+        external_descriptor: stored.external_descriptor,
+        internal_descriptor: stored.internal_descriptor,
+        network: stored.network,
+        created_at: stored.created_at,
+        device_registrations,
+    }
+}
+
+fn info_to_stored(info: &WalletDescriptorInfo) -> StoredDescriptor {
+    StoredDescriptor {
+        group_pubkey: info.group_pubkey.clone(),
+        external_descriptor: info.external_descriptor.clone(),
+        internal_descriptor: info.internal_descriptor.clone(),
+        network: info.network.clone(),
+        created_at: info.created_at,
+        device_registrations: info
+            .device_registrations
+            .iter()
+            .map(|r| StoredDeviceRegistration {
+                signer_pubkey: r.signer_pubkey.clone(),
+                wallet_name: r.wallet_name.clone(),
+                hmac: r.hmac.clone(),
+                registered_at: r.registered_at,
+            })
+            .collect(),
+    }
 }
 
 pub(crate) fn delete_descriptor(

--- a/keep-mobile/src/storage.rs
+++ b/keep-mobile/src/storage.rs
@@ -35,6 +35,14 @@ pub struct StoredShareInfo {
     pub did_backup: bool,
 }
 
+/// Platform-provided secure storage for encrypted share data and wallet
+/// descriptor records.
+///
+/// Implementations **must** be backed by platform secure storage (iOS
+/// Keychain, Android Keystore-backed EncryptedSharedPreferences or
+/// equivalent): records persisted through this trait include authentication
+/// material (device-returned registration tokens on wallet descriptor
+/// records) and FROST share data. Plain-disk file storage is NOT acceptable.
 #[uniffi::export(with_foreign)]
 pub trait SecureStorage: Send + Sync {
     fn store_share(

--- a/keep-mobile/src/types.rs
+++ b/keep-mobile/src/types.rs
@@ -80,6 +80,7 @@ pub struct WalletDescriptorInfo {
     pub internal_descriptor: String,
     pub network: String,
     pub created_at: u64,
+    pub device_registrations: Vec<DeviceRegistrationInfo>,
 }
 
 impl std::fmt::Debug for WalletDescriptorInfo {
@@ -90,8 +91,17 @@ impl std::fmt::Debug for WalletDescriptorInfo {
             .field("internal_descriptor", &"[redacted]")
             .field("network", &self.network)
             .field("created_at", &self.created_at)
+            .field("device_registrations", &self.device_registrations.len())
             .finish()
     }
+}
+
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct DeviceRegistrationInfo {
+    pub signer_pubkey: String,
+    pub wallet_name: String,
+    pub hmac: Option<String>,
+    pub registered_at: u64,
 }
 
 #[derive(uniffi::Record, Clone, Debug)]

--- a/keep-mobile/src/types.rs
+++ b/keep-mobile/src/types.rs
@@ -96,12 +96,23 @@ impl std::fmt::Debug for WalletDescriptorInfo {
     }
 }
 
-#[derive(uniffi::Record, Clone, Debug)]
+#[derive(uniffi::Record, Clone)]
 pub struct DeviceRegistrationInfo {
     pub signer_pubkey: String,
     pub wallet_name: String,
     pub hmac: Option<String>,
     pub registered_at: u64,
+}
+
+impl std::fmt::Debug for DeviceRegistrationInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeviceRegistrationInfo")
+            .field("signer_pubkey", &self.signer_pubkey)
+            .field("wallet_name", &self.wallet_name)
+            .field("hmac", &self.hmac.as_ref().map(|_| "<redacted>"))
+            .field("registered_at", &self.registered_at)
+            .finish()
+    }
 }
 
 #[derive(uniffi::Record, Clone, Debug)]

--- a/keep-nip46/Cargo.toml
+++ b/keep-nip46/Cargo.toml
@@ -26,6 +26,7 @@ sha2 = "0.10"
 zeroize.workspace = true
 
 [dev-dependencies]
+keep-core = { path = "../keep-core", features = ["allow-ws", "allow-internal"] }
 nostr-relay-builder = "0.44"
 rustls = { version = "0.23", features = ["ring"] }
 tracing-subscriber = "0.3"

--- a/keep-nip46/src/bunker.rs
+++ b/keep-nip46/src/bunker.rs
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: © 2026 PrivKey LLC
 // SPDX-License-Identifier: MIT
-use keep_core::relay::{normalize_relay_url, validate_relay_url, MAX_RELAYS};
+use keep_core::relay::{
+    normalize_relay_url, validate_relay_url, validate_relay_url_allow_internal,
+    ALLOW_INTERNAL_HOSTS, MAX_RELAYS,
+};
 use nostr_sdk::prelude::*;
 
 pub fn generate_bunker_url(
@@ -136,14 +139,19 @@ pub fn parse_bunker_url(
     let mut relays = Vec::new();
     let mut secret = None;
 
+    let validate = if ALLOW_INTERNAL_HOSTS {
+        validate_relay_url_allow_internal
+    } else {
+        validate_relay_url
+    };
+
     for (key, value) in url.query_pairs() {
         match key.as_ref() {
             "relay" => {
                 if relays.len() >= MAX_RELAYS {
                     continue;
                 }
-                validate_relay_url(&value)
-                    .map_err(|e| format!("Invalid relay URL '{value}': {e}"))?;
+                validate(&value).map_err(|e| format!("Invalid relay URL '{value}': {e}"))?;
                 relays.push(normalize_relay_url(&value));
             }
             "secret" => secret = Some(value.to_string()),

--- a/keep-nip46/src/bunker.rs
+++ b/keep-nip46/src/bunker.rs
@@ -81,10 +81,16 @@ pub fn parse_nostrconnect_uri(uri: &str) -> std::result::Result<NostrConnectRequ
     let mut image = None;
     let mut perms = None;
 
+    let validate = if ALLOW_INTERNAL_HOSTS {
+        validate_relay_url_allow_internal
+    } else {
+        validate_relay_url
+    };
+
     for (key, value) in parsed.query_pairs() {
         match key.as_ref() {
             "relay" => {
-                if relays.len() < MAX_NOSTRCONNECT_RELAYS && validate_relay_url(&value).is_ok() {
+                if relays.len() < MAX_NOSTRCONNECT_RELAYS && validate(&value).is_ok() {
                     relays.push(normalize_relay_url(&value));
                 }
             }

--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+use std::time::Duration;
+
+use nostr_sdk::prelude::*;
+use tracing::{debug, warn};
+
+use keep_core::error::{CryptoError, NetworkError, StorageError};
+use keep_core::relay::TIMESTAMP_TWEAK_RANGE;
+
+use crate::bunker::parse_bunker_url;
+use crate::error::Result;
+use crate::types::Nip46Response;
+
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+const MAX_RESPONSE_SIZE: usize = 64 * 1024;
+pub const MAX_WALLET_NAME_LEN: usize = 64;
+pub const MAX_DESCRIPTOR_LEN: usize = 4096;
+
+/// Outcome of a successful `register_wallet` request.
+#[derive(Debug, Clone)]
+pub struct RegisterWalletResponse {
+    pub hmac: Option<Vec<u8>>,
+}
+
+/// Client that sends NIP-46 requests to a remote signer (e.g. a hardware wallet).
+pub struct Nip46Client {
+    signer_pubkey: PublicKey,
+    relays: Vec<String>,
+    secret: Option<String>,
+    client_keys: Keys,
+    client: Client,
+}
+
+impl Nip46Client {
+    pub async fn connect_to(uri: &str) -> Result<Self> {
+        let (signer_pubkey, relays, secret) = parse_bunker_url(uri).map_err(|e| {
+            keep_core::error::KeepError::InvalidInput(format!("invalid NIP-46 URI: {e}"))
+        })?;
+        Self::connect_with(signer_pubkey, relays, secret).await
+    }
+
+    pub async fn connect_with(
+        signer_pubkey: PublicKey,
+        relays: Vec<String>,
+        secret: Option<String>,
+    ) -> Result<Self> {
+        if relays.is_empty() {
+            return Err(NetworkError::relay("at least one relay required").into());
+        }
+
+        let client_keys = Keys::generate();
+        let client = Client::new(client_keys.clone());
+        for relay in &relays {
+            client
+                .add_relay(relay.as_str())
+                .await
+                .map_err(|e| NetworkError::relay(format!("add relay: {e}")))?;
+        }
+        client.connect().await;
+
+        let filter = Filter::new()
+            .kind(Kind::NostrConnect)
+            .pubkey(client_keys.public_key());
+        client
+            .subscribe(filter, None)
+            .await
+            .map_err(|e| NetworkError::subscribe(e.to_string()))?;
+
+        Ok(Self {
+            signer_pubkey,
+            relays,
+            secret,
+            client_keys,
+            client,
+        })
+    }
+
+    pub fn signer_pubkey(&self) -> PublicKey {
+        self.signer_pubkey
+    }
+
+    pub fn relays(&self) -> &[String] {
+        &self.relays
+    }
+
+    pub async fn disconnect(self) {
+        self.client.disconnect().await;
+    }
+
+    pub async fn connect(&self) -> Result<()> {
+        let mut params = vec![self.signer_pubkey.to_hex()];
+        if let Some(ref s) = self.secret {
+            params.push(s.clone());
+        }
+        let id = new_request_id();
+        let response = self.request(&id, "connect", params).await?;
+        match (response.result.as_deref(), response.error.as_deref()) {
+            (Some(_), None) => Ok(()),
+            (_, Some(err)) => {
+                Err(NetworkError::response(format!("connect rejected: {err}")).into())
+            }
+            _ => Err(NetworkError::response("connect returned no result").into()),
+        }
+    }
+
+    pub async fn register_wallet(
+        &self,
+        name: &str,
+        descriptor: &str,
+    ) -> Result<RegisterWalletResponse> {
+        if name.is_empty() {
+            return Err(keep_core::error::KeepError::InvalidInput(
+                "wallet name must not be empty".into(),
+            ));
+        }
+        if name.len() > MAX_WALLET_NAME_LEN {
+            return Err(keep_core::error::KeepError::InvalidInput(format!(
+                "wallet name exceeds {MAX_WALLET_NAME_LEN} bytes"
+            )));
+        }
+        if descriptor.is_empty() {
+            return Err(keep_core::error::KeepError::InvalidInput(
+                "descriptor must not be empty".into(),
+            ));
+        }
+        if descriptor.len() > MAX_DESCRIPTOR_LEN {
+            return Err(keep_core::error::KeepError::InvalidInput(format!(
+                "descriptor exceeds {MAX_DESCRIPTOR_LEN} bytes"
+            )));
+        }
+
+        let id = new_request_id();
+        let response = self
+            .request(
+                &id,
+                "register_wallet",
+                vec![name.to_string(), descriptor.to_string()],
+            )
+            .await?;
+
+        if let Some(err) = response.error {
+            return Err(NetworkError::response(format!("register_wallet rejected: {err}")).into());
+        }
+
+        let hmac = match response.result.as_deref() {
+            None | Some("") | Some("null") => None,
+            Some(hex_str) => Some(hex::decode(hex_str.trim()).map_err(|e| {
+                StorageError::invalid_format(format!("register_wallet hmac hex: {e}"))
+            })?),
+        };
+        Ok(RegisterWalletResponse { hmac })
+    }
+
+    async fn request(&self, id: &str, method: &str, params: Vec<String>) -> Result<Nip46Response> {
+        let mut notifications = self.client.notifications();
+
+        let request = serde_json::json!({
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        let payload = serde_json::to_string(&request)
+            .map_err(|e| StorageError::serialization(e.to_string()))?;
+
+        let encrypted = nip44::encrypt(
+            self.client_keys.secret_key(),
+            &self.signer_pubkey,
+            &payload,
+            nip44::Version::V2,
+        )
+        .map_err(|e| CryptoError::encryption(e.to_string()))?;
+
+        let event = EventBuilder::new(Kind::NostrConnect, encrypted)
+            .custom_created_at(Timestamp::tweaked(TIMESTAMP_TWEAK_RANGE))
+            .tag(Tag::public_key(self.signer_pubkey))
+            .sign_with_keys(&self.client_keys)
+            .map_err(|e| CryptoError::invalid_signature(format!("sign request: {e}")))?;
+
+        self.client
+            .send_event(&event)
+            .await
+            .map_err(|e| NetworkError::publish(format!("send request: {e}")))?;
+
+        debug!(method, id, "NIP-46 client request sent");
+
+        self.wait_for_response(id, &mut notifications).await
+    }
+
+    async fn wait_for_response(
+        &self,
+        id: &str,
+        notifications: &mut tokio::sync::broadcast::Receiver<RelayPoolNotification>,
+    ) -> Result<Nip46Response> {
+        let deadline = tokio::time::Instant::now() + DEFAULT_REQUEST_TIMEOUT;
+
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(NetworkError::timeout(format!("no response for request {id}")).into());
+            }
+
+            let notif = match tokio::time::timeout(remaining, notifications.recv()).await {
+                Ok(Ok(n)) => n,
+                Ok(Err(_)) => {
+                    return Err(NetworkError::response("notification stream closed").into());
+                }
+                Err(_) => {
+                    return Err(
+                        NetworkError::timeout(format!("no response for request {id}")).into(),
+                    );
+                }
+            };
+
+            let RelayPoolNotification::Event { event, .. } = notif else {
+                continue;
+            };
+            if event.kind != Kind::NostrConnect {
+                continue;
+            }
+            if event.pubkey != self.signer_pubkey {
+                continue;
+            }
+
+            if event.content.len() > MAX_RESPONSE_SIZE {
+                warn!("NIP-46 response too large, ignoring");
+                continue;
+            }
+
+            let plaintext = match nip44::decrypt(
+                self.client_keys.secret_key(),
+                &event.pubkey,
+                &event.content,
+            ) {
+                Ok(p) => p,
+                Err(e) => {
+                    debug!(error = %e, "failed to decrypt NIP-46 response");
+                    continue;
+                }
+            };
+
+            let response: Nip46Response = match serde_json::from_str(&plaintext) {
+                Ok(r) => r,
+                Err(e) => {
+                    debug!(error = %e, "failed to parse NIP-46 response");
+                    continue;
+                }
+            };
+
+            if response.id != id {
+                continue;
+            }
+            return Ok(response);
+        }
+    }
+}
+
+fn new_request_id() -> String {
+    hex::encode(keep_core::crypto::random_bytes::<16>())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_request_id_is_unique() {
+        let a = new_request_id();
+        let b = new_request_id();
+        assert_ne!(a, b);
+        assert_eq!(a.len(), 32);
+    }
+}

--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use nostr_sdk::prelude::*;
 use tracing::{debug, warn};
-use zeroize::Zeroizing;
+use zeroize::{Zeroize, Zeroizing};
 
 use keep_core::error::{CryptoError, KeepError, NetworkError, StorageError};
 use keep_core::relay::{
@@ -213,7 +213,7 @@ impl Nip46Client {
         }
 
         let id = new_request_id();
-        let response = self
+        let mut response = self
             .request_with_timeout(
                 &id,
                 "register_wallet",
@@ -229,17 +229,23 @@ impl Nip46Client {
             return Err(NetworkError::response(format!("register_wallet rejected: {err}")).into());
         }
 
-        let hmac = match response.result.as_deref() {
-            None | Some("") => None,
+        let hmac = match response.result.as_mut() {
+            None => None,
+            Some(hex_str) if hex_str.trim().is_empty() => {
+                hex_str.zeroize();
+                None
+            }
             Some(hex_str) => {
-                let trimmed = hex_str.trim();
-                if trimmed.len() > MAX_HMAC_HEX_LEN {
+                let trimmed_len = hex_str.trim().len();
+                if trimmed_len > MAX_HMAC_HEX_LEN {
+                    hex_str.zeroize();
                     return Err(KeepError::InvalidInput(format!(
-                        "register_wallet hmac too long: {} hex chars (max {MAX_HMAC_HEX_LEN})",
-                        trimmed.len()
+                        "register_wallet hmac too long: {trimmed_len} hex chars (max {MAX_HMAC_HEX_LEN})"
                     )));
                 }
-                let decoded = hex::decode(trimmed).map_err(|e| {
+                let decode_result = hex::decode(hex_str.trim());
+                hex_str.zeroize();
+                let decoded = decode_result.map_err(|e| {
                     StorageError::invalid_format(format!("register_wallet hmac hex: {e}"))
                 })?;
                 if decoded.len() != HMAC_SHA256_LEN {

--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -171,10 +171,9 @@ impl Nip46Client {
                 "descriptor exceeds {MAX_DESCRIPTOR_LEN} bytes"
             )));
         }
-        let has_multipath = descriptor.contains("<0;1>") || descriptor.contains("<1;0>");
-        let has_single_path = ["/0/*)", "/0/*,", "/1/*)", "/1/*,"]
-            .iter()
-            .any(|p| descriptor.contains(p));
+        let body = descriptor.split('#').next().unwrap_or(descriptor);
+        let has_multipath = keep_core::descriptor::has_multipath_marker(body);
+        let has_single_path = keep_core::descriptor::has_single_path_tail(body);
         if has_single_path {
             let msg = if has_multipath {
                 "descriptor mixes multipath and single-path keys; normalize all keys to <0;1>"
@@ -183,7 +182,12 @@ impl Nip46Client {
             };
             return Err(KeepError::InvalidInput(msg.into()));
         }
-        if !has_multipath && descriptor.contains('*') {
+        if body.contains("<1;0>") {
+            return Err(KeepError::InvalidInput(
+                "descriptor must use <0;1> multipath order; reorder before sending".into(),
+            ));
+        }
+        if !has_multipath && body.contains('*') {
             return Err(KeepError::InvalidInput(
                 "descriptor must be multipath (e.g. <0;1>) so the device can derive change".into(),
             ));

--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -20,6 +20,7 @@ const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 const REGISTER_WALLET_TIMEOUT: Duration = Duration::from_secs(180);
 const MAX_RESPONSE_SIZE: usize = 64 * 1024;
 const MAX_HMAC_HEX_LEN: usize = 128;
+const HMAC_SHA256_LEN: usize = 32;
 pub const MAX_WALLET_NAME_LEN: usize = 64;
 pub const MAX_DESCRIPTOR_LEN: usize = 4096;
 
@@ -70,21 +71,37 @@ impl Nip46Client {
 
         let client_keys = Keys::generate();
         let client = Client::new(client_keys.clone());
-        for relay in &relays {
-            client
-                .add_relay(relay.as_str())
-                .await
-                .map_err(|e| NetworkError::relay(format!("add relay: {e}")))?;
-        }
-        client.connect().await;
 
-        let filter = Filter::new()
-            .kind(Kind::NostrConnect)
-            .pubkey(client_keys.public_key());
-        client
-            .subscribe(filter, None)
-            .await
-            .map_err(|e| NetworkError::subscribe(e.to_string()))?;
+        let setup = async {
+            for relay in &relays {
+                client
+                    .add_relay(relay.as_str())
+                    .await
+                    .map_err(|e| NetworkError::relay(format!("add relay: {e}")))?;
+            }
+            client.connect().await;
+
+            let filter = Filter::new()
+                .kind(Kind::NostrConnect)
+                .pubkey(client_keys.public_key());
+            client
+                .subscribe(filter, None)
+                .await
+                .map_err(|e| NetworkError::subscribe(e.to_string()))?;
+            Ok::<_, KeepError>(())
+        };
+
+        match tokio::time::timeout(DEFAULT_REQUEST_TIMEOUT, setup).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => return Err(e),
+            Err(_) => {
+                client.disconnect().await;
+                return Err(NetworkError::timeout(
+                    "timed out connecting to NIP-46 relay".to_string(),
+                )
+                .into());
+            }
+        }
 
         Ok(Self {
             signer_pubkey,
@@ -166,6 +183,11 @@ impl Nip46Client {
             };
             return Err(KeepError::InvalidInput(msg.into()));
         }
+        if !has_multipath && descriptor.contains('*') {
+            return Err(KeepError::InvalidInput(
+                "descriptor must be multipath (e.g. <0;1>) so the device can derive change".into(),
+            ));
+        }
 
         let id = new_request_id();
         let response = self
@@ -191,9 +213,16 @@ impl Nip46Client {
                         trimmed.len()
                     )));
                 }
-                Some(hex::decode(trimmed).map_err(|e| {
+                let decoded = hex::decode(trimmed).map_err(|e| {
                     StorageError::invalid_format(format!("register_wallet hmac hex: {e}"))
-                })?)
+                })?;
+                if decoded.len() != HMAC_SHA256_LEN {
+                    return Err(KeepError::InvalidInput(format!(
+                        "register_wallet hmac must be {HMAC_SHA256_LEN} bytes, got {}",
+                        decoded.len()
+                    )));
+                }
+                Some(decoded)
             }
         };
         Ok(RegisterWalletResponse { hmac })

--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -4,16 +4,19 @@ use std::time::Duration;
 
 use nostr_sdk::prelude::*;
 use tracing::{debug, warn};
+use zeroize::Zeroizing;
 
 use keep_core::error::{CryptoError, NetworkError, StorageError};
-use keep_core::relay::TIMESTAMP_TWEAK_RANGE;
+use keep_core::relay::{normalize_relay_url, validate_relay_url, TIMESTAMP_TWEAK_RANGE};
 
 use crate::bunker::parse_bunker_url;
 use crate::error::Result;
 use crate::types::Nip46Response;
 
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+const REGISTER_WALLET_TIMEOUT: Duration = Duration::from_secs(180);
 const MAX_RESPONSE_SIZE: usize = 64 * 1024;
+const MAX_HMAC_HEX_LEN: usize = 128;
 pub const MAX_WALLET_NAME_LEN: usize = 64;
 pub const MAX_DESCRIPTOR_LEN: usize = 4096;
 
@@ -27,7 +30,7 @@ pub struct RegisterWalletResponse {
 pub struct Nip46Client {
     signer_pubkey: PublicKey,
     relays: Vec<String>,
-    secret: Option<String>,
+    secret: Option<Zeroizing<String>>,
     client_keys: Keys,
     client: Client,
 }
@@ -48,6 +51,17 @@ impl Nip46Client {
         if relays.is_empty() {
             return Err(NetworkError::relay("at least one relay required").into());
         }
+
+        let mut normalized = Vec::with_capacity(relays.len());
+        for relay in &relays {
+            validate_relay_url(relay).map_err(|e| {
+                keep_core::error::KeepError::InvalidInput(format!(
+                    "invalid relay URL '{relay}': {e}"
+                ))
+            })?;
+            normalized.push(normalize_relay_url(relay));
+        }
+        let relays = normalized;
 
         let client_keys = Keys::generate();
         let client = Client::new(client_keys.clone());
@@ -70,7 +84,7 @@ impl Nip46Client {
         Ok(Self {
             signer_pubkey,
             relays,
-            secret,
+            secret: secret.map(Zeroizing::new),
             client_keys,
             client,
         })
@@ -91,7 +105,7 @@ impl Nip46Client {
     pub async fn connect(&self) -> Result<()> {
         let mut params = vec![self.signer_pubkey.to_hex()];
         if let Some(ref s) = self.secret {
-            params.push(s.clone());
+            params.push(s.as_str().to_string());
         }
         let id = new_request_id();
         let response = self.request(&id, "connect", params).await?;
@@ -104,6 +118,12 @@ impl Nip46Client {
         }
     }
 
+    /// Register a wallet descriptor on the remote signer.
+    ///
+    /// The `descriptor` must already encode both the external (receive) and
+    /// internal (change) paths, typically as a BIP-389 multipath descriptor
+    /// (e.g. `tr(...<0;1>/*)`). Sending only a single-path descriptor prevents
+    /// the device from deriving change addresses.
     pub async fn register_wallet(
         &self,
         name: &str,
@@ -129,13 +149,21 @@ impl Nip46Client {
                 "descriptor exceeds {MAX_DESCRIPTOR_LEN} bytes"
             )));
         }
+        let has_multipath = descriptor.contains("<0;1>") || descriptor.contains("<1;0>");
+        let has_single_path = descriptor.contains("/0/*") || descriptor.contains("/1/*");
+        if has_single_path && !has_multipath {
+            return Err(keep_core::error::KeepError::InvalidInput(
+                "descriptor must be multipath (e.g. <0;1>) so the device can derive change".into(),
+            ));
+        }
 
         let id = new_request_id();
         let response = self
-            .request(
+            .request_with_timeout(
                 &id,
                 "register_wallet",
                 vec![name.to_string(), descriptor.to_string()],
+                REGISTER_WALLET_TIMEOUT,
             )
             .await?;
 
@@ -144,15 +172,35 @@ impl Nip46Client {
         }
 
         let hmac = match response.result.as_deref() {
-            None | Some("") | Some("null") => None,
-            Some(hex_str) => Some(hex::decode(hex_str.trim()).map_err(|e| {
-                StorageError::invalid_format(format!("register_wallet hmac hex: {e}"))
-            })?),
+            None | Some("") => None,
+            Some(hex_str) => {
+                let trimmed = hex_str.trim();
+                if trimmed.len() > MAX_HMAC_HEX_LEN {
+                    return Err(keep_core::error::KeepError::InvalidInput(format!(
+                        "register_wallet hmac too long: {} hex chars (max {MAX_HMAC_HEX_LEN})",
+                        trimmed.len()
+                    )));
+                }
+                Some(hex::decode(trimmed).map_err(|e| {
+                    StorageError::invalid_format(format!("register_wallet hmac hex: {e}"))
+                })?)
+            }
         };
         Ok(RegisterWalletResponse { hmac })
     }
 
     async fn request(&self, id: &str, method: &str, params: Vec<String>) -> Result<Nip46Response> {
+        self.request_with_timeout(id, method, params, DEFAULT_REQUEST_TIMEOUT)
+            .await
+    }
+
+    async fn request_with_timeout(
+        &self,
+        id: &str,
+        method: &str,
+        params: Vec<String>,
+        timeout: Duration,
+    ) -> Result<Nip46Response> {
         let mut notifications = self.client.notifications();
 
         let request = serde_json::json!({
@@ -184,15 +232,17 @@ impl Nip46Client {
 
         debug!(method, id, "NIP-46 client request sent");
 
-        self.wait_for_response(id, &mut notifications).await
+        self.wait_for_response(id, &mut notifications, timeout)
+            .await
     }
 
     async fn wait_for_response(
         &self,
         id: &str,
         notifications: &mut tokio::sync::broadcast::Receiver<RelayPoolNotification>,
+        timeout: Duration,
     ) -> Result<Nip46Response> {
-        let deadline = tokio::time::Instant::now() + DEFAULT_REQUEST_TIMEOUT;
+        let deadline = tokio::time::Instant::now() + timeout;
 
         loop {
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
@@ -202,7 +252,11 @@ impl Nip46Client {
 
             let notif = match tokio::time::timeout(remaining, notifications.recv()).await {
                 Ok(Ok(n)) => n,
-                Ok(Err(_)) => {
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(n))) => {
+                    warn!(dropped = n, "NIP-46 notification stream lagged");
+                    continue;
+                }
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
                     return Err(NetworkError::response("notification stream closed").into());
                 }
                 Err(_) => {

--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -143,8 +143,7 @@ impl Nip46Client {
     }
 
     pub async fn connect(&self) -> Result<()> {
-        let mut params: Vec<Zeroizing<String>> =
-            vec![Zeroizing::new(self.signer_pubkey.to_hex())];
+        let mut params: Vec<Zeroizing<String>> = vec![Zeroizing::new(self.signer_pubkey.to_hex())];
         if let Some(ref s) = self.secret {
             params.push(Zeroizing::new(s.as_str().to_string()));
         }
@@ -405,8 +404,7 @@ fn new_request_id() -> String {
 /// so a secret passed here never lives in a non-zeroized `String`.
 fn append_json_string(buf: &mut Zeroizing<String>, value: &str) -> Result<()> {
     let escaped = Zeroizing::new(
-        serde_json::to_string(value)
-            .map_err(|e| StorageError::serialization(e.to_string()))?,
+        serde_json::to_string(value).map_err(|e| StorageError::serialization(e.to_string()))?,
     );
     buf.push_str(escaped.as_str());
     Ok(())

--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -25,9 +25,27 @@ pub const MAX_WALLET_NAME_LEN: usize = 64;
 pub const MAX_DESCRIPTOR_LEN: usize = 4096;
 
 /// Outcome of a successful `register_wallet` request.
-#[derive(Debug, Clone)]
+///
+/// `hmac` is an opaque device-returned token. It is **not** cryptographically
+/// verified by this client; callers must not treat it as an authenticator
+/// unless a verification protocol is added on top.
+#[derive(Clone)]
 pub struct RegisterWalletResponse {
-    pub hmac: Option<Vec<u8>>,
+    pub hmac: Option<Zeroizing<Vec<u8>>>,
+}
+
+impl std::fmt::Debug for RegisterWalletResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegisterWalletResponse")
+            .field(
+                "hmac",
+                &self
+                    .hmac
+                    .as_ref()
+                    .map(|h| format!("<redacted; {} bytes>", h.len())),
+            )
+            .finish()
+    }
 }
 
 /// Client that sends NIP-46 requests to a remote signer (e.g. a hardware wallet).
@@ -125,9 +143,10 @@ impl Nip46Client {
     }
 
     pub async fn connect(&self) -> Result<()> {
-        let mut params = vec![self.signer_pubkey.to_hex()];
+        let mut params: Vec<Zeroizing<String>> =
+            vec![Zeroizing::new(self.signer_pubkey.to_hex())];
         if let Some(ref s) = self.secret {
-            params.push(s.as_str().to_string());
+            params.push(Zeroizing::new(s.as_str().to_string()));
         }
         let id = new_request_id();
         let response = self.request(&id, "connect", params).await?;
@@ -198,7 +217,10 @@ impl Nip46Client {
             .request_with_timeout(
                 &id,
                 "register_wallet",
-                vec![name.to_string(), descriptor.to_string()],
+                vec![
+                    Zeroizing::new(name.to_string()),
+                    Zeroizing::new(descriptor.to_string()),
+                ],
                 REGISTER_WALLET_TIMEOUT,
             )
             .await?;
@@ -226,13 +248,18 @@ impl Nip46Client {
                         decoded.len()
                     )));
                 }
-                Some(decoded)
+                Some(Zeroizing::new(decoded))
             }
         };
         Ok(RegisterWalletResponse { hmac })
     }
 
-    async fn request(&self, id: &str, method: &str, params: Vec<String>) -> Result<Nip46Response> {
+    async fn request(
+        &self,
+        id: &str,
+        method: &str,
+        params: Vec<Zeroizing<String>>,
+    ) -> Result<Nip46Response> {
         self.request_with_timeout(id, method, params, DEFAULT_REQUEST_TIMEOUT)
             .await
     }
@@ -241,20 +268,32 @@ impl Nip46Client {
         &self,
         id: &str,
         method: &str,
-        params: Vec<String>,
+        params: Vec<Zeroizing<String>>,
         timeout: Duration,
     ) -> Result<Nip46Response> {
         let mut notifications = self.client.notifications();
 
-        let request = serde_json::json!({
-            "id": id,
-            "method": method,
-            "params": params,
-        });
-        let payload = Zeroizing::new(
-            serde_json::to_string(&request)
-                .map_err(|e| StorageError::serialization(e.to_string()))?,
-        );
+        // Build the JSON payload directly into a Zeroizing<String> so secret
+        // params (e.g. bunker connect secret) never land in an intermediate
+        // serde_json::Value::String or non-zeroizing String buffer. Only the
+        // per-param JSON-escaping allocation happens on the heap, and we drop
+        // that allocation back into a Zeroizing wrapper immediately.
+        let mut payload = Zeroizing::new(String::with_capacity(128));
+        payload.push_str("{\"id\":");
+        append_json_string(&mut payload, id)?;
+        payload.push_str(",\"method\":");
+        append_json_string(&mut payload, method)?;
+        payload.push_str(",\"params\":[");
+        for (i, p) in params.iter().enumerate() {
+            if i > 0 {
+                payload.push(',');
+            }
+            append_json_string(&mut payload, p.as_str())?;
+        }
+        payload.push_str("]}");
+        // Drop the original params eagerly; each element is Zeroizing<String>
+        // and will zero its backing allocation here.
+        drop(params);
 
         let encrypted = nip44::encrypt(
             self.client_keys.secret_key(),
@@ -353,6 +392,18 @@ impl Nip46Client {
 
 fn new_request_id() -> String {
     hex::encode(keep_core::crypto::random_bytes::<16>())
+}
+
+/// JSON-escape `value` and append the quoted result to `buf`. The intermediate
+/// escape allocation is wrapped in `Zeroizing` and dropped at function return,
+/// so a secret passed here never lives in a non-zeroized `String`.
+fn append_json_string(buf: &mut Zeroizing<String>, value: &str) -> Result<()> {
+    let escaped = Zeroizing::new(
+        serde_json::to_string(value)
+            .map_err(|e| StorageError::serialization(e.to_string()))?,
+    );
+    buf.push_str(escaped.as_str());
+    Ok(())
 }
 
 #[cfg(test)]

--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -6,8 +6,11 @@ use nostr_sdk::prelude::*;
 use tracing::{debug, warn};
 use zeroize::Zeroizing;
 
-use keep_core::error::{CryptoError, NetworkError, StorageError};
-use keep_core::relay::{normalize_relay_url, validate_relay_url, TIMESTAMP_TWEAK_RANGE};
+use keep_core::error::{CryptoError, KeepError, NetworkError, StorageError};
+use keep_core::relay::{
+    normalize_relay_url, validate_relay_url, validate_relay_url_allow_internal,
+    ALLOW_INTERNAL_HOSTS, TIMESTAMP_TWEAK_RANGE,
+};
 
 use crate::bunker::parse_bunker_url;
 use crate::error::Result;
@@ -37,9 +40,8 @@ pub struct Nip46Client {
 
 impl Nip46Client {
     pub async fn connect_to(uri: &str) -> Result<Self> {
-        let (signer_pubkey, relays, secret) = parse_bunker_url(uri).map_err(|e| {
-            keep_core::error::KeepError::InvalidInput(format!("invalid NIP-46 URI: {e}"))
-        })?;
+        let (signer_pubkey, relays, secret) = parse_bunker_url(uri)
+            .map_err(|e| KeepError::InvalidInput(format!("invalid NIP-46 URI: {e}")))?;
         Self::connect_with(signer_pubkey, relays, secret).await
     }
 
@@ -52,12 +54,15 @@ impl Nip46Client {
             return Err(NetworkError::relay("at least one relay required").into());
         }
 
+        let validate = if ALLOW_INTERNAL_HOSTS {
+            validate_relay_url_allow_internal
+        } else {
+            validate_relay_url
+        };
         let mut normalized = Vec::with_capacity(relays.len());
         for relay in &relays {
-            validate_relay_url(relay).map_err(|e| {
-                keep_core::error::KeepError::InvalidInput(format!(
-                    "invalid relay URL '{relay}': {e}"
-                ))
+            validate(relay).map_err(|e| {
+                KeepError::InvalidInput(format!("invalid relay URL '{relay}': {e}"))
             })?;
             normalized.push(normalize_relay_url(relay));
         }
@@ -130,31 +135,36 @@ impl Nip46Client {
         descriptor: &str,
     ) -> Result<RegisterWalletResponse> {
         if name.is_empty() {
-            return Err(keep_core::error::KeepError::InvalidInput(
+            return Err(KeepError::InvalidInput(
                 "wallet name must not be empty".into(),
             ));
         }
         if name.len() > MAX_WALLET_NAME_LEN {
-            return Err(keep_core::error::KeepError::InvalidInput(format!(
+            return Err(KeepError::InvalidInput(format!(
                 "wallet name exceeds {MAX_WALLET_NAME_LEN} bytes"
             )));
         }
         if descriptor.is_empty() {
-            return Err(keep_core::error::KeepError::InvalidInput(
+            return Err(KeepError::InvalidInput(
                 "descriptor must not be empty".into(),
             ));
         }
         if descriptor.len() > MAX_DESCRIPTOR_LEN {
-            return Err(keep_core::error::KeepError::InvalidInput(format!(
+            return Err(KeepError::InvalidInput(format!(
                 "descriptor exceeds {MAX_DESCRIPTOR_LEN} bytes"
             )));
         }
         let has_multipath = descriptor.contains("<0;1>") || descriptor.contains("<1;0>");
-        let has_single_path = descriptor.contains("/0/*") || descriptor.contains("/1/*");
-        if has_single_path && !has_multipath {
-            return Err(keep_core::error::KeepError::InvalidInput(
-                "descriptor must be multipath (e.g. <0;1>) so the device can derive change".into(),
-            ));
+        let has_single_path = ["/0/*)", "/0/*,", "/1/*)", "/1/*,"]
+            .iter()
+            .any(|p| descriptor.contains(p));
+        if has_single_path {
+            let msg = if has_multipath {
+                "descriptor mixes multipath and single-path keys; normalize all keys to <0;1>"
+            } else {
+                "descriptor must be multipath (e.g. <0;1>) so the device can derive change"
+            };
+            return Err(KeepError::InvalidInput(msg.into()));
         }
 
         let id = new_request_id();
@@ -176,7 +186,7 @@ impl Nip46Client {
             Some(hex_str) => {
                 let trimmed = hex_str.trim();
                 if trimmed.len() > MAX_HMAC_HEX_LEN {
-                    return Err(keep_core::error::KeepError::InvalidInput(format!(
+                    return Err(KeepError::InvalidInput(format!(
                         "register_wallet hmac too long: {} hex chars (max {MAX_HMAC_HEX_LEN})",
                         trimmed.len()
                     )));
@@ -208,13 +218,15 @@ impl Nip46Client {
             "method": method,
             "params": params,
         });
-        let payload = serde_json::to_string(&request)
-            .map_err(|e| StorageError::serialization(e.to_string()))?;
+        let payload = Zeroizing::new(
+            serde_json::to_string(&request)
+                .map_err(|e| StorageError::serialization(e.to_string()))?,
+        );
 
         let encrypted = nip44::encrypt(
             self.client_keys.secret_key(),
             &self.signer_pubkey,
-            &payload,
+            payload.as_str(),
             nip44::Version::V2,
         )
         .map_err(|e| CryptoError::encryption(e.to_string()))?;
@@ -243,11 +255,12 @@ impl Nip46Client {
         timeout: Duration,
     ) -> Result<Nip46Response> {
         let deadline = tokio::time::Instant::now() + timeout;
+        let timeout_err = || NetworkError::timeout(format!("no response for request {id}"));
 
         loop {
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
             if remaining.is_zero() {
-                return Err(NetworkError::timeout(format!("no response for request {id}")).into());
+                return Err(timeout_err().into());
             }
 
             let notif = match tokio::time::timeout(remaining, notifications.recv()).await {
@@ -259,11 +272,7 @@ impl Nip46Client {
                 Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
                     return Err(NetworkError::response("notification stream closed").into());
                 }
-                Err(_) => {
-                    return Err(
-                        NetworkError::timeout(format!("no response for request {id}")).into(),
-                    );
-                }
+                Err(_) => return Err(timeout_err().into()),
             };
 
             let RelayPoolNotification::Event { event, .. } = notif else {

--- a/keep-nip46/src/lib.rs
+++ b/keep-nip46/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod audit;
 pub mod bunker;
+pub mod client;
 pub mod error;
 pub mod frost_signer;
 pub mod handler;
@@ -19,6 +20,7 @@ pub use audit::{AuditAction, AuditEntry, AuditLog};
 pub use bunker::{
     generate_bunker_url, parse_bunker_url, parse_nostrconnect_uri, NostrConnectRequest,
 };
+pub use client::{Nip46Client, RegisterWalletResponse, MAX_DESCRIPTOR_LEN, MAX_WALLET_NAME_LEN};
 pub use error::Result;
 pub use frost_signer::{FrostSigner, NetworkFrostSigner};
 pub use handler::SignerHandler;

--- a/keep-nip46/src/types.rs
+++ b/keep-nip46/src/types.rs
@@ -35,7 +35,7 @@ pub(crate) struct Nip46Request {
     pub params: Vec<String>,
 }
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct Nip46Response {
     pub id: String,
     pub result: Option<String>,

--- a/keep-nip46/tests/client_integration.rs
+++ b/keep-nip46/tests/client_integration.rs
@@ -204,18 +204,23 @@ async fn test_nip46_client_register_wallet_returns_hmac() {
 
 #[tokio::test]
 async fn test_nip46_client_register_wallet_rejects_empty_name() {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+
+    let mock_relay = MockRelay::run().await.expect("mock relay");
+    let relay_url = mock_relay.url().await.to_string();
+
     let signer_keys = Keys::generate();
-    let client = Nip46Client::connect_with(
-        signer_keys.public_key(),
-        vec!["wss://relay.example.com/".into()],
-        None,
-    )
-    .await;
-    // If connect_with times out dialing a fake relay it's fine — we just
-    // verify the input validation path fires.
-    if let Ok(client) = client {
-        let err = client.register_wallet("", "tr(...)").await.unwrap_err();
-        assert!(err.to_string().contains("wallet name must not be empty"));
-        client.disconnect().await;
-    }
+    let client = Nip46Client::connect_with(signer_keys.public_key(), vec![relay_url], None)
+        .await
+        .expect("client connect");
+
+    let err = client
+        .register_wallet("", "tr(xpub.../<0;1>/*)")
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("wallet name must not be empty"));
+
+    client.disconnect().await;
 }

--- a/keep-nip46/tests/client_integration.rs
+++ b/keep-nip46/tests/client_integration.rs
@@ -1,0 +1,221 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use nostr_relay_builder::prelude::*;
+use nostr_sdk::prelude::{Keys, PublicKey};
+use tokio::sync::Mutex;
+
+use keep_core::keyring::Keyring;
+use keep_core::keys::{KeyType, NostrKeypair};
+use keep_nip46::{generate_bunker_url, Nip46Client, Server, ServerConfig};
+
+fn setup_keyring() -> (Arc<Mutex<Keyring>>, PublicKey) {
+    let mut keyring = Keyring::new();
+    let keypair = NostrKeypair::generate().unwrap();
+    let pubkey_bytes = *keypair.public_bytes();
+    keyring
+        .load_key(
+            *keypair.public_bytes(),
+            *keypair.secret_bytes(),
+            KeyType::Nostr,
+            "test".to_string(),
+        )
+        .unwrap();
+    let pubkey = PublicKey::from_slice(&pubkey_bytes).unwrap();
+    (Arc::new(Mutex::new(keyring)), pubkey)
+}
+
+#[tokio::test]
+async fn test_nip46_client_rejects_unknown_method() {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+
+    let mock_relay = MockRelay::run().await.expect("mock relay");
+    let relay_url = mock_relay.url().await.to_string();
+
+    let (keyring, _signer_pubkey) = setup_keyring();
+    let mut server = Server::new_with_config(
+        keyring,
+        None,
+        None,
+        std::slice::from_ref(&relay_url),
+        None,
+        ServerConfig {
+            auto_approve: true,
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("server creation failed");
+
+    let bunker_url = server.bunker_url();
+    let bunker_secret = url::Url::parse(&bunker_url).ok().and_then(|u| {
+        u.query_pairs()
+            .find(|(k, _)| k == "secret")
+            .map(|(_, v)| v.to_string())
+    });
+    let server_pubkey = server.pubkey();
+
+    let server_handle = tokio::spawn(async move {
+        let _ = server.run().await;
+    });
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let client = Nip46Client::connect_with(server_pubkey, vec![relay_url.clone()], bunker_secret)
+        .await
+        .expect("client connect");
+    client.connect().await.expect("connect handshake");
+
+    // The keep-nip46 server does not implement register_wallet — it should
+    // respond with an "Unknown method" error. Verify the client surfaces it.
+    let err = client
+        .register_wallet("test-wallet", "tr([deadbeef]xpub6.../<0;1>/*)")
+        .await
+        .expect_err("register_wallet should error against a non-hardware signer");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("register_wallet rejected") || msg.contains("Unknown method"),
+        "unexpected error: {msg}"
+    );
+
+    client.disconnect().await;
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn test_nip46_client_parses_bunker_url() {
+    let keys = Keys::generate();
+    let url = generate_bunker_url(
+        &keys.public_key(),
+        &["wss://relay.example.com/".into()],
+        Some("topsecretbunker12"),
+    );
+
+    // Parsing is covered here by connection-free checks: build a client URL and
+    // ensure connect_to accepts a well-formed bunker URL structure.
+    // We don't actually dial a real relay in this sub-test.
+    let bad = Nip46Client::connect_to("not-a-bunker-url").await;
+    assert!(bad.is_err(), "invalid URL must be rejected");
+
+    let _ = url;
+}
+
+// Simulates a remote hardware signer that accepts register_wallet and replies
+// with a deterministic HMAC so we can exercise the full happy-path client flow.
+async fn run_stub_signer(
+    signer_keys: Keys,
+    relay_url: String,
+    hmac_hex: String,
+) -> tokio::task::JoinHandle<()> {
+    use nostr_sdk::prelude::{
+        nip44, Client, EventBuilder, Filter, Kind, RelayPoolNotification, Tag, Timestamp,
+    };
+
+    tokio::spawn(async move {
+        let client = Client::new(signer_keys.clone());
+        client.add_relay(relay_url.as_str()).await.unwrap();
+        client.connect().await;
+        let filter = Filter::new()
+            .kind(Kind::NostrConnect)
+            .pubkey(signer_keys.public_key());
+        client.subscribe(filter, None).await.unwrap();
+
+        let mut notifications = client.notifications();
+        while let Ok(notif) = notifications.recv().await {
+            let RelayPoolNotification::Event { event, .. } = notif else {
+                continue;
+            };
+            if event.kind != Kind::NostrConnect {
+                continue;
+            }
+            let app_pubkey = event.pubkey;
+            let Ok(plaintext) =
+                nip44::decrypt(signer_keys.secret_key(), &app_pubkey, &event.content)
+            else {
+                continue;
+            };
+            let Ok(request): Result<serde_json::Value, _> = serde_json::from_str(&plaintext) else {
+                continue;
+            };
+            let id = request
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let method = request.get("method").and_then(|v| v.as_str()).unwrap_or("");
+
+            let response = match method {
+                "connect" => serde_json::json!({"id": id, "result": "ack"}),
+                "register_wallet" => serde_json::json!({"id": id, "result": hmac_hex}),
+                _ => serde_json::json!({"id": id, "error": "Unknown method"}),
+            };
+
+            let body = serde_json::to_string(&response).unwrap();
+            let ct = nip44::encrypt(
+                signer_keys.secret_key(),
+                &app_pubkey,
+                &body,
+                nip44::Version::V2,
+            )
+            .unwrap();
+            let ev = EventBuilder::new(Kind::NostrConnect, ct)
+                .custom_created_at(Timestamp::now())
+                .tag(Tag::public_key(app_pubkey))
+                .sign_with_keys(&signer_keys)
+                .unwrap();
+            let _ = client.send_event(&ev).await;
+        }
+    })
+}
+
+#[tokio::test]
+async fn test_nip46_client_register_wallet_returns_hmac() {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+
+    let mock_relay = MockRelay::run().await.expect("mock relay");
+    let relay_url = mock_relay.url().await.to_string();
+
+    let signer_keys = Keys::generate();
+    let signer_pubkey = signer_keys.public_key();
+    let hmac_hex = "deadbeef".repeat(8);
+
+    let signer_handle = run_stub_signer(signer_keys, relay_url.clone(), hmac_hex.clone()).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let client = Nip46Client::connect_with(signer_pubkey, vec![relay_url], None)
+        .await
+        .expect("client connect");
+    client.connect().await.expect("connect handshake");
+
+    let resp = client
+        .register_wallet("treasury", "tr([deadbeef]xpub6.../<0;1>/*)")
+        .await
+        .expect("register_wallet succeeds");
+
+    let decoded = resp.hmac.expect("hmac returned");
+    assert_eq!(hex::encode(decoded), hmac_hex);
+
+    client.disconnect().await;
+    signer_handle.abort();
+}
+
+#[tokio::test]
+async fn test_nip46_client_register_wallet_rejects_empty_name() {
+    let signer_keys = Keys::generate();
+    let client = Nip46Client::connect_with(
+        signer_keys.public_key(),
+        vec!["wss://relay.example.com/".into()],
+        None,
+    )
+    .await;
+    // If connect_with times out dialing a fake relay it's fine — we just
+    // verify the input validation path fires.
+    if let Ok(client) = client {
+        let err = client.register_wallet("", "tr(...)").await.unwrap_err();
+        assert!(err.to_string().contains("wallet name must not be empty"));
+        client.disconnect().await;
+    }
+}

--- a/keep-nip46/tests/client_integration.rs
+++ b/keep-nip46/tests/client_integration.rs
@@ -85,20 +85,22 @@ async fn test_nip46_client_rejects_unknown_method() {
 
 #[tokio::test]
 async fn test_nip46_client_parses_bunker_url() {
-    let keys = Keys::generate();
-    let url = generate_bunker_url(
-        &keys.public_key(),
-        &["wss://relay.example.com/".into()],
-        Some("topsecretbunker12"),
-    );
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
 
-    // Parsing is covered here by connection-free checks: build a client URL and
-    // ensure connect_to accepts a well-formed bunker URL structure.
-    // We don't actually dial a real relay in this sub-test.
     let bad = Nip46Client::connect_to("not-a-bunker-url").await;
     assert!(bad.is_err(), "invalid URL must be rejected");
 
-    let _ = url;
+    let mock_relay = MockRelay::run().await.expect("mock relay");
+    let relay_url = mock_relay.url().await.to_string();
+    let keys = Keys::generate();
+    let url = generate_bunker_url(&keys.public_key(), &[relay_url], Some("topsecretbunker12"));
+
+    let client = Nip46Client::connect_to(&url)
+        .await
+        .expect("well-formed bunker URL connects");
+    client.disconnect().await;
 }
 
 // Simulates a remote hardware signer that accepts register_wallet and replies
@@ -107,12 +109,17 @@ async fn run_stub_signer(
     signer_keys: Keys,
     relay_url: String,
     hmac_hex: String,
-) -> tokio::task::JoinHandle<()> {
+) -> (
+    tokio::task::JoinHandle<()>,
+    tokio::sync::oneshot::Receiver<()>,
+) {
     use nostr_sdk::prelude::{
         nip44, Client, EventBuilder, Filter, Kind, RelayPoolNotification, Tag, Timestamp,
     };
 
-    tokio::spawn(async move {
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+
+    let handle = tokio::spawn(async move {
         let client = Client::new(signer_keys.clone());
         client.add_relay(relay_url.as_str()).await.unwrap();
         client.connect().await;
@@ -120,6 +127,7 @@ async fn run_stub_signer(
             .kind(Kind::NostrConnect)
             .pubkey(signer_keys.public_key());
         client.subscribe(filter, None).await.unwrap();
+        let _ = ready_tx.send(());
 
         let mut notifications = client.notifications();
         while let Ok(notif) = notifications.recv().await {
@@ -166,7 +174,9 @@ async fn run_stub_signer(
                 .unwrap();
             let _ = client.send_event(&ev).await;
         }
-    })
+    });
+
+    (handle, ready_rx)
 }
 
 #[tokio::test]
@@ -182,8 +192,9 @@ async fn test_nip46_client_register_wallet_returns_hmac() {
     let signer_pubkey = signer_keys.public_key();
     let hmac_hex = "deadbeef".repeat(8);
 
-    let signer_handle = run_stub_signer(signer_keys, relay_url.clone(), hmac_hex.clone()).await;
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    let (signer_handle, signer_ready) =
+        run_stub_signer(signer_keys, relay_url.clone(), hmac_hex.clone()).await;
+    signer_ready.await.expect("stub signer ready");
 
     let client = Nip46Client::connect_with(signer_pubkey, vec![relay_url], None)
         .await

--- a/keep-nip46/tests/client_integration.rs
+++ b/keep-nip46/tests/client_integration.rs
@@ -5,6 +5,7 @@ use nostr_relay_builder::prelude::*;
 use nostr_sdk::prelude::{Keys, PublicKey};
 use tokio::sync::Mutex;
 
+use keep_core::error::{KeepError, NetworkError};
 use keep_core::keyring::Keyring;
 use keep_core::keys::{KeyType, NostrKeypair};
 use keep_nip46::{generate_bunker_url, Nip46Client, Server, ServerConfig};
@@ -67,17 +68,24 @@ async fn test_nip46_client_rejects_unknown_method() {
         .expect("client connect");
     client.connect().await.expect("connect handshake");
 
-    // The keep-nip46 server does not implement register_wallet — it should
-    // respond with an "Unknown method" error. Verify the client surfaces it.
+    // The keep-nip46 server does not implement register_wallet, so it should
+    // respond with an "Unknown method" error. Verify the client surfaces it as
+    // a typed NetworkError::Response with a non-empty message.
     let err = client
         .register_wallet("test-wallet", "tr([deadbeef]xpub6.../<0;1>/*)")
         .await
         .expect_err("register_wallet should error against a non-hardware signer");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("register_wallet rejected") || msg.contains("Unknown method"),
-        "unexpected error: {msg}"
-    );
+    match err {
+        KeepError::NetworkErr(NetworkError::Response { message, .. }) => {
+            assert!(!message.is_empty(), "empty response error message");
+            assert!(
+                message.contains("register_wallet rejected")
+                    || message.contains("Unknown method"),
+                "unexpected response error: {message}"
+            );
+        }
+        other => panic!("expected NetworkError::Response, got {other:?}"),
+    }
 
     client.disconnect().await;
     server_handle.abort();
@@ -207,7 +215,7 @@ async fn test_nip46_client_register_wallet_returns_hmac() {
         .expect("register_wallet succeeds");
 
     let decoded = resp.hmac.expect("hmac returned");
-    assert_eq!(hex::encode(decoded), hmac_hex);
+    assert_eq!(hex::encode(decoded.as_slice()), hmac_hex);
 
     client.disconnect().await;
     signer_handle.abort();

--- a/keep-nip46/tests/client_integration.rs
+++ b/keep-nip46/tests/client_integration.rs
@@ -79,8 +79,7 @@ async fn test_nip46_client_rejects_unknown_method() {
         KeepError::NetworkErr(NetworkError::Response { message, .. }) => {
             assert!(!message.is_empty(), "empty response error message");
             assert!(
-                message.contains("register_wallet rejected")
-                    || message.contains("Unknown method"),
+                message.contains("register_wallet rejected") || message.contains("Unknown method"),
                 "unexpected response error: {message}"
             );
         }


### PR DESCRIPTION
Closes #333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add wallet hardware registration flow: CLI commands to register and list device registrations.
  * NIP‑46 signer support for connecting, registering wallets, and returning registration tokens.
  * Automatic conversion/validation of descriptors to BIP‑389 multipath form for registration.
  * Desktop UI: "Register on Device" workflow with async register status and toasts.
  * Mobile: API and storage support for device registrations and backup/restore of registration data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->