### PR TITLE
bump rustls-webpki to 0.103.12 for RUSTSEC-2026-0099

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7206,9 +7206,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

Bumps `rustls-webpki` from `0.103.11` to `0.103.12` to address [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099).

Cargo.lock-only change; no source modifications.

## Verification

- `cargo build --workspace` — clean build, no warnings or errors
- `cargo audit` — RUSTSEC-2026-0099 no longer flagged
- `cargo test --workspace` — 756 passed, 0 failed, 13 ignored; no regressions

## Follow-up

`cargo audit` surfaces a separate pre-existing advisory, [RUSTSEC-2026-0037](https://rustsec.org/advisories/RUSTSEC-2026-0037) in `quinn-proto 0.11.13` (pulled in via `reqwest` → `keep-cli`). Fix requires bumping to `>=0.11.14`. Out of scope for this PR; recommend a separate follow-up.