### PR TITLE
Track device kind/fingerprint and add NIP-46 get_device_info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7219,9 +7219,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -211,6 +211,12 @@ pub(crate) enum WalletCommands {
         name: Option<String>,
         #[arg(long, help = "Print the registration token (HMAC) to the terminal")]
         show_token: bool,
+        #[arg(long, help = "Device kind label (e.g. Coldcard, Ledger, BitBox02)")]
+        kind: Option<String>,
+        #[arg(long, help = "BIP32 master key fingerprint, 8 hex chars")]
+        fingerprint: Option<String>,
+        #[arg(long, help = "Firmware version string reported by the signer")]
+        firmware_version: Option<String>,
     },
     /// List hardware signers that have registered a stored wallet
     Registrations {

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -219,6 +219,7 @@ pub fn cmd_wallet_descriptor(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn cmd_wallet_register(
     out: &Output,
     path: &Path,
@@ -226,8 +227,16 @@ pub fn cmd_wallet_register(
     device_uri: &str,
     name: Option<&str>,
     show_token: bool,
+    kind_arg: Option<&str>,
+    fingerprint_arg: Option<&str>,
+    firmware_version_arg: Option<&str>,
 ) -> Result<()> {
     debug!(group, device = %mask_secret(device_uri), "wallet register");
+
+    let fingerprint_arg_bytes = match fingerprint_arg {
+        Some(s) => Some(parse_fingerprint_hex(s)?),
+        None => None,
+    };
 
     let group_pubkey = parse_group_id(group)?;
 
@@ -292,13 +301,24 @@ pub fn cmd_wallet_register(
                 .map_err(|e| KeepError::Runtime(format!("handshake: {e}")))?;
             spinner.finish();
 
+            // Best-effort device info probe; failure must not block registration.
+            let spinner = out.spinner("Probing device info...");
+            let device_info = match client.get_device_info().await {
+                Ok(info) => Some(info),
+                Err(e) => {
+                    debug!("get_device_info failed (best-effort): {e}");
+                    None
+                }
+            };
+            spinner.finish();
+
             let spinner = out.spinner("Registering wallet on device (confirm on device)...");
             let response = client
                 .register_wallet(&wallet_name, &multipath)
                 .await
                 .map_err(|e| KeepError::Runtime(format!("register_wallet: {e}")))?;
             spinner.finish();
-            Ok::<_, KeepError>(response)
+            Ok::<_, KeepError>((response, device_info))
         }
         .await;
 
@@ -309,7 +329,7 @@ pub fn cmd_wallet_register(
     // runtime down; avoids aborting in-flight disconnect cleanup.
     rt.shutdown_timeout(Duration::from_secs(2));
 
-    let (signer_pubkey, response) = register_outcome?;
+    let (signer_pubkey, (response, device_info)) = register_outcome?;
 
     let signer_bytes = signer_pubkey.to_bytes();
     let signer_hex = hex::encode(signer_bytes);
@@ -318,11 +338,32 @@ pub fn cmd_wallet_register(
         .unwrap_or_default()
         .as_secs();
 
+    // CLI flags take precedence; fall back to the device-reported values.
+    let device_kind = kind_arg
+        .map(|s| s.to_string())
+        .or_else(|| device_info.as_ref().map(|d| d.kind.as_str().to_string()));
+    let fingerprint =
+        fingerprint_arg_bytes.or_else(|| device_info.as_ref().and_then(|d| d.fingerprint_bytes()));
+    let firmware_version = firmware_version_arg.map(|s| s.to_string()).or_else(|| {
+        device_info
+            .as_ref()
+            .and_then(|d| d.firmware_version.clone())
+    });
+
     // Surface the device-side outcome before attempting local persistence so an
     // operator knows registration already took effect on the signer if the
     // local save errors below. Re-running register is idempotent.
     out.success("Device accepted the wallet registration");
     out.field("Signer pubkey", &signer_hex);
+    if let Some(k) = device_kind.as_deref() {
+        out.field("Device kind", k);
+    }
+    if let Some(fp) = fingerprint {
+        out.field("Fingerprint", &hex::encode(fp));
+    }
+    if let Some(fw) = firmware_version.as_deref() {
+        out.field("Firmware version", fw);
+    }
     match response.hmac.as_deref() {
         Some(hmac) => out.field("Registration token", &format_token(hmac, show_token)),
         None => out.info("Device did not return a registration token."),
@@ -340,6 +381,9 @@ pub fn cmd_wallet_register(
             wallet_name: wallet_name.clone(),
             hmac: response.hmac.clone(),
             registered_at: now,
+            device_kind,
+            fingerprint,
+            firmware_version,
         },
     )
     .map_err(|e| {
@@ -386,6 +430,15 @@ pub fn cmd_wallet_registrations(
         out.field("Signer pubkey", &hex::encode(reg.signer_pubkey));
         out.field("Wallet name", &reg.wallet_name);
         out.field("Registered at", &format_registered_at(reg.registered_at));
+        if let Some(k) = reg.device_kind.as_deref() {
+            out.field("Device kind", k);
+        }
+        if let Some(fp) = reg.fingerprint {
+            out.field("Fingerprint", &hex::encode(fp));
+        }
+        if let Some(fw) = reg.firmware_version.as_deref() {
+            out.field("Firmware version", fw);
+        }
         if let Some(hmac) = reg.hmac.as_deref() {
             out.field("Registration token", &format_token(hmac, show_token));
         }
@@ -424,6 +477,20 @@ fn truncate_relay_for_log(relay: &str) -> String {
     }
     let prefix: String = relay.chars().take(PREFIX_LEN).collect();
     format!("{prefix}...")
+}
+
+fn parse_fingerprint_hex(s: &str) -> Result<[u8; 4]> {
+    let trimmed = s.trim().trim_start_matches("0x");
+    if trimmed.len() != 8 {
+        return Err(KeepError::InvalidInput(
+            "fingerprint must be 8 hex characters (4 bytes)".into(),
+        ));
+    }
+    let bytes = hex::decode(trimmed)
+        .map_err(|e| KeepError::InvalidInput(format!("invalid fingerprint hex: {e}")))?;
+    bytes
+        .try_into()
+        .map_err(|_| KeepError::InvalidInput("fingerprint must be 4 bytes".into()))
 }
 
 fn format_token(hmac: &[u8], show_token: bool) -> String {

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -241,30 +241,15 @@ pub fn cmd_wallet_register(
         None => None,
     };
     if let Some(k) = kind_arg {
-        if k.is_empty() || k.len() > keep_nip46::MAX_DEVICE_KIND_LEN {
-            return Err(KeepError::InvalidInput(format!(
-                "--kind must be 1..={} bytes",
-                keep_nip46::MAX_DEVICE_KIND_LEN
-            )));
-        }
-        if keep_nip46::contains_control_chars(k) {
-            return Err(KeepError::InvalidInput(
-                "--kind must not contain control characters".to_string(),
-            ));
-        }
+        keep_nip46::validate_metadata_field("--kind", k, 1, keep_nip46::MAX_DEVICE_KIND_LEN)?;
     }
     if let Some(fw) = firmware_version_arg {
-        if fw.len() > keep_nip46::MAX_FIRMWARE_VERSION_LEN {
-            return Err(KeepError::InvalidInput(format!(
-                "--firmware-version exceeds {} bytes",
-                keep_nip46::MAX_FIRMWARE_VERSION_LEN
-            )));
-        }
-        if keep_nip46::contains_control_chars(fw) {
-            return Err(KeepError::InvalidInput(
-                "--firmware-version must not contain control characters".to_string(),
-            ));
-        }
+        keep_nip46::validate_metadata_field(
+            "--firmware-version",
+            fw,
+            0,
+            keep_nip46::MAX_FIRMWARE_VERSION_LEN,
+        )?;
     }
 
     let group_pubkey = parse_group_id(group)?;

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -345,6 +345,11 @@ pub fn cmd_wallet_register(
                 keep_nip46::MAX_DEVICE_KIND_LEN
             )));
         }
+        if k.chars().any(|c| c.is_control()) {
+            return Err(KeepError::InvalidInput(
+                "--kind must not contain control characters".to_string(),
+            ));
+        }
     }
     if let Some(fw) = firmware_version_arg {
         if fw.len() > keep_nip46::MAX_FIRMWARE_VERSION_LEN {
@@ -352,6 +357,11 @@ pub fn cmd_wallet_register(
                 "--firmware-version exceeds {} bytes",
                 keep_nip46::MAX_FIRMWARE_VERSION_LEN
             )));
+        }
+        if fw.chars().any(|c| c.is_control()) {
+            return Err(KeepError::InvalidInput(
+                "--firmware-version must not contain control characters".to_string(),
+            ));
         }
     }
 

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -338,12 +338,56 @@ pub fn cmd_wallet_register(
         .unwrap_or_default()
         .as_secs();
 
+    if let Some(k) = kind_arg {
+        if k.is_empty() || k.len() > keep_nip46::MAX_DEVICE_KIND_LEN {
+            return Err(KeepError::InvalidInput(format!(
+                "--kind must be 1..={} bytes",
+                keep_nip46::MAX_DEVICE_KIND_LEN
+            )));
+        }
+    }
+    if let Some(fw) = firmware_version_arg {
+        if fw.len() > keep_nip46::MAX_FIRMWARE_VERSION_LEN {
+            return Err(KeepError::InvalidInput(format!(
+                "--firmware-version exceeds {} bytes",
+                keep_nip46::MAX_FIRMWARE_VERSION_LEN
+            )));
+        }
+    }
+
     // CLI flags take precedence; fall back to the device-reported values.
-    let device_kind = kind_arg
-        .map(|s| s.to_string())
-        .or_else(|| device_info.as_ref().map(|d| d.kind.as_str().to_string()));
-    let fingerprint =
-        fingerprint_arg_bytes.or_else(|| device_info.as_ref().and_then(|d| d.fingerprint_bytes()));
+    // Warn loudly when the operator overrides what the device reported, so the
+    // mismatch is visible in audit output.
+    let device_kind = match (kind_arg, device_info.as_ref()) {
+        (Some(k), Some(d)) if k != d.kind.as_str() => {
+            out.warn(&format!(
+                "--kind '{}' overrides device-reported '{}'",
+                k,
+                d.kind.as_str()
+            ));
+            Some(k.to_string())
+        }
+        (Some(k), _) => Some(k.to_string()),
+        (None, Some(d)) => Some(d.kind.as_str().to_string()),
+        (None, None) => None,
+    };
+    let fingerprint = match (fingerprint_arg_bytes, device_info.as_ref()) {
+        (Some(fp), Some(d)) => {
+            if let Some(dfp) = d.fingerprint_bytes() {
+                if fp != dfp {
+                    out.warn(&format!(
+                        "--fingerprint {} overrides device-reported {}",
+                        hex::encode(fp),
+                        hex::encode(dfp),
+                    ));
+                }
+            }
+            Some(fp)
+        }
+        (Some(fp), None) => Some(fp),
+        (None, Some(d)) => d.fingerprint_bytes(),
+        (None, None) => None,
+    };
     let firmware_version = firmware_version_arg.map(|s| s.to_string()).or_else(|| {
         device_info
             .as_ref()
@@ -355,6 +399,9 @@ pub fn cmd_wallet_register(
     // local save errors below. Re-running register is idempotent.
     out.success("Device accepted the wallet registration");
     out.field("Signer pubkey", &signer_hex);
+    if device_info.is_some() {
+        out.info("Device metadata below is self-reported by the signer and not cryptographically verified.");
+    }
     if let Some(k) = device_kind.as_deref() {
         out.field("Device kind", k);
     }
@@ -480,13 +527,13 @@ fn truncate_relay_for_log(relay: &str) -> String {
 }
 
 fn parse_fingerprint_hex(s: &str) -> Result<[u8; 4]> {
-    let trimmed = s.trim().trim_start_matches("0x");
+    let trimmed = s.trim().trim_start_matches("0x").to_ascii_lowercase();
     if trimmed.len() != 8 {
         return Err(KeepError::InvalidInput(
             "fingerprint must be 8 hex characters (4 bytes)".into(),
         ));
     }
-    let bytes = hex::decode(trimmed)
+    let bytes = hex::decode(&trimmed)
         .map_err(|e| KeepError::InvalidInput(format!("invalid fingerprint hex: {e}")))?;
     bytes
         .try_into()

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -576,9 +576,15 @@ fn parse_fingerprint_hex(s: &str) -> Result<[u8; 4]> {
     }
     let bytes = hex::decode(&trimmed)
         .map_err(|e| KeepError::InvalidInput(format!("invalid fingerprint hex: {e}")))?;
-    bytes
+    let arr: [u8; 4] = bytes
         .try_into()
-        .map_err(|_| KeepError::InvalidInput("fingerprint must be 4 bytes".into()))
+        .map_err(|_| KeepError::InvalidInput("fingerprint must be 4 bytes".into()))?;
+    if arr == [0u8; 4] {
+        return Err(KeepError::InvalidInput(
+            "fingerprint 00000000 is reserved by BIP32 for 'no parent'".into(),
+        ));
+    }
+    Ok(arr)
 }
 
 fn format_token(hmac: &[u8], show_token: bool) -> String {

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -233,10 +233,39 @@ pub fn cmd_wallet_register(
 ) -> Result<()> {
     debug!(group, device = %mask_secret(device_uri), "wallet register");
 
+    // Validate ALL host-supplied flags up front, before any signer RPC or
+    // local mutation. A bad flag combined with a successful device-side
+    // register_wallet would leave the host and signer out of sync.
     let fingerprint_arg_bytes = match fingerprint_arg {
         Some(s) => Some(parse_fingerprint_hex(s)?),
         None => None,
     };
+    if let Some(k) = kind_arg {
+        if k.is_empty() || k.len() > keep_nip46::MAX_DEVICE_KIND_LEN {
+            return Err(KeepError::InvalidInput(format!(
+                "--kind must be 1..={} bytes",
+                keep_nip46::MAX_DEVICE_KIND_LEN
+            )));
+        }
+        if keep_nip46::contains_control_chars(k) {
+            return Err(KeepError::InvalidInput(
+                "--kind must not contain control characters".to_string(),
+            ));
+        }
+    }
+    if let Some(fw) = firmware_version_arg {
+        if fw.len() > keep_nip46::MAX_FIRMWARE_VERSION_LEN {
+            return Err(KeepError::InvalidInput(format!(
+                "--firmware-version exceeds {} bytes",
+                keep_nip46::MAX_FIRMWARE_VERSION_LEN
+            )));
+        }
+        if keep_nip46::contains_control_chars(fw) {
+            return Err(KeepError::InvalidInput(
+                "--firmware-version must not contain control characters".to_string(),
+            ));
+        }
+    }
 
     let group_pubkey = parse_group_id(group)?;
 
@@ -338,36 +367,10 @@ pub fn cmd_wallet_register(
         .unwrap_or_default()
         .as_secs();
 
-    if let Some(k) = kind_arg {
-        if k.is_empty() || k.len() > keep_nip46::MAX_DEVICE_KIND_LEN {
-            return Err(KeepError::InvalidInput(format!(
-                "--kind must be 1..={} bytes",
-                keep_nip46::MAX_DEVICE_KIND_LEN
-            )));
-        }
-        if k.chars().any(|c| c.is_control()) {
-            return Err(KeepError::InvalidInput(
-                "--kind must not contain control characters".to_string(),
-            ));
-        }
-    }
-    if let Some(fw) = firmware_version_arg {
-        if fw.len() > keep_nip46::MAX_FIRMWARE_VERSION_LEN {
-            return Err(KeepError::InvalidInput(format!(
-                "--firmware-version exceeds {} bytes",
-                keep_nip46::MAX_FIRMWARE_VERSION_LEN
-            )));
-        }
-        if fw.chars().any(|c| c.is_control()) {
-            return Err(KeepError::InvalidInput(
-                "--firmware-version must not contain control characters".to_string(),
-            ));
-        }
-    }
-
     // CLI flags take precedence; fall back to the device-reported values.
     // Warn loudly when the operator overrides what the device reported, so the
-    // mismatch is visible in audit output.
+    // mismatch is visible both interactively (out.warn) and in audit logs
+    // (tracing::warn). Flag validation already happened up front.
     let device_kind = match (kind_arg, device_info.as_ref()) {
         (Some(k), Some(d)) if k != d.kind.as_str() => {
             out.warn(&format!(
@@ -375,6 +378,12 @@ pub fn cmd_wallet_register(
                 k,
                 d.kind.as_str()
             ));
+            tracing::warn!(
+                signer = %signer_hex,
+                user_kind = %k,
+                device_kind = d.kind.as_str(),
+                "--kind flag overrides device-reported kind",
+            );
             Some(k.to_string())
         }
         (Some(k), _) => Some(k.to_string()),
@@ -390,6 +399,12 @@ pub fn cmd_wallet_register(
                         hex::encode(fp),
                         hex::encode(dfp),
                     ));
+                    tracing::warn!(
+                        signer = %signer_hex,
+                        user_fingerprint = %hex::encode(fp),
+                        device_fingerprint = %hex::encode(dfp),
+                        "--fingerprint flag overrides device-reported fingerprint",
+                    );
                 }
             }
             Some(fp)
@@ -398,11 +413,27 @@ pub fn cmd_wallet_register(
         (None, Some(d)) => d.fingerprint_bytes(),
         (None, None) => None,
     };
-    let firmware_version = firmware_version_arg.map(|s| s.to_string()).or_else(|| {
-        device_info
-            .as_ref()
-            .and_then(|d| d.firmware_version.clone())
-    });
+    let firmware_version = match (firmware_version_arg, device_info.as_ref()) {
+        (Some(fw), Some(d)) => {
+            if let Some(dfw) = d.firmware_version.as_deref() {
+                if fw != dfw {
+                    out.warn(&format!(
+                        "--firmware-version '{fw}' overrides device-reported '{dfw}'"
+                    ));
+                    tracing::warn!(
+                        signer = %signer_hex,
+                        user_firmware = %fw,
+                        device_firmware = %dfw,
+                        "--firmware-version flag overrides device-reported firmware",
+                    );
+                }
+            }
+            Some(fw.to_string())
+        }
+        (Some(fw), None) => Some(fw.to_string()),
+        (None, Some(d)) => d.firmware_version.clone(),
+        (None, None) => None,
+    };
 
     // Surface the device-side outcome before attempting local persistence so an
     // operator knows registration already took effect on the signer if the

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -475,6 +475,9 @@ fn dispatch_wallet(
             device,
             name,
             show_token,
+            kind,
+            fingerprint,
+            firmware_version,
         } => commands::wallet::cmd_wallet_register(
             out,
             path,
@@ -482,6 +485,9 @@ fn dispatch_wallet(
             &device,
             name.as_deref(),
             show_token,
+            kind.as_deref(),
+            fingerprint.as_deref(),
+            firmware_version.as_deref(),
         ),
         WalletCommands::Registrations { group, show_token } => {
             commands::wallet::cmd_wallet_registrations(out, path, &group, show_token)

--- a/keep-core/src/wallet.rs
+++ b/keep-core/src/wallet.rs
@@ -273,6 +273,38 @@ mod tests {
     }
 
     #[test]
+    fn test_wallet_descriptor_roundtrip_preserves_device_registrations() {
+        let reg = DeviceRegistration {
+            signer_pubkey: [7u8; 32],
+            wallet_name: "primary".into(),
+            hmac: Some(Zeroizing::new(vec![0xaa; 32])),
+            registered_at: 1234,
+            device_kind: Some("Ledger".into()),
+            fingerprint: Some([0x01, 0x02, 0x03, 0x04]),
+            firmware_version: Some("2.1.0".into()),
+        };
+        let desc = WalletDescriptor {
+            group_pubkey: [9u8; 32],
+            external_descriptor: "tr(xpub.../0/*)".into(),
+            internal_descriptor: "tr(xpub.../1/*)".into(),
+            network: "bitcoin".into(),
+            created_at: 1700000000,
+            device_registrations: vec![reg],
+            policy_hash: [0u8; 32],
+        };
+        let json = serde_json::to_string(&desc).unwrap();
+        let back: WalletDescriptor = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.device_registrations.len(), 1);
+        let r = &back.device_registrations[0];
+        assert_eq!(r.signer_pubkey, [7u8; 32]);
+        assert_eq!(r.wallet_name, "primary");
+        assert_eq!(r.device_kind.as_deref(), Some("Ledger"));
+        assert_eq!(r.fingerprint, Some([0x01, 0x02, 0x03, 0x04]));
+        assert_eq!(r.firmware_version.as_deref(), Some("2.1.0"));
+        assert_eq!(r.hmac.as_deref().map(|h| h.to_vec()), Some(vec![0xaa; 32]));
+    }
+
+    #[test]
     fn test_empty_registrations_roundtrip_omits_field() {
         let desc = WalletDescriptor {
             group_pubkey: [0u8; 32],

--- a/keep-core/src/wallet.rs
+++ b/keep-core/src/wallet.rs
@@ -61,6 +61,15 @@ pub struct DeviceRegistration {
     pub hmac: Option<Zeroizing<Vec<u8>>>,
     /// Unix timestamp of the successful registration.
     pub registered_at: u64,
+    /// Device kind reported by the signer (e.g. "Coldcard", "Ledger"), if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub device_kind: Option<String>,
+    /// BIP32 master key fingerprint reported by the signer, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fingerprint: Option<[u8; 4]>,
+    /// Firmware version string reported by the signer, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub firmware_version: Option<String>,
 }
 
 mod zeroizing_vec_opt {
@@ -98,6 +107,9 @@ impl std::fmt::Debug for DeviceRegistration {
                     .map(|h| format!("<redacted; {} bytes>", h.len())),
             )
             .field("registered_at", &self.registered_at)
+            .field("device_kind", &self.device_kind)
+            .field("fingerprint", &self.fingerprint.map(hex::encode))
+            .field("firmware_version", &self.firmware_version)
             .finish()
     }
 }
@@ -199,12 +211,18 @@ mod tests {
             wallet_name: "first".into(),
             hmac: Some(Zeroizing::new(vec![1, 2, 3])),
             registered_at: 1,
+            device_kind: None,
+            fingerprint: None,
+            firmware_version: None,
         });
         desc.upsert_device_registration(DeviceRegistration {
             signer_pubkey: signer,
             wallet_name: "second".into(),
             hmac: Some(Zeroizing::new(vec![9, 9, 9])),
             registered_at: 2,
+            device_kind: None,
+            fingerprint: None,
+            firmware_version: None,
         });
         assert_eq!(desc.device_registrations.len(), 1);
         let reg = desc.device_registration(&signer).unwrap();
@@ -213,6 +231,45 @@ mod tests {
             reg.hmac.as_ref().map(|v| v.as_slice()),
             Some(&[9, 9, 9][..])
         );
+    }
+
+    #[test]
+    fn test_device_registration_back_compat_without_metadata_fields() {
+        // Existing on-disk shape, no device_kind/fingerprint/firmware_version
+        let json = r#"{
+            "signer_pubkey": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+            "wallet_name": "legacy",
+            "registered_at": 1700000000
+        }"#;
+        let reg: DeviceRegistration =
+            serde_json::from_str(json).expect("legacy DeviceRegistration deserializes");
+        assert!(reg.device_kind.is_none());
+        assert!(reg.fingerprint.is_none());
+        assert!(reg.firmware_version.is_none());
+        assert!(reg.hmac.is_none());
+        let json_out = serde_json::to_string(&reg).unwrap();
+        assert!(!json_out.contains("device_kind"));
+        assert!(!json_out.contains("fingerprint"));
+        assert!(!json_out.contains("firmware_version"));
+        assert!(!json_out.contains("hmac"));
+    }
+
+    #[test]
+    fn test_device_registration_roundtrip_with_metadata_fields() {
+        let reg = DeviceRegistration {
+            signer_pubkey: [1u8; 32],
+            wallet_name: "treasury".into(),
+            hmac: None,
+            registered_at: 42,
+            device_kind: Some("Coldcard".into()),
+            fingerprint: Some([0xde, 0xad, 0xbe, 0xef]),
+            firmware_version: Some("1.2.3".into()),
+        };
+        let json = serde_json::to_string(&reg).unwrap();
+        let back: DeviceRegistration = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.device_kind.as_deref(), Some("Coldcard"));
+        assert_eq!(back.fingerprint, Some([0xde, 0xad, 0xbe, 0xef]));
+        assert_eq!(back.firmware_version.as_deref(), Some("1.2.3"));
     }
 
     #[test]

--- a/keep-desktop/src/app/wallet.rs
+++ b/keep-desktop/src/app/wallet.rs
@@ -406,6 +406,16 @@ impl App {
                         "device metadata is self-reported by signer and not cryptographically verified",
                     );
                 }
+                if let Some(ref k) = user_device_kind {
+                    if k.chars().any(|c| c.is_control()) {
+                        warn!(
+                            group = %group_hex,
+                            signer = %signer_hex,
+                            "user-supplied device kind contains control characters; rejecting",
+                        );
+                        return Err("device kind must not contain control characters".to_string());
+                    }
+                }
                 let device_kind = match (user_device_kind.as_deref(), device_info.as_ref()) {
                     (Some(k), Some(d)) if k != d.kind.as_str() => {
                         warn!(

--- a/keep-desktop/src/app/wallet.rs
+++ b/keep-desktop/src/app/wallet.rs
@@ -398,9 +398,29 @@ impl App {
                     .unwrap_or_default()
                     .as_secs();
 
-                let device_kind = user_device_kind
-                    .clone()
-                    .or_else(|| device_info.as_ref().map(|d| d.kind.as_str().to_string()));
+                if let Some(ref info) = device_info {
+                    warn!(
+                        group = %group_hex,
+                        signer = %signer_hex,
+                        kind = info.kind.as_str(),
+                        "device metadata is self-reported by signer and not cryptographically verified",
+                    );
+                }
+                let device_kind = match (user_device_kind.as_deref(), device_info.as_ref()) {
+                    (Some(k), Some(d)) if k != d.kind.as_str() => {
+                        warn!(
+                            group = %group_hex,
+                            signer = %signer_hex,
+                            user_kind = %k,
+                            device_kind = d.kind.as_str(),
+                            "user-supplied device kind overrides device-reported value",
+                        );
+                        Some(k.to_string())
+                    }
+                    (Some(k), _) => Some(k.to_string()),
+                    (None, Some(d)) => Some(d.kind.as_str().to_string()),
+                    (None, None) => None,
+                };
                 let fingerprint = device_info.as_ref().and_then(|d| d.fingerprint_bytes());
                 let firmware_version = device_info
                     .as_ref()

--- a/keep-desktop/src/app/wallet.rs
+++ b/keep-desktop/src/app/wallet.rs
@@ -407,7 +407,7 @@ impl App {
                     );
                 }
                 if let Some(ref k) = user_device_kind {
-                    if k.chars().any(|c| c.is_control()) {
+                    if keep_nip46::contains_control_chars(k) {
                         warn!(
                             group = %group_hex,
                             signer = %signer_hex,

--- a/keep-desktop/src/app/wallet.rs
+++ b/keep-desktop/src/app/wallet.rs
@@ -1,5 +1,5 @@
 use iced::Task;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::message::Message;
 use crate::screen::wallet::{self, DescriptorProgress, SetupPhase};
@@ -73,11 +73,13 @@ impl App {
                 external_descriptor,
                 device_uri,
                 wallet_name,
+                device_kind,
             } => self.begin_register_on_device(
                 group_pubkey,
                 external_descriptor,
                 device_uri,
                 wallet_name,
+                device_kind,
             ),
             wallet::Event::RejectPsbt(session_id) => {
                 Task::done(Message::RejectPsbtSignature(session_id))
@@ -316,6 +318,7 @@ impl App {
         external_descriptor: String,
         device_uri: String,
         wallet_name: String,
+        user_device_kind: Option<String>,
     ) -> Task<Message> {
         let multipath = match keep_bitcoin::multipath_from_external(&external_descriptor) {
             Ok(m) => m,
@@ -359,7 +362,19 @@ impl App {
                         );
                         format!("handshake: {e}")
                     })?;
-                    client
+                    // Best-effort: failure must not block registration.
+                    let device_info = match client.get_device_info().await {
+                        Ok(info) => Some(info),
+                        Err(e) => {
+                            debug!(
+                                group = %group_hex,
+                                signer = %signer_hex,
+                                "get_device_info failed (best-effort): {e}",
+                            );
+                            None
+                        }
+                    };
+                    let resp = client
                         .register_wallet(&wallet_name, &multipath)
                         .await
                         .map_err(|e| {
@@ -369,18 +384,27 @@ impl App {
                                 "register_wallet rejected: {e}",
                             );
                             format!("register_wallet: {e}")
-                        })
+                        })?;
+                    Ok::<_, String>((resp, device_info))
                 }
                 .await;
 
                 client.disconnect().await;
-                let response = register_outcome?;
+                let (response, device_info) = register_outcome?;
 
                 let signer_bytes = signer.to_bytes();
                 let now = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
                     .as_secs();
+
+                let device_kind = user_device_kind
+                    .clone()
+                    .or_else(|| device_info.as_ref().map(|d| d.kind.as_str().to_string()));
+                let fingerprint = device_info.as_ref().and_then(|d| d.fingerprint_bytes());
+                let firmware_version = device_info
+                    .as_ref()
+                    .and_then(|d| d.firmware_version.clone());
 
                 let group_hex_for_save = group_hex.clone();
                 let signer_hex_for_save = signer_hex.clone();
@@ -394,6 +418,9 @@ impl App {
                                 wallet_name: wallet_name_saved,
                                 hmac: response.hmac.clone(),
                                 registered_at: now,
+                                device_kind,
+                                fingerprint,
+                                firmware_version,
                             },
                         )
                         .map_err(friendly_err)

--- a/keep-desktop/src/frost.rs
+++ b/keep-desktop/src/frost.rs
@@ -1431,6 +1431,7 @@ impl App {
                     internal_descriptor,
                     network,
                     created_at,
+                    device_registrations: Vec::new(),
                 });
             }
         }

--- a/keep-desktop/src/screen/wallet.rs
+++ b/keep-desktop/src/screen/wallet.rs
@@ -505,7 +505,7 @@ impl State {
             }
             Message::RegisterDeviceKindChanged(v) => {
                 if let Some(r) = &mut self.register {
-                    r.device_kind = truncate_to_bytes(&v, 32);
+                    r.device_kind = truncate_to_bytes(&v, keep_nip46::MAX_DEVICE_KIND_LEN);
                 }
                 None
             }
@@ -1262,7 +1262,7 @@ impl State {
             if !entry.device_registrations.is_empty() {
                 details = details.push(Space::new().height(theme::space::SM));
                 details = details.push(
-                    text("Registered devices")
+                    text("Registered devices (self-reported, unverified)")
                         .size(theme::size::SMALL)
                         .color(theme::color::TEXT_MUTED),
                 );

--- a/keep-desktop/src/screen/wallet.rs
+++ b/keep-desktop/src/screen/wallet.rs
@@ -62,6 +62,15 @@ fn parse_psbt_text(input: &str) -> Result<Vec<u8>, String> {
 }
 
 #[derive(Debug, Clone)]
+pub struct WalletEntryDeviceRegistration {
+    pub signer_pubkey_hex: String,
+    pub wallet_name: String,
+    pub device_kind: Option<String>,
+    pub fingerprint_hex: Option<String>,
+    pub firmware_version: Option<String>,
+}
+
+#[derive(Debug, Clone)]
 pub struct WalletEntry {
     #[allow(dead_code)]
     pub group_pubkey: [u8; 32],
@@ -70,11 +79,23 @@ pub struct WalletEntry {
     pub internal_descriptor: String,
     pub network: String,
     pub created_at: u64,
+    pub device_registrations: Vec<WalletEntryDeviceRegistration>,
 }
 
 impl WalletEntry {
     pub fn from_descriptor(d: &keep_core::WalletDescriptor) -> Self {
         let group_hex = hex::encode(d.group_pubkey);
+        let device_registrations = d
+            .device_registrations
+            .iter()
+            .map(|r| WalletEntryDeviceRegistration {
+                signer_pubkey_hex: hex::encode(r.signer_pubkey),
+                wallet_name: r.wallet_name.clone(),
+                device_kind: r.device_kind.clone(),
+                fingerprint_hex: r.fingerprint.map(hex::encode),
+                firmware_version: r.firmware_version.clone(),
+            })
+            .collect();
         Self {
             group_pubkey: d.group_pubkey,
             group_hex,
@@ -82,6 +103,7 @@ impl WalletEntry {
             internal_descriptor: d.internal_descriptor.clone(),
             network: d.network.clone(),
             created_at: d.created_at,
+            device_registrations,
         }
     }
 
@@ -135,6 +157,7 @@ pub struct RegisterState {
     pub default_wallet_name: String,
     pub device_uri: String,
     pub wallet_name: String,
+    pub device_kind: String,
     pub error: Option<String>,
     pub submitting: bool,
 }
@@ -189,6 +212,7 @@ pub enum Message {
     StartRegister(usize),
     RegisterDeviceUriChanged(String),
     RegisterNameChanged(String),
+    RegisterDeviceKindChanged(String),
     CancelRegister,
     SubmitRegister,
     RejectPsbt([u8; 32]),
@@ -230,6 +254,9 @@ impl std::fmt::Debug for Message {
                 write!(f, "RegisterDeviceUriChanged(<redacted>)")
             }
             Self::RegisterNameChanged(n) => f.debug_tuple("RegisterNameChanged").field(n).finish(),
+            Self::RegisterDeviceKindChanged(n) => {
+                f.debug_tuple("RegisterDeviceKindChanged").field(n).finish()
+            }
             Self::CancelRegister => write!(f, "CancelRegister"),
             Self::SubmitRegister => write!(f, "SubmitRegister"),
             Self::RejectPsbt(id) => f.debug_tuple("RejectPsbt").field(&hex::encode(id)).finish(),
@@ -273,6 +300,7 @@ pub enum Event {
         external_descriptor: String,
         device_uri: String,
         wallet_name: String,
+        device_kind: Option<String>,
     },
     RejectPsbt([u8; 32]),
     StartSpend {
@@ -456,6 +484,7 @@ impl State {
                         default_wallet_name: format!("keep-{default_name}"),
                         device_uri: String::new(),
                         wallet_name: String::new(),
+                        device_kind: String::new(),
                         error: None,
                         submitting: false,
                     });
@@ -471,6 +500,12 @@ impl State {
             Message::RegisterNameChanged(v) => {
                 if let Some(r) = &mut self.register {
                     r.wallet_name = truncate_to_bytes(&v, keep_nip46::MAX_WALLET_NAME_LEN);
+                }
+                None
+            }
+            Message::RegisterDeviceKindChanged(v) => {
+                if let Some(r) = &mut self.register {
+                    r.device_kind = truncate_to_bytes(&v, 32);
                 }
                 None
             }
@@ -552,6 +587,12 @@ impl State {
                 } else {
                     name_trimmed.to_string()
                 };
+                let device_kind_trimmed = r.device_kind.trim();
+                let device_kind = if device_kind_trimmed.is_empty() {
+                    None
+                } else {
+                    Some(device_kind_trimmed.to_string())
+                };
                 r.error = None;
                 r.submitting = true;
                 Some(Event::SubmitRegister {
@@ -559,6 +600,7 @@ impl State {
                     external_descriptor: r.external_descriptor.clone(),
                     device_uri,
                     wallet_name,
+                    device_kind,
                 })
             }
         }
@@ -1207,17 +1249,47 @@ impl State {
 
             let actions_row = row![register_btn, spend_btn].spacing(theme::space::SM);
 
-            let details = column![
+            let mut details = column![
                 ext_row,
                 ext_value,
                 int_row,
                 int_value,
                 hex_full,
                 created_text,
-                Space::new().height(theme::space::SM),
-                actions_row,
             ]
             .spacing(theme::space::XS);
+
+            if !entry.device_registrations.is_empty() {
+                details = details.push(Space::new().height(theme::space::SM));
+                details = details.push(
+                    text("Registered devices")
+                        .size(theme::size::SMALL)
+                        .color(theme::color::TEXT_MUTED),
+                );
+                for reg in &entry.device_registrations {
+                    let kind = reg.device_kind.as_deref().unwrap_or("unknown");
+                    let fp = reg.fingerprint_hex.as_deref().unwrap_or("--");
+                    let fw = reg.firmware_version.as_deref().unwrap_or("");
+                    let line = if fw.is_empty() {
+                        format!("- {} [{}] ({})", reg.wallet_name, kind, fp)
+                    } else {
+                        format!("- {} [{} {}] ({})", reg.wallet_name, kind, fw, fp)
+                    };
+                    details = details.push(
+                        text(line)
+                            .size(theme::size::TINY)
+                            .color(theme::color::TEXT_DIM),
+                    );
+                    details = details.push(
+                        text(format!("  signer: {}", reg.signer_pubkey_hex))
+                            .size(theme::size::TINY)
+                            .color(theme::color::TEXT_DIM),
+                    );
+                }
+            }
+
+            details = details.push(Space::new().height(theme::space::SM));
+            details = details.push(actions_row);
 
             card_content = card_content.push(details);
         }
@@ -1342,6 +1414,15 @@ impl State {
             name_input = name_input.on_input(Message::RegisterNameChanged);
         }
 
+        let mut kind_input = text_input(
+            "auto-detected if signer supports get_device_info",
+            &state.device_kind,
+        )
+        .padding(theme::space::SM);
+        if !state.submitting {
+            kind_input = kind_input.on_input(Message::RegisterDeviceKindChanged);
+        }
+
         let can_submit = !state.submitting && !state.device_uri.trim().is_empty();
         let submit_label = if state.submitting {
             "Registering..."
@@ -1365,6 +1446,9 @@ impl State {
             Space::new().height(theme::space::XS),
             theme::label("Wallet name (optional)"),
             name_input,
+            Space::new().height(theme::space::XS),
+            theme::label("Device kind (optional)"),
+            kind_input,
             Space::new().height(theme::space::MD),
             submit_btn,
         ]

--- a/keep-desktop/src/screen/wallet.rs
+++ b/keep-desktop/src/screen/wallet.rs
@@ -493,19 +493,25 @@ impl State {
             }
             Message::RegisterDeviceUriChanged(v) => {
                 if let Some(r) = &mut self.register {
-                    r.device_uri = truncate_to_bytes(&v, MAX_DEVICE_URI_LEN);
+                    let cleaned: String = v.chars().filter(|c| !c.is_control()).collect();
+                    r.device_uri = truncate_to_bytes(&cleaned, MAX_DEVICE_URI_LEN);
                 }
                 None
             }
             Message::RegisterNameChanged(v) => {
                 if let Some(r) = &mut self.register {
-                    r.wallet_name = truncate_to_bytes(&v, keep_nip46::MAX_WALLET_NAME_LEN);
+                    let cleaned: String = v.chars().filter(|c| !c.is_control()).collect();
+                    r.wallet_name = truncate_to_bytes(&cleaned, keep_nip46::MAX_WALLET_NAME_LEN);
                 }
                 None
             }
             Message::RegisterDeviceKindChanged(v) => {
                 if let Some(r) = &mut self.register {
-                    r.device_kind = truncate_to_bytes(&v, keep_nip46::MAX_DEVICE_KIND_LEN);
+                    // Drop control chars as the user types so they never enter
+                    // the field, instead of being surfaced as a post-submit
+                    // error. Length-cap after stripping.
+                    let cleaned: String = v.chars().filter(|c| !c.is_control()).collect();
+                    r.device_kind = truncate_to_bytes(&cleaned, keep_nip46::MAX_DEVICE_KIND_LEN);
                 }
                 None
             }

--- a/keep-mobile/src/keep_mobile.udl
+++ b/keep-mobile/src/keep_mobile.udl
@@ -164,6 +164,9 @@ dictionary DeviceRegistrationInfo {
     string wallet_name;
     string? hmac;
     u64 registered_at;
+    string? device_kind;
+    string? fingerprint_hex;
+    string? firmware_version;
 };
 
 dictionary RecoveryTierConfig {

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1186,24 +1186,30 @@ impl KeepMobile {
                 msg: format!("build multipath descriptor: {e}"),
             })?;
 
-        let (signer_hex, hmac_hex) = self.runtime.block_on(async {
+        let (signer_hex, hmac_hex, device_info) = self.runtime.block_on(async {
             let client = keep_nip46::Nip46Client::connect_to(&device_uri)
                 .await
                 .map_err(nip46_to_mobile_error)?;
             let signer_hex = hex::encode(client.signer_pubkey().to_bytes());
 
-            let outcome: Result<Option<String>, KeepMobileError> = async {
-                client.connect().await.map_err(nip46_to_mobile_error)?;
-                let response = client
-                    .register_wallet(&name, &multipath)
-                    .await
-                    .map_err(nip46_to_mobile_error)?;
-                Ok(response.hmac.as_deref().map(|h| hex::encode(h.as_slice())))
-            }
-            .await;
+            let outcome: Result<(Option<String>, Option<keep_nip46::DeviceInfo>), KeepMobileError> =
+                async {
+                    client.connect().await.map_err(nip46_to_mobile_error)?;
+                    // Best-effort: failure must not block registration.
+                    let device_info = client.get_device_info().await.ok();
+                    let response = client
+                        .register_wallet(&name, &multipath)
+                        .await
+                        .map_err(nip46_to_mobile_error)?;
+                    Ok((
+                        response.hmac.as_deref().map(|h| hex::encode(h.as_slice())),
+                        device_info,
+                    ))
+                }
+                .await;
 
             client.disconnect().await;
-            outcome.map(|hmac_hex| (signer_hex, hmac_hex))
+            outcome.map(|(hmac_hex, info)| (signer_hex, hmac_hex, info))
         })?;
 
         let now = std::time::SystemTime::now()
@@ -1226,6 +1232,14 @@ impl KeepMobile {
                 wallet_name: name,
                 hmac: hmac_hex,
                 registered_at: now,
+                device_kind: device_info.as_ref().map(|d| d.kind.as_str().to_string()),
+                fingerprint_hex: device_info
+                    .as_ref()
+                    .and_then(|d| d.fingerprint_bytes())
+                    .map(hex::encode),
+                firmware_version: device_info
+                    .as_ref()
+                    .and_then(|d| d.firmware_version.clone()),
             };
             if let Some(slot) = desc
                 .device_registrations
@@ -1702,11 +1716,28 @@ impl KeepMobile {
                     }
                     None => None,
                 };
+                let fingerprint = match reg.fingerprint_hex.as_deref() {
+                    Some(s) => {
+                        let bytes = decode_hex(s, "device_registration fingerprint")?;
+                        if bytes.len() != 4 {
+                            return Err(KeepMobileError::BackupError {
+                                msg: "device_registration fingerprint must be 4 bytes".into(),
+                            });
+                        }
+                        let mut arr = [0u8; 4];
+                        arr.copy_from_slice(&bytes);
+                        Some(arr)
+                    }
+                    None => None,
+                };
                 device_registrations.push(keep_core::DeviceRegistration {
                     signer_pubkey,
                     wallet_name: reg.wallet_name.clone(),
                     hmac,
                     registered_at: reg.registered_at,
+                    device_kind: reg.device_kind.clone(),
+                    fingerprint,
+                    firmware_version: reg.firmware_version.clone(),
                 });
             }
             let policy_hash = match d.policy_hash_hex.as_deref() {
@@ -1921,6 +1952,9 @@ impl KeepMobile {
                         wallet_name: r.wallet_name.clone(),
                         hmac: r.hmac.as_deref().map(hex::encode),
                         registered_at: r.registered_at,
+                        device_kind: r.device_kind.clone(),
+                        fingerprint_hex: r.fingerprint.map(hex::encode),
+                        firmware_version: r.firmware_version.clone(),
                     })
                     .collect(),
                 policy_hash_hex,

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1747,8 +1747,9 @@ impl KeepMobile {
                         || k.chars().any(|c| c.is_control())
                     {
                         return Err(KeepMobileError::BackupError {
-                            msg: "device_registration device_kind invalid (length or control chars)"
-                                .into(),
+                            msg:
+                                "device_registration device_kind invalid (length or control chars)"
+                                    .into(),
                         });
                     }
                 }

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1730,10 +1730,13 @@ impl KeepMobile {
                 };
                 let fingerprint = match reg.fingerprint_hex.as_deref() {
                     Some(s) => {
-                        let bytes = decode_hex(s, "device_registration fingerprint")?;
+                        let bytes = decode_hex(s, "device_registration.fingerprint_hex")?;
                         if bytes.len() != 4 {
                             return Err(KeepMobileError::BackupError {
-                                msg: "device_registration fingerprint must be 4 bytes".into(),
+                                msg: format!(
+                                    "device_registration.fingerprint_hex must decode to 4 bytes, got {}",
+                                    bytes.len()
+                                ),
                             });
                         }
                         let mut arr = [0u8; 4];
@@ -1744,7 +1747,7 @@ impl KeepMobile {
                 };
                 if let Some(ref k) = reg.device_kind {
                     if k.len() > keep_nip46::MAX_DEVICE_KIND_LEN
-                        || k.chars().any(|c| c.is_control())
+                        || keep_nip46::contains_control_chars(k)
                     {
                         return Err(KeepMobileError::BackupError {
                             msg:
@@ -1755,7 +1758,7 @@ impl KeepMobile {
                 }
                 if let Some(ref fw) = reg.firmware_version {
                     if fw.len() > keep_nip46::MAX_FIRMWARE_VERSION_LEN
-                        || fw.chars().any(|c| c.is_control())
+                        || keep_nip46::contains_control_chars(fw)
                     {
                         return Err(KeepMobileError::BackupError {
                             msg: "device_registration firmware_version invalid (length or control chars)"

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1751,25 +1751,22 @@ impl KeepMobile {
                     None => None,
                 };
                 if let Some(ref k) = reg.device_kind {
-                    if k.len() > keep_nip46::MAX_DEVICE_KIND_LEN
-                        || keep_nip46::contains_control_chars(k)
-                    {
-                        return Err(KeepMobileError::BackupError {
-                            msg:
-                                "device_registration device_kind invalid (length or control chars)"
-                                    .into(),
-                        });
-                    }
+                    keep_nip46::validate_metadata_field(
+                        "device_registration.device_kind",
+                        k,
+                        0,
+                        keep_nip46::MAX_DEVICE_KIND_LEN,
+                    )
+                    .map_err(|e| KeepMobileError::BackupError { msg: e.to_string() })?;
                 }
                 if let Some(ref fw) = reg.firmware_version {
-                    if fw.len() > keep_nip46::MAX_FIRMWARE_VERSION_LEN
-                        || keep_nip46::contains_control_chars(fw)
-                    {
-                        return Err(KeepMobileError::BackupError {
-                            msg: "device_registration firmware_version invalid (length or control chars)"
-                                .into(),
-                        });
-                    }
+                    keep_nip46::validate_metadata_field(
+                        "device_registration.firmware_version",
+                        fw,
+                        0,
+                        keep_nip46::MAX_FIRMWARE_VERSION_LEN,
+                    )
+                    .map_err(|e| KeepMobileError::BackupError { msg: e.to_string() })?;
                 }
                 device_registrations.push(keep_core::DeviceRegistration {
                     signer_pubkey,

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1245,7 +1245,10 @@ impl KeepMobile {
                 hmac: hmac_hex,
                 registered_at: now,
                 device_kind: device_info.as_ref().map(|d| d.kind.as_str().to_string()),
-                fingerprint_hex: device_info.as_ref().map(|d| d.fingerprint.clone()),
+                fingerprint_hex: device_info
+                    .as_ref()
+                    .and_then(|d| d.fingerprint_bytes())
+                    .map(hex::encode),
                 firmware_version: device_info
                     .as_ref()
                     .and_then(|d| d.firmware_version.clone()),

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1741,6 +1741,11 @@ impl KeepMobile {
                         }
                         let mut arr = [0u8; 4];
                         arr.copy_from_slice(&bytes);
+                        if arr == [0u8; 4] {
+                            return Err(KeepMobileError::BackupError {
+                                msg: "device_registration.fingerprint_hex 00000000 is reserved by BIP32 for 'no parent'".into(),
+                            });
+                        }
                         Some(arr)
                     }
                     None => None,

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1196,7 +1196,19 @@ impl KeepMobile {
                 async {
                     client.connect().await.map_err(nip46_to_mobile_error)?;
                     // Best-effort: failure must not block registration.
-                    let device_info = client.get_device_info().await.ok();
+                    let device_info = match client.get_device_info().await {
+                        Ok(info) => Some(info),
+                        Err(e) => {
+                            tracing::warn!("get_device_info failed (best-effort): {e}");
+                            None
+                        }
+                    };
+                    if let Some(ref info) = device_info {
+                        tracing::warn!(
+                            kind = info.kind.as_str(),
+                            "device metadata is self-reported by signer and not cryptographically verified",
+                        );
+                    }
                     let response = client
                         .register_wallet(&name, &multipath)
                         .await
@@ -1233,10 +1245,7 @@ impl KeepMobile {
                 hmac: hmac_hex,
                 registered_at: now,
                 device_kind: device_info.as_ref().map(|d| d.kind.as_str().to_string()),
-                fingerprint_hex: device_info
-                    .as_ref()
-                    .and_then(|d| d.fingerprint_bytes())
-                    .map(hex::encode),
+                fingerprint_hex: device_info.as_ref().map(|d| d.fingerprint.clone()),
                 firmware_version: device_info
                     .as_ref()
                     .and_then(|d| d.firmware_version.clone()),
@@ -1730,6 +1739,26 @@ impl KeepMobile {
                     }
                     None => None,
                 };
+                if let Some(ref k) = reg.device_kind {
+                    if k.len() > keep_nip46::MAX_DEVICE_KIND_LEN
+                        || k.chars().any(|c| c.is_control())
+                    {
+                        return Err(KeepMobileError::BackupError {
+                            msg: "device_registration device_kind invalid (length or control chars)"
+                                .into(),
+                        });
+                    }
+                }
+                if let Some(ref fw) = reg.firmware_version {
+                    if fw.len() > keep_nip46::MAX_FIRMWARE_VERSION_LEN
+                        || fw.chars().any(|c| c.is_control())
+                    {
+                        return Err(KeepMobileError::BackupError {
+                            msg: "device_registration firmware_version invalid (length or control chars)"
+                                .into(),
+                        });
+                    }
+                }
                 device_registrations.push(keep_core::DeviceRegistration {
                     signer_pubkey,
                     wallet_name: reg.wallet_name.clone(),

--- a/keep-mobile/src/persistence.rs
+++ b/keep-mobile/src/persistence.rs
@@ -239,6 +239,13 @@ pub(crate) struct StoredDeviceRegistration {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hmac: Option<String>,
     pub registered_at: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub device_kind: Option<String>,
+    /// Hex-encoded 8 chars (4-byte BIP32 master fingerprint).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fingerprint_hex: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub firmware_version: Option<String>,
 }
 
 const HMAC_SHA256_HEX_LEN: usize = 64;
@@ -382,6 +389,9 @@ fn stored_to_info(stored: StoredDescriptor) -> WalletDescriptorInfo {
                 wallet_name: r.wallet_name,
                 hmac: r.hmac,
                 registered_at: r.registered_at,
+                device_kind: r.device_kind,
+                fingerprint_hex: r.fingerprint_hex,
+                firmware_version: r.firmware_version,
             })
         })
         .collect();
@@ -412,6 +422,9 @@ fn info_to_stored(info: &WalletDescriptorInfo) -> StoredDescriptor {
                 wallet_name: r.wallet_name.clone(),
                 hmac: r.hmac.clone(),
                 registered_at: r.registered_at,
+                device_kind: r.device_kind.clone(),
+                fingerprint_hex: r.fingerprint_hex.clone(),
+                firmware_version: r.firmware_version.clone(),
             })
             .collect(),
     }

--- a/keep-mobile/src/types.rs
+++ b/keep-mobile/src/types.rs
@@ -104,6 +104,9 @@ pub struct DeviceRegistrationInfo {
     pub wallet_name: String,
     pub hmac: Option<String>,
     pub registered_at: u64,
+    pub device_kind: Option<String>,
+    pub fingerprint_hex: Option<String>,
+    pub firmware_version: Option<String>,
 }
 
 impl std::fmt::Debug for DeviceRegistrationInfo {
@@ -113,6 +116,9 @@ impl std::fmt::Debug for DeviceRegistrationInfo {
             .field("wallet_name", &self.wallet_name)
             .field("hmac", &self.hmac.as_ref().map(|_| "<redacted>"))
             .field("registered_at", &self.registered_at)
+            .field("device_kind", &self.device_kind)
+            .field("fingerprint_hex", &self.fingerprint_hex)
+            .field("firmware_version", &self.firmware_version)
             .finish()
     }
 }

--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -18,11 +18,19 @@ use crate::types::Nip46Response;
 
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 const REGISTER_WALLET_TIMEOUT: Duration = Duration::from_secs(180);
+const GET_DEVICE_INFO_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_RESPONSE_SIZE: usize = 64 * 1024;
 const MAX_HMAC_HEX_LEN: usize = 128;
 const HMAC_SHA256_LEN: usize = 32;
 pub const MAX_WALLET_NAME_LEN: usize = 64;
 pub const MAX_DESCRIPTOR_LEN: usize = 4096;
+/// Size cap on the JSON result string returned by `get_device_info`.
+pub const MAX_DEVICE_INFO_JSON_LEN: usize = 2048;
+/// Size caps on individual fields of `DeviceInfo`.
+const MAX_DEVICE_KIND_LEN: usize = 32;
+const MAX_FIRMWARE_VERSION_LEN: usize = 64;
+const MAX_CAPABILITIES: usize = 32;
+const MAX_CAPABILITY_LEN: usize = 32;
 
 /// Outcome of a successful `register_wallet` request.
 ///
@@ -45,6 +53,67 @@ impl std::fmt::Debug for RegisterWalletResponse {
                     .map(|h| format!("<redacted; {} bytes>", h.len())),
             )
             .finish()
+    }
+}
+
+/// Device kind reported by a remote signer in response to `get_device_info`.
+///
+/// Free-form `Other(String)` arm preserves forward compatibility with signers
+/// that report a model name not yet known to this client. Stricter callers can
+/// match on the named variants and fall back to the user-supplied value for
+/// `Other`.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum DeviceKind {
+    Coldcard,
+    Ledger,
+    BitBox02,
+    Jade,
+    Trezor,
+    Other(String),
+}
+
+impl DeviceKind {
+    /// Display name for the device, suitable for persisting in
+    /// `DeviceRegistration::device_kind`.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Coldcard => "Coldcard",
+            Self::Ledger => "Ledger",
+            Self::BitBox02 => "BitBox02",
+            Self::Jade => "Jade",
+            Self::Trezor => "Trezor",
+            Self::Other(s) => s.as_str(),
+        }
+    }
+}
+
+/// Typed `get_device_info` response.
+///
+/// `fingerprint` is the BIP32 master key fingerprint as a hex string (8 chars);
+/// `capabilities` is a free-form list. Both are validated when received: the
+/// fingerprint must decode to exactly 4 bytes and capability strings are
+/// length-capped.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeviceInfo {
+    pub kind: DeviceKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub firmware_version: Option<String>,
+    /// 8 hex chars; BIP32 master key fingerprint.
+    pub fingerprint: String,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+}
+
+impl DeviceInfo {
+    /// Decode the hex fingerprint into 4 bytes, if well-formed.
+    pub fn fingerprint_bytes(&self) -> Option<[u8; 4]> {
+        let s = self.fingerprint.trim();
+        if s.len() != 8 || !s.chars().all(|c| c.is_ascii_hexdigit()) {
+            return None;
+        }
+        let bytes = hex::decode(s).ok()?;
+        bytes.try_into().ok()
     }
 }
 
@@ -259,6 +328,66 @@ impl Nip46Client {
         Ok(RegisterWalletResponse { hmac })
     }
 
+    /// Request `DeviceInfo` from the remote signer.
+    ///
+    /// This is best-effort: callers should treat any error as "info unavailable"
+    /// and fall back to user-supplied values rather than aborting wallet
+    /// registration.
+    pub async fn get_device_info(&self) -> Result<DeviceInfo> {
+        let id = new_request_id();
+        let response = self
+            .request_with_timeout(&id, "get_device_info", Vec::new(), GET_DEVICE_INFO_TIMEOUT)
+            .await?;
+
+        if let Some(err) = response.error {
+            return Err(NetworkError::response(format!("get_device_info rejected: {err}")).into());
+        }
+
+        let result = response
+            .result
+            .ok_or_else(|| NetworkError::response("get_device_info returned no result"))?;
+        if result.len() > MAX_DEVICE_INFO_JSON_LEN {
+            return Err(KeepError::InvalidInput(format!(
+                "get_device_info payload exceeds {MAX_DEVICE_INFO_JSON_LEN} bytes"
+            )));
+        }
+        let info: DeviceInfo = serde_json::from_str(&result)
+            .map_err(|e| StorageError::invalid_format(format!("get_device_info payload: {e}")))?;
+
+        if let DeviceKind::Other(ref s) = info.kind {
+            if s.is_empty() || s.len() > MAX_DEVICE_KIND_LEN {
+                return Err(KeepError::InvalidInput(format!(
+                    "device kind 'Other' label must be 1..={MAX_DEVICE_KIND_LEN} bytes"
+                )));
+            }
+        }
+        if let Some(ref fw) = info.firmware_version {
+            if fw.len() > MAX_FIRMWARE_VERSION_LEN {
+                return Err(KeepError::InvalidInput(format!(
+                    "firmware_version exceeds {MAX_FIRMWARE_VERSION_LEN} bytes"
+                )));
+            }
+        }
+        if info.fingerprint_bytes().is_none() {
+            return Err(KeepError::InvalidInput(
+                "fingerprint must be 8 hex characters (4 bytes)".into(),
+            ));
+        }
+        if info.capabilities.len() > MAX_CAPABILITIES {
+            return Err(KeepError::InvalidInput(format!(
+                "capabilities list exceeds {MAX_CAPABILITIES} entries"
+            )));
+        }
+        for cap in &info.capabilities {
+            if cap.is_empty() || cap.len() > MAX_CAPABILITY_LEN {
+                return Err(KeepError::InvalidInput(format!(
+                    "capability label must be 1..={MAX_CAPABILITY_LEN} bytes"
+                )));
+            }
+        }
+        Ok(info)
+    }
+
     async fn request(
         &self,
         id: &str,
@@ -413,6 +542,42 @@ fn append_json_string(buf: &mut Zeroizing<String>, value: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_device_info_roundtrip_named_kind() {
+        let json = r#"{"kind":"Coldcard","firmware_version":"1.2.3","fingerprint":"deadbeef","capabilities":["miniscript","tapminiscript"]}"#;
+        let info: DeviceInfo = serde_json::from_str(json).expect("parse named kind");
+        assert_eq!(info.kind, DeviceKind::Coldcard);
+        assert_eq!(info.fingerprint_bytes(), Some([0xde, 0xad, 0xbe, 0xef]));
+        assert_eq!(info.kind.as_str(), "Coldcard");
+    }
+
+    #[test]
+    fn test_device_info_roundtrip_other_kind() {
+        let json = r#"{"kind":{"Other":"Foundation"},"fingerprint":"00112233","capabilities":[]}"#;
+        let info: DeviceInfo = serde_json::from_str(json).expect("parse other kind");
+        assert_eq!(info.kind, DeviceKind::Other("Foundation".into()));
+        assert_eq!(info.kind.as_str(), "Foundation");
+        assert!(info.firmware_version.is_none());
+    }
+
+    #[test]
+    fn test_device_info_rejects_unknown_fields() {
+        let json = r#"{"kind":"Ledger","fingerprint":"deadbeef","capabilities":[],"extra":"nope"}"#;
+        let err = serde_json::from_str::<DeviceInfo>(json).unwrap_err();
+        assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn test_fingerprint_bytes_rejects_malformed() {
+        let info = DeviceInfo {
+            kind: DeviceKind::Trezor,
+            firmware_version: None,
+            fingerprint: "zz".into(),
+            capabilities: Vec::new(),
+        };
+        assert!(info.fingerprint_bytes().is_none());
+    }
 
     #[test]
     fn test_new_request_id_is_unique() {

--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -29,8 +29,8 @@ pub const MAX_DEVICE_INFO_JSON_LEN: usize = 2048;
 /// Size caps on individual fields of `DeviceInfo`.
 pub const MAX_DEVICE_KIND_LEN: usize = 32;
 pub const MAX_FIRMWARE_VERSION_LEN: usize = 64;
-pub const MAX_CAPABILITIES: usize = 32;
-pub const MAX_CAPABILITY_LEN: usize = 32;
+const MAX_CAPABILITIES: usize = 32;
+const MAX_CAPABILITY_LEN: usize = 32;
 
 /// Reject signer-supplied strings that contain control characters. Strings are
 /// surfaced verbatim in CLI/UI output, so any C0/C1 control codes would corrupt
@@ -132,11 +132,10 @@ impl DeviceInfo {
     /// Decode the hex fingerprint into 4 bytes, if well-formed.
     pub fn fingerprint_bytes(&self) -> Option<[u8; 4]> {
         let s = self.fingerprint.trim();
-        if s.len() != 8 || !s.chars().all(|c| c.is_ascii_hexdigit()) {
+        if s.len() != 8 {
             return None;
         }
-        let bytes = hex::decode(s).ok()?;
-        bytes.try_into().ok()
+        hex::decode(s).ok()?.try_into().ok()
     }
 }
 

--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -27,10 +27,17 @@ pub const MAX_DESCRIPTOR_LEN: usize = 4096;
 /// Size cap on the JSON result string returned by `get_device_info`.
 pub const MAX_DEVICE_INFO_JSON_LEN: usize = 2048;
 /// Size caps on individual fields of `DeviceInfo`.
-const MAX_DEVICE_KIND_LEN: usize = 32;
-const MAX_FIRMWARE_VERSION_LEN: usize = 64;
-const MAX_CAPABILITIES: usize = 32;
-const MAX_CAPABILITY_LEN: usize = 32;
+pub const MAX_DEVICE_KIND_LEN: usize = 32;
+pub const MAX_FIRMWARE_VERSION_LEN: usize = 64;
+pub const MAX_CAPABILITIES: usize = 32;
+pub const MAX_CAPABILITY_LEN: usize = 32;
+
+/// Reject signer-supplied strings that contain control characters. Strings are
+/// surfaced verbatim in CLI/UI output, so any C0/C1 control codes would corrupt
+/// the terminal or hide content. Accept all other printable Unicode.
+fn contains_control_chars(s: &str) -> bool {
+    s.chars().any(|c| c.is_control())
+}
 
 /// Outcome of a successful `register_wallet` request.
 ///
@@ -83,6 +90,22 @@ impl DeviceKind {
             Self::Jade => "Jade",
             Self::Trezor => "Trezor",
             Self::Other(s) => s.as_str(),
+        }
+    }
+
+    /// Promote `Other("Coldcard")` etc. to the matching named variant so two
+    /// registrations of the same device do not appear distinct.
+    fn normalize(self) -> Self {
+        match self {
+            Self::Other(s) => match s.as_str() {
+                "Coldcard" => Self::Coldcard,
+                "Ledger" => Self::Ledger,
+                "BitBox02" => Self::BitBox02,
+                "Jade" => Self::Jade,
+                "Trezor" => Self::Trezor,
+                _ => Self::Other(s),
+            },
+            other => other,
         }
     }
 }
@@ -351,8 +374,9 @@ impl Nip46Client {
                 "get_device_info payload exceeds {MAX_DEVICE_INFO_JSON_LEN} bytes"
             )));
         }
-        let info: DeviceInfo = serde_json::from_str(&result)
+        let mut info: DeviceInfo = serde_json::from_str(&result)
             .map_err(|e| StorageError::invalid_format(format!("get_device_info payload: {e}")))?;
+        info.kind = info.kind.normalize();
 
         if let DeviceKind::Other(ref s) = info.kind {
             if s.is_empty() || s.len() > MAX_DEVICE_KIND_LEN {
@@ -360,12 +384,22 @@ impl Nip46Client {
                     "device kind 'Other' label must be 1..={MAX_DEVICE_KIND_LEN} bytes"
                 )));
             }
+            if contains_control_chars(s) {
+                return Err(KeepError::InvalidInput(
+                    "device kind 'Other' label contains control characters".into(),
+                ));
+            }
         }
         if let Some(ref fw) = info.firmware_version {
             if fw.len() > MAX_FIRMWARE_VERSION_LEN {
                 return Err(KeepError::InvalidInput(format!(
                     "firmware_version exceeds {MAX_FIRMWARE_VERSION_LEN} bytes"
                 )));
+            }
+            if contains_control_chars(fw) {
+                return Err(KeepError::InvalidInput(
+                    "firmware_version contains control characters".into(),
+                ));
             }
         }
         if info.fingerprint_bytes().is_none() {
@@ -383,6 +417,11 @@ impl Nip46Client {
                 return Err(KeepError::InvalidInput(format!(
                     "capability label must be 1..={MAX_CAPABILITY_LEN} bytes"
                 )));
+            }
+            if contains_control_chars(cap) {
+                return Err(KeepError::InvalidInput(
+                    "capability label contains control characters".into(),
+                ));
             }
         }
         Ok(info)
@@ -577,6 +616,30 @@ mod tests {
             capabilities: Vec::new(),
         };
         assert!(info.fingerprint_bytes().is_none());
+    }
+
+    #[test]
+    fn test_device_kind_normalize_promotes_other() {
+        assert_eq!(
+            DeviceKind::Other("Coldcard".into()).normalize(),
+            DeviceKind::Coldcard
+        );
+        assert_eq!(
+            DeviceKind::Other("Ledger".into()).normalize(),
+            DeviceKind::Ledger
+        );
+        assert_eq!(
+            DeviceKind::Other("Foundation".into()).normalize(),
+            DeviceKind::Other("Foundation".into())
+        );
+    }
+
+    #[test]
+    fn test_contains_control_chars_rejects_c0() {
+        assert!(contains_control_chars("hello\nworld"));
+        assert!(contains_control_chars("ansi\x1b[31mred"));
+        assert!(!contains_control_chars("ColdcardMk4"));
+        assert!(!contains_control_chars("1.2.3-beta"));
     }
 
     #[test]

--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -18,7 +18,10 @@ use crate::types::Nip46Response;
 
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 const REGISTER_WALLET_TIMEOUT: Duration = Duration::from_secs(180);
-const GET_DEVICE_INFO_TIMEOUT: Duration = Duration::from_secs(30);
+/// Default timeout for the best-effort `get_device_info` probe. Kept short so a
+/// silent or hostile signer cannot stall registration UX. Callers that need to
+/// override (e.g. a known-slow device) can wrap with their own `tokio::time::timeout`.
+pub const GET_DEVICE_INFO_TIMEOUT: Duration = Duration::from_secs(8);
 const MAX_RESPONSE_SIZE: usize = 64 * 1024;
 const MAX_HMAC_HEX_LEN: usize = 128;
 const HMAC_SHA256_LEN: usize = 32;
@@ -29,13 +32,13 @@ pub const MAX_DEVICE_INFO_JSON_LEN: usize = 2048;
 /// Size caps on individual fields of `DeviceInfo`.
 pub const MAX_DEVICE_KIND_LEN: usize = 32;
 pub const MAX_FIRMWARE_VERSION_LEN: usize = 64;
-const MAX_CAPABILITIES: usize = 32;
-const MAX_CAPABILITY_LEN: usize = 32;
+pub const MAX_CAPABILITIES: usize = 32;
+pub const MAX_CAPABILITY_LEN: usize = 32;
 
 /// Reject signer-supplied strings that contain control characters. Strings are
 /// surfaced verbatim in CLI/UI output, so any C0/C1 control codes would corrupt
 /// the terminal or hide content. Accept all other printable Unicode.
-fn contains_control_chars(s: &str) -> bool {
+pub fn contains_control_chars(s: &str) -> bool {
     s.chars().any(|c| c.is_control())
 }
 
@@ -94,15 +97,17 @@ impl DeviceKind {
     }
 
     /// Promote `Other("Coldcard")` etc. to the matching named variant so two
-    /// registrations of the same device do not appear distinct.
+    /// registrations of the same device do not appear distinct. Matching is
+    /// case-insensitive ("COLDCARD", "ColdCard", "coldcard" all normalize to
+    /// `Coldcard`).
     fn normalize(self) -> Self {
         match self {
-            Self::Other(s) => match s.as_str() {
-                "Coldcard" => Self::Coldcard,
-                "Ledger" => Self::Ledger,
-                "BitBox02" => Self::BitBox02,
-                "Jade" => Self::Jade,
-                "Trezor" => Self::Trezor,
+            Self::Other(s) => match s.to_ascii_lowercase().as_str() {
+                "coldcard" => Self::Coldcard,
+                "ledger" => Self::Ledger,
+                "bitbox02" => Self::BitBox02,
+                "jade" => Self::Jade,
+                "trezor" => Self::Trezor,
                 _ => Self::Other(s),
             },
             other => other,
@@ -112,10 +117,11 @@ impl DeviceKind {
 
 /// Typed `get_device_info` response.
 ///
-/// `fingerprint` is the BIP32 master key fingerprint as a hex string (8 chars);
-/// `capabilities` is a free-form list. Both are validated when received: the
-/// fingerprint must decode to exactly 4 bytes and capability strings are
-/// length-capped.
+/// `fingerprint` is the BIP32 master key fingerprint as a hex string (8 chars).
+/// It is validated when received: must decode to exactly 4 bytes, and the
+/// all-zero sentinel (`00000000`, which BIP32 reserves for "no parent") is
+/// rejected. Stored normalized to lower-case so later string comparisons /
+/// serialization are stable.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeviceInfo {
@@ -401,11 +407,17 @@ impl Nip46Client {
                 ));
             }
         }
-        if info.fingerprint_bytes().is_none() {
+        let fp_bytes = info.fingerprint_bytes().ok_or_else(|| {
+            KeepError::InvalidInput("fingerprint must be 8 hex characters (4 bytes)".into())
+        })?;
+        if fp_bytes == [0u8; 4] {
             return Err(KeepError::InvalidInput(
-                "fingerprint must be 8 hex characters (4 bytes)".into(),
+                "fingerprint 00000000 is reserved by BIP32 for 'no parent' and cannot identify a device".into(),
             ));
         }
+        // Normalize hex to lower-case-no-whitespace so later comparisons /
+        // serialization are stable regardless of what the signer sent.
+        info.fingerprint = hex::encode(fp_bytes);
         if info.capabilities.len() > MAX_CAPABILITIES {
             return Err(KeepError::InvalidInput(format!(
                 "capabilities list exceeds {MAX_CAPABILITIES} entries"
@@ -630,6 +642,30 @@ mod tests {
         assert_eq!(
             DeviceKind::Other("Foundation".into()).normalize(),
             DeviceKind::Other("Foundation".into())
+        );
+    }
+
+    #[test]
+    fn test_device_kind_normalize_case_insensitive() {
+        assert_eq!(
+            DeviceKind::Other("COLDCARD".into()).normalize(),
+            DeviceKind::Coldcard
+        );
+        assert_eq!(
+            DeviceKind::Other("coldcard".into()).normalize(),
+            DeviceKind::Coldcard
+        );
+        assert_eq!(
+            DeviceKind::Other("ColdCard".into()).normalize(),
+            DeviceKind::Coldcard
+        );
+        assert_eq!(
+            DeviceKind::Other("trezor".into()).normalize(),
+            DeviceKind::Trezor
+        );
+        assert_eq!(
+            DeviceKind::Other("BITBOX02".into()).normalize(),
+            DeviceKind::BitBox02
         );
     }
 

--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -42,6 +42,28 @@ pub fn contains_control_chars(s: &str) -> bool {
     s.chars().any(|c| c.is_control())
 }
 
+/// Validate a free-form metadata string from a signer or operator: enforce
+/// `min_len..=max_len` byte length and reject control characters. `field` is
+/// used only for error messages.
+pub fn validate_metadata_field(
+    field: &str,
+    value: &str,
+    min_len: usize,
+    max_len: usize,
+) -> Result<()> {
+    if value.len() < min_len || value.len() > max_len {
+        return Err(KeepError::InvalidInput(format!(
+            "{field} must be {min_len}..={max_len} bytes"
+        )));
+    }
+    if contains_control_chars(value) {
+        return Err(KeepError::InvalidInput(format!(
+            "{field} contains control characters"
+        )));
+    }
+    Ok(())
+}
+
 /// Outcome of a successful `register_wallet` request.
 ///
 /// `hmac` is an opaque device-returned token. It is **not** cryptographically
@@ -384,28 +406,10 @@ impl Nip46Client {
         info.kind = info.kind.normalize();
 
         if let DeviceKind::Other(ref s) = info.kind {
-            if s.is_empty() || s.len() > MAX_DEVICE_KIND_LEN {
-                return Err(KeepError::InvalidInput(format!(
-                    "device kind 'Other' label must be 1..={MAX_DEVICE_KIND_LEN} bytes"
-                )));
-            }
-            if contains_control_chars(s) {
-                return Err(KeepError::InvalidInput(
-                    "device kind 'Other' label contains control characters".into(),
-                ));
-            }
+            validate_metadata_field("device kind 'Other' label", s, 1, MAX_DEVICE_KIND_LEN)?;
         }
         if let Some(ref fw) = info.firmware_version {
-            if fw.len() > MAX_FIRMWARE_VERSION_LEN {
-                return Err(KeepError::InvalidInput(format!(
-                    "firmware_version exceeds {MAX_FIRMWARE_VERSION_LEN} bytes"
-                )));
-            }
-            if contains_control_chars(fw) {
-                return Err(KeepError::InvalidInput(
-                    "firmware_version contains control characters".into(),
-                ));
-            }
+            validate_metadata_field("firmware_version", fw, 0, MAX_FIRMWARE_VERSION_LEN)?;
         }
         let fp_bytes = info.fingerprint_bytes().ok_or_else(|| {
             KeepError::InvalidInput("fingerprint must be 8 hex characters (4 bytes)".into())
@@ -415,8 +419,6 @@ impl Nip46Client {
                 "fingerprint 00000000 is reserved by BIP32 for 'no parent' and cannot identify a device".into(),
             ));
         }
-        // Normalize hex to lower-case-no-whitespace so later comparisons /
-        // serialization are stable regardless of what the signer sent.
         info.fingerprint = hex::encode(fp_bytes);
         if info.capabilities.len() > MAX_CAPABILITIES {
             return Err(KeepError::InvalidInput(format!(
@@ -424,16 +426,7 @@ impl Nip46Client {
             )));
         }
         for cap in &info.capabilities {
-            if cap.is_empty() || cap.len() > MAX_CAPABILITY_LEN {
-                return Err(KeepError::InvalidInput(format!(
-                    "capability label must be 1..={MAX_CAPABILITY_LEN} bytes"
-                )));
-            }
-            if contains_control_chars(cap) {
-                return Err(KeepError::InvalidInput(
-                    "capability label contains control characters".into(),
-                ));
-            }
+            validate_metadata_field("capability label", cap, 1, MAX_CAPABILITY_LEN)?;
         }
         Ok(info)
     }

--- a/keep-nip46/src/lib.rs
+++ b/keep-nip46/src/lib.rs
@@ -21,9 +21,10 @@ pub use bunker::{
     generate_bunker_url, parse_bunker_url, parse_nostrconnect_uri, NostrConnectRequest,
 };
 pub use client::{
-    contains_control_chars, DeviceInfo, DeviceKind, Nip46Client, RegisterWalletResponse,
-    GET_DEVICE_INFO_TIMEOUT, MAX_CAPABILITIES, MAX_CAPABILITY_LEN, MAX_DESCRIPTOR_LEN,
-    MAX_DEVICE_INFO_JSON_LEN, MAX_DEVICE_KIND_LEN, MAX_FIRMWARE_VERSION_LEN, MAX_WALLET_NAME_LEN,
+    contains_control_chars, validate_metadata_field, DeviceInfo, DeviceKind, Nip46Client,
+    RegisterWalletResponse, GET_DEVICE_INFO_TIMEOUT, MAX_CAPABILITIES, MAX_CAPABILITY_LEN,
+    MAX_DESCRIPTOR_LEN, MAX_DEVICE_INFO_JSON_LEN, MAX_DEVICE_KIND_LEN, MAX_FIRMWARE_VERSION_LEN,
+    MAX_WALLET_NAME_LEN,
 };
 pub use error::Result;
 pub use frost_signer::{FrostSigner, NetworkFrostSigner};

--- a/keep-nip46/src/lib.rs
+++ b/keep-nip46/src/lib.rs
@@ -21,7 +21,8 @@ pub use bunker::{
     generate_bunker_url, parse_bunker_url, parse_nostrconnect_uri, NostrConnectRequest,
 };
 pub use client::{
-    DeviceInfo, DeviceKind, Nip46Client, RegisterWalletResponse, MAX_DESCRIPTOR_LEN,
+    contains_control_chars, DeviceInfo, DeviceKind, Nip46Client, RegisterWalletResponse,
+    GET_DEVICE_INFO_TIMEOUT, MAX_CAPABILITIES, MAX_CAPABILITY_LEN, MAX_DESCRIPTOR_LEN,
     MAX_DEVICE_INFO_JSON_LEN, MAX_DEVICE_KIND_LEN, MAX_FIRMWARE_VERSION_LEN, MAX_WALLET_NAME_LEN,
 };
 pub use error::Result;

--- a/keep-nip46/src/lib.rs
+++ b/keep-nip46/src/lib.rs
@@ -21,9 +21,8 @@ pub use bunker::{
     generate_bunker_url, parse_bunker_url, parse_nostrconnect_uri, NostrConnectRequest,
 };
 pub use client::{
-    DeviceInfo, DeviceKind, Nip46Client, RegisterWalletResponse, MAX_CAPABILITIES,
-    MAX_CAPABILITY_LEN, MAX_DESCRIPTOR_LEN, MAX_DEVICE_INFO_JSON_LEN, MAX_DEVICE_KIND_LEN,
-    MAX_FIRMWARE_VERSION_LEN, MAX_WALLET_NAME_LEN,
+    DeviceInfo, DeviceKind, Nip46Client, RegisterWalletResponse, MAX_DESCRIPTOR_LEN,
+    MAX_DEVICE_INFO_JSON_LEN, MAX_DEVICE_KIND_LEN, MAX_FIRMWARE_VERSION_LEN, MAX_WALLET_NAME_LEN,
 };
 pub use error::Result;
 pub use frost_signer::{FrostSigner, NetworkFrostSigner};

--- a/keep-nip46/src/lib.rs
+++ b/keep-nip46/src/lib.rs
@@ -20,7 +20,10 @@ pub use audit::{AuditAction, AuditEntry, AuditLog};
 pub use bunker::{
     generate_bunker_url, parse_bunker_url, parse_nostrconnect_uri, NostrConnectRequest,
 };
-pub use client::{Nip46Client, RegisterWalletResponse, MAX_DESCRIPTOR_LEN, MAX_WALLET_NAME_LEN};
+pub use client::{
+    DeviceInfo, DeviceKind, Nip46Client, RegisterWalletResponse, MAX_DESCRIPTOR_LEN,
+    MAX_DEVICE_INFO_JSON_LEN, MAX_WALLET_NAME_LEN,
+};
 pub use error::Result;
 pub use frost_signer::{FrostSigner, NetworkFrostSigner};
 pub use handler::SignerHandler;

--- a/keep-nip46/src/lib.rs
+++ b/keep-nip46/src/lib.rs
@@ -21,8 +21,9 @@ pub use bunker::{
     generate_bunker_url, parse_bunker_url, parse_nostrconnect_uri, NostrConnectRequest,
 };
 pub use client::{
-    DeviceInfo, DeviceKind, Nip46Client, RegisterWalletResponse, MAX_DESCRIPTOR_LEN,
-    MAX_DEVICE_INFO_JSON_LEN, MAX_WALLET_NAME_LEN,
+    DeviceInfo, DeviceKind, Nip46Client, RegisterWalletResponse, MAX_CAPABILITIES,
+    MAX_CAPABILITY_LEN, MAX_DESCRIPTOR_LEN, MAX_DEVICE_INFO_JSON_LEN, MAX_DEVICE_KIND_LEN,
+    MAX_FIRMWARE_VERSION_LEN, MAX_WALLET_NAME_LEN,
 };
 pub use error::Result;
 pub use frost_signer::{FrostSigner, NetworkFrostSigner};

--- a/keep-nip46/tests/get_device_info.rs
+++ b/keep-nip46/tests/get_device_info.rs
@@ -1,15 +1,13 @@
 // SPDX-FileCopyrightText: © 2026 PrivKey LLC
 // SPDX-License-Identifier: MIT
 
-use std::time::Duration;
-
 use nostr_relay_builder::prelude::*;
 use nostr_sdk::prelude::{
     nip44, Client, EventBuilder, Filter, Keys, Kind, RelayPoolNotification, Tag, Timestamp,
 };
 
 use keep_core::error::{KeepError, NetworkError};
-use keep_nip46::{DeviceKind, Nip46Client};
+use keep_nip46::{DeviceKind, Nip46Client, MAX_DEVICE_INFO_JSON_LEN};
 
 async fn run_stub_signer(
     signer_keys: Keys,
@@ -113,10 +111,11 @@ async fn test_get_device_info_happy_path() {
 
     client.disconnect().await;
     signer_handle.abort();
+    let _ = signer_handle.await;
 }
 
 #[tokio::test]
-async fn test_get_device_info_unknown_method_errors() {
+async fn test_get_device_info_malformed_payload_errors() {
     rustls::crypto::ring::default_provider()
         .install_default()
         .ok();
@@ -158,7 +157,230 @@ async fn test_get_device_info_unknown_method_errors() {
 
     client.disconnect().await;
     signer_handle.abort();
+    let _ = signer_handle.await;
+}
 
-    // Give the runtime a beat to drain background tasks before the test exits.
-    tokio::time::sleep(Duration::from_millis(50)).await;
+/// Stub that returns a NIP-46-level error for `get_device_info`, exercising
+/// the `response.error` branch in the client.
+async fn run_unknown_method_signer(
+    signer_keys: Keys,
+    relay_url: String,
+) -> (
+    tokio::task::JoinHandle<()>,
+    tokio::sync::oneshot::Receiver<()>,
+) {
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+
+    let handle = tokio::spawn(async move {
+        let client = Client::new(signer_keys.clone());
+        client.add_relay(relay_url.as_str()).await.unwrap();
+        client.connect().await;
+        let filter = Filter::new()
+            .kind(Kind::NostrConnect)
+            .pubkey(signer_keys.public_key());
+        client.subscribe(filter, None).await.unwrap();
+        let _ = ready_tx.send(());
+
+        let mut notifications = client.notifications();
+        while let Ok(notif) = notifications.recv().await {
+            let RelayPoolNotification::Event { event, .. } = notif else {
+                continue;
+            };
+            if event.kind != Kind::NostrConnect {
+                continue;
+            }
+            let app_pubkey = event.pubkey;
+            let Ok(plaintext) =
+                nip44::decrypt(signer_keys.secret_key(), &app_pubkey, &event.content)
+            else {
+                continue;
+            };
+            let Ok(request): Result<serde_json::Value, _> = serde_json::from_str(&plaintext) else {
+                continue;
+            };
+            let id = request
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let method = request.get("method").and_then(|v| v.as_str()).unwrap_or("");
+            let response = match method {
+                "connect" => serde_json::json!({"id": id, "result": "ack"}),
+                _ => serde_json::json!({"id": id, "error": "Unknown method"}),
+            };
+            let body = serde_json::to_string(&response).unwrap();
+            let ct = nip44::encrypt(
+                signer_keys.secret_key(),
+                &app_pubkey,
+                &body,
+                nip44::Version::V2,
+            )
+            .unwrap();
+            let ev = EventBuilder::new(Kind::NostrConnect, ct)
+                .custom_created_at(Timestamp::now())
+                .tag(Tag::public_key(app_pubkey))
+                .sign_with_keys(&signer_keys)
+                .unwrap();
+            let _ = client.send_event(&ev).await;
+        }
+    });
+
+    (handle, ready_rx)
+}
+
+#[tokio::test]
+async fn test_get_device_info_unknown_method_errors() {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+
+    let mock_relay = MockRelay::run().await.expect("mock relay");
+    let relay_url = mock_relay.url().await.to_string();
+
+    let signer_keys = Keys::generate();
+    let signer_pubkey = signer_keys.public_key();
+
+    let (signer_handle, signer_ready) =
+        run_unknown_method_signer(signer_keys, relay_url.clone()).await;
+    signer_ready.await.expect("stub signer ready");
+
+    let client = Nip46Client::connect_with(signer_pubkey, vec![relay_url], None)
+        .await
+        .expect("client connect");
+    client.connect().await.expect("connect handshake");
+
+    let err = client
+        .get_device_info()
+        .await
+        .expect_err("unknown method must error");
+    match err {
+        KeepError::NetworkErr(NetworkError::Response { .. }) => {}
+        other => panic!("unexpected error: {other:?}"),
+    }
+
+    client.disconnect().await;
+    signer_handle.abort();
+    let _ = signer_handle.await;
+}
+
+async fn expect_error_for_payload(payload: String) -> KeepError {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+    let mock_relay = MockRelay::run().await.expect("mock relay");
+    let relay_url = mock_relay.url().await.to_string();
+    let signer_keys = Keys::generate();
+    let signer_pubkey = signer_keys.public_key();
+    let (handle, ready) = run_stub_signer(signer_keys, relay_url.clone(), payload).await;
+    ready.await.expect("ready");
+
+    let client = Nip46Client::connect_with(signer_pubkey, vec![relay_url], None)
+        .await
+        .expect("connect");
+    client.connect().await.expect("handshake");
+    let err = client.get_device_info().await.expect_err("must error");
+
+    client.disconnect().await;
+    handle.abort();
+    let _ = handle.await;
+    err
+}
+
+#[tokio::test]
+async fn test_get_device_info_rejects_oversize_json() {
+    let big_cap = "a".repeat(32);
+    let mut caps = String::from("[");
+    for i in 0..(MAX_DEVICE_INFO_JSON_LEN / 35) {
+        if i > 0 {
+            caps.push(',');
+        }
+        caps.push_str(&format!("\"{big_cap}\""));
+    }
+    caps.push(']');
+    let payload =
+        format!(r#"{{"kind":"Coldcard","fingerprint":"deadbeef","capabilities":{caps}}}"#);
+    assert!(payload.len() > MAX_DEVICE_INFO_JSON_LEN);
+    let err = expect_error_for_payload(payload).await;
+    match err {
+        KeepError::InvalidInput(msg) => assert!(msg.contains("payload exceeds")),
+        other => panic!("unexpected: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_get_device_info_rejects_oversize_capability_label() {
+    let big_cap = "x".repeat(33);
+    let payload = format!(
+        r#"{{"kind":"Ledger","fingerprint":"00112233","capabilities":["{big_cap}"]}}"#
+    );
+    let err = expect_error_for_payload(payload).await;
+    match err {
+        KeepError::InvalidInput(msg) => assert!(msg.contains("capability label")),
+        other => panic!("unexpected: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_get_device_info_rejects_too_many_capabilities() {
+    let caps: Vec<String> = (0..33).map(|i| format!("\"c{i}\"")).collect();
+    let payload = format!(
+        r#"{{"kind":"Jade","fingerprint":"00112233","capabilities":[{}]}}"#,
+        caps.join(",")
+    );
+    let err = expect_error_for_payload(payload).await;
+    match err {
+        KeepError::InvalidInput(msg) => assert!(msg.contains("capabilities list")),
+        other => panic!("unexpected: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_get_device_info_rejects_oversize_other_label() {
+    let label = "z".repeat(33);
+    let payload = format!(
+        r#"{{"kind":{{"Other":"{label}"}},"fingerprint":"deadbeef","capabilities":[]}}"#
+    );
+    let err = expect_error_for_payload(payload).await;
+    match err {
+        KeepError::InvalidInput(msg) => assert!(msg.contains("'Other' label")),
+        other => panic!("unexpected: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_get_device_info_rejects_control_chars_in_other() {
+    let payload =
+        r#"{"kind":{"Other":"Cold\ncard"},"fingerprint":"deadbeef","capabilities":[]}"#
+            .to_string();
+    let err = expect_error_for_payload(payload).await;
+    match err {
+        KeepError::InvalidInput(msg) => assert!(msg.contains("control")),
+        other => panic!("unexpected: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_get_device_info_normalizes_other_to_known_kind() {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+    let mock_relay = MockRelay::run().await.expect("mock relay");
+    let relay_url = mock_relay.url().await.to_string();
+    let signer_keys = Keys::generate();
+    let signer_pubkey = signer_keys.public_key();
+    let payload =
+        r#"{"kind":{"Other":"Coldcard"},"fingerprint":"deadbeef","capabilities":[]}"#.to_string();
+    let (handle, ready) = run_stub_signer(signer_keys, relay_url.clone(), payload).await;
+    ready.await.expect("ready");
+
+    let client = Nip46Client::connect_with(signer_pubkey, vec![relay_url], None)
+        .await
+        .expect("connect");
+    client.connect().await.expect("handshake");
+    let info = client.get_device_info().await.expect("ok");
+    assert_eq!(info.kind, DeviceKind::Coldcard);
+
+    client.disconnect().await;
+    handle.abort();
+    let _ = handle.await;
 }

--- a/keep-nip46/tests/get_device_info.rs
+++ b/keep-nip46/tests/get_device_info.rs
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+use std::time::Duration;
+
+use nostr_relay_builder::prelude::*;
+use nostr_sdk::prelude::{
+    nip44, Client, EventBuilder, Filter, Keys, Kind, RelayPoolNotification, Tag, Timestamp,
+};
+
+use keep_core::error::{KeepError, NetworkError};
+use keep_nip46::{DeviceKind, Nip46Client};
+
+async fn run_stub_signer(
+    signer_keys: Keys,
+    relay_url: String,
+    device_info_json: String,
+) -> (
+    tokio::task::JoinHandle<()>,
+    tokio::sync::oneshot::Receiver<()>,
+) {
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+
+    let handle = tokio::spawn(async move {
+        let client = Client::new(signer_keys.clone());
+        client.add_relay(relay_url.as_str()).await.unwrap();
+        client.connect().await;
+        let filter = Filter::new()
+            .kind(Kind::NostrConnect)
+            .pubkey(signer_keys.public_key());
+        client.subscribe(filter, None).await.unwrap();
+        let _ = ready_tx.send(());
+
+        let mut notifications = client.notifications();
+        while let Ok(notif) = notifications.recv().await {
+            let RelayPoolNotification::Event { event, .. } = notif else {
+                continue;
+            };
+            if event.kind != Kind::NostrConnect {
+                continue;
+            }
+            let app_pubkey = event.pubkey;
+            let Ok(plaintext) =
+                nip44::decrypt(signer_keys.secret_key(), &app_pubkey, &event.content)
+            else {
+                continue;
+            };
+            let Ok(request): Result<serde_json::Value, _> = serde_json::from_str(&plaintext) else {
+                continue;
+            };
+            let id = request
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let method = request.get("method").and_then(|v| v.as_str()).unwrap_or("");
+
+            let response = match method {
+                "connect" => serde_json::json!({"id": id, "result": "ack"}),
+                "get_device_info" => {
+                    serde_json::json!({"id": id, "result": device_info_json.clone()})
+                }
+                _ => serde_json::json!({"id": id, "error": "Unknown method"}),
+            };
+
+            let body = serde_json::to_string(&response).unwrap();
+            let ct = nip44::encrypt(
+                signer_keys.secret_key(),
+                &app_pubkey,
+                &body,
+                nip44::Version::V2,
+            )
+            .unwrap();
+            let ev = EventBuilder::new(Kind::NostrConnect, ct)
+                .custom_created_at(Timestamp::now())
+                .tag(Tag::public_key(app_pubkey))
+                .sign_with_keys(&signer_keys)
+                .unwrap();
+            let _ = client.send_event(&ev).await;
+        }
+    });
+
+    (handle, ready_rx)
+}
+
+#[tokio::test]
+async fn test_get_device_info_happy_path() {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+
+    let mock_relay = MockRelay::run().await.expect("mock relay");
+    let relay_url = mock_relay.url().await.to_string();
+
+    let signer_keys = Keys::generate();
+    let signer_pubkey = signer_keys.public_key();
+    let info_json = r#"{"kind":"Coldcard","firmware_version":"5.1.2","fingerprint":"deadbeef","capabilities":["miniscript","tapminiscript","multisig"]}"#.to_string();
+
+    let (signer_handle, signer_ready) =
+        run_stub_signer(signer_keys, relay_url.clone(), info_json).await;
+    signer_ready.await.expect("stub signer ready");
+
+    let client = Nip46Client::connect_with(signer_pubkey, vec![relay_url], None)
+        .await
+        .expect("client connect");
+    client.connect().await.expect("connect handshake");
+
+    let info = client.get_device_info().await.expect("get_device_info");
+    assert_eq!(info.kind, DeviceKind::Coldcard);
+    assert_eq!(info.firmware_version.as_deref(), Some("5.1.2"));
+    assert_eq!(info.fingerprint_bytes(), Some([0xde, 0xad, 0xbe, 0xef]));
+    assert_eq!(info.capabilities.len(), 3);
+
+    client.disconnect().await;
+    signer_handle.abort();
+}
+
+#[tokio::test]
+async fn test_get_device_info_unknown_method_errors() {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+
+    let mock_relay = MockRelay::run().await.expect("mock relay");
+    let relay_url = mock_relay.url().await.to_string();
+
+    let signer_keys = Keys::generate();
+    let signer_pubkey = signer_keys.public_key();
+
+    // Stub that only answers connect; any other method gets "Unknown method".
+    let (signer_handle, signer_ready) = run_stub_signer(
+        signer_keys,
+        relay_url.clone(),
+        // Send an "Unknown method" by configuring the stub with a payload that
+        // will never be returned for non-get_device_info methods. We trigger
+        // the error path by sending get_device_info to a signer that answers
+        // it with malformed JSON (force JSON parse error).
+        "not-json".into(),
+    )
+    .await;
+    signer_ready.await.expect("stub signer ready");
+
+    let client = Nip46Client::connect_with(signer_pubkey, vec![relay_url], None)
+        .await
+        .expect("client connect");
+    client.connect().await.expect("connect handshake");
+
+    let err = client
+        .get_device_info()
+        .await
+        .expect_err("malformed payload must error");
+    // We accept either an InvalidFormat (parse error) or a Response error.
+    match err {
+        KeepError::StorageErr(_) | KeepError::InvalidInput(_) => {}
+        KeepError::NetworkErr(NetworkError::Response { .. }) => {}
+        other => panic!("unexpected error: {other:?}"),
+    }
+
+    client.disconnect().await;
+    signer_handle.abort();
+
+    // Give the runtime a beat to drain background tasks before the test exits.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+}

--- a/keep-nip46/tests/get_device_info.rs
+++ b/keep-nip46/tests/get_device_info.rs
@@ -310,9 +310,8 @@ async fn test_get_device_info_rejects_oversize_json() {
 #[tokio::test]
 async fn test_get_device_info_rejects_oversize_capability_label() {
     let big_cap = "x".repeat(33);
-    let payload = format!(
-        r#"{{"kind":"Ledger","fingerprint":"00112233","capabilities":["{big_cap}"]}}"#
-    );
+    let payload =
+        format!(r#"{{"kind":"Ledger","fingerprint":"00112233","capabilities":["{big_cap}"]}}"#);
     let err = expect_error_for_payload(payload).await;
     match err {
         KeepError::InvalidInput(msg) => assert!(msg.contains("capability label")),
@@ -337,9 +336,8 @@ async fn test_get_device_info_rejects_too_many_capabilities() {
 #[tokio::test]
 async fn test_get_device_info_rejects_oversize_other_label() {
     let label = "z".repeat(33);
-    let payload = format!(
-        r#"{{"kind":{{"Other":"{label}"}},"fingerprint":"deadbeef","capabilities":[]}}"#
-    );
+    let payload =
+        format!(r#"{{"kind":{{"Other":"{label}"}},"fingerprint":"deadbeef","capabilities":[]}}"#);
     let err = expect_error_for_payload(payload).await;
     match err {
         KeepError::InvalidInput(msg) => assert!(msg.contains("'Other' label")),
@@ -350,8 +348,7 @@ async fn test_get_device_info_rejects_oversize_other_label() {
 #[tokio::test]
 async fn test_get_device_info_rejects_control_chars_in_other() {
     let payload =
-        r#"{"kind":{"Other":"Cold\ncard"},"fingerprint":"deadbeef","capabilities":[]}"#
-            .to_string();
+        r#"{"kind":{"Other":"Cold\ncard"},"fingerprint":"deadbeef","capabilities":[]}"#.to_string();
     let err = expect_error_for_payload(payload).await;
     match err {
         KeepError::InvalidInput(msg) => assert!(msg.contains("control")),

--- a/keep-nip46/tests/get_device_info.rs
+++ b/keep-nip46/tests/get_device_info.rs
@@ -346,6 +346,17 @@ async fn test_get_device_info_rejects_oversize_other_label() {
 }
 
 #[tokio::test]
+async fn test_get_device_info_rejects_zero_fingerprint() {
+    let payload =
+        r#"{"kind":"Coldcard","fingerprint":"00000000","capabilities":[]}"#.to_string();
+    let err = expect_error_for_payload(payload).await;
+    match err {
+        KeepError::InvalidInput(msg) => assert!(msg.contains("00000000")),
+        other => panic!("unexpected: {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn test_get_device_info_rejects_control_chars_in_other() {
     let payload =
         r#"{"kind":{"Other":"Cold\ncard"},"fingerprint":"deadbeef","capabilities":[]}"#.to_string();

--- a/keep-nip46/tests/get_device_info.rs
+++ b/keep-nip46/tests/get_device_info.rs
@@ -347,8 +347,7 @@ async fn test_get_device_info_rejects_oversize_other_label() {
 
 #[tokio::test]
 async fn test_get_device_info_rejects_zero_fingerprint() {
-    let payload =
-        r#"{"kind":"Coldcard","fingerprint":"00000000","capabilities":[]}"#.to_string();
+    let payload = r#"{"kind":"Coldcard","fingerprint":"00000000","capabilities":[]}"#.to_string();
     let err = expect_error_for_payload(payload).await;
     match err {
         KeepError::InvalidInput(msg) => assert!(msg.contains("00000000")),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device registration captures optional hardware metadata: device kind, fingerprint, firmware version
  * UI: optional "Device kind" input on registration and wallet details now show "Registered devices (self-reported, unverified)"
  * CLI: new --kind, --fingerprint, --firmware-version flags
  * Best-effort metadata probe during registration (failures do not block)
  * Metadata persisted and included in backup/restore; CLI/UI emit warnings when user overrides differ from device-reported values

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->