### PR TITLE
recovery-tier PSBT signing flow

### DIFF
--- a/keep-bitcoin/src/lib.rs
+++ b/keep-bitcoin/src/lib.rs
@@ -21,7 +21,8 @@ pub use recovery::{
     PolicyInput, PolicyTierInput, RecoveryConfig, RecoveryOutput, RecoveryTier, SpendingTier,
 };
 pub use recovery_tx::{
-    merge_tap_script_sig, script_spend_sighashes, RecoveryTxBuilder, ScriptSpendSighash,
+    merge_tap_script_sig, script_spend_sighashes, verify_script_spend_input_binding,
+    RecoveryTxBuilder, ScriptSpendSighash, TAPROOT_DUST_LIMIT_SATS,
 };
 pub use signer::BitcoinSigner;
 

--- a/keep-bitcoin/src/lib.rs
+++ b/keep-bitcoin/src/lib.rs
@@ -21,8 +21,9 @@ pub use recovery::{
     PolicyInput, PolicyTierInput, RecoveryConfig, RecoveryOutput, RecoveryTier, SpendingTier,
 };
 pub use recovery_tx::{
-    merge_tap_script_sig, script_spend_sighashes, verify_script_spend_input_binding,
-    RecoveryTxBuilder, ScriptSpendSighash, TAPROOT_DUST_LIMIT_SATS,
+    merge_tap_script_sig, script_spend_sighashes, verify_all_script_spend_input_bindings,
+    verify_script_spend_input_binding, RecoveryTxBuilder, ScriptSpendSighash,
+    TAPROOT_DUST_LIMIT_SATS,
 };
 pub use signer::BitcoinSigner;
 

--- a/keep-bitcoin/src/lib.rs
+++ b/keep-bitcoin/src/lib.rs
@@ -20,9 +20,12 @@ pub use psbt::{PsbtAnalysis, PsbtSigner};
 pub use recovery::{
     PolicyInput, PolicyTierInput, RecoveryConfig, RecoveryOutput, RecoveryTier, SpendingTier,
 };
-pub use recovery_tx::RecoveryTxBuilder;
+pub use recovery_tx::{
+    merge_tap_script_sig, script_spend_sighashes, RecoveryTxBuilder, ScriptSpendSighash,
+};
 pub use signer::BitcoinSigner;
 
+pub use bitcoin;
 pub use bitcoin::Network;
 
 fn aux_rand() -> Result<zeroize::Zeroizing<[u8; 32]>> {

--- a/keep-bitcoin/src/recovery_tx.rs
+++ b/keep-bitcoin/src/recovery_tx.rs
@@ -167,6 +167,12 @@ impl RecoveryTxBuilder {
     /// scripts, so this layout is guaranteed by construction.
     pub fn finalize_recovery(&self, psbt: &mut Psbt, tier_index: usize) -> Result<Transaction> {
         let tier = self.get_tier(tier_index)?;
+        if psbt.inputs.len() != 1 || psbt.unsigned_tx.input.len() != 1 {
+            return Err(BitcoinError::Recovery(format!(
+                "finalize_recovery requires exactly one PSBT input, got {}",
+                psbt.inputs.len()
+            )));
+        }
         let control_block = self.control_block(tier)?;
         // Defensive check: a CHECKSIGADD witness needs one push per key, so a
         // tier with zero keys cannot be finalized. Fail closed rather than

--- a/keep-bitcoin/src/recovery_tx.rs
+++ b/keep-bitcoin/src/recovery_tx.rs
@@ -5,8 +5,9 @@ use crate::recovery::{RecoveryOutput, TierInfo};
 use bitcoin::key::Secp256k1;
 use bitcoin::psbt::Psbt;
 use bitcoin::secp256k1::{All, Keypair, Message};
+use bitcoin::hashes::Hash as _;
 use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
-use bitcoin::taproot::{ControlBlock, LeafVersion, Signature as TaprootSignature};
+use bitcoin::taproot::{ControlBlock, LeafVersion, Signature as TaprootSignature, TapLeafHash};
 use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness};
 use zeroize::Zeroize;
 
@@ -197,6 +198,95 @@ impl RecoveryTxBuilder {
             .control_block(&(tier.script.clone(), LeafVersion::TapScript))
             .ok_or_else(|| BitcoinError::Recovery("no control block for tier script".into()))
     }
+}
+
+/// Per-input recovery-tier script-spend sighash bundle.
+///
+/// Returned by [`script_spend_sighashes`]. Each entry contains the BIP-341
+/// sighash bytes the remote signer must sign, plus the leaf hash, leaf script,
+/// and control block needed to merge the resulting Schnorr signature back into
+/// the PSBT via [`merge_tap_script_sig`].
+#[derive(Clone, Debug)]
+pub struct ScriptSpendSighash {
+    pub input_index: usize,
+    pub sighash: [u8; 32],
+    pub leaf_hash: TapLeafHash,
+    pub script: ScriptBuf,
+    pub control_block: ControlBlock,
+}
+
+/// Compute the BIP-341 script-spend sighash for every input of `psbt` using
+/// the tap_scripts entries already attached to the PSBT. Each input must carry
+/// exactly one `tap_scripts` entry (as inserted by [`RecoveryTxBuilder::build_recovery_psbt`])
+/// and a `witness_utxo`. Returns one [`ScriptSpendSighash`] per input.
+pub fn script_spend_sighashes(psbt: &Psbt) -> Result<Vec<ScriptSpendSighash>> {
+    let prevouts: Vec<TxOut> = psbt
+        .inputs
+        .iter()
+        .enumerate()
+        .map(|(i, input)| {
+            input
+                .witness_utxo
+                .clone()
+                .ok_or(BitcoinError::MissingWitnessUtxo(i))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut sighash_cache = SighashCache::new(&psbt.unsigned_tx);
+    let mut out = Vec::with_capacity(psbt.inputs.len());
+    for (i, input) in psbt.inputs.iter().enumerate() {
+        let mut iter = input.tap_scripts.iter();
+        let (control_block, (script, leaf_version)) = iter.next().ok_or_else(|| {
+            BitcoinError::Recovery(format!("input {i} has no tap_scripts entry"))
+        })?;
+        if iter.next().is_some() {
+            return Err(BitcoinError::Recovery(format!(
+                "input {i} has more than one tap_scripts entry; ambiguous tier"
+            )));
+        }
+        let leaf_hash = TapLeafHash::from_script(script, *leaf_version);
+        let sighash = sighash_cache
+            .taproot_script_spend_signature_hash(
+                i,
+                &Prevouts::All(&prevouts),
+                leaf_hash,
+                TapSighashType::Default,
+            )
+            .map_err(|e| BitcoinError::Sighash(e.to_string()))?;
+        out.push(ScriptSpendSighash {
+            input_index: i,
+            sighash: sighash.to_byte_array(),
+            leaf_hash,
+            script: script.clone(),
+            control_block: control_block.clone(),
+        });
+    }
+    Ok(out)
+}
+
+/// Insert a remote Schnorr signature into `psbt.inputs[input_index].tap_script_sigs`
+/// keyed by `(xonly_pubkey, leaf_hash)` with `SIGHASH_DEFAULT`.
+pub fn merge_tap_script_sig(
+    psbt: &mut Psbt,
+    input_index: usize,
+    xonly_pubkey: bitcoin::XOnlyPublicKey,
+    leaf_hash: TapLeafHash,
+    schnorr_sig: [u8; 64],
+) -> Result<()> {
+    let input = psbt
+        .inputs
+        .get_mut(input_index)
+        .ok_or_else(|| BitcoinError::Recovery(format!("input {input_index} out of range")))?;
+    let signature = bitcoin::secp256k1::schnorr::Signature::from_slice(&schnorr_sig)
+        .map_err(|e| BitcoinError::Signing(format!("invalid schnorr sig: {e}")))?;
+    input.tap_script_sigs.insert(
+        (xonly_pubkey, leaf_hash),
+        TaprootSignature {
+            signature,
+            sighash_type: TapSighashType::Default,
+        },
+    );
+    Ok(())
 }
 
 #[cfg(test)]

--- a/keep-bitcoin/src/recovery_tx.rs
+++ b/keep-bitcoin/src/recovery_tx.rs
@@ -2,16 +2,21 @@
 // SPDX-License-Identifier: MIT
 use crate::error::{BitcoinError, Result};
 use crate::recovery::{RecoveryOutput, TierInfo};
+use bitcoin::hashes::Hash as _;
 use bitcoin::key::Secp256k1;
 use bitcoin::psbt::Psbt;
 use bitcoin::secp256k1::{All, Keypair, Message};
-use bitcoin::hashes::Hash as _;
 use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
 use bitcoin::taproot::{ControlBlock, LeafVersion, Signature as TaprootSignature, TapLeafHash};
-use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness};
-use zeroize::Zeroize;
+use bitcoin::{
+    Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness, XOnlyPublicKey,
+};
+use zeroize::Zeroizing;
 
 const MAX_FEE_SATS: u64 = 100_000_000; // 1 BTC
+/// Bitcoin Core's default dust threshold for taproot (P2TR) outputs in sats.
+/// Outputs smaller than this are non-standard and unlikely to relay.
+pub const TAPROOT_DUST_LIMIT_SATS: u64 = 330;
 
 pub struct RecoveryTxBuilder {
     recovery_output: RecoveryOutput,
@@ -45,10 +50,10 @@ impl RecoveryTxBuilder {
             return Err(BitcoinError::Recovery("insufficient funds".into()));
         }
         let output_value = utxo_value - fee_sats;
-        if output_value < 330 {
-            return Err(BitcoinError::Recovery(
-                "output below dust threshold (330 sats)".into(),
-            ));
+        if output_value < TAPROOT_DUST_LIMIT_SATS {
+            return Err(BitcoinError::Recovery(format!(
+                "output below dust threshold ({TAPROOT_DUST_LIMIT_SATS} sats)"
+            )));
         }
 
         let sequence = match tier.timelock_blocks {
@@ -87,6 +92,12 @@ impl RecoveryTxBuilder {
         Ok(psbt)
     }
 
+    /// Sign the single input of `psbt` for the given recovery tier.
+    ///
+    /// `psbt` MUST contain exactly one input. This is the recovery-tier
+    /// invariant: every PSBT produced by [`Self::build_recovery_psbt`] is
+    /// single-input, and finalize_recovery / aggregate_partial_psbts assume
+    /// the same shape. Multi-input PSBTs are rejected.
     pub fn sign_recovery(
         &self,
         psbt: &mut Psbt,
@@ -94,12 +105,15 @@ impl RecoveryTxBuilder {
         secret_key: &[u8; 32],
     ) -> Result<()> {
         let tier = self.get_tier(tier_index)?;
-        let mut sk_bytes = *secret_key;
-        let keypair = Keypair::from_seckey_slice(&self.secp, &sk_bytes).map_err(|e| {
-            sk_bytes.zeroize();
-            BitcoinError::InvalidSecretKey(e.to_string())
-        })?;
-        sk_bytes.zeroize();
+        if psbt.inputs.len() != 1 {
+            return Err(BitcoinError::Recovery(format!(
+                "sign_recovery requires exactly one PSBT input, got {}",
+                psbt.inputs.len()
+            )));
+        }
+        let sk_bytes = Zeroizing::new(*secret_key);
+        let keypair = Keypair::from_seckey_slice(&self.secp, &*sk_bytes)
+            .map_err(|e| BitcoinError::InvalidSecretKey(e.to_string()))?;
         let (x_only, _) = keypair.x_only_public_key();
 
         let prevouts: Vec<TxOut> = psbt
@@ -145,9 +159,23 @@ impl RecoveryTxBuilder {
         Ok(())
     }
 
+    /// Finalize a recovery PSBT by attaching the witness stack for the given
+    /// tier. Assumes `tier.script` is the CHECKSIGADD-style multisig script
+    /// produced by `RecoveryConfig::build` (one stack push per key, in
+    /// reverse-key order, followed by the leaf script and control block).
+    /// `RecoveryConfig::build` is the only sanctioned producer of tier
+    /// scripts, so this layout is guaranteed by construction.
     pub fn finalize_recovery(&self, psbt: &mut Psbt, tier_index: usize) -> Result<Transaction> {
         let tier = self.get_tier(tier_index)?;
         let control_block = self.control_block(tier)?;
+        // Defensive check: number of script signature slots must equal the
+        // number of keys in the tier. If RecoveryConfig::build ever emits a
+        // non-CHECKSIGADD layout this assert catches it before producing an
+        // invalid witness.
+        assert!(
+            !tier.keys.is_empty(),
+            "tier {tier_index} has no keys; finalize_recovery cannot build CHECKSIGADD witness",
+        );
 
         let sig_count = psbt.inputs[0]
             .tap_script_sigs
@@ -236,9 +264,9 @@ pub fn script_spend_sighashes(psbt: &Psbt) -> Result<Vec<ScriptSpendSighash>> {
     let mut out = Vec::with_capacity(psbt.inputs.len());
     for (i, input) in psbt.inputs.iter().enumerate() {
         let mut iter = input.tap_scripts.iter();
-        let (control_block, (script, leaf_version)) = iter.next().ok_or_else(|| {
-            BitcoinError::Recovery(format!("input {i} has no tap_scripts entry"))
-        })?;
+        let (control_block, (script, leaf_version)) = iter
+            .next()
+            .ok_or_else(|| BitcoinError::Recovery(format!("input {i} has no tap_scripts entry")))?;
         if iter.next().is_some() {
             return Err(BitcoinError::Recovery(format!(
                 "input {i} has more than one tap_scripts entry; ambiguous tier"
@@ -266,11 +294,18 @@ pub fn script_spend_sighashes(psbt: &Psbt) -> Result<Vec<ScriptSpendSighash>> {
 
 /// Insert a remote Schnorr signature into `psbt.inputs[input_index].tap_script_sigs`
 /// keyed by `(xonly_pubkey, leaf_hash)` with `SIGHASH_DEFAULT`.
+///
+/// `sighash` MUST be the BIP-341 script-spend sighash bytes for this input
+/// (typically the value taken from the corresponding [`ScriptSpendSighash`]).
+/// The signature is verified against `(sighash, xonly_pubkey)` before being
+/// inserted; an invalid signature is rejected so callers cannot silently
+/// merge garbage from a malicious or buggy remote signer.
 pub fn merge_tap_script_sig(
     psbt: &mut Psbt,
     input_index: usize,
     xonly_pubkey: bitcoin::XOnlyPublicKey,
     leaf_hash: TapLeafHash,
+    sighash: &[u8; 32],
     schnorr_sig: [u8; 64],
 ) -> Result<()> {
     let input = psbt
@@ -279,6 +314,11 @@ pub fn merge_tap_script_sig(
         .ok_or_else(|| BitcoinError::Recovery(format!("input {input_index} out of range")))?;
     let signature = bitcoin::secp256k1::schnorr::Signature::from_slice(&schnorr_sig)
         .map_err(|e| BitcoinError::Signing(format!("invalid schnorr sig: {e}")))?;
+    let msg = Message::from_digest_slice(sighash)
+        .map_err(|e| BitcoinError::Signing(format!("invalid sighash: {e}")))?;
+    let secp = Secp256k1::verification_only();
+    secp.verify_schnorr(&signature, &msg, &xonly_pubkey)
+        .map_err(|e| BitcoinError::Signing(format!("schnorr verify failed: {e}")))?;
     input.tap_script_sigs.insert(
         (xonly_pubkey, leaf_hash),
         TaprootSignature {
@@ -287,6 +327,123 @@ pub fn merge_tap_script_sig(
         },
     );
     Ok(())
+}
+
+/// Verify that the script-spend bundle for `input_index` of `psbt` is bound
+/// to the input's `witness_utxo` and that the leaf script commits to
+/// `local_xonly`.
+///
+/// This is the security-critical gate that turns a "blind sighash signer"
+/// into one that can only sign for outputs it actually controls. It enforces:
+///
+/// 1. `witness_utxo` is set and is a 34-byte P2TR script (so the output
+///    key can be extracted).
+/// 2. The PSBT input carries exactly one `tap_scripts` entry. Multiple
+///    candidate scripts make the leaf-hash ambiguous and are rejected.
+/// 3. The `(control_block, script, leaf_version)` triple committed to the
+///    `witness_utxo`'s taproot output key — i.e. the leaf is provably part
+///    of the taproot tree being spent.
+/// 4. The leaf script contains `local_xonly` as a 32-byte push. This binds
+///    the responder's signing key to a key actually present in the leaf;
+///    without it a malicious proposer could ask the responder to sign for
+///    an unrelated taproot leaf that happens to commit to the same output.
+///
+/// Returns the verified [`ScriptSpendSighash`] for this input on success.
+pub fn verify_script_spend_input_binding(
+    psbt: &Psbt,
+    input_index: usize,
+    local_xonly: &[u8; 32],
+) -> Result<ScriptSpendSighash> {
+    let input = psbt
+        .inputs
+        .get(input_index)
+        .ok_or_else(|| BitcoinError::Recovery(format!("input {input_index} out of range")))?;
+
+    let wu = input
+        .witness_utxo
+        .as_ref()
+        .ok_or(BitcoinError::MissingWitnessUtxo(input_index))?;
+    let spk = wu.script_pubkey.as_bytes();
+    if !wu.script_pubkey.is_p2tr() || spk.len() != 34 {
+        return Err(BitcoinError::Recovery(format!(
+            "input {input_index} witness_utxo is not a P2TR output",
+        )));
+    }
+    let mut output_key_bytes = [0u8; 32];
+    output_key_bytes.copy_from_slice(&spk[2..34]);
+    let output_key = XOnlyPublicKey::from_slice(&output_key_bytes).map_err(|e| {
+        BitcoinError::Recovery(format!(
+            "input {input_index} witness_utxo output key invalid: {e}"
+        ))
+    })?;
+
+    let mut iter = input.tap_scripts.iter();
+    let (control_block, (script, leaf_version)) = iter.next().ok_or_else(|| {
+        BitcoinError::Recovery(format!("input {input_index} has no tap_scripts entry"))
+    })?;
+    if iter.next().is_some() {
+        return Err(BitcoinError::Recovery(format!(
+            "input {input_index} has more than one tap_scripts entry; ambiguous tier"
+        )));
+    }
+
+    let secp = Secp256k1::verification_only();
+    if !control_block.verify_taproot_commitment(&secp, output_key, script) {
+        return Err(BitcoinError::Recovery(format!(
+            "input {input_index} tap_scripts entry does not commit to the witness_utxo output key",
+        )));
+    }
+
+    if !script_contains_xonly(script, local_xonly) {
+        return Err(BitcoinError::Recovery(format!(
+            "input {input_index} leaf script does not reference the local responder x-only key",
+        )));
+    }
+
+    let leaf_hash = TapLeafHash::from_script(script, *leaf_version);
+
+    let prevouts: Vec<TxOut> = psbt
+        .inputs
+        .iter()
+        .enumerate()
+        .map(|(i, inp)| {
+            inp.witness_utxo
+                .clone()
+                .ok_or(BitcoinError::MissingWitnessUtxo(i))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let mut sighash_cache = SighashCache::new(&psbt.unsigned_tx);
+    let sighash = sighash_cache
+        .taproot_script_spend_signature_hash(
+            input_index,
+            &Prevouts::All(&prevouts),
+            leaf_hash,
+            TapSighashType::Default,
+        )
+        .map_err(|e| BitcoinError::Sighash(e.to_string()))?;
+
+    Ok(ScriptSpendSighash {
+        input_index,
+        sighash: sighash.to_byte_array(),
+        leaf_hash,
+        script: script.clone(),
+        control_block: control_block.clone(),
+    })
+}
+
+/// Scan `script` opcodes for any 32-byte push equal to `xonly`. Recovery
+/// tier leaves built by `RecoveryConfig::build` push each x-only key with
+/// `OP_PUSHBYTES_32`, so any participating key shows up as such a push.
+fn script_contains_xonly(script: &bitcoin::Script, xonly: &[u8; 32]) -> bool {
+    use bitcoin::script::Instruction;
+    for instr in script.instructions() {
+        if let Ok(Instruction::PushBytes(b)) = instr {
+            if b.as_bytes() == xonly.as_slice() {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 #[cfg(test)]

--- a/keep-bitcoin/src/recovery_tx.rs
+++ b/keep-bitcoin/src/recovery_tx.rs
@@ -168,14 +168,14 @@ impl RecoveryTxBuilder {
     pub fn finalize_recovery(&self, psbt: &mut Psbt, tier_index: usize) -> Result<Transaction> {
         let tier = self.get_tier(tier_index)?;
         let control_block = self.control_block(tier)?;
-        // Defensive check: number of script signature slots must equal the
-        // number of keys in the tier. If RecoveryConfig::build ever emits a
-        // non-CHECKSIGADD layout this assert catches it before producing an
-        // invalid witness.
-        assert!(
-            !tier.keys.is_empty(),
-            "tier {tier_index} has no keys; finalize_recovery cannot build CHECKSIGADD witness",
-        );
+        // Defensive check: a CHECKSIGADD witness needs one push per key, so a
+        // tier with zero keys cannot be finalized. Fail closed rather than
+        // panic — a malformed RecoveryConfig must not crash the node.
+        if tier.keys.is_empty() {
+            return Err(BitcoinError::Recovery(format!(
+                "tier {tier_index} has no keys; cannot build CHECKSIGADD witness"
+            )));
+        }
 
         let sig_count = psbt.inputs[0]
             .tap_script_sigs
@@ -429,6 +429,21 @@ pub fn verify_script_spend_input_binding(
         script: script.clone(),
         control_block: control_block.clone(),
     })
+}
+
+/// Verify every PSBT input's script-spend binding upfront and return the
+/// per-input [`ScriptSpendSighash`] bundles. Errors with the offending
+/// input index if any input fails the security-critical binding check in
+/// [`verify_script_spend_input_binding`].
+pub fn verify_all_script_spend_input_bindings(
+    psbt: &Psbt,
+    local_xonly: &[u8; 32],
+) -> Result<Vec<ScriptSpendSighash>> {
+    let mut out = Vec::with_capacity(psbt.inputs.len());
+    for i in 0..psbt.inputs.len() {
+        out.push(verify_script_spend_input_binding(psbt, i, local_xonly)?);
+    }
+    Ok(out)
 }
 
 /// Scan `script` opcodes for any 32-byte push equal to `xonly`. Recovery

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -282,6 +282,34 @@ pub(crate) enum WalletCommands {
         #[arg(long, help = "Session timeout in seconds (max 86400)")]
         timeout: Option<u64>,
     },
+    /// Approve a pending recovery-tier PSBT proposal as an external signer
+    /// holder (responder side). Resolves the locally-held NIP-46 signer for
+    /// the matching xpub fingerprint, signs the tap script, merges the sig,
+    /// and contributes it back to the initiator.
+    ApprovePsbt {
+        #[arg(short, long, help = "FROST group npub or hex")]
+        group: String,
+        #[arg(
+            long,
+            help = "Specific PSBT session id (hex, 64 chars). Required unless --auto."
+        )]
+        session: Option<String>,
+        #[arg(
+            long,
+            help = "Local signer mapping 'fingerprint:bunker://...' (8 hex fp, colon, URI). Repeatable.",
+            required = true
+        )]
+        signer_bunker: Vec<String>,
+        #[arg(long, help = "Share index to use for participation")]
+        share: Option<u16>,
+        #[arg(short, long, help = "Nostr relay URL")]
+        relay: Option<String>,
+        #[arg(
+            long,
+            help = "Headless mode: stay connected and auto-approve every matching PSBT proposal."
+        )]
+        auto: bool,
+    },
 }
 
 #[derive(Clone, Debug, ValueEnum)]

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -291,9 +291,10 @@ pub(crate) enum WalletCommands {
         group: String,
         #[arg(
             long,
-            help = "Specific PSBT session id (hex, 64 chars). Required unless --auto."
+            help = "PSBT session id to approve (hex, 64 chars).",
+            required = true
         )]
-        session: Option<String>,
+        session: String,
         #[arg(
             long,
             help = "Local signer mapping 'fingerprint:bunker://...' (8 hex fp, colon, URI). Repeatable.",
@@ -304,11 +305,6 @@ pub(crate) enum WalletCommands {
         share: Option<u16>,
         #[arg(short, long, help = "Nostr relay URL")]
         relay: Option<String>,
-        #[arg(
-            long,
-            help = "Headless mode: stay connected and auto-approve every matching PSBT proposal."
-        )]
-        auto: bool,
     },
 }
 

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -197,7 +197,18 @@ pub fn cmd_frost_network_serve(
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .unwrap_or_default()
                                 .as_secs();
-                            let policy_value = serde_json::to_value(&policy).ok();
+                            let policy_value = match serde_json::to_value(&policy) {
+                                Ok(v) => Some(v),
+                                Err(e) => {
+                                    tracing::error!(
+                                        error = %e,
+                                        session = %hex::encode(&session_id[..8]),
+                                        group = %hex::encode(group_pubkey),
+                                        "failed to serialize WalletPolicy to JSON (recovery-tier verification will be unavailable for this descriptor)",
+                                    );
+                                    None
+                                }
+                            };
                             // The predecessor lookup and the subsequent store
                             // are not held under a single critical section
                             // beyond `keep.lock()`; a second migrate event

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -181,6 +181,7 @@ pub fn cmd_frost_network_serve(
                         internal_descriptor,
                         network,
                         policy_hash,
+                        policy,
                     }) => {
                         let session = hex::encode(&session_id[..8]);
                         let desc_short = match external_descriptor.get(..40) {
@@ -195,6 +196,7 @@ pub fn cmd_frost_network_serve(
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .unwrap_or_default()
                                 .as_secs();
+                            let policy_value = serde_json::to_value(&policy).ok();
                             let descriptor = WalletDescriptor {
                                 group_pubkey,
                                 external_descriptor,
@@ -203,6 +205,7 @@ pub fn cmd_frost_network_serve(
                                 created_at: now,
                                 device_registrations: Vec::new(),
                                 policy_hash,
+                                policy: policy_value,
                             };
                             let guard = keep.lock().expect("keep mutex poisoned");
                             match guard.store_wallet_descriptor(&descriptor) {

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -182,6 +182,7 @@ pub fn cmd_frost_network_serve(
                         network,
                         policy_hash,
                         version,
+                        policy,
                     }) => {
                         let session = hex::encode(&session_id[..8]);
                         let desc_short = match external_descriptor.get(..40) {
@@ -196,6 +197,7 @@ pub fn cmd_frost_network_serve(
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .unwrap_or_default()
                                 .as_secs();
+                            let policy_value = serde_json::to_value(&policy).ok();
                             // The predecessor lookup and the subsequent store
                             // are not held under a single critical section
                             // beyond `keep.lock()`; a second migrate event
@@ -247,6 +249,7 @@ pub fn cmd_frost_network_serve(
                                 policy_hash,
                                 version,
                                 previous_descriptor_hash,
+                                policy: policy_value,
                             };
                             match guard.store_wallet_descriptor(&descriptor) {
                                 Ok(()) => {

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1625,9 +1625,9 @@ async fn approve_psbt_session(
     bunker_uri: zeroize::Zeroizing<String>,
     expected_psbt_hash: Option<[u8; 32]>,
 ) -> Result<()> {
-    let (initiator_pubkey, session_descriptor_hash, tier_index) =
-        node.psbt_session_routing(&session_id)
-            .ok_or_else(|| KeepError::Frost("unknown PSBT session id".into()))?;
+    let (initiator_pubkey, session_descriptor_hash, tier_index) = node
+        .psbt_session_routing(&session_id)
+        .ok_or_else(|| KeepError::Frost("unknown PSBT session id".into()))?;
     let psbt_bytes = node
         .psbt_session_proposal_psbt(&session_id)
         .ok_or_else(|| KeepError::Frost("session has no proposal PSBT".into()))?;

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1890,9 +1890,11 @@ pub fn cmd_wallet_approve_psbt(
             }
         });
 
+        const PROPOSAL_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
+        const POST_APPROVAL_DRAIN: Duration = Duration::from_secs(2);
         let target_sid = session_id;
         let spinner = out.spinner("Waiting for proposal...");
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+        let deadline = tokio::time::Instant::now() + PROPOSAL_WAIT_TIMEOUT;
         let mut approved = false;
         while tokio::time::Instant::now() < deadline {
             let remaining = deadline - tokio::time::Instant::now();
@@ -1952,11 +1954,12 @@ pub fn cmd_wallet_approve_psbt(
         if !approved {
             node_handle.abort();
             return Err(KeepError::Frost(format!(
-                "did not receive PsbtSignatureNeeded for session {} within 60s",
-                hex::encode(&target_sid[..8])
+                "did not receive PsbtSignatureNeeded for session {} within {}s",
+                hex::encode(&target_sid[..8]),
+                PROPOSAL_WAIT_TIMEOUT.as_secs()
             )));
         }
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(POST_APPROVAL_DRAIN).await;
         node_handle.abort();
         Ok::<_, KeepError>(())
     })?;

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1599,9 +1599,6 @@ fn parse_session_id(s: &str) -> Result<[u8; 32]> {
     })
 }
 
-/// Deserialize a persisted `WalletPolicy` JSON value and verify its
-/// integrity by recomputing `derive_policy_hash` and comparing it to
-/// `expected_policy_hash`. Returns the verified `WalletPolicy` on success.
 /// Execute the full responder approval chain for a single PSBT session: load
 /// the descriptor, verify the policy integrity, verify the PSBT is bound to
 /// the recovery tier we expect, derive the local x-only pubkey, build the
@@ -1874,7 +1871,7 @@ pub fn cmd_wallet_approve_psbt(
             .map_err(|e| KeepError::Frost(e.to_string()))?;
         let node = node.with_descriptor_lookup(Arc::new(descriptor_lookup_for(keep.clone())));
         let node = node.with_recovery_signer_registry(registry.clone());
-        let node = std::sync::Arc::new(node);
+        let node = Arc::new(node);
 
         node.announce()
             .await

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1559,6 +1559,399 @@ pub fn cmd_wallet_spend(
     Ok(())
 }
 
+/// Parse a `--signer-bunker fp:bunker://...` argument into `(fingerprint, uri)`.
+fn parse_signer_bunker(spec: &str) -> Result<(String, String)> {
+    let (fp, uri) = spec.split_once(':').ok_or_else(|| {
+        KeepError::InvalidInput(
+            "--signer-bunker expects 'fingerprint:bunker://...' (8 hex fingerprint, colon, URI)"
+                .into(),
+        )
+    })?;
+    let fp = fp.trim().to_ascii_lowercase();
+    if fp.len() != 8 || !fp.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(KeepError::InvalidInput(format!(
+            "--signer-bunker fingerprint '{fp}' must be 8 hex characters"
+        )));
+    }
+    let uri = uri.trim().to_string();
+    if !uri.starts_with("bunker://") {
+        return Err(KeepError::InvalidInput(
+            "--signer-bunker URI must start with bunker://".into(),
+        ));
+    }
+    Ok((fp, uri))
+}
+
+/// Parse a session id hex string (32 bytes / 64 hex chars).
+fn parse_session_id(s: &str) -> Result<[u8; 32]> {
+    let bytes = hex::decode(s)
+        .map_err(|e| KeepError::InvalidInput(format!("invalid session id hex: {e}")))?;
+    bytes.try_into().map_err(|v: Vec<u8>| {
+        KeepError::InvalidInput(format!(
+            "session id must be exactly 32 bytes, got {}",
+            v.len()
+        ))
+    })
+}
+
+/// Resolve a tier's external `(xpub, fingerprint)` slot whose fingerprint
+/// matches `local_fp`. Returns the xpub string.
+fn find_local_external_xpub(
+    policy_json: &serde_json::Value,
+    tier_index: u32,
+    local_fp: &str,
+) -> Result<String> {
+    let policy: keep_frost_net::WalletPolicy = serde_json::from_value(policy_json.clone())
+        .map_err(|e| KeepError::InvalidInput(format!("invalid persisted wallet policy: {e}")))?;
+    let tier = policy
+        .recovery_tiers
+        .get(tier_index as usize)
+        .ok_or_else(|| {
+            KeepError::InvalidInput(format!(
+                "tier {tier_index} not present in persisted policy"
+            ))
+        })?;
+    let lower = local_fp.to_ascii_lowercase();
+    for slot in &tier.key_slots {
+        if let keep_frost_net::KeySlot::External { xpub, fingerprint } = slot {
+            if fingerprint.eq_ignore_ascii_case(&lower) {
+                return Ok(xpub.clone());
+            }
+        }
+    }
+    Err(KeepError::InvalidInput(format!(
+        "no External key slot with fingerprint {lower} found in tier {tier_index}"
+    )))
+}
+
+/// Execute the full responder approval chain for a single PSBT session: load
+/// the descriptor, derive the local x-only pubkey, build the script-spend
+/// sighash for every input, request a Schnorr signature per input from the
+/// NIP-46 signer at `bunker_uri`, merge the signatures, and contribute the
+/// PSBT back to the initiator.
+#[allow(clippy::too_many_arguments)]
+async fn approve_psbt_session(
+    out: &Output,
+    keep: Arc<Mutex<Keep>>,
+    node: Arc<keep_frost_net::KfpNode>,
+    session_id: [u8; 32],
+    group_pubkey: [u8; 32],
+    local_fp: String,
+    bunker_uri: String,
+) -> Result<()> {
+    let (initiator_pubkey, _descriptor_hash, tier_index) = node
+        .psbt_session_routing(&session_id)
+        .ok_or_else(|| KeepError::Frost("unknown PSBT session id".into()))?;
+    let psbt_bytes = node
+        .psbt_session_proposal_psbt(&session_id)
+        .ok_or_else(|| KeepError::Frost("session has no proposal PSBT".into()))?;
+
+    let descriptor = {
+        let guard = keep.lock().expect("keep mutex poisoned");
+        guard
+            .get_wallet_descriptor(&group_pubkey)?
+            .ok_or_else(|| KeepError::KeyNotFound("no wallet descriptor for this group".into()))?
+    };
+    let policy_json = descriptor.policy.clone().ok_or_else(|| {
+        KeepError::InvalidInput(
+            "persisted descriptor has no WalletPolicy; cannot derive recovery tier metadata"
+                .into(),
+        )
+    })?;
+
+    let xpub_str = find_local_external_xpub(&policy_json, tier_index, &local_fp)?;
+    let network = <keep_bitcoin::Network as std::str::FromStr>::from_str(&descriptor.network)
+        .map_err(|e| KeepError::InvalidInput(format!("invalid network: {e}")))?;
+    let xonly_bytes = keep_bitcoin::xpub_to_x_only(&xpub_str, network)
+        .map_err(|e| KeepError::InvalidInput(format!("xpub_to_x_only: {e}")))?;
+    let xonly =
+        keep_bitcoin::bitcoin::XOnlyPublicKey::from_slice(&xonly_bytes).map_err(|e| {
+            KeepError::InvalidInput(format!("xonly_pubkey decode: {e}"))
+        })?;
+
+    let mut psbt = keep_bitcoin::bitcoin::psbt::Psbt::deserialize(&psbt_bytes)
+        .map_err(|e| KeepError::InvalidInput(format!("decode PSBT: {e}")))?;
+    let sighashes = keep_bitcoin::script_spend_sighashes(&psbt)
+        .map_err(|e| KeepError::InvalidInput(format!("compute sighashes: {e}")))?;
+    if sighashes.is_empty() {
+        return Err(KeepError::InvalidInput(
+            "PSBT has no inputs to sign".into(),
+        ));
+    }
+
+    out.info(&format!(
+        "Approving session {} (tier {}, {} input(s)) via signer {}",
+        hex::encode(&session_id[..8]),
+        tier_index,
+        sighashes.len(),
+        local_fp
+    ));
+
+    let client = keep_nip46::Nip46Client::connect_to(&bunker_uri)
+        .await
+        .map_err(|e| KeepError::Frost(format!("NIP-46 connect: {e}")))?;
+    let signed_outcome = async {
+        client
+            .connect()
+            .await
+            .map_err(|e| format!("NIP-46 handshake: {e}"))?;
+        for sh in &sighashes {
+            let leaf_hash_bytes: [u8; 32] = {
+                use keep_bitcoin::bitcoin::hashes::Hash as _;
+                sh.leaf_hash.to_byte_array()
+            };
+            let sig = client
+                .sign_tap_script(
+                    &sh.sighash,
+                    &xonly_bytes,
+                    &leaf_hash_bytes,
+                    sh.script.as_bytes(),
+                    &descriptor.external_descriptor,
+                )
+                .await
+                .map_err(|e| format!("sign_tap_script: {e}"))?;
+            keep_bitcoin::merge_tap_script_sig(
+                &mut psbt,
+                sh.input_index,
+                xonly,
+                sh.leaf_hash,
+                sig,
+            )
+            .map_err(|e| format!("merge sig: {e}"))?;
+        }
+        Ok::<(), String>(())
+    }
+    .await;
+    client.disconnect().await;
+    signed_outcome.map_err(KeepError::Frost)?;
+
+    let merged = psbt.serialize();
+    node.contribute_psbt_signature(
+        session_id,
+        &initiator_pubkey,
+        keep_frost_net::SignerId::Fingerprint(local_fp.clone()),
+        merged,
+    )
+    .await
+    .map_err(|e| KeepError::Frost(format!("contribute_psbt_signature: {e}")))?;
+
+    out.success(&format!(
+        "Submitted signature for session {}",
+        hex::encode(&session_id[..8])
+    ));
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn cmd_wallet_approve_psbt(
+    out: &Output,
+    path: &Path,
+    group: &str,
+    session_hex: Option<&str>,
+    signer_bunker: &[String],
+    share_index: Option<u16>,
+    relay: &str,
+    auto: bool,
+) -> Result<()> {
+    debug!(group, ?session_hex, relay, auto, "wallet approve-psbt");
+
+    if !auto && session_hex.is_none() {
+        return Err(KeepError::InvalidInput(
+            "either --session <id> or --auto must be specified".into(),
+        ));
+    }
+    if signer_bunker.is_empty() {
+        return Err(KeepError::InvalidInput(
+            "at least one --signer-bunker fp:bunker:// is required".into(),
+        ));
+    }
+
+    let mut registry_entries: Vec<(String, String)> = Vec::with_capacity(signer_bunker.len());
+    for spec in signer_bunker {
+        let (fp, uri) = parse_signer_bunker(spec)?;
+        registry_entries.push((fp, uri));
+    }
+    let mut seen_fps = std::collections::HashSet::new();
+    for (fp, _) in &registry_entries {
+        if !seen_fps.insert(fp.clone()) {
+            return Err(KeepError::InvalidInput(format!(
+                "duplicate --signer-bunker fingerprint: {fp}"
+            )));
+        }
+    }
+
+    let session_id_opt = match session_hex {
+        Some(s) => Some(parse_session_id(s)?),
+        None => None,
+    };
+
+    let group_pubkey = parse_group_id(group)?;
+
+    let mut keep = Keep::open(path)?;
+    let password = get_password("Enter password")?;
+
+    let spinner = out.spinner("Unlocking vault...");
+    keep.unlock(password.expose_secret())?;
+    spinner.finish();
+
+    let share = match share_index {
+        Some(idx) => keep.frost_get_share_by_index(&group_pubkey, idx)?,
+        None => keep.frost_get_share(&group_pubkey)?,
+    };
+
+    out.newline();
+    out.header("WDC Recovery Spend Approval");
+    out.field("Group", &hex::encode(group_pubkey));
+    out.field(
+        "Mode",
+        if auto { "auto (headless)" } else { "single session" },
+    );
+    if let Some(sid) = session_id_opt {
+        out.field("Session", &hex::encode(&sid[..8]));
+    }
+    out.field(
+        "Local signers",
+        &registry_entries
+            .iter()
+            .map(|(fp, _)| fp.as_str())
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
+    out.field("Relay", relay);
+    out.newline();
+
+    let rt =
+        tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
+    let keep = Arc::new(Mutex::new(keep));
+
+    rt.block_on(async {
+        let registry = Arc::new(keep_frost_net::InMemoryRecoverySignerRegistry::new());
+        for (fp, uri) in &registry_entries {
+            registry.insert(fp, format!("signer-{fp}"), uri.clone());
+        }
+
+        let node = keep_frost_net::KfpNode::new(share, vec![relay.to_string()])
+            .await
+            .map_err(|e| KeepError::Frost(e.to_string()))?;
+        let node = node.with_descriptor_lookup(Arc::new(descriptor_lookup_for(keep.clone())));
+        let node = node.with_recovery_signer_registry(registry.clone());
+        let node = std::sync::Arc::new(node);
+
+        node.announce()
+            .await
+            .map_err(|e| KeepError::Frost(e.to_string()))?;
+
+        let mut event_rx = node.subscribe();
+        let node_handle = tokio::spawn({
+            let node = node.clone();
+            async move {
+                if let Err(e) = node.run().await {
+                    tracing::error!(error = %e, "FROST node error");
+                }
+            }
+        });
+
+        let bunker_for = |fp: &str| -> Option<String> {
+            registry_entries
+                .iter()
+                .find(|(f, _)| f.eq_ignore_ascii_case(fp))
+                .map(|(_, u)| u.clone())
+        };
+
+        if let Some(target_sid) = session_id_opt {
+            let spinner = out.spinner("Waiting for proposal...");
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+            let mut approved = false;
+            while tokio::time::Instant::now() < deadline {
+                let remaining = deadline - tokio::time::Instant::now();
+                match tokio::time::timeout(remaining, event_rx.recv()).await {
+                    Ok(Ok(keep_frost_net::KfpNodeEvent::PsbtSignatureNeeded {
+                        session_id,
+                        ..
+                    })) if session_id == target_sid => {
+                        spinner.finish();
+                        let fp = registry_entries[0].0.clone();
+                        let bunker = bunker_for(&fp).expect("fp present");
+                        approve_psbt_session(
+                            out,
+                            keep.clone(),
+                            node.clone(),
+                            session_id,
+                            group_pubkey,
+                            fp,
+                            bunker,
+                        )
+                        .await?;
+                        approved = true;
+                        break;
+                    }
+                    Ok(Err(_)) => break,
+                    Err(_) => break,
+                    _ => {}
+                }
+            }
+            if !approved {
+                node_handle.abort();
+                return Err(KeepError::Frost(format!(
+                    "did not receive PsbtSignatureNeeded for session {} within 60s",
+                    hex::encode(&target_sid[..8])
+                )));
+            }
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            node_handle.abort();
+            return Ok::<_, KeepError>(());
+        }
+
+        // Auto mode: loop until Ctrl-C, approving every matching proposal.
+        out.info("Auto-approve mode: waiting for PSBT proposals (Ctrl+C to stop)");
+        loop {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {
+                    out.info("Shutting down");
+                    break;
+                }
+                ev = event_rx.recv() => match ev {
+                    Ok(keep_frost_net::KfpNodeEvent::PsbtSignatureNeeded {
+                        session_id,
+                        tier_index,
+                        ..
+                    }) => {
+                        let fp = registry_entries[0].0.clone();
+                        let Some(bunker) = bunker_for(&fp) else { continue };
+                        out.info(&format!(
+                            "[auto] PSBT proposal received: session={} tier={}",
+                            hex::encode(&session_id[..8]),
+                            tier_index
+                        ));
+                        let keep_c = keep.clone();
+                        let node_c = node.clone();
+                        let out_c = out.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = approve_psbt_session(
+                                &out_c, keep_c, node_c, session_id, group_pubkey, fp, bunker,
+                            )
+                            .await
+                            {
+                                tracing::error!(
+                                    session = %hex::encode(&session_id[..8]),
+                                    error = %e,
+                                    "auto-approve failed"
+                                );
+                            }
+                        });
+                    }
+                    Ok(_) => {}
+                    Err(_) => break,
+                },
+            }
+        }
+        node_handle.abort();
+        Ok::<_, KeepError>(())
+    })?;
+
+    Ok(())
+}
+
 fn read_psbt_file(path: &Path) -> Result<Vec<u8>> {
     // Cap file size before touching it so a hostile caller cannot exhaust
     // memory by pointing at a huge file. The `* 2` budget accounts for

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -197,6 +197,7 @@ pub fn cmd_wallet_descriptor(
         policy_hash: [0u8; 32],
         version: INITIAL_DESCRIPTOR_VERSION,
         previous_descriptor_hash: None,
+        policy: None,
     };
 
     let mut keep = Keep::open(path)?;
@@ -843,6 +844,8 @@ pub fn cmd_wallet_propose(
     let total_shares = share.metadata.total_shares;
 
     let policy = parse_recovery_policy(recovery, total_shares)?;
+    let policy_json = serde_json::to_value(&policy)
+        .map_err(|e| KeepError::Runtime(format!("serialize policy: {e}")))?;
 
     out.newline();
     out.header("Wallet Descriptor Proposal");
@@ -1082,6 +1085,7 @@ pub fn cmd_wallet_propose(
             policy_hash: finalized_policy_hash,
             version: INITIAL_DESCRIPTOR_VERSION,
             previous_descriptor_hash: None,
+            policy: Some(policy_json),
         };
 
         keep.lock()

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1597,57 +1597,6 @@ fn parse_session_id(s: &str) -> Result<[u8; 32]> {
 /// Deserialize a persisted `WalletPolicy` JSON value and verify its
 /// integrity by recomputing `derive_policy_hash` and comparing it to
 /// `expected_policy_hash`. Returns the verified `WalletPolicy` on success.
-fn load_verified_policy(
-    policy_json: &serde_json::Value,
-    expected_policy_hash: &[u8; 32],
-) -> Result<keep_frost_net::WalletPolicy> {
-    let policy: keep_frost_net::WalletPolicy = serde_json::from_value(policy_json.clone())
-        .map_err(|e| KeepError::InvalidInput(format!("invalid persisted wallet policy: {e}")))?;
-    let recomputed = keep_frost_net::derive_policy_hash(&policy);
-    if &recomputed != expected_policy_hash {
-        return Err(KeepError::InvalidInput(
-            "persisted wallet policy hash does not match stored descriptor.policy_hash; refusing to use it".into(),
-        ));
-    }
-    Ok(policy)
-}
-
-/// Resolve a tier's external `(xpub, fingerprint)` slot whose fingerprint
-/// matches `local_fp`. Returns the xpub string. Errors if more than one
-/// External slot in the tier shares the same fingerprint, since that
-/// makes responder selection ambiguous.
-fn find_local_external_xpub(
-    policy: &keep_frost_net::WalletPolicy,
-    tier_index: u32,
-    local_fp: &str,
-) -> Result<String> {
-    let tier = policy
-        .recovery_tiers
-        .get(tier_index as usize)
-        .ok_or_else(|| {
-            KeepError::InvalidInput(format!("tier {tier_index} not present in persisted policy"))
-        })?;
-    let lower = local_fp.to_ascii_lowercase();
-    let mut found: Option<String> = None;
-    for slot in &tier.key_slots {
-        if let keep_frost_net::KeySlot::External { xpub, fingerprint } = slot {
-            if fingerprint.eq_ignore_ascii_case(&lower) {
-                if found.is_some() {
-                    return Err(KeepError::InvalidInput(format!(
-                        "tier {tier_index} has more than one External slot with fingerprint {lower}; ambiguous responder",
-                    )));
-                }
-                found = Some(xpub.clone());
-            }
-        }
-    }
-    found.ok_or_else(|| {
-        KeepError::InvalidInput(format!(
-            "no External key slot with fingerprint {lower} found in tier {tier_index}"
-        ))
-    })
-}
-
 /// Execute the full responder approval chain for a single PSBT session: load
 /// the descriptor, verify the policy integrity, verify the PSBT is bound to
 /// the recovery tier we expect, derive the local x-only pubkey, build the
@@ -1700,8 +1649,10 @@ async fn approve_psbt_session(
         )
     })?;
 
-    let policy = load_verified_policy(&policy_json, &descriptor.policy_hash)?;
-    let xpub_str = find_local_external_xpub(&policy, tier_index, &local_fp)?;
+    let policy = keep_frost_net::load_verified_wallet_policy(&policy_json, &descriptor.policy_hash)
+        .map_err(KeepError::InvalidInput)?;
+    let xpub_str = keep_frost_net::find_local_external_xpub_in_tier(&policy, tier_index, &local_fp)
+        .map_err(KeepError::InvalidInput)?;
     let network = <keep_bitcoin::Network as std::str::FromStr>::from_str(&descriptor.network)
         .map_err(|e| KeepError::InvalidInput(format!("invalid network: {e}")))?;
     let xonly_bytes = keep_bitcoin::xpub_to_x_only(&xpub_str, network)
@@ -1715,18 +1666,10 @@ async fn approve_psbt_session(
         return Err(KeepError::InvalidInput("PSBT has no inputs to sign".into()));
     }
 
-    // Verify every input's tap_scripts entry is bound to its witness_utxo and
-    // references our local x-only key BEFORE asking the bunker to sign.
-    // Failing closed here turns the responder from a blind signing oracle
-    // into one that only signs for outputs it actually controls.
-    let mut sighashes = Vec::with_capacity(psbt.inputs.len());
-    for i in 0..psbt.inputs.len() {
-        let bundle = keep_bitcoin::verify_script_spend_input_binding(&psbt, i, &xonly_bytes)
-            .map_err(|e| {
-                KeepError::InvalidInput(format!("PSBT input {i} binding verification failed: {e}"))
-            })?;
-        sighashes.push(bundle);
-    }
+    // Verify every input upfront so the responder only forwards sighashes for
+    // outputs it actually controls; fail closed before contacting the bunker.
+    let sighashes = keep_bitcoin::verify_all_script_spend_input_bindings(&psbt, &xonly_bytes)
+        .map_err(|e| KeepError::InvalidInput(format!("PSBT binding verification failed: {e}")))?;
 
     out.info(&format!(
         "Approving session {} (tier {}, {} input(s)) via signer {}",
@@ -1864,7 +1807,7 @@ pub fn cmd_wallet_approve_psbt(
     rt.block_on(async {
         let registry = Arc::new(keep_frost_net::InMemoryRecoverySignerRegistry::new());
         for (fp, uri) in &registry_entries {
-            registry.insert(fp, format!("signer-{fp}"), uri.as_str().to_string());
+            registry.insert(fp, format!("signer-{fp}"), uri.clone());
         }
 
         let node = keep_frost_net::KfpNode::new(share, vec![relay.to_string()])

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1625,7 +1625,7 @@ async fn approve_psbt_session(
     bunker_uri: zeroize::Zeroizing<String>,
     expected_psbt_hash: Option<[u8; 32]>,
 ) -> Result<()> {
-    let (initiator_pubkey, _descriptor_hash, tier_index) =
+    let (initiator_pubkey, session_descriptor_hash, tier_index) =
         node.psbt_session_routing(&session_id)
             .ok_or_else(|| KeepError::Frost("unknown PSBT session id".into()))?;
     let psbt_bytes = node
@@ -1648,6 +1648,11 @@ async fn approve_psbt_session(
             .get_wallet_descriptor(&group_pubkey)?
             .ok_or_else(|| KeepError::KeyNotFound("no wallet descriptor for this group".into()))?
     };
+    if descriptor.canonical_hash() != session_descriptor_hash {
+        return Err(KeepError::Frost(
+            "stored descriptor hash does not match PSBT session descriptor_hash".into(),
+        ));
+    }
     let policy_json = descriptor.policy.clone().ok_or_else(|| {
         KeepError::InvalidInput(
             "persisted descriptor has no WalletPolicy; cannot derive recovery tier metadata".into(),
@@ -1856,8 +1861,26 @@ pub fn cmd_wallet_approve_psbt(
                         let h: [u8; 32] = Sha256::digest(&bytes).into();
                         h
                     });
-                    let fp = registry_entries[0].0.clone();
-                    let bunker = registry_entries[0].1.clone();
+                    let expected_fps = node
+                        .psbt_session_expected_fingerprints(&session_id)
+                        .unwrap_or_default();
+                    let match_idx = registry_entries.iter().position(|(fp, _)| {
+                        expected_fps
+                            .iter()
+                            .any(|e| e.eq_ignore_ascii_case(fp))
+                    });
+                    let idx = match match_idx {
+                        Some(i) => i,
+                        None => {
+                            node_handle.abort();
+                            return Err(KeepError::InvalidInput(format!(
+                                "no --signer-bunker fingerprint matches an expected external signer for session {}",
+                                hex::encode(&session_id[..8])
+                            )));
+                        }
+                    };
+                    let fp = registry_entries[idx].0.clone();
+                    let bunker = registry_entries[idx].1.clone();
                     approve_psbt_session(
                         out,
                         keep.clone(),

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -15,7 +15,7 @@ use keep_core::Keep;
 use crate::cli::WalletExportFormat;
 use crate::output::Output;
 
-use super::get_password;
+use super::{get_confirm, get_password};
 
 /// Build a `KeepDescriptorLookup` from an `Arc<Mutex<Keep>>`. Logs a warning
 /// and returns no match when the vault is locked or the mutex is poisoned.
@@ -1680,6 +1680,58 @@ async fn approve_psbt_session(
     // outputs it actually controls; fail closed before contacting the bunker.
     let sighashes = keep_bitcoin::verify_all_script_spend_input_bindings(&psbt, &xonly_bytes)
         .map_err(|e| KeepError::InvalidInput(format!("PSBT binding verification failed: {e}")))?;
+
+    // Display every destination (address + amount) and require explicit
+    // operator confirmation before signing. The input-binding check above only
+    // proves we control the spent UTXOs; it says nothing about where the funds
+    // go. Without this gate a malicious initiator could propose a spend that
+    // sweeps a recovered UTXO to an attacker address and the signer would sign
+    // it blindly (the bunker only ever sees an opaque sighash). Fail closed if
+    // outputs cannot be decoded.
+    use keep_bitcoin::bitcoin::Address;
+    let mut total_out: u64 = 0;
+    out.newline();
+    out.header(&format!(
+        "Recovery spend destinations (tier {}, {} input(s))",
+        tier_index,
+        sighashes.len()
+    ));
+    if psbt.unsigned_tx.output.is_empty() {
+        return Err(KeepError::InvalidInput(
+            "PSBT has no outputs to confirm; refusing to sign".into(),
+        ));
+    }
+    for (i, o) in psbt.unsigned_tx.output.iter().enumerate() {
+        let dest = match Address::from_script(&o.script_pubkey, network) {
+            Ok(addr) => addr.to_string(),
+            Err(_) => format!("script:{}", hex::encode(o.script_pubkey.as_bytes())),
+        };
+        let sats = o.value.to_sat();
+        total_out = total_out.checked_add(sats).ok_or_else(|| {
+            KeepError::InvalidInput("PSBT output total overflows; refusing to sign".into())
+        })?;
+        out.field(&format!("Output {i}"), &format!("{dest}  ({sats} sats)"));
+    }
+    // Inputs on the recovery path always carry witness_utxo (enforced by the
+    // binding verification above), so the fee is computable and worth showing.
+    let total_in: Option<u64> = psbt
+        .inputs
+        .iter()
+        .try_fold(0u64, |acc, inp| {
+            inp.witness_utxo
+                .as_ref()
+                .and_then(|t| acc.checked_add(t.value.to_sat()))
+        });
+    if let Some(fee) = total_in.and_then(|i| i.checked_sub(total_out)) {
+        out.field("Fee", &format!("{fee} sats"));
+    }
+    out.newline();
+
+    if !get_confirm("Sign this recovery spend?")? {
+        return Err(KeepError::InvalidInput(
+            "operator declined PSBT approval".into(),
+        ));
+    }
 
     out.info(&format!(
         "Approving session {} (tier {}, {} input(s)) via signer {}",

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1602,57 +1602,6 @@ fn parse_session_id(s: &str) -> Result<[u8; 32]> {
 /// Deserialize a persisted `WalletPolicy` JSON value and verify its
 /// integrity by recomputing `derive_policy_hash` and comparing it to
 /// `expected_policy_hash`. Returns the verified `WalletPolicy` on success.
-fn load_verified_policy(
-    policy_json: &serde_json::Value,
-    expected_policy_hash: &[u8; 32],
-) -> Result<keep_frost_net::WalletPolicy> {
-    let policy: keep_frost_net::WalletPolicy = serde_json::from_value(policy_json.clone())
-        .map_err(|e| KeepError::InvalidInput(format!("invalid persisted wallet policy: {e}")))?;
-    let recomputed = keep_frost_net::derive_policy_hash(&policy);
-    if &recomputed != expected_policy_hash {
-        return Err(KeepError::InvalidInput(
-            "persisted wallet policy hash does not match stored descriptor.policy_hash; refusing to use it".into(),
-        ));
-    }
-    Ok(policy)
-}
-
-/// Resolve a tier's external `(xpub, fingerprint)` slot whose fingerprint
-/// matches `local_fp`. Returns the xpub string. Errors if more than one
-/// External slot in the tier shares the same fingerprint, since that
-/// makes responder selection ambiguous.
-fn find_local_external_xpub(
-    policy: &keep_frost_net::WalletPolicy,
-    tier_index: u32,
-    local_fp: &str,
-) -> Result<String> {
-    let tier = policy
-        .recovery_tiers
-        .get(tier_index as usize)
-        .ok_or_else(|| {
-            KeepError::InvalidInput(format!("tier {tier_index} not present in persisted policy"))
-        })?;
-    let lower = local_fp.to_ascii_lowercase();
-    let mut found: Option<String> = None;
-    for slot in &tier.key_slots {
-        if let keep_frost_net::KeySlot::External { xpub, fingerprint } = slot {
-            if fingerprint.eq_ignore_ascii_case(&lower) {
-                if found.is_some() {
-                    return Err(KeepError::InvalidInput(format!(
-                        "tier {tier_index} has more than one External slot with fingerprint {lower}; ambiguous responder",
-                    )));
-                }
-                found = Some(xpub.clone());
-            }
-        }
-    }
-    found.ok_or_else(|| {
-        KeepError::InvalidInput(format!(
-            "no External key slot with fingerprint {lower} found in tier {tier_index}"
-        ))
-    })
-}
-
 /// Execute the full responder approval chain for a single PSBT session: load
 /// the descriptor, verify the policy integrity, verify the PSBT is bound to
 /// the recovery tier we expect, derive the local x-only pubkey, build the
@@ -1705,8 +1654,10 @@ async fn approve_psbt_session(
         )
     })?;
 
-    let policy = load_verified_policy(&policy_json, &descriptor.policy_hash)?;
-    let xpub_str = find_local_external_xpub(&policy, tier_index, &local_fp)?;
+    let policy = keep_frost_net::load_verified_wallet_policy(&policy_json, &descriptor.policy_hash)
+        .map_err(KeepError::InvalidInput)?;
+    let xpub_str = keep_frost_net::find_local_external_xpub_in_tier(&policy, tier_index, &local_fp)
+        .map_err(KeepError::InvalidInput)?;
     let network = <keep_bitcoin::Network as std::str::FromStr>::from_str(&descriptor.network)
         .map_err(|e| KeepError::InvalidInput(format!("invalid network: {e}")))?;
     let xonly_bytes = keep_bitcoin::xpub_to_x_only(&xpub_str, network)
@@ -1720,18 +1671,10 @@ async fn approve_psbt_session(
         return Err(KeepError::InvalidInput("PSBT has no inputs to sign".into()));
     }
 
-    // Verify every input's tap_scripts entry is bound to its witness_utxo and
-    // references our local x-only key BEFORE asking the bunker to sign.
-    // Failing closed here turns the responder from a blind signing oracle
-    // into one that only signs for outputs it actually controls.
-    let mut sighashes = Vec::with_capacity(psbt.inputs.len());
-    for i in 0..psbt.inputs.len() {
-        let bundle = keep_bitcoin::verify_script_spend_input_binding(&psbt, i, &xonly_bytes)
-            .map_err(|e| {
-                KeepError::InvalidInput(format!("PSBT input {i} binding verification failed: {e}"))
-            })?;
-        sighashes.push(bundle);
-    }
+    // Verify every input upfront so the responder only forwards sighashes for
+    // outputs it actually controls; fail closed before contacting the bunker.
+    let sighashes = keep_bitcoin::verify_all_script_spend_input_bindings(&psbt, &xonly_bytes)
+        .map_err(|e| KeepError::InvalidInput(format!("PSBT binding verification failed: {e}")))?;
 
     out.info(&format!(
         "Approving session {} (tier {}, {} input(s)) via signer {}",
@@ -1869,7 +1812,7 @@ pub fn cmd_wallet_approve_psbt(
     rt.block_on(async {
         let registry = Arc::new(keep_frost_net::InMemoryRecoverySignerRegistry::new());
         for (fp, uri) in &registry_entries {
-            registry.insert(fp, format!("signer-{fp}"), uri.as_str().to_string());
+            registry.insert(fp, format!("signer-{fp}"), uri.clone());
         }
 
         let node = keep_frost_net::KfpNode::new(share, vec![relay.to_string()])

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -195,6 +195,7 @@ pub fn cmd_wallet_descriptor(
         created_at: now,
         device_registrations: Vec::new(),
         policy_hash: [0u8; 32],
+        policy: None,
     };
 
     let mut keep = Keep::open(path)?;
@@ -840,6 +841,8 @@ pub fn cmd_wallet_propose(
     let total_shares = share.metadata.total_shares;
 
     let policy = parse_recovery_policy(recovery, total_shares)?;
+    let policy_json = serde_json::to_value(&policy)
+        .map_err(|e| KeepError::Runtime(format!("serialize policy: {e}")))?;
 
     out.newline();
     out.header("Wallet Descriptor Proposal");
@@ -1077,6 +1080,7 @@ pub fn cmd_wallet_propose(
             created_at: now,
             device_registrations: Vec::new(),
             policy_hash: finalized_policy_hash,
+            policy: Some(policy_json),
         };
 
         keep.lock()

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1564,6 +1564,399 @@ pub fn cmd_wallet_spend(
     Ok(())
 }
 
+/// Parse a `--signer-bunker fp:bunker://...` argument into `(fingerprint, uri)`.
+fn parse_signer_bunker(spec: &str) -> Result<(String, String)> {
+    let (fp, uri) = spec.split_once(':').ok_or_else(|| {
+        KeepError::InvalidInput(
+            "--signer-bunker expects 'fingerprint:bunker://...' (8 hex fingerprint, colon, URI)"
+                .into(),
+        )
+    })?;
+    let fp = fp.trim().to_ascii_lowercase();
+    if fp.len() != 8 || !fp.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(KeepError::InvalidInput(format!(
+            "--signer-bunker fingerprint '{fp}' must be 8 hex characters"
+        )));
+    }
+    let uri = uri.trim().to_string();
+    if !uri.starts_with("bunker://") {
+        return Err(KeepError::InvalidInput(
+            "--signer-bunker URI must start with bunker://".into(),
+        ));
+    }
+    Ok((fp, uri))
+}
+
+/// Parse a session id hex string (32 bytes / 64 hex chars).
+fn parse_session_id(s: &str) -> Result<[u8; 32]> {
+    let bytes = hex::decode(s)
+        .map_err(|e| KeepError::InvalidInput(format!("invalid session id hex: {e}")))?;
+    bytes.try_into().map_err(|v: Vec<u8>| {
+        KeepError::InvalidInput(format!(
+            "session id must be exactly 32 bytes, got {}",
+            v.len()
+        ))
+    })
+}
+
+/// Resolve a tier's external `(xpub, fingerprint)` slot whose fingerprint
+/// matches `local_fp`. Returns the xpub string.
+fn find_local_external_xpub(
+    policy_json: &serde_json::Value,
+    tier_index: u32,
+    local_fp: &str,
+) -> Result<String> {
+    let policy: keep_frost_net::WalletPolicy = serde_json::from_value(policy_json.clone())
+        .map_err(|e| KeepError::InvalidInput(format!("invalid persisted wallet policy: {e}")))?;
+    let tier = policy
+        .recovery_tiers
+        .get(tier_index as usize)
+        .ok_or_else(|| {
+            KeepError::InvalidInput(format!(
+                "tier {tier_index} not present in persisted policy"
+            ))
+        })?;
+    let lower = local_fp.to_ascii_lowercase();
+    for slot in &tier.key_slots {
+        if let keep_frost_net::KeySlot::External { xpub, fingerprint } = slot {
+            if fingerprint.eq_ignore_ascii_case(&lower) {
+                return Ok(xpub.clone());
+            }
+        }
+    }
+    Err(KeepError::InvalidInput(format!(
+        "no External key slot with fingerprint {lower} found in tier {tier_index}"
+    )))
+}
+
+/// Execute the full responder approval chain for a single PSBT session: load
+/// the descriptor, derive the local x-only pubkey, build the script-spend
+/// sighash for every input, request a Schnorr signature per input from the
+/// NIP-46 signer at `bunker_uri`, merge the signatures, and contribute the
+/// PSBT back to the initiator.
+#[allow(clippy::too_many_arguments)]
+async fn approve_psbt_session(
+    out: &Output,
+    keep: Arc<Mutex<Keep>>,
+    node: Arc<keep_frost_net::KfpNode>,
+    session_id: [u8; 32],
+    group_pubkey: [u8; 32],
+    local_fp: String,
+    bunker_uri: String,
+) -> Result<()> {
+    let (initiator_pubkey, _descriptor_hash, tier_index) = node
+        .psbt_session_routing(&session_id)
+        .ok_or_else(|| KeepError::Frost("unknown PSBT session id".into()))?;
+    let psbt_bytes = node
+        .psbt_session_proposal_psbt(&session_id)
+        .ok_or_else(|| KeepError::Frost("session has no proposal PSBT".into()))?;
+
+    let descriptor = {
+        let guard = keep.lock().expect("keep mutex poisoned");
+        guard
+            .get_wallet_descriptor(&group_pubkey)?
+            .ok_or_else(|| KeepError::KeyNotFound("no wallet descriptor for this group".into()))?
+    };
+    let policy_json = descriptor.policy.clone().ok_or_else(|| {
+        KeepError::InvalidInput(
+            "persisted descriptor has no WalletPolicy; cannot derive recovery tier metadata"
+                .into(),
+        )
+    })?;
+
+    let xpub_str = find_local_external_xpub(&policy_json, tier_index, &local_fp)?;
+    let network = <keep_bitcoin::Network as std::str::FromStr>::from_str(&descriptor.network)
+        .map_err(|e| KeepError::InvalidInput(format!("invalid network: {e}")))?;
+    let xonly_bytes = keep_bitcoin::xpub_to_x_only(&xpub_str, network)
+        .map_err(|e| KeepError::InvalidInput(format!("xpub_to_x_only: {e}")))?;
+    let xonly =
+        keep_bitcoin::bitcoin::XOnlyPublicKey::from_slice(&xonly_bytes).map_err(|e| {
+            KeepError::InvalidInput(format!("xonly_pubkey decode: {e}"))
+        })?;
+
+    let mut psbt = keep_bitcoin::bitcoin::psbt::Psbt::deserialize(&psbt_bytes)
+        .map_err(|e| KeepError::InvalidInput(format!("decode PSBT: {e}")))?;
+    let sighashes = keep_bitcoin::script_spend_sighashes(&psbt)
+        .map_err(|e| KeepError::InvalidInput(format!("compute sighashes: {e}")))?;
+    if sighashes.is_empty() {
+        return Err(KeepError::InvalidInput(
+            "PSBT has no inputs to sign".into(),
+        ));
+    }
+
+    out.info(&format!(
+        "Approving session {} (tier {}, {} input(s)) via signer {}",
+        hex::encode(&session_id[..8]),
+        tier_index,
+        sighashes.len(),
+        local_fp
+    ));
+
+    let client = keep_nip46::Nip46Client::connect_to(&bunker_uri)
+        .await
+        .map_err(|e| KeepError::Frost(format!("NIP-46 connect: {e}")))?;
+    let signed_outcome = async {
+        client
+            .connect()
+            .await
+            .map_err(|e| format!("NIP-46 handshake: {e}"))?;
+        for sh in &sighashes {
+            let leaf_hash_bytes: [u8; 32] = {
+                use keep_bitcoin::bitcoin::hashes::Hash as _;
+                sh.leaf_hash.to_byte_array()
+            };
+            let sig = client
+                .sign_tap_script(
+                    &sh.sighash,
+                    &xonly_bytes,
+                    &leaf_hash_bytes,
+                    sh.script.as_bytes(),
+                    &descriptor.external_descriptor,
+                )
+                .await
+                .map_err(|e| format!("sign_tap_script: {e}"))?;
+            keep_bitcoin::merge_tap_script_sig(
+                &mut psbt,
+                sh.input_index,
+                xonly,
+                sh.leaf_hash,
+                sig,
+            )
+            .map_err(|e| format!("merge sig: {e}"))?;
+        }
+        Ok::<(), String>(())
+    }
+    .await;
+    client.disconnect().await;
+    signed_outcome.map_err(KeepError::Frost)?;
+
+    let merged = psbt.serialize();
+    node.contribute_psbt_signature(
+        session_id,
+        &initiator_pubkey,
+        keep_frost_net::SignerId::Fingerprint(local_fp.clone()),
+        merged,
+    )
+    .await
+    .map_err(|e| KeepError::Frost(format!("contribute_psbt_signature: {e}")))?;
+
+    out.success(&format!(
+        "Submitted signature for session {}",
+        hex::encode(&session_id[..8])
+    ));
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn cmd_wallet_approve_psbt(
+    out: &Output,
+    path: &Path,
+    group: &str,
+    session_hex: Option<&str>,
+    signer_bunker: &[String],
+    share_index: Option<u16>,
+    relay: &str,
+    auto: bool,
+) -> Result<()> {
+    debug!(group, ?session_hex, relay, auto, "wallet approve-psbt");
+
+    if !auto && session_hex.is_none() {
+        return Err(KeepError::InvalidInput(
+            "either --session <id> or --auto must be specified".into(),
+        ));
+    }
+    if signer_bunker.is_empty() {
+        return Err(KeepError::InvalidInput(
+            "at least one --signer-bunker fp:bunker:// is required".into(),
+        ));
+    }
+
+    let mut registry_entries: Vec<(String, String)> = Vec::with_capacity(signer_bunker.len());
+    for spec in signer_bunker {
+        let (fp, uri) = parse_signer_bunker(spec)?;
+        registry_entries.push((fp, uri));
+    }
+    let mut seen_fps = std::collections::HashSet::new();
+    for (fp, _) in &registry_entries {
+        if !seen_fps.insert(fp.clone()) {
+            return Err(KeepError::InvalidInput(format!(
+                "duplicate --signer-bunker fingerprint: {fp}"
+            )));
+        }
+    }
+
+    let session_id_opt = match session_hex {
+        Some(s) => Some(parse_session_id(s)?),
+        None => None,
+    };
+
+    let group_pubkey = parse_group_id(group)?;
+
+    let mut keep = Keep::open(path)?;
+    let password = get_password("Enter password")?;
+
+    let spinner = out.spinner("Unlocking vault...");
+    keep.unlock(password.expose_secret())?;
+    spinner.finish();
+
+    let share = match share_index {
+        Some(idx) => keep.frost_get_share_by_index(&group_pubkey, idx)?,
+        None => keep.frost_get_share(&group_pubkey)?,
+    };
+
+    out.newline();
+    out.header("WDC Recovery Spend Approval");
+    out.field("Group", &hex::encode(group_pubkey));
+    out.field(
+        "Mode",
+        if auto { "auto (headless)" } else { "single session" },
+    );
+    if let Some(sid) = session_id_opt {
+        out.field("Session", &hex::encode(&sid[..8]));
+    }
+    out.field(
+        "Local signers",
+        &registry_entries
+            .iter()
+            .map(|(fp, _)| fp.as_str())
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
+    out.field("Relay", relay);
+    out.newline();
+
+    let rt =
+        tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
+    let keep = Arc::new(Mutex::new(keep));
+
+    rt.block_on(async {
+        let registry = Arc::new(keep_frost_net::InMemoryRecoverySignerRegistry::new());
+        for (fp, uri) in &registry_entries {
+            registry.insert(fp, format!("signer-{fp}"), uri.clone());
+        }
+
+        let node = keep_frost_net::KfpNode::new(share, vec![relay.to_string()])
+            .await
+            .map_err(|e| KeepError::Frost(e.to_string()))?;
+        let node = node.with_descriptor_lookup(Arc::new(descriptor_lookup_for(keep.clone())));
+        let node = node.with_recovery_signer_registry(registry.clone());
+        let node = std::sync::Arc::new(node);
+
+        node.announce()
+            .await
+            .map_err(|e| KeepError::Frost(e.to_string()))?;
+
+        let mut event_rx = node.subscribe();
+        let node_handle = tokio::spawn({
+            let node = node.clone();
+            async move {
+                if let Err(e) = node.run().await {
+                    tracing::error!(error = %e, "FROST node error");
+                }
+            }
+        });
+
+        let bunker_for = |fp: &str| -> Option<String> {
+            registry_entries
+                .iter()
+                .find(|(f, _)| f.eq_ignore_ascii_case(fp))
+                .map(|(_, u)| u.clone())
+        };
+
+        if let Some(target_sid) = session_id_opt {
+            let spinner = out.spinner("Waiting for proposal...");
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+            let mut approved = false;
+            while tokio::time::Instant::now() < deadline {
+                let remaining = deadline - tokio::time::Instant::now();
+                match tokio::time::timeout(remaining, event_rx.recv()).await {
+                    Ok(Ok(keep_frost_net::KfpNodeEvent::PsbtSignatureNeeded {
+                        session_id,
+                        ..
+                    })) if session_id == target_sid => {
+                        spinner.finish();
+                        let fp = registry_entries[0].0.clone();
+                        let bunker = bunker_for(&fp).expect("fp present");
+                        approve_psbt_session(
+                            out,
+                            keep.clone(),
+                            node.clone(),
+                            session_id,
+                            group_pubkey,
+                            fp,
+                            bunker,
+                        )
+                        .await?;
+                        approved = true;
+                        break;
+                    }
+                    Ok(Err(_)) => break,
+                    Err(_) => break,
+                    _ => {}
+                }
+            }
+            if !approved {
+                node_handle.abort();
+                return Err(KeepError::Frost(format!(
+                    "did not receive PsbtSignatureNeeded for session {} within 60s",
+                    hex::encode(&target_sid[..8])
+                )));
+            }
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            node_handle.abort();
+            return Ok::<_, KeepError>(());
+        }
+
+        // Auto mode: loop until Ctrl-C, approving every matching proposal.
+        out.info("Auto-approve mode: waiting for PSBT proposals (Ctrl+C to stop)");
+        loop {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {
+                    out.info("Shutting down");
+                    break;
+                }
+                ev = event_rx.recv() => match ev {
+                    Ok(keep_frost_net::KfpNodeEvent::PsbtSignatureNeeded {
+                        session_id,
+                        tier_index,
+                        ..
+                    }) => {
+                        let fp = registry_entries[0].0.clone();
+                        let Some(bunker) = bunker_for(&fp) else { continue };
+                        out.info(&format!(
+                            "[auto] PSBT proposal received: session={} tier={}",
+                            hex::encode(&session_id[..8]),
+                            tier_index
+                        ));
+                        let keep_c = keep.clone();
+                        let node_c = node.clone();
+                        let out_c = out.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = approve_psbt_session(
+                                &out_c, keep_c, node_c, session_id, group_pubkey, fp, bunker,
+                            )
+                            .await
+                            {
+                                tracing::error!(
+                                    session = %hex::encode(&session_id[..8]),
+                                    error = %e,
+                                    "auto-approve failed"
+                                );
+                            }
+                        });
+                    }
+                    Ok(_) => {}
+                    Err(_) => break,
+                },
+            }
+        }
+        node_handle.abort();
+        Ok::<_, KeepError>(())
+    })?;
+
+    Ok(())
+}
+
 fn read_psbt_file(path: &Path) -> Result<Vec<u8>> {
     // Cap file size before touching it so a hostile caller cannot exhaust
     // memory by pointing at a huge file. The `* 2` budget accounts for

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1594,41 +1594,72 @@ fn parse_session_id(s: &str) -> Result<[u8; 32]> {
     })
 }
 
-/// Resolve a tier's external `(xpub, fingerprint)` slot whose fingerprint
-/// matches `local_fp`. Returns the xpub string.
-fn find_local_external_xpub(
+/// Deserialize a persisted `WalletPolicy` JSON value and verify its
+/// integrity by recomputing `derive_policy_hash` and comparing it to
+/// `expected_policy_hash`. Returns the verified `WalletPolicy` on success.
+fn load_verified_policy(
     policy_json: &serde_json::Value,
+    expected_policy_hash: &[u8; 32],
+) -> Result<keep_frost_net::WalletPolicy> {
+    let policy: keep_frost_net::WalletPolicy = serde_json::from_value(policy_json.clone())
+        .map_err(|e| KeepError::InvalidInput(format!("invalid persisted wallet policy: {e}")))?;
+    let recomputed = keep_frost_net::derive_policy_hash(&policy);
+    if &recomputed != expected_policy_hash {
+        return Err(KeepError::InvalidInput(
+            "persisted wallet policy hash does not match stored descriptor.policy_hash; refusing to use it".into(),
+        ));
+    }
+    Ok(policy)
+}
+
+/// Resolve a tier's external `(xpub, fingerprint)` slot whose fingerprint
+/// matches `local_fp`. Returns the xpub string. Errors if more than one
+/// External slot in the tier shares the same fingerprint, since that
+/// makes responder selection ambiguous.
+fn find_local_external_xpub(
+    policy: &keep_frost_net::WalletPolicy,
     tier_index: u32,
     local_fp: &str,
 ) -> Result<String> {
-    let policy: keep_frost_net::WalletPolicy = serde_json::from_value(policy_json.clone())
-        .map_err(|e| KeepError::InvalidInput(format!("invalid persisted wallet policy: {e}")))?;
     let tier = policy
         .recovery_tiers
         .get(tier_index as usize)
         .ok_or_else(|| {
-            KeepError::InvalidInput(format!(
-                "tier {tier_index} not present in persisted policy"
-            ))
+            KeepError::InvalidInput(format!("tier {tier_index} not present in persisted policy"))
         })?;
     let lower = local_fp.to_ascii_lowercase();
+    let mut found: Option<String> = None;
     for slot in &tier.key_slots {
         if let keep_frost_net::KeySlot::External { xpub, fingerprint } = slot {
             if fingerprint.eq_ignore_ascii_case(&lower) {
-                return Ok(xpub.clone());
+                if found.is_some() {
+                    return Err(KeepError::InvalidInput(format!(
+                        "tier {tier_index} has more than one External slot with fingerprint {lower}; ambiguous responder",
+                    )));
+                }
+                found = Some(xpub.clone());
             }
         }
     }
-    Err(KeepError::InvalidInput(format!(
-        "no External key slot with fingerprint {lower} found in tier {tier_index}"
-    )))
+    found.ok_or_else(|| {
+        KeepError::InvalidInput(format!(
+            "no External key slot with fingerprint {lower} found in tier {tier_index}"
+        ))
+    })
 }
 
 /// Execute the full responder approval chain for a single PSBT session: load
-/// the descriptor, derive the local x-only pubkey, build the script-spend
-/// sighash for every input, request a Schnorr signature per input from the
-/// NIP-46 signer at `bunker_uri`, merge the signatures, and contribute the
-/// PSBT back to the initiator.
+/// the descriptor, verify the policy integrity, verify the PSBT is bound to
+/// the recovery tier we expect, derive the local x-only pubkey, build the
+/// script-spend sighash for every input, request a Schnorr signature per
+/// input from the NIP-46 signer at `bunker_uri`, merge the signatures (with
+/// signature verification on each merge), and contribute the PSBT back to
+/// the initiator.
+///
+/// `expected_psbt_hash`, when `Some`, must equal `sha256(proposal_psbt)`
+/// captured at the time the operator approved the session; mismatches abort
+/// the approval. This closes the preview/sign decoupling window where the
+/// proposer could swap the PSBT between review and sign.
 #[allow(clippy::too_many_arguments)]
 async fn approve_psbt_session(
     out: &Output,
@@ -1637,14 +1668,25 @@ async fn approve_psbt_session(
     session_id: [u8; 32],
     group_pubkey: [u8; 32],
     local_fp: String,
-    bunker_uri: String,
+    bunker_uri: zeroize::Zeroizing<String>,
+    expected_psbt_hash: Option<[u8; 32]>,
 ) -> Result<()> {
-    let (initiator_pubkey, _descriptor_hash, tier_index) = node
-        .psbt_session_routing(&session_id)
-        .ok_or_else(|| KeepError::Frost("unknown PSBT session id".into()))?;
+    let (initiator_pubkey, _descriptor_hash, tier_index) =
+        node.psbt_session_routing(&session_id)
+            .ok_or_else(|| KeepError::Frost("unknown PSBT session id".into()))?;
     let psbt_bytes = node
         .psbt_session_proposal_psbt(&session_id)
         .ok_or_else(|| KeepError::Frost("session has no proposal PSBT".into()))?;
+
+    if let Some(expected) = expected_psbt_hash {
+        use sha2::{Digest, Sha256};
+        let recomputed: [u8; 32] = Sha256::digest(&psbt_bytes).into();
+        if recomputed != expected {
+            return Err(KeepError::Frost(
+                "PSBT hash changed between preview and sign; aborting".into(),
+            ));
+        }
+    }
 
     let descriptor = {
         let guard = keep.lock().expect("keep mutex poisoned");
@@ -1654,29 +1696,36 @@ async fn approve_psbt_session(
     };
     let policy_json = descriptor.policy.clone().ok_or_else(|| {
         KeepError::InvalidInput(
-            "persisted descriptor has no WalletPolicy; cannot derive recovery tier metadata"
-                .into(),
+            "persisted descriptor has no WalletPolicy; cannot derive recovery tier metadata".into(),
         )
     })?;
 
-    let xpub_str = find_local_external_xpub(&policy_json, tier_index, &local_fp)?;
+    let policy = load_verified_policy(&policy_json, &descriptor.policy_hash)?;
+    let xpub_str = find_local_external_xpub(&policy, tier_index, &local_fp)?;
     let network = <keep_bitcoin::Network as std::str::FromStr>::from_str(&descriptor.network)
         .map_err(|e| KeepError::InvalidInput(format!("invalid network: {e}")))?;
     let xonly_bytes = keep_bitcoin::xpub_to_x_only(&xpub_str, network)
         .map_err(|e| KeepError::InvalidInput(format!("xpub_to_x_only: {e}")))?;
-    let xonly =
-        keep_bitcoin::bitcoin::XOnlyPublicKey::from_slice(&xonly_bytes).map_err(|e| {
-            KeepError::InvalidInput(format!("xonly_pubkey decode: {e}"))
-        })?;
+    let xonly = keep_bitcoin::bitcoin::XOnlyPublicKey::from_slice(&xonly_bytes)
+        .map_err(|e| KeepError::InvalidInput(format!("xonly_pubkey decode: {e}")))?;
 
     let mut psbt = keep_bitcoin::bitcoin::psbt::Psbt::deserialize(&psbt_bytes)
         .map_err(|e| KeepError::InvalidInput(format!("decode PSBT: {e}")))?;
-    let sighashes = keep_bitcoin::script_spend_sighashes(&psbt)
-        .map_err(|e| KeepError::InvalidInput(format!("compute sighashes: {e}")))?;
-    if sighashes.is_empty() {
-        return Err(KeepError::InvalidInput(
-            "PSBT has no inputs to sign".into(),
-        ));
+    if psbt.inputs.is_empty() {
+        return Err(KeepError::InvalidInput("PSBT has no inputs to sign".into()));
+    }
+
+    // Verify every input's tap_scripts entry is bound to its witness_utxo and
+    // references our local x-only key BEFORE asking the bunker to sign.
+    // Failing closed here turns the responder from a blind signing oracle
+    // into one that only signs for outputs it actually controls.
+    let mut sighashes = Vec::with_capacity(psbt.inputs.len());
+    for i in 0..psbt.inputs.len() {
+        let bundle = keep_bitcoin::verify_script_spend_input_binding(&psbt, i, &xonly_bytes)
+            .map_err(|e| {
+                KeepError::InvalidInput(format!("PSBT input {i} binding verification failed: {e}"))
+            })?;
+        sighashes.push(bundle);
     }
 
     out.info(&format!(
@@ -1715,6 +1764,7 @@ async fn approve_psbt_session(
                 sh.input_index,
                 xonly,
                 sh.leaf_hash,
+                &sh.sighash,
                 sig,
             )
             .map_err(|e| format!("merge sig: {e}"))?;
@@ -1747,29 +1797,26 @@ pub fn cmd_wallet_approve_psbt(
     out: &Output,
     path: &Path,
     group: &str,
-    session_hex: Option<&str>,
+    session_hex: &str,
     signer_bunker: &[String],
     share_index: Option<u16>,
     relay: &str,
-    auto: bool,
 ) -> Result<()> {
-    debug!(group, ?session_hex, relay, auto, "wallet approve-psbt");
+    debug!(group, session_hex, relay, "wallet approve-psbt");
 
-    if !auto && session_hex.is_none() {
-        return Err(KeepError::InvalidInput(
-            "either --session <id> or --auto must be specified".into(),
-        ));
-    }
     if signer_bunker.is_empty() {
         return Err(KeepError::InvalidInput(
             "at least one --signer-bunker fp:bunker:// is required".into(),
         ));
     }
 
-    let mut registry_entries: Vec<(String, String)> = Vec::with_capacity(signer_bunker.len());
+    // Bunker URIs may embed single-use connect secrets; keep them in
+    // Zeroizing<String> end-to-end and never format them into log/output.
+    let mut registry_entries: Vec<(String, zeroize::Zeroizing<String>)> =
+        Vec::with_capacity(signer_bunker.len());
     for spec in signer_bunker {
         let (fp, uri) = parse_signer_bunker(spec)?;
-        registry_entries.push((fp, uri));
+        registry_entries.push((fp, zeroize::Zeroizing::new(uri)));
     }
     let mut seen_fps = std::collections::HashSet::new();
     for (fp, _) in &registry_entries {
@@ -1780,11 +1827,7 @@ pub fn cmd_wallet_approve_psbt(
         }
     }
 
-    let session_id_opt = match session_hex {
-        Some(s) => Some(parse_session_id(s)?),
-        None => None,
-    };
-
+    let session_id = parse_session_id(session_hex)?;
     let group_pubkey = parse_group_id(group)?;
 
     let mut keep = Keep::open(path)?;
@@ -1802,13 +1845,7 @@ pub fn cmd_wallet_approve_psbt(
     out.newline();
     out.header("WDC Recovery Spend Approval");
     out.field("Group", &hex::encode(group_pubkey));
-    out.field(
-        "Mode",
-        if auto { "auto (headless)" } else { "single session" },
-    );
-    if let Some(sid) = session_id_opt {
-        out.field("Session", &hex::encode(&sid[..8]));
-    }
+    out.field("Session", &hex::encode(&session_id[..8]));
     out.field(
         "Local signers",
         &registry_entries
@@ -1827,7 +1864,7 @@ pub fn cmd_wallet_approve_psbt(
     rt.block_on(async {
         let registry = Arc::new(keep_frost_net::InMemoryRecoverySignerRegistry::new());
         for (fp, uri) in &registry_entries {
-            registry.insert(fp, format!("signer-{fp}"), uri.clone());
+            registry.insert(fp, format!("signer-{fp}"), uri.as_str().to_string());
         }
 
         let node = keep_frost_net::KfpNode::new(share, vec![relay.to_string()])
@@ -1851,100 +1888,55 @@ pub fn cmd_wallet_approve_psbt(
             }
         });
 
-        let bunker_for = |fp: &str| -> Option<String> {
-            registry_entries
-                .iter()
-                .find(|(f, _)| f.eq_ignore_ascii_case(fp))
-                .map(|(_, u)| u.clone())
-        };
-
-        if let Some(target_sid) = session_id_opt {
-            let spinner = out.spinner("Waiting for proposal...");
-            let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
-            let mut approved = false;
-            while tokio::time::Instant::now() < deadline {
-                let remaining = deadline - tokio::time::Instant::now();
-                match tokio::time::timeout(remaining, event_rx.recv()).await {
-                    Ok(Ok(keep_frost_net::KfpNodeEvent::PsbtSignatureNeeded {
+        let target_sid = session_id;
+        let spinner = out.spinner("Waiting for proposal...");
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+        let mut approved = false;
+        while tokio::time::Instant::now() < deadline {
+            let remaining = deadline - tokio::time::Instant::now();
+            match tokio::time::timeout(remaining, event_rx.recv()).await {
+                Ok(Ok(keep_frost_net::KfpNodeEvent::PsbtSignatureNeeded {
+                    session_id, ..
+                })) if session_id == target_sid => {
+                    spinner.finish();
+                    // Capture the PSBT hash NOW (before any user/operator
+                    // review window) and pass it through to approve so that
+                    // a swap by the proposer between snapshot and sign is
+                    // detected and aborted.
+                    let expected_hash = node.psbt_session_proposal_psbt(&session_id).map(|bytes| {
+                        use sha2::{Digest, Sha256};
+                        let h: [u8; 32] = Sha256::digest(&bytes).into();
+                        h
+                    });
+                    let fp = registry_entries[0].0.clone();
+                    let bunker = registry_entries[0].1.clone();
+                    approve_psbt_session(
+                        out,
+                        keep.clone(),
+                        node.clone(),
                         session_id,
-                        ..
-                    })) if session_id == target_sid => {
-                        spinner.finish();
-                        let fp = registry_entries[0].0.clone();
-                        let bunker = bunker_for(&fp).expect("fp present");
-                        approve_psbt_session(
-                            out,
-                            keep.clone(),
-                            node.clone(),
-                            session_id,
-                            group_pubkey,
-                            fp,
-                            bunker,
-                        )
-                        .await?;
-                        approved = true;
-                        break;
-                    }
-                    Ok(Err(_)) => break,
-                    Err(_) => break,
-                    _ => {}
-                }
-            }
-            if !approved {
-                node_handle.abort();
-                return Err(KeepError::Frost(format!(
-                    "did not receive PsbtSignatureNeeded for session {} within 60s",
-                    hex::encode(&target_sid[..8])
-                )));
-            }
-            tokio::time::sleep(Duration::from_secs(2)).await;
-            node_handle.abort();
-            return Ok::<_, KeepError>(());
-        }
-
-        // Auto mode: loop until Ctrl-C, approving every matching proposal.
-        out.info("Auto-approve mode: waiting for PSBT proposals (Ctrl+C to stop)");
-        loop {
-            tokio::select! {
-                _ = tokio::signal::ctrl_c() => {
-                    out.info("Shutting down");
+                        group_pubkey,
+                        fp,
+                        bunker,
+                        expected_hash,
+                    )
+                    .await?;
+                    approved = true;
                     break;
                 }
-                ev = event_rx.recv() => match ev {
-                    Ok(keep_frost_net::KfpNodeEvent::PsbtSignatureNeeded {
-                        session_id,
-                        tier_index,
-                        ..
-                    }) => {
-                        let fp = registry_entries[0].0.clone();
-                        let Some(bunker) = bunker_for(&fp) else { continue };
-                        out.info(&format!(
-                            "[auto] PSBT proposal received: session={} tier={}",
-                            hex::encode(&session_id[..8]),
-                            tier_index
-                        ));
-                        let keep_c = keep.clone();
-                        let node_c = node.clone();
-                        let out_c = out.clone();
-                        tokio::spawn(async move {
-                            if let Err(e) = approve_psbt_session(
-                                &out_c, keep_c, node_c, session_id, group_pubkey, fp, bunker,
-                            )
-                            .await
-                            {
-                                tracing::error!(
-                                    session = %hex::encode(&session_id[..8]),
-                                    error = %e,
-                                    "auto-approve failed"
-                                );
-                            }
-                        });
-                    }
-                    Ok(_) => {}
-                    Err(_) => break,
-                },
+                Ok(Err(_)) => break,
+                Err(_) => break,
+                _ => {}
             }
         }
+        if !approved {
+            node_handle.abort();
+            return Err(KeepError::Frost(format!(
+                "did not receive PsbtSignatureNeeded for session {} within 60s",
+                hex::encode(&target_sid[..8])
+            )));
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
         node_handle.abort();
         Ok::<_, KeepError>(())
     })?;

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1599,41 +1599,72 @@ fn parse_session_id(s: &str) -> Result<[u8; 32]> {
     })
 }
 
-/// Resolve a tier's external `(xpub, fingerprint)` slot whose fingerprint
-/// matches `local_fp`. Returns the xpub string.
-fn find_local_external_xpub(
+/// Deserialize a persisted `WalletPolicy` JSON value and verify its
+/// integrity by recomputing `derive_policy_hash` and comparing it to
+/// `expected_policy_hash`. Returns the verified `WalletPolicy` on success.
+fn load_verified_policy(
     policy_json: &serde_json::Value,
+    expected_policy_hash: &[u8; 32],
+) -> Result<keep_frost_net::WalletPolicy> {
+    let policy: keep_frost_net::WalletPolicy = serde_json::from_value(policy_json.clone())
+        .map_err(|e| KeepError::InvalidInput(format!("invalid persisted wallet policy: {e}")))?;
+    let recomputed = keep_frost_net::derive_policy_hash(&policy);
+    if &recomputed != expected_policy_hash {
+        return Err(KeepError::InvalidInput(
+            "persisted wallet policy hash does not match stored descriptor.policy_hash; refusing to use it".into(),
+        ));
+    }
+    Ok(policy)
+}
+
+/// Resolve a tier's external `(xpub, fingerprint)` slot whose fingerprint
+/// matches `local_fp`. Returns the xpub string. Errors if more than one
+/// External slot in the tier shares the same fingerprint, since that
+/// makes responder selection ambiguous.
+fn find_local_external_xpub(
+    policy: &keep_frost_net::WalletPolicy,
     tier_index: u32,
     local_fp: &str,
 ) -> Result<String> {
-    let policy: keep_frost_net::WalletPolicy = serde_json::from_value(policy_json.clone())
-        .map_err(|e| KeepError::InvalidInput(format!("invalid persisted wallet policy: {e}")))?;
     let tier = policy
         .recovery_tiers
         .get(tier_index as usize)
         .ok_or_else(|| {
-            KeepError::InvalidInput(format!(
-                "tier {tier_index} not present in persisted policy"
-            ))
+            KeepError::InvalidInput(format!("tier {tier_index} not present in persisted policy"))
         })?;
     let lower = local_fp.to_ascii_lowercase();
+    let mut found: Option<String> = None;
     for slot in &tier.key_slots {
         if let keep_frost_net::KeySlot::External { xpub, fingerprint } = slot {
             if fingerprint.eq_ignore_ascii_case(&lower) {
-                return Ok(xpub.clone());
+                if found.is_some() {
+                    return Err(KeepError::InvalidInput(format!(
+                        "tier {tier_index} has more than one External slot with fingerprint {lower}; ambiguous responder",
+                    )));
+                }
+                found = Some(xpub.clone());
             }
         }
     }
-    Err(KeepError::InvalidInput(format!(
-        "no External key slot with fingerprint {lower} found in tier {tier_index}"
-    )))
+    found.ok_or_else(|| {
+        KeepError::InvalidInput(format!(
+            "no External key slot with fingerprint {lower} found in tier {tier_index}"
+        ))
+    })
 }
 
 /// Execute the full responder approval chain for a single PSBT session: load
-/// the descriptor, derive the local x-only pubkey, build the script-spend
-/// sighash for every input, request a Schnorr signature per input from the
-/// NIP-46 signer at `bunker_uri`, merge the signatures, and contribute the
-/// PSBT back to the initiator.
+/// the descriptor, verify the policy integrity, verify the PSBT is bound to
+/// the recovery tier we expect, derive the local x-only pubkey, build the
+/// script-spend sighash for every input, request a Schnorr signature per
+/// input from the NIP-46 signer at `bunker_uri`, merge the signatures (with
+/// signature verification on each merge), and contribute the PSBT back to
+/// the initiator.
+///
+/// `expected_psbt_hash`, when `Some`, must equal `sha256(proposal_psbt)`
+/// captured at the time the operator approved the session; mismatches abort
+/// the approval. This closes the preview/sign decoupling window where the
+/// proposer could swap the PSBT between review and sign.
 #[allow(clippy::too_many_arguments)]
 async fn approve_psbt_session(
     out: &Output,
@@ -1642,14 +1673,25 @@ async fn approve_psbt_session(
     session_id: [u8; 32],
     group_pubkey: [u8; 32],
     local_fp: String,
-    bunker_uri: String,
+    bunker_uri: zeroize::Zeroizing<String>,
+    expected_psbt_hash: Option<[u8; 32]>,
 ) -> Result<()> {
-    let (initiator_pubkey, _descriptor_hash, tier_index) = node
-        .psbt_session_routing(&session_id)
-        .ok_or_else(|| KeepError::Frost("unknown PSBT session id".into()))?;
+    let (initiator_pubkey, _descriptor_hash, tier_index) =
+        node.psbt_session_routing(&session_id)
+            .ok_or_else(|| KeepError::Frost("unknown PSBT session id".into()))?;
     let psbt_bytes = node
         .psbt_session_proposal_psbt(&session_id)
         .ok_or_else(|| KeepError::Frost("session has no proposal PSBT".into()))?;
+
+    if let Some(expected) = expected_psbt_hash {
+        use sha2::{Digest, Sha256};
+        let recomputed: [u8; 32] = Sha256::digest(&psbt_bytes).into();
+        if recomputed != expected {
+            return Err(KeepError::Frost(
+                "PSBT hash changed between preview and sign; aborting".into(),
+            ));
+        }
+    }
 
     let descriptor = {
         let guard = keep.lock().expect("keep mutex poisoned");
@@ -1659,29 +1701,36 @@ async fn approve_psbt_session(
     };
     let policy_json = descriptor.policy.clone().ok_or_else(|| {
         KeepError::InvalidInput(
-            "persisted descriptor has no WalletPolicy; cannot derive recovery tier metadata"
-                .into(),
+            "persisted descriptor has no WalletPolicy; cannot derive recovery tier metadata".into(),
         )
     })?;
 
-    let xpub_str = find_local_external_xpub(&policy_json, tier_index, &local_fp)?;
+    let policy = load_verified_policy(&policy_json, &descriptor.policy_hash)?;
+    let xpub_str = find_local_external_xpub(&policy, tier_index, &local_fp)?;
     let network = <keep_bitcoin::Network as std::str::FromStr>::from_str(&descriptor.network)
         .map_err(|e| KeepError::InvalidInput(format!("invalid network: {e}")))?;
     let xonly_bytes = keep_bitcoin::xpub_to_x_only(&xpub_str, network)
         .map_err(|e| KeepError::InvalidInput(format!("xpub_to_x_only: {e}")))?;
-    let xonly =
-        keep_bitcoin::bitcoin::XOnlyPublicKey::from_slice(&xonly_bytes).map_err(|e| {
-            KeepError::InvalidInput(format!("xonly_pubkey decode: {e}"))
-        })?;
+    let xonly = keep_bitcoin::bitcoin::XOnlyPublicKey::from_slice(&xonly_bytes)
+        .map_err(|e| KeepError::InvalidInput(format!("xonly_pubkey decode: {e}")))?;
 
     let mut psbt = keep_bitcoin::bitcoin::psbt::Psbt::deserialize(&psbt_bytes)
         .map_err(|e| KeepError::InvalidInput(format!("decode PSBT: {e}")))?;
-    let sighashes = keep_bitcoin::script_spend_sighashes(&psbt)
-        .map_err(|e| KeepError::InvalidInput(format!("compute sighashes: {e}")))?;
-    if sighashes.is_empty() {
-        return Err(KeepError::InvalidInput(
-            "PSBT has no inputs to sign".into(),
-        ));
+    if psbt.inputs.is_empty() {
+        return Err(KeepError::InvalidInput("PSBT has no inputs to sign".into()));
+    }
+
+    // Verify every input's tap_scripts entry is bound to its witness_utxo and
+    // references our local x-only key BEFORE asking the bunker to sign.
+    // Failing closed here turns the responder from a blind signing oracle
+    // into one that only signs for outputs it actually controls.
+    let mut sighashes = Vec::with_capacity(psbt.inputs.len());
+    for i in 0..psbt.inputs.len() {
+        let bundle = keep_bitcoin::verify_script_spend_input_binding(&psbt, i, &xonly_bytes)
+            .map_err(|e| {
+                KeepError::InvalidInput(format!("PSBT input {i} binding verification failed: {e}"))
+            })?;
+        sighashes.push(bundle);
     }
 
     out.info(&format!(
@@ -1720,6 +1769,7 @@ async fn approve_psbt_session(
                 sh.input_index,
                 xonly,
                 sh.leaf_hash,
+                &sh.sighash,
                 sig,
             )
             .map_err(|e| format!("merge sig: {e}"))?;
@@ -1752,29 +1802,26 @@ pub fn cmd_wallet_approve_psbt(
     out: &Output,
     path: &Path,
     group: &str,
-    session_hex: Option<&str>,
+    session_hex: &str,
     signer_bunker: &[String],
     share_index: Option<u16>,
     relay: &str,
-    auto: bool,
 ) -> Result<()> {
-    debug!(group, ?session_hex, relay, auto, "wallet approve-psbt");
+    debug!(group, session_hex, relay, "wallet approve-psbt");
 
-    if !auto && session_hex.is_none() {
-        return Err(KeepError::InvalidInput(
-            "either --session <id> or --auto must be specified".into(),
-        ));
-    }
     if signer_bunker.is_empty() {
         return Err(KeepError::InvalidInput(
             "at least one --signer-bunker fp:bunker:// is required".into(),
         ));
     }
 
-    let mut registry_entries: Vec<(String, String)> = Vec::with_capacity(signer_bunker.len());
+    // Bunker URIs may embed single-use connect secrets; keep them in
+    // Zeroizing<String> end-to-end and never format them into log/output.
+    let mut registry_entries: Vec<(String, zeroize::Zeroizing<String>)> =
+        Vec::with_capacity(signer_bunker.len());
     for spec in signer_bunker {
         let (fp, uri) = parse_signer_bunker(spec)?;
-        registry_entries.push((fp, uri));
+        registry_entries.push((fp, zeroize::Zeroizing::new(uri)));
     }
     let mut seen_fps = std::collections::HashSet::new();
     for (fp, _) in &registry_entries {
@@ -1785,11 +1832,7 @@ pub fn cmd_wallet_approve_psbt(
         }
     }
 
-    let session_id_opt = match session_hex {
-        Some(s) => Some(parse_session_id(s)?),
-        None => None,
-    };
-
+    let session_id = parse_session_id(session_hex)?;
     let group_pubkey = parse_group_id(group)?;
 
     let mut keep = Keep::open(path)?;
@@ -1807,13 +1850,7 @@ pub fn cmd_wallet_approve_psbt(
     out.newline();
     out.header("WDC Recovery Spend Approval");
     out.field("Group", &hex::encode(group_pubkey));
-    out.field(
-        "Mode",
-        if auto { "auto (headless)" } else { "single session" },
-    );
-    if let Some(sid) = session_id_opt {
-        out.field("Session", &hex::encode(&sid[..8]));
-    }
+    out.field("Session", &hex::encode(&session_id[..8]));
     out.field(
         "Local signers",
         &registry_entries
@@ -1832,7 +1869,7 @@ pub fn cmd_wallet_approve_psbt(
     rt.block_on(async {
         let registry = Arc::new(keep_frost_net::InMemoryRecoverySignerRegistry::new());
         for (fp, uri) in &registry_entries {
-            registry.insert(fp, format!("signer-{fp}"), uri.clone());
+            registry.insert(fp, format!("signer-{fp}"), uri.as_str().to_string());
         }
 
         let node = keep_frost_net::KfpNode::new(share, vec![relay.to_string()])
@@ -1856,100 +1893,55 @@ pub fn cmd_wallet_approve_psbt(
             }
         });
 
-        let bunker_for = |fp: &str| -> Option<String> {
-            registry_entries
-                .iter()
-                .find(|(f, _)| f.eq_ignore_ascii_case(fp))
-                .map(|(_, u)| u.clone())
-        };
-
-        if let Some(target_sid) = session_id_opt {
-            let spinner = out.spinner("Waiting for proposal...");
-            let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
-            let mut approved = false;
-            while tokio::time::Instant::now() < deadline {
-                let remaining = deadline - tokio::time::Instant::now();
-                match tokio::time::timeout(remaining, event_rx.recv()).await {
-                    Ok(Ok(keep_frost_net::KfpNodeEvent::PsbtSignatureNeeded {
+        let target_sid = session_id;
+        let spinner = out.spinner("Waiting for proposal...");
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+        let mut approved = false;
+        while tokio::time::Instant::now() < deadline {
+            let remaining = deadline - tokio::time::Instant::now();
+            match tokio::time::timeout(remaining, event_rx.recv()).await {
+                Ok(Ok(keep_frost_net::KfpNodeEvent::PsbtSignatureNeeded {
+                    session_id, ..
+                })) if session_id == target_sid => {
+                    spinner.finish();
+                    // Capture the PSBT hash NOW (before any user/operator
+                    // review window) and pass it through to approve so that
+                    // a swap by the proposer between snapshot and sign is
+                    // detected and aborted.
+                    let expected_hash = node.psbt_session_proposal_psbt(&session_id).map(|bytes| {
+                        use sha2::{Digest, Sha256};
+                        let h: [u8; 32] = Sha256::digest(&bytes).into();
+                        h
+                    });
+                    let fp = registry_entries[0].0.clone();
+                    let bunker = registry_entries[0].1.clone();
+                    approve_psbt_session(
+                        out,
+                        keep.clone(),
+                        node.clone(),
                         session_id,
-                        ..
-                    })) if session_id == target_sid => {
-                        spinner.finish();
-                        let fp = registry_entries[0].0.clone();
-                        let bunker = bunker_for(&fp).expect("fp present");
-                        approve_psbt_session(
-                            out,
-                            keep.clone(),
-                            node.clone(),
-                            session_id,
-                            group_pubkey,
-                            fp,
-                            bunker,
-                        )
-                        .await?;
-                        approved = true;
-                        break;
-                    }
-                    Ok(Err(_)) => break,
-                    Err(_) => break,
-                    _ => {}
-                }
-            }
-            if !approved {
-                node_handle.abort();
-                return Err(KeepError::Frost(format!(
-                    "did not receive PsbtSignatureNeeded for session {} within 60s",
-                    hex::encode(&target_sid[..8])
-                )));
-            }
-            tokio::time::sleep(Duration::from_secs(2)).await;
-            node_handle.abort();
-            return Ok::<_, KeepError>(());
-        }
-
-        // Auto mode: loop until Ctrl-C, approving every matching proposal.
-        out.info("Auto-approve mode: waiting for PSBT proposals (Ctrl+C to stop)");
-        loop {
-            tokio::select! {
-                _ = tokio::signal::ctrl_c() => {
-                    out.info("Shutting down");
+                        group_pubkey,
+                        fp,
+                        bunker,
+                        expected_hash,
+                    )
+                    .await?;
+                    approved = true;
                     break;
                 }
-                ev = event_rx.recv() => match ev {
-                    Ok(keep_frost_net::KfpNodeEvent::PsbtSignatureNeeded {
-                        session_id,
-                        tier_index,
-                        ..
-                    }) => {
-                        let fp = registry_entries[0].0.clone();
-                        let Some(bunker) = bunker_for(&fp) else { continue };
-                        out.info(&format!(
-                            "[auto] PSBT proposal received: session={} tier={}",
-                            hex::encode(&session_id[..8]),
-                            tier_index
-                        ));
-                        let keep_c = keep.clone();
-                        let node_c = node.clone();
-                        let out_c = out.clone();
-                        tokio::spawn(async move {
-                            if let Err(e) = approve_psbt_session(
-                                &out_c, keep_c, node_c, session_id, group_pubkey, fp, bunker,
-                            )
-                            .await
-                            {
-                                tracing::error!(
-                                    session = %hex::encode(&session_id[..8]),
-                                    error = %e,
-                                    "auto-approve failed"
-                                );
-                            }
-                        });
-                    }
-                    Ok(_) => {}
-                    Err(_) => break,
-                },
+                Ok(Err(_)) => break,
+                Err(_) => break,
+                _ => {}
             }
         }
+        if !approved {
+            node_handle.abort();
+            return Err(KeepError::Frost(format!(
+                "did not receive PsbtSignatureNeeded for session {} within 60s",
+                hex::encode(&target_sid[..8])
+            )));
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
         node_handle.abort();
         Ok::<_, KeepError>(())
     })?;

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1714,14 +1714,11 @@ async fn approve_psbt_session(
     }
     // Inputs on the recovery path always carry witness_utxo (enforced by the
     // binding verification above), so the fee is computable and worth showing.
-    let total_in: Option<u64> = psbt
-        .inputs
-        .iter()
-        .try_fold(0u64, |acc, inp| {
-            inp.witness_utxo
-                .as_ref()
-                .and_then(|t| acc.checked_add(t.value.to_sat()))
-        });
+    let total_in: Option<u64> = psbt.inputs.iter().try_fold(0u64, |acc, inp| {
+        inp.witness_utxo
+            .as_ref()
+            .and_then(|t| acc.checked_add(t.value.to_sat()))
+    });
     if let Some(fee) = total_in.and_then(|i| i.checked_sub(total_out)) {
         out.field("Fee", &format!("{fee} sats"));
     }

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -526,18 +526,16 @@ fn dispatch_wallet(
             signer_bunker,
             share,
             relay,
-            auto,
         } => {
             let relay = relay.as_deref().unwrap_or_else(|| cfg.default_relay());
             commands::wallet::cmd_wallet_approve_psbt(
                 out,
                 path,
                 &group,
-                session.as_deref(),
+                &session,
                 &signer_bunker,
                 share,
                 relay,
-                auto,
             )
         }
     }

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -520,6 +520,26 @@ fn dispatch_wallet(
                 timeout,
             )
         }
+        WalletCommands::ApprovePsbt {
+            group,
+            session,
+            signer_bunker,
+            share,
+            relay,
+            auto,
+        } => {
+            let relay = relay.as_deref().unwrap_or_else(|| cfg.default_relay());
+            commands::wallet::cmd_wallet_approve_psbt(
+                out,
+                path,
+                &group,
+                session.as_deref(),
+                &signer_bunker,
+                share,
+                relay,
+                auto,
+            )
+        }
     }
 }
 

--- a/keep-cli/src/output.rs
+++ b/keep-cli/src/output.rs
@@ -4,6 +4,7 @@ use console::{style, Term};
 use indicatif::{ProgressBar, ProgressStyle};
 use std::time::Duration;
 
+#[derive(Clone)]
 pub struct Output {
     term: Term,
 }

--- a/keep-core/src/wallet.rs
+++ b/keep-core/src/wallet.rs
@@ -149,6 +149,12 @@ pub struct WalletDescriptor {
     /// migration. `None` for the initial descriptor.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub previous_descriptor_hash: Option<[u8; 32]>,
+    /// The wallet policy that produced this descriptor, persisted as an opaque
+    /// JSON value so `keep-core` does not depend on `keep-frost-net`. Callers
+    /// reconstruct `WalletPolicy` via `serde_json::from_value`. Older records
+    /// without this field deserialize with `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy: Option<serde_json::Value>,
 }
 
 /// The version assigned to the initial wallet descriptor for a group.
@@ -328,6 +334,7 @@ mod tests {
             policy_hash: [0u8; 32],
             version: 1,
             previous_descriptor_hash: None,
+            policy: None,
         };
         let signer = [7u8; 32];
         desc.upsert_device_registration(DeviceRegistration {
@@ -417,6 +424,7 @@ mod tests {
             policy_hash: [0u8; 32],
             version: 1,
             previous_descriptor_hash: None,
+            policy: None,
         };
         let json = serde_json::to_string(&desc).unwrap();
         let back: WalletDescriptor = serde_json::from_str(&json).unwrap();
@@ -494,8 +502,50 @@ mod tests {
             policy_hash: [0u8; 32],
             version: 1,
             previous_descriptor_hash: None,
+            policy: None,
         };
         let json = serde_json::to_string(&desc).unwrap();
         assert!(!json.contains("device_registrations"));
+        assert!(!json.contains("\"policy\""));
+    }
+
+    #[test]
+    fn test_descriptor_back_compat_deserializes_without_policy() {
+        let json = r#"{
+            "group_pubkey": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+            "external_descriptor": "tr(xpub.../0/*)#abc",
+            "internal_descriptor": "tr(xpub.../1/*)#def",
+            "network": "testnet",
+            "created_at": 1700000000
+        }"#;
+        let desc: WalletDescriptor = serde_json::from_str(json).expect("back-compat deserialize");
+        assert!(desc.policy.is_none());
+    }
+
+    #[test]
+    fn test_descriptor_policy_roundtrips() {
+        let policy = serde_json::json!({
+            "recovery_tiers": [{
+                "threshold": 2,
+                "timelock_months": 6,
+                "key_slots": [
+                    {"type": "participant", "share_index": 1},
+                    {"type": "external", "xpub": "xpub6...", "fingerprint": "abcdef01"}
+                ]
+            }]
+        });
+        let desc = WalletDescriptor {
+            group_pubkey: [0u8; 32],
+            external_descriptor: "a".into(),
+            internal_descriptor: "b".into(),
+            network: "testnet".into(),
+            created_at: 1,
+            device_registrations: Vec::new(),
+            policy_hash: [0u8; 32],
+            policy: Some(policy.clone()),
+        };
+        let json = serde_json::to_string(&desc).unwrap();
+        let parsed: WalletDescriptor = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.policy.as_ref(), Some(&policy));
     }
 }

--- a/keep-core/src/wallet.rs
+++ b/keep-core/src/wallet.rs
@@ -454,6 +454,7 @@ mod tests {
             policy_hash: [0xAAu8; 32],
             version: 1,
             previous_descriptor_hash: None,
+            policy: None,
         };
         // Pinned bytes computed against the legacy formula:
         // sha256(le_u64(len(ext)) || ext || le_u64(len(int)) || int || policy_hash)
@@ -483,6 +484,7 @@ mod tests {
             policy_hash: [0u8; 32],
             version: 1,
             previous_descriptor_hash: None,
+            policy: None,
         };
         let h1 = v1.canonical_hash();
         v1.version = 2;
@@ -542,6 +544,8 @@ mod tests {
             created_at: 1,
             device_registrations: Vec::new(),
             policy_hash: [0u8; 32],
+            version: 1,
+            previous_descriptor_hash: None,
             policy: Some(policy.clone()),
         };
         let json = serde_json::to_string(&desc).unwrap();

--- a/keep-core/src/wallet.rs
+++ b/keep-core/src/wallet.rs
@@ -136,6 +136,12 @@ pub struct WalletDescriptor {
     /// `sha256(len(ext) || ext || len(int) || int || policy_hash)`).
     #[serde(default)]
     pub policy_hash: [u8; 32],
+    /// The wallet policy that produced this descriptor, persisted as an opaque
+    /// JSON value so `keep-core` does not depend on `keep-frost-net`. Callers
+    /// reconstruct `WalletPolicy` via `serde_json::from_value`. Older records
+    /// without this field deserialize with `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy: Option<serde_json::Value>,
 }
 
 impl WalletDescriptor {
@@ -204,6 +210,7 @@ mod tests {
             created_at: 0,
             device_registrations: Vec::new(),
             policy_hash: [0u8; 32],
+            policy: None,
         };
         let signer = [7u8; 32];
         desc.upsert_device_registration(DeviceRegistration {
@@ -291,6 +298,7 @@ mod tests {
             created_at: 1700000000,
             device_registrations: vec![reg],
             policy_hash: [0u8; 32],
+            policy: None,
         };
         let json = serde_json::to_string(&desc).unwrap();
         let back: WalletDescriptor = serde_json::from_str(&json).unwrap();
@@ -314,8 +322,50 @@ mod tests {
             created_at: 1,
             device_registrations: Vec::new(),
             policy_hash: [0u8; 32],
+            policy: None,
         };
         let json = serde_json::to_string(&desc).unwrap();
         assert!(!json.contains("device_registrations"));
+        assert!(!json.contains("\"policy\""));
+    }
+
+    #[test]
+    fn test_descriptor_back_compat_deserializes_without_policy() {
+        let json = r#"{
+            "group_pubkey": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+            "external_descriptor": "tr(xpub.../0/*)#abc",
+            "internal_descriptor": "tr(xpub.../1/*)#def",
+            "network": "testnet",
+            "created_at": 1700000000
+        }"#;
+        let desc: WalletDescriptor = serde_json::from_str(json).expect("back-compat deserialize");
+        assert!(desc.policy.is_none());
+    }
+
+    #[test]
+    fn test_descriptor_policy_roundtrips() {
+        let policy = serde_json::json!({
+            "recovery_tiers": [{
+                "threshold": 2,
+                "timelock_months": 6,
+                "key_slots": [
+                    {"type": "participant", "share_index": 1},
+                    {"type": "external", "xpub": "xpub6...", "fingerprint": "abcdef01"}
+                ]
+            }]
+        });
+        let desc = WalletDescriptor {
+            group_pubkey: [0u8; 32],
+            external_descriptor: "a".into(),
+            internal_descriptor: "b".into(),
+            network: "testnet".into(),
+            created_at: 1,
+            device_registrations: Vec::new(),
+            policy_hash: [0u8; 32],
+            policy: Some(policy.clone()),
+        };
+        let json = serde_json::to_string(&desc).unwrap();
+        let parsed: WalletDescriptor = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.policy.as_ref(), Some(&policy));
     }
 }

--- a/keep-desktop/src/app/mod.rs
+++ b/keep-desktop/src/app/mod.rs
@@ -327,6 +327,7 @@ impl App {
                 | Message::RestoreResult(..)
                 | Message::KillSwitchDeactivateResult(..)
                 | Message::RejectPsbtSignatureResult(..)
+                | Message::ApprovePsbtResult(..)
                 | Message::CancelSpendResult(..)
                 | Message::SpendStartedResult(..)
         );
@@ -412,6 +413,7 @@ impl App {
             | Message::WalletRegisterResult(..)
             | Message::RejectPsbtSignature(..)
             | Message::RejectPsbtSignatureResult(..)
+            | Message::ApprovePsbtResult(..)
             | Message::CancelSpendResult(..)
             | Message::SpendStartedResult(..) => self.handle_wallet_global_message(message),
 

--- a/keep-desktop/src/app/wallet.rs
+++ b/keep-desktop/src/app/wallet.rs
@@ -589,7 +589,7 @@ impl App {
         let keep_arc = self.keep.clone();
         Task::perform(
             async move {
-                let (initiator_pubkey, _descriptor_hash, tier_index) = node
+                let (initiator_pubkey, session_descriptor_hash, tier_index) = node
                     .psbt_session_routing(&session_id)
                     .ok_or_else(|| "unknown PSBT session".to_string())?;
                 let psbt_bytes = node
@@ -620,6 +620,16 @@ impl App {
                 })
                 .await
                 .map_err(|_| "Background task failed".to_string())??;
+
+                // SEC: confirm the locally stored descriptor matches the one
+                // the session was coordinated against. Fail closed on mismatch
+                // to prevent signing under a substituted descriptor.
+                if descriptor.canonical_hash() != session_descriptor_hash {
+                    return Err(
+                        "stored descriptor hash does not match PSBT session descriptor_hash"
+                            .to_string(),
+                    );
+                }
 
                 let policy_value = descriptor
                     .policy

--- a/keep-desktop/src/app/wallet.rs
+++ b/keep-desktop/src/app/wallet.rs
@@ -625,42 +625,15 @@ impl App {
                     .policy
                     .clone()
                     .ok_or_else(|| "Descriptor has no persisted WalletPolicy".to_string())?;
-                let policy: keep_frost_net::WalletPolicy = serde_json::from_value(policy_value)
-                    .map_err(|e| format!("invalid persisted policy: {e}"))?;
-                // SEC: re-derive the policy hash and require it equals the
-                // hash stored alongside the descriptor. Otherwise a tampered
-                // policy could swap our resolved External slot xpub.
-                let recomputed_hash = keep_frost_net::derive_policy_hash(&policy);
-                if recomputed_hash != descriptor.policy_hash {
-                    return Err(
-                        "persisted policy hash does not match stored descriptor.policy_hash; refusing"
-                            .to_string(),
-                    );
-                }
-                let tier = policy
-                    .recovery_tiers
-                    .get(tier_index as usize)
-                    .ok_or_else(|| format!("tier {tier_index} not in persisted policy"))?;
-                let mut xpub_str: Option<String> = None;
-                for slot in &tier.key_slots {
-                    if let keep_frost_net::KeySlot::External {
-                        xpub,
-                        fingerprint: fp,
-                    } = slot
-                    {
-                        if fp.eq_ignore_ascii_case(&fingerprint) {
-                            if xpub_str.is_some() {
-                                return Err(format!(
-                                    "tier {tier_index} has more than one External slot with fingerprint {fingerprint}; ambiguous responder"
-                                ));
-                            }
-                            xpub_str = Some(xpub.clone());
-                        }
-                    }
-                }
-                let xpub_str = xpub_str.ok_or_else(|| {
-                    format!("no External key slot with fingerprint {fingerprint}")
-                })?;
+                let policy = keep_frost_net::load_verified_wallet_policy(
+                    &policy_value,
+                    &descriptor.policy_hash,
+                )?;
+                let xpub_str = keep_frost_net::find_local_external_xpub_in_tier(
+                    &policy,
+                    tier_index,
+                    &fingerprint,
+                )?;
 
                 let network =
                     <keep_bitcoin::Network as std::str::FromStr>::from_str(&descriptor.network)
@@ -676,18 +649,12 @@ impl App {
                     return Err("PSBT has no inputs".to_string());
                 }
 
-                // SEC: verify every input's tap_scripts entry is bound to
-                // its witness_utxo and references our x-only key BEFORE
-                // forwarding any sighash to the bunker. Fail closed.
-                let mut sighashes = Vec::with_capacity(psbt.inputs.len());
-                for i in 0..psbt.inputs.len() {
-                    let bundle =
-                        keep_bitcoin::verify_script_spend_input_binding(&psbt, i, &xonly_bytes)
-                            .map_err(|e| {
-                                format!("PSBT input {i} binding verification failed: {e}")
-                            })?;
-                    sighashes.push(bundle);
-                }
+                // SEC: verify every input upfront so we only forward sighashes
+                // for outputs we actually control. Fail closed before contacting
+                // the bunker.
+                let sighashes =
+                    keep_bitcoin::verify_all_script_spend_input_bindings(&psbt, &xonly_bytes)
+                        .map_err(|e| format!("PSBT binding verification failed: {e}"))?;
 
                 let client = keep_nip46::Nip46Client::connect_to(&bunker_uri)
                     .await

--- a/keep-desktop/src/app/wallet.rs
+++ b/keep-desktop/src/app/wallet.rs
@@ -88,7 +88,8 @@ impl App {
                 session_id,
                 fingerprint,
                 bunker_uri,
-            } => self.begin_approve_psbt(session_id, fingerprint, bunker_uri),
+                psbt_hash,
+            } => self.begin_approve_psbt(session_id, fingerprint, bunker_uri, psbt_hash),
             wallet::Event::StartSpend { wallet_idx } => {
                 if let Screen::Wallet(ws) = &mut self.screen {
                     if let Some(entry) = ws.descriptors.get(wallet_idx).cloned() {
@@ -308,10 +309,7 @@ impl App {
                                 s.approve = None;
                             }
                         }
-                        self.set_toast(
-                            "PSBT signature submitted".into(),
-                            ToastKind::Success,
-                        );
+                        self.set_toast("PSBT signature submitted".into(), ToastKind::Success);
                     }
                     Err(e) => {
                         if let Screen::Wallet(s) = &mut self.screen {
@@ -579,7 +577,8 @@ impl App {
         &mut self,
         session_id: [u8; 32],
         fingerprint: String,
-        bunker_uri: String,
+        bunker_uri: zeroize::Zeroizing<String>,
+        snapshot_psbt_hash: [u8; 32],
     ) -> Task<Message> {
         let Some(node) = self.get_frost_node() else {
             return Task::done(Message::ApprovePsbtResult(
@@ -596,6 +595,20 @@ impl App {
                 let psbt_bytes = node
                     .psbt_session_proposal_psbt(&session_id)
                     .ok_or_else(|| "session has no proposal PSBT".to_string())?;
+
+                // SEC: Re-hash the in-flight proposal PSBT and compare to the
+                // hash captured at the moment the operator opened the
+                // approve pane. Catches proposer-side swaps in the
+                // preview/sign window. Fail closed.
+                {
+                    use keep_bitcoin::bitcoin::hashes::{sha256, Hash as _};
+                    let recomputed: [u8; 32] = sha256::Hash::hash(&psbt_bytes).to_byte_array();
+                    if recomputed != snapshot_psbt_hash {
+                        return Err(
+                            "PSBT hash changed between preview and sign; aborting".to_string()
+                        );
+                    }
+                }
 
                 let group_pubkey = *node.group_pubkey();
                 let descriptor = tokio::task::spawn_blocking(move || {
@@ -614,41 +627,66 @@ impl App {
                     .ok_or_else(|| "Descriptor has no persisted WalletPolicy".to_string())?;
                 let policy: keep_frost_net::WalletPolicy = serde_json::from_value(policy_value)
                     .map_err(|e| format!("invalid persisted policy: {e}"))?;
+                // SEC: re-derive the policy hash and require it equals the
+                // hash stored alongside the descriptor. Otherwise a tampered
+                // policy could swap our resolved External slot xpub.
+                let recomputed_hash = keep_frost_net::derive_policy_hash(&policy);
+                if recomputed_hash != descriptor.policy_hash {
+                    return Err(
+                        "persisted policy hash does not match stored descriptor.policy_hash; refusing"
+                            .to_string(),
+                    );
+                }
                 let tier = policy
                     .recovery_tiers
                     .get(tier_index as usize)
                     .ok_or_else(|| format!("tier {tier_index} not in persisted policy"))?;
-                let xpub_str = tier
-                    .key_slots
-                    .iter()
-                    .find_map(|s| match s {
-                        keep_frost_net::KeySlot::External { xpub, fingerprint: fp }
-                            if fp.eq_ignore_ascii_case(&fingerprint) =>
-                        {
-                            Some(xpub.clone())
+                let mut xpub_str: Option<String> = None;
+                for slot in &tier.key_slots {
+                    if let keep_frost_net::KeySlot::External {
+                        xpub,
+                        fingerprint: fp,
+                    } = slot
+                    {
+                        if fp.eq_ignore_ascii_case(&fingerprint) {
+                            if xpub_str.is_some() {
+                                return Err(format!(
+                                    "tier {tier_index} has more than one External slot with fingerprint {fingerprint}; ambiguous responder"
+                                ));
+                            }
+                            xpub_str = Some(xpub.clone());
                         }
-                        _ => None,
-                    })
-                    .ok_or_else(|| {
-                        format!("no External key slot with fingerprint {fingerprint}")
-                    })?;
+                    }
+                }
+                let xpub_str = xpub_str.ok_or_else(|| {
+                    format!("no External key slot with fingerprint {fingerprint}")
+                })?;
 
-                let network = <keep_bitcoin::Network as std::str::FromStr>::from_str(
-                    &descriptor.network,
-                )
-                .map_err(|e| format!("invalid network: {e}"))?;
+                let network =
+                    <keep_bitcoin::Network as std::str::FromStr>::from_str(&descriptor.network)
+                        .map_err(|e| format!("invalid network: {e}"))?;
                 let xonly_bytes = keep_bitcoin::xpub_to_x_only(&xpub_str, network)
                     .map_err(|e| format!("xpub_to_x_only: {e}"))?;
                 let xonly = keep_bitcoin::bitcoin::XOnlyPublicKey::from_slice(&xonly_bytes)
                     .map_err(|e| format!("xonly decode: {e}"))?;
 
-                let mut psbt =
-                    keep_bitcoin::bitcoin::psbt::Psbt::deserialize(&psbt_bytes)
-                        .map_err(|e| format!("decode PSBT: {e}"))?;
-                let sighashes = keep_bitcoin::script_spend_sighashes(&psbt)
-                    .map_err(|e| format!("compute sighashes: {e}"))?;
-                if sighashes.is_empty() {
+                let mut psbt = keep_bitcoin::bitcoin::psbt::Psbt::deserialize(&psbt_bytes)
+                    .map_err(|e| format!("decode PSBT: {e}"))?;
+                if psbt.inputs.is_empty() {
                     return Err("PSBT has no inputs".to_string());
+                }
+
+                // SEC: verify every input's tap_scripts entry is bound to
+                // its witness_utxo and references our x-only key BEFORE
+                // forwarding any sighash to the bunker. Fail closed.
+                let mut sighashes = Vec::with_capacity(psbt.inputs.len());
+                for i in 0..psbt.inputs.len() {
+                    let bundle =
+                        keep_bitcoin::verify_script_spend_input_binding(&psbt, i, &xonly_bytes)
+                            .map_err(|e| {
+                                format!("PSBT input {i} binding verification failed: {e}")
+                            })?;
+                    sighashes.push(bundle);
                 }
 
                 let client = keep_nip46::Nip46Client::connect_to(&bunker_uri)
@@ -679,6 +717,7 @@ impl App {
                             sh.input_index,
                             xonly,
                             sh.leaf_hash,
+                            &sh.sighash,
                             sig,
                         )
                         .map_err(|e| format!("merge sig: {e}"))?;

--- a/keep-desktop/src/app/wallet.rs
+++ b/keep-desktop/src/app/wallet.rs
@@ -84,6 +84,11 @@ impl App {
             wallet::Event::RejectPsbt(session_id) => {
                 Task::done(Message::RejectPsbtSignature(session_id))
             }
+            wallet::Event::ApprovePsbt {
+                session_id,
+                fingerprint,
+                bunker_uri,
+            } => self.begin_approve_psbt(session_id, fingerprint, bunker_uri),
             wallet::Event::StartSpend { wallet_idx } => {
                 if let Screen::Wallet(ws) = &mut self.screen {
                     if let Some(entry) = ws.descriptors.get(wallet_idx).cloned() {
@@ -287,6 +292,37 @@ impl App {
                     }
                     Err(e) => {
                         self.set_toast(format!("PSBT reject failed: {e}"), ToastKind::Error);
+                    }
+                }
+                Task::none()
+            }
+            Message::ApprovePsbtResult(session_id, result) => {
+                match result {
+                    Ok(()) => {
+                        self.pending_psbt_signatures
+                            .retain(|e| e.session_id != session_id);
+                        if let Screen::Wallet(s) = &mut self.screen {
+                            s.pending_psbt_signatures
+                                .retain(|e| e.session_id != session_id);
+                            if s.approve.as_ref().map(|a| a.session_id) == Some(session_id) {
+                                s.approve = None;
+                            }
+                        }
+                        self.set_toast(
+                            "PSBT signature submitted".into(),
+                            ToastKind::Success,
+                        );
+                    }
+                    Err(e) => {
+                        if let Screen::Wallet(s) = &mut self.screen {
+                            if let Some(a) = s.approve.as_mut() {
+                                if a.session_id == session_id {
+                                    a.submitting = false;
+                                    a.error = Some(e.clone());
+                                }
+                            }
+                        }
+                        self.set_toast(format!("Approve failed: {e}"), ToastKind::Error);
                     }
                 }
                 Task::none()
@@ -531,6 +567,141 @@ impl App {
                 .map_err(|e| format!("{e}"))
             },
             Message::SpendStartedResult,
+        )
+    }
+
+    /// Run the responder approve chain for a single PSBT session: resolve the
+    /// xpub for `fingerprint` from the persisted `WalletPolicy`, compute the
+    /// script-spend sighash from the in-flight proposal PSBT, request a
+    /// Schnorr signature from the NIP-46 signer at `bunker_uri`, merge it,
+    /// and contribute the partial PSBT back to the initiator.
+    pub(crate) fn begin_approve_psbt(
+        &mut self,
+        session_id: [u8; 32],
+        fingerprint: String,
+        bunker_uri: String,
+    ) -> Task<Message> {
+        let Some(node) = self.get_frost_node() else {
+            return Task::done(Message::ApprovePsbtResult(
+                session_id,
+                Err("Relay not connected".into()),
+            ));
+        };
+        let keep_arc = self.keep.clone();
+        Task::perform(
+            async move {
+                let (initiator_pubkey, _descriptor_hash, tier_index) = node
+                    .psbt_session_routing(&session_id)
+                    .ok_or_else(|| "unknown PSBT session".to_string())?;
+                let psbt_bytes = node
+                    .psbt_session_proposal_psbt(&session_id)
+                    .ok_or_else(|| "session has no proposal PSBT".to_string())?;
+
+                let group_pubkey = *node.group_pubkey();
+                let descriptor = tokio::task::spawn_blocking(move || {
+                    with_keep_blocking(&keep_arc, "Failed to load descriptor", move |keep| {
+                        keep.get_wallet_descriptor(&group_pubkey)
+                            .map_err(friendly_err)?
+                            .ok_or_else(|| "No wallet descriptor for this group".to_string())
+                    })
+                })
+                .await
+                .map_err(|_| "Background task failed".to_string())??;
+
+                let policy_value = descriptor
+                    .policy
+                    .clone()
+                    .ok_or_else(|| "Descriptor has no persisted WalletPolicy".to_string())?;
+                let policy: keep_frost_net::WalletPolicy = serde_json::from_value(policy_value)
+                    .map_err(|e| format!("invalid persisted policy: {e}"))?;
+                let tier = policy
+                    .recovery_tiers
+                    .get(tier_index as usize)
+                    .ok_or_else(|| format!("tier {tier_index} not in persisted policy"))?;
+                let xpub_str = tier
+                    .key_slots
+                    .iter()
+                    .find_map(|s| match s {
+                        keep_frost_net::KeySlot::External { xpub, fingerprint: fp }
+                            if fp.eq_ignore_ascii_case(&fingerprint) =>
+                        {
+                            Some(xpub.clone())
+                        }
+                        _ => None,
+                    })
+                    .ok_or_else(|| {
+                        format!("no External key slot with fingerprint {fingerprint}")
+                    })?;
+
+                let network = <keep_bitcoin::Network as std::str::FromStr>::from_str(
+                    &descriptor.network,
+                )
+                .map_err(|e| format!("invalid network: {e}"))?;
+                let xonly_bytes = keep_bitcoin::xpub_to_x_only(&xpub_str, network)
+                    .map_err(|e| format!("xpub_to_x_only: {e}"))?;
+                let xonly = keep_bitcoin::bitcoin::XOnlyPublicKey::from_slice(&xonly_bytes)
+                    .map_err(|e| format!("xonly decode: {e}"))?;
+
+                let mut psbt =
+                    keep_bitcoin::bitcoin::psbt::Psbt::deserialize(&psbt_bytes)
+                        .map_err(|e| format!("decode PSBT: {e}"))?;
+                let sighashes = keep_bitcoin::script_spend_sighashes(&psbt)
+                    .map_err(|e| format!("compute sighashes: {e}"))?;
+                if sighashes.is_empty() {
+                    return Err("PSBT has no inputs".to_string());
+                }
+
+                let client = keep_nip46::Nip46Client::connect_to(&bunker_uri)
+                    .await
+                    .map_err(|e| format!("NIP-46 connect: {e}"))?;
+                let outcome: Result<(), String> = async {
+                    client
+                        .connect()
+                        .await
+                        .map_err(|e| format!("NIP-46 handshake: {e}"))?;
+                    for sh in &sighashes {
+                        let leaf_hash_bytes: [u8; 32] = {
+                            use keep_bitcoin::bitcoin::hashes::Hash as _;
+                            sh.leaf_hash.to_byte_array()
+                        };
+                        let sig = client
+                            .sign_tap_script(
+                                &sh.sighash,
+                                &xonly_bytes,
+                                &leaf_hash_bytes,
+                                sh.script.as_bytes(),
+                                &descriptor.external_descriptor,
+                            )
+                            .await
+                            .map_err(|e| format!("sign_tap_script: {e}"))?;
+                        keep_bitcoin::merge_tap_script_sig(
+                            &mut psbt,
+                            sh.input_index,
+                            xonly,
+                            sh.leaf_hash,
+                            sig,
+                        )
+                        .map_err(|e| format!("merge sig: {e}"))?;
+                    }
+                    Ok(())
+                }
+                .await;
+                client.disconnect().await;
+                outcome?;
+
+                let merged = psbt.serialize();
+                node.contribute_psbt_signature(
+                    session_id,
+                    &initiator_pubkey,
+                    keep_frost_net::SignerId::Fingerprint(fingerprint.clone()),
+                    merged,
+                )
+                .await
+                .map_err(|e| format!("contribute_psbt_signature: {e}"))?;
+
+                Ok::<(), String>(())
+            },
+            move |r| Message::ApprovePsbtResult(session_id, r),
         )
     }
 

--- a/keep-desktop/src/frost.rs
+++ b/keep-desktop/src/frost.rs
@@ -648,7 +648,17 @@ pub(crate) async fn frost_event_listener(
                         ..
                     }) => {
                         log!(EventLogType::Descriptor, "Descriptor complete".to_string());
-                        let policy_value = serde_json::to_value(&policy).ok();
+                        let policy_value = match serde_json::to_value(&policy) {
+                            Ok(v) => Some(v),
+                            Err(e) => {
+                                tracing::error!(
+                                    error = %e,
+                                    session = %hex::encode(&session_id[..8]),
+                                    "failed to serialize WalletPolicy to JSON (recovery-tier verification will be unavailable for this descriptor)",
+                                );
+                                None
+                            }
+                        };
                         push_frost_event(
                             &frost_events,
                             FrostNodeMsg::DescriptorComplete {

--- a/keep-desktop/src/frost.rs
+++ b/keep-desktop/src/frost.rs
@@ -643,9 +643,11 @@ pub(crate) async fn frost_event_listener(
                         external_descriptor,
                         internal_descriptor,
                         policy_hash,
+                        policy,
                         ..
                     }) => {
                         log!(EventLogType::Descriptor, "Descriptor complete".to_string());
+                        let policy_value = serde_json::to_value(&policy).ok();
                         push_frost_event(
                             &frost_events,
                             FrostNodeMsg::DescriptorComplete {
@@ -653,6 +655,7 @@ pub(crate) async fn frost_event_listener(
                                 external_descriptor,
                                 internal_descriptor,
                                 policy_hash,
+                                policy: policy_value,
                             },
                         );
                     }
@@ -1004,12 +1007,14 @@ impl App {
                 external_descriptor,
                 internal_descriptor,
                 policy_hash,
+                policy,
             } => {
                 self.handle_descriptor_complete(
                     session_id,
                     external_descriptor,
                     internal_descriptor,
                     policy_hash,
+                    policy,
                 );
             }
             FrostNodeMsg::DescriptorNacked {
@@ -1386,6 +1391,7 @@ impl App {
         external_descriptor: String,
         internal_descriptor: String,
         policy_hash: [u8; 32],
+        policy: Option<serde_json::Value>,
     ) {
         let Some(coord) = self.active_coordinations.remove(&session_id) else {
             return;
@@ -1402,6 +1408,7 @@ impl App {
             created_at,
             device_registrations: Vec::new(),
             policy_hash,
+            policy,
         };
 
         let store_result = {

--- a/keep-desktop/src/frost.rs
+++ b/keep-desktop/src/frost.rs
@@ -644,9 +644,11 @@ pub(crate) async fn frost_event_listener(
                         external_descriptor,
                         internal_descriptor,
                         policy_hash,
+                        policy,
                         ..
                     }) => {
                         log!(EventLogType::Descriptor, "Descriptor complete".to_string());
+                        let policy_value = serde_json::to_value(&policy).ok();
                         push_frost_event(
                             &frost_events,
                             FrostNodeMsg::DescriptorComplete {
@@ -654,6 +656,7 @@ pub(crate) async fn frost_event_listener(
                                 external_descriptor,
                                 internal_descriptor,
                                 policy_hash,
+                                policy: policy_value,
                             },
                         );
                     }
@@ -1012,12 +1015,14 @@ impl App {
                 external_descriptor,
                 internal_descriptor,
                 policy_hash,
+                policy,
             } => {
                 self.handle_descriptor_complete(
                     session_id,
                     external_descriptor,
                     internal_descriptor,
                     policy_hash,
+                    policy,
                 );
             }
             FrostNodeMsg::DescriptorNacked {
@@ -1394,6 +1399,7 @@ impl App {
         external_descriptor: String,
         internal_descriptor: String,
         policy_hash: [u8; 32],
+        policy: Option<serde_json::Value>,
     ) {
         let Some(coord) = self.active_coordinations.remove(&session_id) else {
             return;
@@ -1412,6 +1418,7 @@ impl App {
             policy_hash,
             version: INITIAL_DESCRIPTOR_VERSION,
             previous_descriptor_hash: None,
+            policy,
         };
 
         let store_result = {

--- a/keep-desktop/src/message.rs
+++ b/keep-desktop/src/message.rs
@@ -194,6 +194,7 @@ pub enum Message {
     WalletRegisterResult(Result<(), String>),
     RejectPsbtSignature([u8; 32]),
     RejectPsbtSignatureResult([u8; 32], Result<(), String>),
+    ApprovePsbtResult([u8; 32], Result<(), String>),
     CancelSpendResult([u8; 32], Result<(), String>),
     SpendStartedResult(Result<[u8; 32], String>),
 
@@ -514,6 +515,11 @@ impl fmt::Debug for Message {
                 .finish(),
             Self::RejectPsbtSignatureResult(id, r) => f
                 .debug_tuple("RejectPsbtSignatureResult")
+                .field(&hex::encode(id))
+                .field(&r.as_ref().map(|_| "ok").map_err(|e| e.as_str()))
+                .finish(),
+            Self::ApprovePsbtResult(id, r) => f
+                .debug_tuple("ApprovePsbtResult")
                 .field(&hex::encode(id))
                 .field(&r.as_ref().map(|_| "ok").map_err(|e| e.as_str()))
                 .finish(),

--- a/keep-desktop/src/message.rs
+++ b/keep-desktop/src/message.rs
@@ -281,6 +281,7 @@ pub enum FrostNodeMsg {
         external_descriptor: String,
         internal_descriptor: String,
         policy_hash: [u8; 32],
+        policy: Option<serde_json::Value>,
     },
     DescriptorAcked {
         session_id: [u8; 32],

--- a/keep-desktop/src/screen/wallet.rs
+++ b/keep-desktop/src/screen/wallet.rs
@@ -1778,10 +1778,12 @@ impl State {
             submit_btn = submit_btn.on_press(Message::SubmitApprovePsbt);
         }
 
-        let cancel_btn = button(text("Cancel").size(theme::size::SMALL))
-            .on_press(Message::CancelApprovePsbt)
+        let mut cancel_btn = button(text("Cancel").size(theme::size::SMALL))
             .style(theme::secondary_button)
             .padding([theme::space::XS, theme::space::MD]);
+        if !state.submitting {
+            cancel_btn = cancel_btn.on_press(Message::CancelApprovePsbt);
+        }
 
         let mut content = column![
             text("Approve via NIP-46 signer")

--- a/keep-desktop/src/screen/wallet.rs
+++ b/keep-desktop/src/screen/wallet.rs
@@ -270,10 +270,9 @@ impl std::fmt::Debug for Message {
                 .field(&hex::encode(id))
                 .finish(),
             Self::ApproveBunkerUriChanged(_) => write!(f, "ApproveBunkerUriChanged(<redacted>)"),
-            Self::ApproveFingerprintChanged(v) => f
-                .debug_tuple("ApproveFingerprintChanged")
-                .field(v)
-                .finish(),
+            Self::ApproveFingerprintChanged(v) => {
+                f.debug_tuple("ApproveFingerprintChanged").field(v).finish()
+            }
             Self::CancelApprovePsbt => write!(f, "CancelApprovePsbt"),
             Self::SubmitApprovePsbt => write!(f, "SubmitApprovePsbt"),
             Self::StartSpend(i) => f.debug_tuple("StartSpend").field(i).finish(),
@@ -322,7 +321,12 @@ pub enum Event {
     ApprovePsbt {
         session_id: [u8; 32],
         fingerprint: String,
-        bunker_uri: String,
+        bunker_uri: zeroize::Zeroizing<String>,
+        /// PSBT hash captured at the moment the operator opened the approve
+        /// pane (i.e. while reviewing the snapshot). If the in-flight
+        /// proposal PSBT no longer hashes to this value at sign time, the
+        /// approval must abort.
+        psbt_hash: [u8; 32],
     },
     StartSpend {
         wallet_idx: usize,
@@ -367,7 +371,7 @@ pub struct State {
     pub peer_xpubs: HashMap<u16, Vec<AnnouncedXpub>>,
     pub pending_psbt_signatures: Vec<PsbtPendingDisplay>,
     pub spend: Option<Box<SpendState>>,
-    pub approve: Option<ApprovePsbtState>,
+    pub approve: Option<Box<ApprovePsbtState>>,
 }
 
 /// Modal state for approving an incoming PSBT signature request. Only shown
@@ -375,10 +379,17 @@ pub struct State {
 /// card's snapshot decoded successfully (so destinations are visible).
 pub struct ApprovePsbtState {
     pub session_id: [u8; 32],
-    pub bunker_uri: String,
+    /// Bunker URI buffer. Wrapped in `Zeroizing` because operators may paste
+    /// URIs that embed a single-use connect secret; we don't want stale
+    /// copies left in the UI heap after the pane closes.
+    pub bunker_uri: zeroize::Zeroizing<String>,
     pub fingerprint: String,
     pub error: Option<String>,
     pub submitting: bool,
+    /// PSBT hash captured from the snapshot at the moment the operator
+    /// opened this approval pane. Sent through to the signer task so it can
+    /// re-verify the proposal PSBT hasn't been swapped mid-review.
+    pub snapshot_psbt_hash: [u8; 32],
 }
 
 pub struct SetupState {
@@ -515,23 +526,27 @@ impl State {
                     .iter()
                     .find(|e| e.session_id == session_id)
                     .cloned();
-                match entry {
-                    Some(entry) if entry.snapshot.is_some() => {
-                        self.approve = Some(ApprovePsbtState {
+                if let Some(entry) = entry {
+                    if let Some(snap) = entry.snapshot.as_ref() {
+                        // Only open the approve pane when the snapshot
+                        // decoded fully (caller already gates the button
+                        // on this, but defense in depth).
+                        self.approve = Some(Box::new(ApprovePsbtState {
                             session_id,
-                            bunker_uri: String::new(),
+                            bunker_uri: zeroize::Zeroizing::new(String::new()),
                             fingerprint: String::new(),
                             error: None,
                             submitting: false,
-                        });
+                            snapshot_psbt_hash: snap.psbt_hash,
+                        }));
                     }
-                    _ => {}
                 }
                 None
             }
             Message::ApproveBunkerUriChanged(v) => {
                 if let Some(a) = &mut self.approve {
-                    a.bunker_uri = v.chars().take(MAX_DEVICE_URI_LEN).collect();
+                    a.bunker_uri =
+                        zeroize::Zeroizing::new(v.chars().take(MAX_DEVICE_URI_LEN).collect());
                 }
                 None
             }
@@ -553,7 +568,7 @@ impl State {
                 let Some(a) = &mut self.approve else {
                     return None;
                 };
-                let uri = a.bunker_uri.trim().to_string();
+                let uri = zeroize::Zeroizing::new(a.bunker_uri.trim().to_string());
                 let fp = a.fingerprint.trim().to_ascii_lowercase();
                 if !uri.starts_with("bunker://") {
                     a.error = Some("Bunker URI must start with bunker://".into());
@@ -565,10 +580,12 @@ impl State {
                 }
                 a.error = None;
                 a.submitting = true;
+                let snapshot_psbt_hash = a.snapshot_psbt_hash;
                 Some(Event::ApprovePsbt {
                     session_id: a.session_id,
                     fingerprint: fp,
                     bunker_uri: uri,
+                    psbt_hash: snapshot_psbt_hash,
                 })
             }
             Message::StartRegister(i) => {
@@ -1842,16 +1859,27 @@ impl State {
                         .size(theme::size::TINY)
                         .color(theme::color::TEXT_MUTED)]
                     .spacing(theme::space::XS);
+                    // Show every output's FULL address (or fail-closed marker
+                    // for un-decodable scripts). Left-truncation here is a
+                    // homograph footgun — the prefix of a benign-looking
+                    // address can be identical to a malicious one.
+                    let mut all_outputs_decoded = !snap.outputs.is_empty();
                     for (addr, sats) in &snap.outputs {
-                        let addr_short = addr.get(..40).unwrap_or(addr.as_str());
+                        if addr.starts_with("script:") {
+                            all_outputs_decoded = false;
+                        }
                         outputs_col = outputs_col.push(
-                            text(format!("  {addr_short}  →  {sats} sats"))
+                            text(format!("  {addr}  ->  {sats} sats"))
                                 .size(theme::size::TINY)
                                 .color(theme::color::TEXT_DIM),
                         );
                     }
 
-                    let preview_decoded = !snap.outputs.is_empty();
+                    // Gate the Approve button on snapshot presence AND every
+                    // output decoding to an address. A `script:` fallback
+                    // means the operator can't actually verify the
+                    // destination, so we must not offer a one-click sign.
+                    let preview_decoded = all_outputs_decoded;
                     let approve_btn: Element<'_, Message> = if preview_decoded
                         && self.approve.as_ref().map(|a| a.session_id) != Some(entry.session_id)
                     {
@@ -1864,11 +1892,14 @@ impl State {
                         text("").into()
                     };
 
-                    let approve_pane: Element<'_, Message> =
-                        match self.approve.as_ref().filter(|a| a.session_id == entry.session_id) {
-                            Some(a) => self.view_approve_pane(a),
-                            None => text("").into(),
-                        };
+                    let approve_pane: Element<'_, Message> = match self
+                        .approve
+                        .as_ref()
+                        .filter(|a| a.session_id == entry.session_id)
+                    {
+                        Some(a) => self.view_approve_pane(a),
+                        None => text("").into(),
+                    };
 
                     container(
                         column![

--- a/keep-desktop/src/screen/wallet.rs
+++ b/keep-desktop/src/screen/wallet.rs
@@ -1759,6 +1759,7 @@ impl State {
     fn view_approve_pane<'a>(&self, state: &'a ApprovePsbtState) -> Element<'a, Message> {
         let uri_input = text_input("bunker://...", &state.bunker_uri)
             .on_input(Message::ApproveBunkerUriChanged)
+            .secure(true)
             .padding(theme::space::SM);
         let fp_input = text_input("8 hex chars", &state.fingerprint)
             .on_input(Message::ApproveFingerprintChanged)

--- a/keep-desktop/src/screen/wallet.rs
+++ b/keep-desktop/src/screen/wallet.rs
@@ -216,6 +216,11 @@ pub enum Message {
     CancelRegister,
     SubmitRegister,
     RejectPsbt([u8; 32]),
+    StartApprovePsbt([u8; 32]),
+    ApproveBunkerUriChanged(String),
+    ApproveFingerprintChanged(String),
+    CancelApprovePsbt,
+    SubmitApprovePsbt,
     StartSpend(usize),
     SpendTierChanged(String),
     SpendPsbtChanged(String),
@@ -260,6 +265,17 @@ impl std::fmt::Debug for Message {
             Self::CancelRegister => write!(f, "CancelRegister"),
             Self::SubmitRegister => write!(f, "SubmitRegister"),
             Self::RejectPsbt(id) => f.debug_tuple("RejectPsbt").field(&hex::encode(id)).finish(),
+            Self::StartApprovePsbt(id) => f
+                .debug_tuple("StartApprovePsbt")
+                .field(&hex::encode(id))
+                .finish(),
+            Self::ApproveBunkerUriChanged(_) => write!(f, "ApproveBunkerUriChanged(<redacted>)"),
+            Self::ApproveFingerprintChanged(v) => f
+                .debug_tuple("ApproveFingerprintChanged")
+                .field(v)
+                .finish(),
+            Self::CancelApprovePsbt => write!(f, "CancelApprovePsbt"),
+            Self::SubmitApprovePsbt => write!(f, "SubmitApprovePsbt"),
             Self::StartSpend(i) => f.debug_tuple("StartSpend").field(i).finish(),
             Self::SpendTierChanged(v) => f.debug_tuple("SpendTierChanged").field(v).finish(),
             Self::SpendPsbtChanged(_) => write!(f, "SpendPsbtChanged(<redacted>)"),
@@ -303,6 +319,11 @@ pub enum Event {
         device_kind: Option<String>,
     },
     RejectPsbt([u8; 32]),
+    ApprovePsbt {
+        session_id: [u8; 32],
+        fingerprint: String,
+        bunker_uri: String,
+    },
     StartSpend {
         wallet_idx: usize,
     },
@@ -346,6 +367,18 @@ pub struct State {
     pub peer_xpubs: HashMap<u16, Vec<AnnouncedXpub>>,
     pub pending_psbt_signatures: Vec<PsbtPendingDisplay>,
     pub spend: Option<Box<SpendState>>,
+    pub approve: Option<ApprovePsbtState>,
+}
+
+/// Modal state for approving an incoming PSBT signature request. Only shown
+/// after the user clicks "Review & Approve" on a pending PSBT card *and* that
+/// card's snapshot decoded successfully (so destinations are visible).
+pub struct ApprovePsbtState {
+    pub session_id: [u8; 32],
+    pub bunker_uri: String,
+    pub fingerprint: String,
+    pub error: Option<String>,
+    pub submitting: bool,
 }
 
 pub struct SetupState {
@@ -369,6 +402,7 @@ impl State {
             peer_xpubs: HashMap::new(),
             pending_psbt_signatures: Vec::new(),
             spend: None,
+            approve: None,
         }
     }
 
@@ -475,6 +509,68 @@ impl State {
             }
             Message::CopyDescriptor(desc) => Some(Event::CopyDescriptor(desc)),
             Message::RejectPsbt(id) => Some(Event::RejectPsbt(id)),
+            Message::StartApprovePsbt(session_id) => {
+                let entry = self
+                    .pending_psbt_signatures
+                    .iter()
+                    .find(|e| e.session_id == session_id)
+                    .cloned();
+                match entry {
+                    Some(entry) if entry.snapshot.is_some() => {
+                        self.approve = Some(ApprovePsbtState {
+                            session_id,
+                            bunker_uri: String::new(),
+                            fingerprint: String::new(),
+                            error: None,
+                            submitting: false,
+                        });
+                    }
+                    _ => {}
+                }
+                None
+            }
+            Message::ApproveBunkerUriChanged(v) => {
+                if let Some(a) = &mut self.approve {
+                    a.bunker_uri = v.chars().take(MAX_DEVICE_URI_LEN).collect();
+                }
+                None
+            }
+            Message::ApproveFingerprintChanged(v) => {
+                if let Some(a) = &mut self.approve {
+                    a.fingerprint = v
+                        .chars()
+                        .filter(|c| c.is_ascii_hexdigit())
+                        .take(8)
+                        .collect();
+                }
+                None
+            }
+            Message::CancelApprovePsbt => {
+                self.approve = None;
+                None
+            }
+            Message::SubmitApprovePsbt => {
+                let Some(a) = &mut self.approve else {
+                    return None;
+                };
+                let uri = a.bunker_uri.trim().to_string();
+                let fp = a.fingerprint.trim().to_ascii_lowercase();
+                if !uri.starts_with("bunker://") {
+                    a.error = Some("Bunker URI must start with bunker://".into());
+                    return None;
+                }
+                if fp.len() != 8 || !fp.chars().all(|c| c.is_ascii_hexdigit()) {
+                    a.error = Some("Fingerprint must be 8 hex characters".into());
+                    return None;
+                }
+                a.error = None;
+                a.submitting = true;
+                Some(Event::ApprovePsbt {
+                    session_id: a.session_id,
+                    fingerprint: fp,
+                    bunker_uri: uri,
+                })
+            }
             Message::StartRegister(i) => {
                 if let Some(entry) = self.descriptors.get(i) {
                     let default_name = hex::encode(&entry.group_pubkey[..4]);
@@ -1643,6 +1739,52 @@ impl State {
             .into()
     }
 
+    fn view_approve_pane<'a>(&self, state: &'a ApprovePsbtState) -> Element<'a, Message> {
+        let uri_input = text_input("bunker://...", &state.bunker_uri)
+            .on_input(Message::ApproveBunkerUriChanged)
+            .padding(theme::space::SM);
+        let fp_input = text_input("8 hex chars", &state.fingerprint)
+            .on_input(Message::ApproveFingerprintChanged)
+            .padding(theme::space::SM)
+            .width(120);
+
+        let uri_valid = state.bunker_uri.trim().starts_with("bunker://");
+        let fp_valid = state.fingerprint.len() == 8
+            && state.fingerprint.chars().all(|c| c.is_ascii_hexdigit());
+        let can_submit = uri_valid && fp_valid && !state.submitting;
+
+        let mut submit_btn = button(text("Confirm Approve").size(theme::size::SMALL))
+            .style(theme::primary_button)
+            .padding([theme::space::XS, theme::space::MD]);
+        if can_submit {
+            submit_btn = submit_btn.on_press(Message::SubmitApprovePsbt);
+        }
+
+        let cancel_btn = button(text("Cancel").size(theme::size::SMALL))
+            .on_press(Message::CancelApprovePsbt)
+            .style(theme::secondary_button)
+            .padding([theme::space::XS, theme::space::MD]);
+
+        let mut content = column![
+            text("Approve via NIP-46 signer")
+                .size(theme::size::SMALL)
+                .color(theme::color::TEXT_MUTED),
+            theme::label("Bunker URI"),
+            uri_input,
+            theme::label("Local xpub fingerprint"),
+            fp_input,
+            row![submit_btn, cancel_btn].spacing(theme::space::SM),
+        ]
+        .spacing(theme::space::XS);
+        if let Some(err) = &state.error {
+            content = content.push(theme::error_text(err.as_str()));
+        }
+        container(content)
+            .padding(theme::space::SM)
+            .width(Length::Fill)
+            .into()
+    }
+
     fn pending_psbt_signatures_section(&self) -> Element<'_, Message> {
         let mut request_list = column![].spacing(theme::space::SM);
 
@@ -1696,9 +1838,47 @@ impl State {
                     ]
                     .spacing(theme::space::XS);
 
+                    let mut outputs_col = column![text("Destinations:")
+                        .size(theme::size::TINY)
+                        .color(theme::color::TEXT_MUTED)]
+                    .spacing(theme::space::XS);
+                    for (addr, sats) in &snap.outputs {
+                        let addr_short = addr.get(..40).unwrap_or(addr.as_str());
+                        outputs_col = outputs_col.push(
+                            text(format!("  {addr_short}  →  {sats} sats"))
+                                .size(theme::size::TINY)
+                                .color(theme::color::TEXT_DIM),
+                        );
+                    }
+
+                    let preview_decoded = !snap.outputs.is_empty();
+                    let approve_btn: Element<'_, Message> = if preview_decoded
+                        && self.approve.as_ref().map(|a| a.session_id) != Some(entry.session_id)
+                    {
+                        button(text("Review & Approve").size(theme::size::SMALL))
+                            .on_press(Message::StartApprovePsbt(entry.session_id))
+                            .style(theme::primary_button)
+                            .padding([theme::space::XS, theme::space::MD])
+                            .into()
+                    } else {
+                        text("").into()
+                    };
+
+                    let approve_pane: Element<'_, Message> =
+                        match self.approve.as_ref().filter(|a| a.session_id == entry.session_id) {
+                            Some(a) => self.view_approve_pane(a),
+                            None => text("").into(),
+                        };
+
                     container(
-                        column![header, details, row![reject_btn].spacing(theme::space::SM)]
-                            .spacing(theme::space::XS),
+                        column![
+                            header,
+                            details,
+                            outputs_col,
+                            approve_pane,
+                            row![reject_btn, approve_btn].spacing(theme::space::SM),
+                        ]
+                        .spacing(theme::space::XS),
                     )
                     .style(theme::warning_style)
                     .padding(theme::space::MD)

--- a/keep-frost-net/src/descriptor_session.rs
+++ b/keep-frost-net/src/descriptor_session.rs
@@ -839,6 +839,55 @@ pub fn derive_policy_hash(policy: &WalletPolicy) -> [u8; 32] {
     hasher.finalize().into()
 }
 
+/// Deserialize a persisted `WalletPolicy` and require its content hash
+/// equals `expected_policy_hash`. A tampered policy could swap the
+/// responder's resolved External slot xpub, so we fail closed.
+pub fn load_verified_wallet_policy(
+    policy_json: &serde_json::Value,
+    expected_policy_hash: &[u8; 32],
+) -> std::result::Result<WalletPolicy, String> {
+    let policy: WalletPolicy = serde_json::from_value(policy_json.clone())
+        .map_err(|e| format!("invalid persisted wallet policy: {e}"))?;
+    if &derive_policy_hash(&policy) != expected_policy_hash {
+        return Err(
+            "persisted wallet policy hash does not match stored descriptor.policy_hash; refusing"
+                .into(),
+        );
+    }
+    Ok(policy)
+}
+
+/// Resolve the External `(xpub, fingerprint)` slot in `tier_index` whose
+/// fingerprint matches `local_fp`. Errors if more than one External slot in
+/// the tier shares the same fingerprint, since that makes responder
+/// selection ambiguous.
+pub fn find_local_external_xpub_in_tier(
+    policy: &WalletPolicy,
+    tier_index: u32,
+    local_fp: &str,
+) -> std::result::Result<String, String> {
+    let tier = policy
+        .recovery_tiers
+        .get(tier_index as usize)
+        .ok_or_else(|| format!("tier {tier_index} not present in persisted policy"))?;
+    let mut found: Option<String> = None;
+    for slot in &tier.key_slots {
+        if let KeySlot::External { xpub, fingerprint } = slot {
+            if fingerprint.eq_ignore_ascii_case(local_fp) {
+                if found.is_some() {
+                    return Err(format!(
+                        "tier {tier_index} has more than one External slot with fingerprint {local_fp}; ambiguous responder"
+                    ));
+                }
+                found = Some(xpub.clone());
+            }
+        }
+    }
+    found.ok_or_else(|| {
+        format!("no External key slot with fingerprint {local_fp} found in tier {tier_index}")
+    })
+}
+
 pub fn derive_descriptor_session_id(
     group_pubkey: &[u8; 32],
     policy: &WalletPolicy,

--- a/keep-frost-net/src/descriptor_session.rs
+++ b/keep-frost-net/src/descriptor_session.rs
@@ -848,6 +848,55 @@ pub fn derive_policy_hash(policy: &WalletPolicy) -> [u8; 32] {
     hasher.finalize().into()
 }
 
+/// Deserialize a persisted `WalletPolicy` and require its content hash
+/// equals `expected_policy_hash`. A tampered policy could swap the
+/// responder's resolved External slot xpub, so we fail closed.
+pub fn load_verified_wallet_policy(
+    policy_json: &serde_json::Value,
+    expected_policy_hash: &[u8; 32],
+) -> std::result::Result<WalletPolicy, String> {
+    let policy: WalletPolicy = serde_json::from_value(policy_json.clone())
+        .map_err(|e| format!("invalid persisted wallet policy: {e}"))?;
+    if &derive_policy_hash(&policy) != expected_policy_hash {
+        return Err(
+            "persisted wallet policy hash does not match stored descriptor.policy_hash; refusing"
+                .into(),
+        );
+    }
+    Ok(policy)
+}
+
+/// Resolve the External `(xpub, fingerprint)` slot in `tier_index` whose
+/// fingerprint matches `local_fp`. Errors if more than one External slot in
+/// the tier shares the same fingerprint, since that makes responder
+/// selection ambiguous.
+pub fn find_local_external_xpub_in_tier(
+    policy: &WalletPolicy,
+    tier_index: u32,
+    local_fp: &str,
+) -> std::result::Result<String, String> {
+    let tier = policy
+        .recovery_tiers
+        .get(tier_index as usize)
+        .ok_or_else(|| format!("tier {tier_index} not present in persisted policy"))?;
+    let mut found: Option<String> = None;
+    for slot in &tier.key_slots {
+        if let KeySlot::External { xpub, fingerprint } = slot {
+            if fingerprint.eq_ignore_ascii_case(local_fp) {
+                if found.is_some() {
+                    return Err(format!(
+                        "tier {tier_index} has more than one External slot with fingerprint {local_fp}; ambiguous responder"
+                    ));
+                }
+                found = Some(xpub.clone());
+            }
+        }
+    }
+    found.ok_or_else(|| {
+        format!("no External key slot with fingerprint {local_fp} found in tier {tier_index}")
+    })
+}
+
 pub fn derive_descriptor_session_id(
     group_pubkey: &[u8; 32],
     policy: &WalletPolicy,

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -70,6 +70,7 @@ mod peer;
 pub mod proof;
 mod protocol;
 mod psbt_session;
+mod recovery_signers;
 mod session;
 
 pub use attestation::{derive_attestation_nonce, verify_peer_attestation, ExpectedPcrs};
@@ -118,6 +119,9 @@ pub use protocol::{
 };
 pub use psbt_session::{
     derive_psbt_session_id, PsbtSession, PsbtSessionManager, PsbtSessionState, SignerId,
+};
+pub use recovery_signers::{
+    InMemoryRecoverySignerRegistry, RecoverySignerHandle, RecoverySignerRegistry,
 };
 pub use session::{derive_session_id, NetworkSession, SessionManager, SessionState};
 

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -77,10 +77,11 @@ pub use attestation::{derive_attestation_nonce, verify_peer_attestation, Expecte
 pub use audit::{SigningAuditEntry, SigningAuditLog, SigningOperation};
 pub use cert_pin::{verify_relay_certificate, CertificatePinSet, SpkiHash};
 pub use descriptor_session::{
-    derive_descriptor_session_id, derive_policy_hash, participant_indices, reconstruct_descriptor,
-    DescriptorSession, DescriptorSessionManager, DescriptorSessionState, DescriptorSessionStore,
-    FinalizedDescriptor, PersistedDescriptorSession, PersistedFinalizedDescriptor,
-    PersistedSessionState, XpubContribution,
+    derive_descriptor_session_id, derive_policy_hash, find_local_external_xpub_in_tier,
+    load_verified_wallet_policy, participant_indices, reconstruct_descriptor, DescriptorSession,
+    DescriptorSessionManager, DescriptorSessionState, DescriptorSessionStore, FinalizedDescriptor,
+    PersistedDescriptorSession, PersistedFinalizedDescriptor, PersistedSessionState,
+    XpubContribution,
 };
 pub use descriptor_session_store::FileDescriptorSessionStore;
 pub use ecdh::{

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -70,6 +70,7 @@ mod peer;
 pub mod proof;
 mod protocol;
 mod psbt_session;
+mod recovery_signers;
 mod session;
 
 pub use attestation::{derive_attestation_nonce, verify_peer_attestation, ExpectedPcrs};
@@ -117,6 +118,9 @@ pub use protocol::{
 };
 pub use psbt_session::{
     derive_psbt_session_id, PsbtSession, PsbtSessionManager, PsbtSessionState, SignerId,
+};
+pub use recovery_signers::{
+    InMemoryRecoverySignerRegistry, RecoverySignerHandle, RecoverySignerRegistry,
 };
 pub use session::{derive_session_id, NetworkSession, SessionManager, SessionState};
 

--- a/keep-frost-net/src/node/descriptor.rs
+++ b/keep-frost-net/src/node/descriptor.rs
@@ -1355,6 +1355,12 @@ impl KfpNode {
             return Ok(());
         }
 
+        if !self.can_receive_from(&sender) {
+            return Err(FrostNetError::PolicyViolation(format!(
+                "Peer {sender} not allowed to announce recovery xpubs"
+            )));
+        }
+
         if !payload.is_within_replay_window(self.replay_window_secs) {
             return Err(FrostNetError::ReplayDetected(
                 "XpubAnnounce timestamp outside replay window".into(),

--- a/keep-frost-net/src/node/descriptor.rs
+++ b/keep-frost-net/src/node/descriptor.rs
@@ -905,7 +905,13 @@ impl KfpNode {
 
         let our_index = self.share.metadata.identifier;
 
-        let (reconstruction_result, session_network, our_xpub, session_policy_version) = {
+        let (
+            reconstruction_result,
+            session_network,
+            our_xpub,
+            session_policy_version,
+            session_policy,
+        ) = {
             let sessions = self.descriptor_sessions.read();
             let session = sessions
                 .get_session(&payload.session_id)
@@ -913,6 +919,7 @@ impl KfpNode {
 
             let network = session.network().to_string();
             let policy_version = session.policy().version;
+            let policy = session.policy().clone();
 
             let initiator = session.initiator().ok_or_else(|| {
                 let _ = self.event_tx.send(KfpNodeEvent::DescriptorFailed {
@@ -955,7 +962,7 @@ impl KfpNode {
                 )
                 .map_err(|e| format!("Descriptor reconstruction failed: {e}"))
             };
-            (result, network, our_xpub, policy_version)
+            (result, network, our_xpub, policy_version, policy)
         };
 
         let (expected_external, expected_internal) = match reconstruction_result {
@@ -1099,6 +1106,7 @@ impl KfpNode {
             network: session_network,
             policy_hash: payload.policy_hash,
             version: session_policy_version,
+            policy: session_policy,
         });
 
         Ok(())
@@ -1302,6 +1310,7 @@ impl KfpNode {
                         network: session.network().to_string(),
                         policy_hash: desc.policy_hash,
                         version: session.policy().version,
+                        policy: session.policy().clone(),
                     });
                 }
             }

--- a/keep-frost-net/src/node/descriptor.rs
+++ b/keep-frost-net/src/node/descriptor.rs
@@ -543,13 +543,14 @@ impl KfpNode {
 
         let our_index = self.share.metadata.identifier;
 
-        let (reconstruction_result, session_network, our_xpub) = {
+        let (reconstruction_result, session_network, our_xpub, session_policy) = {
             let sessions = self.descriptor_sessions.read();
             let session = sessions
                 .get_session(&payload.session_id)
                 .ok_or_else(|| FrostNetError::Session("unknown descriptor session".into()))?;
 
             let network = session.network().to_string();
+            let policy = session.policy().clone();
 
             let initiator = session.initiator().ok_or_else(|| {
                 let _ = self.event_tx.send(KfpNodeEvent::DescriptorFailed {
@@ -592,7 +593,7 @@ impl KfpNode {
                 )
                 .map_err(|e| format!("Descriptor reconstruction failed: {e}"))
             };
-            (result, network, our_xpub)
+            (result, network, our_xpub, policy)
         };
 
         let (expected_external, expected_internal) = match reconstruction_result {
@@ -734,6 +735,7 @@ impl KfpNode {
             internal_descriptor: payload.internal_descriptor,
             network: session_network,
             policy_hash: payload.policy_hash,
+            policy: session_policy,
         });
 
         Ok(())
@@ -936,6 +938,7 @@ impl KfpNode {
                         internal_descriptor: desc.internal.clone(),
                         network: session.network().to_string(),
                         policy_hash: desc.policy_hash,
+                        policy: session.policy().clone(),
                     });
                 }
             }

--- a/keep-frost-net/src/node/descriptor.rs
+++ b/keep-frost-net/src/node/descriptor.rs
@@ -1397,6 +1397,7 @@ impl KfpNode {
             let Some(peer) = peers.get_peer_mut(payload.share_index) else {
                 return Ok(());
             };
+            peer.touch();
             peer.set_recovery_xpubs(payload.recovery_xpubs.clone());
         }
 

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -305,6 +305,7 @@ pub enum KfpNodeEvent {
         /// migration lineage is preserved when this completion was a v2+
         /// descriptor.
         version: u32,
+        policy: WalletPolicy,
     },
     DescriptorAcked {
         session_id: [u8; 32],
@@ -561,6 +562,8 @@ pub struct KfpNode {
     pub(crate) psbt_proposers: RwLock<HashSet<u16>>,
     pub(crate) local_recovery_xpubs: RwLock<Vec<AnnouncedXpub>>,
     pub(crate) descriptor_lookup: Option<Arc<dyn PersistedDescriptorLookup>>,
+    pub(crate) recovery_signer_registry:
+        Option<Arc<dyn crate::recovery_signers::RecoverySignerRegistry>>,
 }
 
 /// Strip control characters, clamp to `MAX_NACK_REASON_LENGTH`, and return a
@@ -728,12 +731,37 @@ impl KfpNode {
             psbt_proposers: RwLock::new(HashSet::new()),
             local_recovery_xpubs: RwLock::new(Vec::new()),
             descriptor_lookup: None,
+            recovery_signer_registry: None,
         })
     }
 
     pub fn with_descriptor_lookup(mut self, lookup: Arc<dyn PersistedDescriptorLookup>) -> Self {
         self.descriptor_lookup = Some(lookup);
         self
+    }
+
+    /// Attach a registry mapping recovery-tier xpub fingerprints to external
+    /// NIP-46 signers. Callers handling `PsbtSignatureNeeded` events use
+    /// `resolve_recovery_signer` to look up the configured bunker URI for a
+    /// given fingerprint.
+    pub fn with_recovery_signer_registry(
+        mut self,
+        registry: Arc<dyn crate::recovery_signers::RecoverySignerRegistry>,
+    ) -> Self {
+        self.recovery_signer_registry = Some(registry);
+        self
+    }
+
+    /// Resolve a recovery-tier xpub fingerprint to a registered external
+    /// signer, or `None` if no registry is attached or the fingerprint has
+    /// no entry.
+    pub fn resolve_recovery_signer(
+        &self,
+        fingerprint: &str,
+    ) -> Option<crate::recovery_signers::RecoverySignerHandle> {
+        self.recovery_signer_registry
+            .as_ref()
+            .and_then(|r| r.resolve(fingerprint))
     }
 
     pub fn with_descriptor_session_store(

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -253,6 +253,7 @@ pub enum KfpNodeEvent {
         internal_descriptor: String,
         network: String,
         policy_hash: [u8; 32],
+        policy: WalletPolicy,
     },
     DescriptorAcked {
         session_id: [u8; 32],
@@ -477,6 +478,8 @@ pub struct KfpNode {
     pub(crate) psbt_proposers: RwLock<HashSet<u16>>,
     pub(crate) local_recovery_xpubs: RwLock<Vec<AnnouncedXpub>>,
     pub(crate) descriptor_lookup: Option<Arc<dyn PersistedDescriptorLookup>>,
+    pub(crate) recovery_signer_registry:
+        Option<Arc<dyn crate::recovery_signers::RecoverySignerRegistry>>,
 }
 
 /// Strip control characters, clamp to `MAX_NACK_REASON_LENGTH`, and return a
@@ -643,12 +646,37 @@ impl KfpNode {
             psbt_proposers: RwLock::new(HashSet::new()),
             local_recovery_xpubs: RwLock::new(Vec::new()),
             descriptor_lookup: None,
+            recovery_signer_registry: None,
         })
     }
 
     pub fn with_descriptor_lookup(mut self, lookup: Arc<dyn PersistedDescriptorLookup>) -> Self {
         self.descriptor_lookup = Some(lookup);
         self
+    }
+
+    /// Attach a registry mapping recovery-tier xpub fingerprints to external
+    /// NIP-46 signers. Callers handling `PsbtSignatureNeeded` events use
+    /// `resolve_recovery_signer` to look up the configured bunker URI for a
+    /// given fingerprint.
+    pub fn with_recovery_signer_registry(
+        mut self,
+        registry: Arc<dyn crate::recovery_signers::RecoverySignerRegistry>,
+    ) -> Self {
+        self.recovery_signer_registry = Some(registry);
+        self
+    }
+
+    /// Resolve a recovery-tier xpub fingerprint to a registered external
+    /// signer, or `None` if no registry is attached or the fingerprint has
+    /// no entry.
+    pub fn resolve_recovery_signer(
+        &self,
+        fingerprint: &str,
+    ) -> Option<crate::recovery_signers::RecoverySignerHandle> {
+        self.recovery_signer_registry
+            .as_ref()
+            .and_then(|r| r.resolve(fingerprint))
     }
 
     pub fn with_descriptor_session_store(

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -571,13 +571,14 @@ impl KfpNode {
                     continue;
                 };
                 saw_any_finalized = true;
-                let mut hasher = Sha256::new();
-                hasher.update((finalized.external.len() as u64).to_le_bytes());
-                hasher.update(finalized.external.as_bytes());
-                hasher.update((finalized.internal.len() as u64).to_le_bytes());
-                hasher.update(finalized.internal.as_bytes());
-                hasher.update(finalized.policy_hash);
-                let expected: [u8; 32] = hasher.finalize().into();
+                let Ok(expected) = keep_core::wallet::canonical_descriptor_hash(
+                    &finalized.external,
+                    &finalized.internal,
+                    &finalized.policy_hash,
+                    session.policy().version,
+                ) else {
+                    continue;
+                };
                 if &expected == descriptor_hash {
                     matched = true;
                     break;
@@ -1258,11 +1259,12 @@ fn aggregate_partial_psbts(
         // recomputed per signature using that signature's own sighash_type so a
         // legitimate non-default sighash is verified rather than silently dropped.
         let mut matching = 0u32;
+        let mut sighash_cache = bitcoin::sighash::SighashCache::new(&aggregated.unsigned_tx);
         for ((pk, leaf_hash), sig) in input.tap_script_sigs.iter() {
             if *leaf_hash != proposed_leaf || !committed_keys.contains(pk) {
                 continue;
             }
-            let sighash = bitcoin::sighash::SighashCache::new(&aggregated.unsigned_tx)
+            let sighash = sighash_cache
                 .taproot_script_spend_signature_hash(
                     idx,
                     &bitcoin::sighash::Prevouts::All(&prevouts),

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -3,6 +3,7 @@
 //! WDC PSBT coordination handlers (recovery tier / scriptpath spends).
 
 use std::collections::HashSet;
+use std::str::FromStr;
 
 use bitcoin::hashes::Hash;
 use nostr_sdk::prelude::*;
@@ -32,6 +33,12 @@ pub struct PsbtSessionSnapshot {
     pub network: String,
     pub threshold: u32,
     pub expected_signers_len: u32,
+    /// Per-output (address string, value sats) decoded from the PSBT's
+    /// unsigned transaction. Entries whose script does not yield a
+    /// network-valid address are rendered as a hex script prefixed with
+    /// `script:` so the UI surfaces *something* rather than dropping the
+    /// output silently.
+    pub outputs: Vec<(String, u64)>,
 }
 
 impl KfpNode {
@@ -50,6 +57,7 @@ impl KfpNode {
             .as_deref()
             .and_then(|l| l.network_for(&self.group_pubkey, &descriptor_hash))
             .unwrap_or_else(|| "unknown".to_string());
+        let outputs = decode_psbt_outputs(session.proposal_psbt(), &network);
         Some(PsbtSessionSnapshot {
             session_id: *session.session_id(),
             tier_index: session.tier_index(),
@@ -60,8 +68,32 @@ impl KfpNode {
             network,
             threshold: session.required_threshold(),
             expected_signers_len: session.expected_signers().len() as u32,
+            outputs,
         })
     }
+    /// Return the proposal PSBT bytes for the given session, or `None` if
+    /// the session is unknown. Used by responders to reconstruct the
+    /// script-spend sighash before forwarding it to a NIP-46 signer.
+    pub fn psbt_session_proposal_psbt(&self, session_id: &[u8; 32]) -> Option<Vec<u8>> {
+        self.psbt_sessions
+            .read()
+            .get_session(session_id)
+            .map(|s| s.proposal_psbt().to_vec())
+    }
+
+    /// Return `(initiator_pubkey, descriptor_hash, tier_index)` for the given
+    /// PSBT session, or `None` if the session is unknown or has no recorded
+    /// initiator.
+    pub fn psbt_session_routing(
+        &self,
+        session_id: &[u8; 32],
+    ) -> Option<(PublicKey, [u8; 32], u32)> {
+        let sessions = self.psbt_sessions.read();
+        let session = sessions.get_session(session_id)?;
+        let initiator = *session.initiator()?;
+        Some((initiator, *session.descriptor_hash(), session.tier_index()))
+    }
+
     /// Propose a PSBT for a recovery tier spend. Publishes `PsbtPropose` to all
     /// expected signers over NIP-44 encrypted channel.
     ///
@@ -1050,6 +1082,35 @@ fn decode_psbt_for_snapshot(psbt_bytes: &[u8]) -> Option<([u8; 32], u32, Option<
     Some((psbt_hash, output_count, fee_sats))
 }
 
+/// Decode each output of `psbt_bytes` into a `(display_string, value_sats)`
+/// pair. Addresses are rendered for the canonical network when known; outputs
+/// whose script does not resolve to a network-valid address fall back to
+/// `script:<hex>` so the UI never silently drops a destination.
+///
+/// Returns an empty vector on decode failure (fail-closed; callers that need
+/// destinations to gate approval must treat empty as "no preview available").
+fn decode_psbt_outputs(psbt_bytes: &[u8], network_str: &str) -> Vec<(String, u64)> {
+    use bitcoin::Address;
+    let Ok(psbt) = bitcoin::psbt::Psbt::deserialize(psbt_bytes) else {
+        return Vec::new();
+    };
+    let network = bitcoin::Network::from_str(network_str).ok();
+    psbt.unsigned_tx
+        .output
+        .iter()
+        .map(|o| {
+            let s = match network {
+                Some(net) => match Address::from_script(&o.script_pubkey, net) {
+                    Ok(addr) => addr.to_string(),
+                    Err(_) => format!("script:{}", hex::encode(o.script_pubkey.as_bytes())),
+                },
+                None => format!("script:{}", hex::encode(o.script_pubkey.as_bytes())),
+            };
+            (s, o.value.to_sat())
+        })
+        .collect()
+}
+
 /// Combine every signer's merged PSBT with the proposal PSBT using
 /// `Psbt::combine`. Fails if any partial is undecodable, combination fails,
 /// or fewer than `required_threshold` distinct tap_script / partial
@@ -1284,5 +1345,32 @@ mod snapshot_decode_tests {
     fn decode_psbt_garbage_returns_none() {
         assert!(decode_psbt_for_snapshot(&[0u8, 1, 2, 3]).is_none());
         assert!(decode_psbt_for_snapshot(&[]).is_none());
+    }
+
+    #[test]
+    fn decode_outputs_emits_address_per_output_on_known_network() {
+        let bytes = fixture_psbt(true);
+        let outs = super::decode_psbt_outputs(&bytes, "regtest");
+        assert_eq!(outs.len(), 1);
+        let (addr, sats) = &outs[0];
+        assert_eq!(*sats, 50_000);
+        assert!(
+            addr.starts_with("bcrt1p"),
+            "expected regtest p2tr bech32m address, got {addr}"
+        );
+    }
+
+    #[test]
+    fn decode_outputs_unknown_network_falls_back_to_script_hex() {
+        let bytes = fixture_psbt(true);
+        let outs = super::decode_psbt_outputs(&bytes, "no-such-network");
+        assert_eq!(outs.len(), 1);
+        assert!(outs[0].0.starts_with("script:"));
+    }
+
+    #[test]
+    fn decode_outputs_garbage_returns_empty() {
+        let outs = super::decode_psbt_outputs(&[0u8, 1, 2], "regtest");
+        assert!(outs.is_empty());
     }
 }

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -1182,6 +1182,17 @@ fn aggregate_partial_psbts(
     // (e.g. one classic ECDSA partial_sig plus their own tap_script_sig).
     // FROST key-path spends produce a single aggregated tap_key_sig regardless
     // of threshold and must use a different aggregator.
+    let prevouts: Vec<_> = aggregated
+        .inputs
+        .iter()
+        .enumerate()
+        .map(|(i, input)| {
+            input.witness_utxo.clone().ok_or_else(|| {
+                FrostNetError::Session(format!("aggregated PSBT input {i} missing witness_utxo"))
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let secp = bitcoin::secp256k1::Secp256k1::verification_only();
     for (idx, input) in aggregated.inputs.iter().enumerate() {
         let mut iter = input.tap_scripts.iter();
         let (_, (script, leaf_version)) = iter.next().ok_or_else(|| {
@@ -1210,10 +1221,32 @@ fn aggregate_partial_psbts(
                 }
             }
         }
+        let sighash = bitcoin::sighash::SighashCache::new(&aggregated.unsigned_tx)
+            .taproot_script_spend_signature_hash(
+                idx,
+                &bitcoin::sighash::Prevouts::All(&prevouts),
+                proposed_leaf,
+                bitcoin::sighash::TapSighashType::Default,
+            )
+            .map_err(|e| {
+                FrostNetError::Session(format!("aggregated PSBT input {idx} sighash failed: {e}"))
+            })?;
+        let msg =
+            bitcoin::secp256k1::Message::from_digest_slice(sighash.as_ref()).map_err(|e| {
+                FrostNetError::Session(format!("aggregated PSBT input {idx} invalid sighash: {e}"))
+            })?;
+        // Count only signatures that actually verify against the proposed leaf's
+        // sighash so a signer cannot pad its partial with bogus tap_script_sigs
+        // for other committed keys to satisfy the threshold.
         let matching = input
             .tap_script_sigs
-            .keys()
-            .filter(|(pk, leaf_hash)| *leaf_hash == proposed_leaf && committed_keys.contains(pk))
+            .iter()
+            .filter(|((pk, leaf_hash), sig)| {
+                *leaf_hash == proposed_leaf
+                    && committed_keys.contains(pk)
+                    && sig.sighash_type == bitcoin::sighash::TapSighashType::Default
+                    && secp.verify_schnorr(&sig.signature, &msg, pk).is_ok()
+            })
             .count() as u32;
         if matching < required_threshold {
             return Err(FrostNetError::Session(format!(

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -97,10 +97,7 @@ impl KfpNode {
     /// Return the lowercase xpub fingerprints listed as expected external
     /// signers for the given PSBT session. Returns `None` if the session is
     /// unknown. Share-based signers are not included.
-    pub fn psbt_session_expected_fingerprints(
-        &self,
-        session_id: &[u8; 32],
-    ) -> Option<Vec<String>> {
+    pub fn psbt_session_expected_fingerprints(&self, session_id: &[u8; 32]) -> Option<Vec<String>> {
         let sessions = self.psbt_sessions.read();
         let session = sessions.get_session(session_id)?;
         Some(

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -1187,9 +1187,30 @@ fn aggregate_partial_psbts(
         .iter()
         .enumerate()
         .map(|(i, input)| {
-            input.witness_utxo.clone().ok_or_else(|| {
-                FrostNetError::Session(format!("aggregated PSBT input {i} missing witness_utxo"))
-            })
+            if let Some(txout) = input.witness_utxo.clone() {
+                return Ok(txout);
+            }
+            if let Some(tx) = input.non_witness_utxo.as_ref() {
+                let vout = aggregated
+                    .unsigned_tx
+                    .input
+                    .get(i)
+                    .ok_or_else(|| {
+                        FrostNetError::Session(format!(
+                            "aggregated PSBT input {i} has no matching unsigned_tx input"
+                        ))
+                    })?
+                    .previous_output
+                    .vout as usize;
+                return tx.output.get(vout).cloned().ok_or_else(|| {
+                    FrostNetError::Session(format!(
+                        "aggregated PSBT input {i} non_witness_utxo has no output at index {vout}"
+                    ))
+                });
+            }
+            Err(FrostNetError::Session(format!(
+                "aggregated PSBT input {i} missing witness_utxo and non_witness_utxo"
+            )))
         })
         .collect::<Result<Vec<_>>>()?;
     let secp = bitcoin::secp256k1::Secp256k1::verification_only();

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -94,6 +94,27 @@ impl KfpNode {
         Some((initiator, *session.descriptor_hash(), session.tier_index()))
     }
 
+    /// Return the lowercase xpub fingerprints listed as expected external
+    /// signers for the given PSBT session. Returns `None` if the session is
+    /// unknown. Share-based signers are not included.
+    pub fn psbt_session_expected_fingerprints(
+        &self,
+        session_id: &[u8; 32],
+    ) -> Option<Vec<String>> {
+        let sessions = self.psbt_sessions.read();
+        let session = sessions.get_session(session_id)?;
+        Some(
+            session
+                .expected_signers()
+                .iter()
+                .filter_map(|s| match s {
+                    crate::psbt_session::SignerId::Fingerprint(fp) => Some(fp.clone()),
+                    _ => None,
+                })
+                .collect(),
+        )
+    }
+
     /// Propose a PSBT for a recovery tier spend. Publishes `PsbtPropose` to all
     /// expected signers over NIP-44 encrypted channel.
     ///

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -1221,33 +1221,38 @@ fn aggregate_partial_psbts(
                 }
             }
         }
-        let sighash = bitcoin::sighash::SighashCache::new(&aggregated.unsigned_tx)
-            .taproot_script_spend_signature_hash(
-                idx,
-                &bitcoin::sighash::Prevouts::All(&prevouts),
-                proposed_leaf,
-                bitcoin::sighash::TapSighashType::Default,
-            )
-            .map_err(|e| {
-                FrostNetError::Session(format!("aggregated PSBT input {idx} sighash failed: {e}"))
-            })?;
-        let msg =
-            bitcoin::secp256k1::Message::from_digest_slice(sighash.as_ref()).map_err(|e| {
-                FrostNetError::Session(format!("aggregated PSBT input {idx} invalid sighash: {e}"))
-            })?;
         // Count only signatures that actually verify against the proposed leaf's
         // sighash so a signer cannot pad its partial with bogus tap_script_sigs
-        // for other committed keys to satisfy the threshold.
-        let matching = input
-            .tap_script_sigs
-            .iter()
-            .filter(|((pk, leaf_hash), sig)| {
-                *leaf_hash == proposed_leaf
-                    && committed_keys.contains(pk)
-                    && sig.sighash_type == bitcoin::sighash::TapSighashType::Default
-                    && secp.verify_schnorr(&sig.signature, &msg, pk).is_ok()
-            })
-            .count() as u32;
+        // for other committed keys to satisfy the threshold. The sighash is
+        // recomputed per signature using that signature's own sighash_type so a
+        // legitimate non-default sighash is verified rather than silently dropped.
+        let mut matching = 0u32;
+        for ((pk, leaf_hash), sig) in input.tap_script_sigs.iter() {
+            if *leaf_hash != proposed_leaf || !committed_keys.contains(pk) {
+                continue;
+            }
+            let sighash = bitcoin::sighash::SighashCache::new(&aggregated.unsigned_tx)
+                .taproot_script_spend_signature_hash(
+                    idx,
+                    &bitcoin::sighash::Prevouts::All(&prevouts),
+                    proposed_leaf,
+                    sig.sighash_type,
+                )
+                .map_err(|e| {
+                    FrostNetError::Session(format!(
+                        "aggregated PSBT input {idx} sighash failed: {e}"
+                    ))
+                })?;
+            let msg =
+                bitcoin::secp256k1::Message::from_digest_slice(sighash.as_ref()).map_err(|e| {
+                    FrostNetError::Session(format!(
+                        "aggregated PSBT input {idx} invalid sighash: {e}"
+                    ))
+                })?;
+            if secp.verify_schnorr(&sig.signature, &msg, pk).is_ok() {
+                matching += 1;
+            }
+        }
         if matching < required_threshold {
             return Err(FrostNetError::Session(format!(
                 "aggregated PSBT input {idx} has {matching} tap_script_sigs for the proposed leaf, below threshold {required_threshold}"

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -571,14 +571,15 @@ impl KfpNode {
                     continue;
                 };
                 saw_any_finalized = true;
-                let Ok(expected) = keep_core::wallet::canonical_descriptor_hash(
+                let expected = keep_core::wallet::canonical_descriptor_hash(
                     &finalized.external,
                     &finalized.internal,
                     &finalized.policy_hash,
                     session.policy().version,
-                ) else {
-                    continue;
-                };
+                )
+                .map_err(|e| {
+                    FrostNetError::Session(format!("canonical descriptor hash failed: {e}"))
+                })?;
                 if &expected == descriptor_hash {
                     matched = true;
                     break;

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -610,9 +610,28 @@ impl KfpNode {
 
         let msg = KfpMessage::PsbtSign(payload);
 
-        // Commit the signature to our local session before sending so we
-        // reject duplicate local contributions on retry, but capture enough
-        // information to roll back if the wire send fails.
+        // SEC/cancel-safety: send the wire event FIRST, then commit to the
+        // local session. The previous order (commit-then-send) leaked a
+        // dangling local signature when the awaiting task was cancelled
+        // between the two steps. Swapping the order means that on a
+        // user-triggered retry of a cancelled `contribute_psbt_signature`
+        // the local `add_signature` call may return "Duplicate signature",
+        // which is the correct behavior since the peer has already counted
+        // our contribution once.
+        let event = KfpEventBuilder::psbt_event(
+            &self.keys,
+            initiator_pubkey,
+            &self.group_pubkey,
+            &session_id,
+            "psbt_sign",
+            &msg,
+        )?;
+
+        self.client
+            .send_event(&event)
+            .await
+            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+
         {
             let mut sessions = self.psbt_sessions.write();
             let session = sessions
@@ -621,40 +640,8 @@ impl KfpNode {
             session.add_signature(signer.clone(), merged_psbt.clone())?;
         }
 
-        let event = match KfpEventBuilder::psbt_event(
-            &self.keys,
-            initiator_pubkey,
-            &self.group_pubkey,
-            &session_id,
-            "psbt_sign",
-            &msg,
-        ) {
-            Ok(e) => e,
-            Err(e) => {
-                self.rollback_local_signature(&session_id, &signer);
-                return Err(e);
-            }
-        };
-
-        if let Err(e) = self.client.send_event(&event).await {
-            self.rollback_local_signature(&session_id, &signer);
-            return Err(FrostNetError::Transport(e.to_string()));
-        }
-
         info!(session_id = %hex::encode(session_id), "Sent PSBT signature contribution");
         Ok(())
-    }
-
-    fn rollback_local_signature(&self, session_id: &[u8; 32], signer: &SignerId) {
-        let mut sessions = self.psbt_sessions.write();
-        if let Some(session) = sessions.get_session_mut(session_id) {
-            if !session.remove_signature(signer) {
-                debug!(
-                    session_id = %hex::encode(session_id),
-                    "rollback_local_signature: no local signature to remove"
-                );
-            }
-        }
     }
 
     pub(crate) async fn handle_psbt_sign(
@@ -727,7 +714,12 @@ impl KfpNode {
             session.add_signature(signer.clone(), payload.psbt)?;
 
             let is_initiator = session.initiator() == Some(&self.keys.public_key());
-            let should_finalize = is_initiator && session.begin_finalize();
+            // Defensive: only attempt to finalize once threshold is met.
+            // `begin_finalize` already gates on threshold_met(), but spell
+            // it out here so the invariant survives future refactors of
+            // PsbtSession.
+            let threshold_met = (session.signature_count() as u32) >= session.required_threshold();
+            let should_finalize = is_initiator && threshold_met && session.begin_finalize();
             let (aggregated, agg_err) = if should_finalize {
                 match aggregate_partial_psbts(
                     session.proposal_psbt(),
@@ -900,6 +892,33 @@ impl KfpNode {
                     return Err(FrostNetError::Session(
                         "PsbtFinalize txid does not match final_tx bytes".into(),
                     ));
+                }
+                // SEC: bind the announced final_tx back to the proposal PSBT
+                // we agreed to coordinate on. compute_txid() ignores witness
+                // data by design, so this compares the input prevouts +
+                // outputs the initiator originally proposed against the
+                // ones in the broadcast tx; a swap is rejected.
+                {
+                    let proposal_psbt = {
+                        let sessions = self.psbt_sessions.read();
+                        sessions
+                            .get_session(&payload.session_id)
+                            .map(|s| s.proposal_psbt().to_vec())
+                    };
+                    if let Some(bytes) = proposal_psbt {
+                        let proposal = bitcoin::psbt::Psbt::deserialize(&bytes).map_err(|e| {
+                            FrostNetError::Session(format!(
+                                "PsbtFinalize: cannot decode proposal PSBT: {e}"
+                            ))
+                        })?;
+                        let proposal_txid: [u8; 32] =
+                            proposal.unsigned_tx.compute_txid().to_byte_array();
+                        if proposal_txid != id {
+                            return Err(FrostNetError::Session(
+                                "PsbtFinalize final_tx does not match the proposal's unsigned-tx txid".into(),
+                            ));
+                        }
+                    }
                 }
                 Some((tx, id))
             }
@@ -1113,8 +1132,14 @@ fn decode_psbt_outputs(psbt_bytes: &[u8], network_str: &str) -> Vec<(String, u64
 
 /// Combine every signer's merged PSBT with the proposal PSBT using
 /// `Psbt::combine`. Fails if any partial is undecodable, combination fails,
-/// or fewer than `required_threshold` distinct tap_script / partial
-/// signatures are present on every input of the aggregated PSBT.
+/// or any input on the aggregated PSBT carries fewer than
+/// `required_threshold` distinct `tap_script_sigs` entries for the same
+/// leaf hash.
+///
+/// Signers are combined in a deterministic order (sorted by SignerId)
+/// because `Psbt::combine` is order-sensitive for fields that aren't pure
+/// set-union — sorting ensures the aggregated bytes are reproducible across
+/// peers.
 fn aggregate_partial_psbts(
     proposal_psbt: &[u8],
     partial_psbts: &std::collections::HashMap<SignerId, Vec<u8>>,
@@ -1122,7 +1147,9 @@ fn aggregate_partial_psbts(
 ) -> Result<Vec<u8>> {
     let mut aggregated = bitcoin::psbt::Psbt::deserialize(proposal_psbt)
         .map_err(|e| FrostNetError::Session(format!("proposal PSBT decode failed: {e}")))?;
-    for (signer, bytes) in partial_psbts {
+    let mut sorted: Vec<(&SignerId, &Vec<u8>)> = partial_psbts.iter().collect();
+    sorted.sort_by(|(a, _), (b, _)| signer_id_sort_key(a).cmp(&signer_id_sort_key(b)));
+    for (signer, bytes) in sorted {
         let partial = bitcoin::psbt::Psbt::deserialize(bytes).map_err(|e| {
             FrostNetError::Session(format!("partial PSBT decode failed for {signer:?}: {e}"))
         })?;
@@ -1130,21 +1157,37 @@ fn aggregate_partial_psbts(
             FrostNetError::Session(format!("PSBT combine failed for {signer:?}: {e}"))
         })?;
     }
-    // Threshold check assumes recovery-tier (tap_script_sigs) or classic multisig
-    // (partial_sigs) semantics where each signer contributes a distinct signature.
-    // FROST key-path spends produce a single aggregated tap_key_sig regardless of
-    // threshold; this check must be revised before reuse on that path.
+    // Threshold check for the recovery-tier (tap-script) path: each input
+    // must carry `required_threshold` distinct tap_script_sigs for the same
+    // leaf hash. Counting partial_sigs / tap_key_sig here would let a single
+    // attacker satisfy the threshold via the wrong signature family
+    // (e.g. one classic ECDSA partial_sig plus their own tap_script_sig).
+    // FROST key-path spends produce a single aggregated tap_key_sig regardless
+    // of threshold and must use a different aggregator.
     for (idx, input) in aggregated.inputs.iter().enumerate() {
-        let sig_count = input.partial_sigs.len()
-            + input.tap_script_sigs.len()
-            + usize::from(input.tap_key_sig.is_some());
-        if (sig_count as u32) < required_threshold {
+        let mut per_leaf: std::collections::HashMap<bitcoin::taproot::TapLeafHash, u32> =
+            std::collections::HashMap::new();
+        for (_, leaf_hash) in input.tap_script_sigs.keys() {
+            *per_leaf.entry(*leaf_hash).or_default() += 1;
+        }
+        let max_for_one_leaf = per_leaf.values().copied().max().unwrap_or(0);
+        if max_for_one_leaf < required_threshold {
             return Err(FrostNetError::Session(format!(
-                "aggregated PSBT input {idx} has {sig_count} signatures, below threshold {required_threshold}"
+                "aggregated PSBT input {idx} has at most {max_for_one_leaf} tap_script_sigs for any single leaf, below threshold {required_threshold}"
             )));
         }
     }
     Ok(aggregated.serialize())
+}
+
+/// Total ordering for `SignerId` so `aggregate_partial_psbts` combines in
+/// a deterministic order. `Share` < `Fingerprint`; within each variant we
+/// order by the numeric / lexicographic key.
+fn signer_id_sort_key(s: &SignerId) -> (u8, u16, String) {
+    match s {
+        SignerId::Share(i) => (0u8, *i, String::new()),
+        SignerId::Fingerprint(fp) => (1u8, 0u16, fp.clone()),
+    }
 }
 
 /// Apply the descriptor_hash verification policy given an in-memory match

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -1183,15 +1183,26 @@ fn aggregate_partial_psbts(
     // FROST key-path spends produce a single aggregated tap_key_sig regardless
     // of threshold and must use a different aggregator.
     for (idx, input) in aggregated.inputs.iter().enumerate() {
-        let mut per_leaf: std::collections::HashMap<bitcoin::taproot::TapLeafHash, u32> =
-            std::collections::HashMap::new();
-        for (_, leaf_hash) in input.tap_script_sigs.keys() {
-            *per_leaf.entry(*leaf_hash).or_default() += 1;
-        }
-        let max_for_one_leaf = per_leaf.values().copied().max().unwrap_or(0);
-        if max_for_one_leaf < required_threshold {
+        let mut iter = input.tap_scripts.iter();
+        let (_, (script, leaf_version)) = iter.next().ok_or_else(|| {
+            FrostNetError::Session(format!(
+                "aggregated PSBT input {idx} has no tap_scripts entry; cannot determine proposed leaf"
+            ))
+        })?;
+        if iter.next().is_some() {
             return Err(FrostNetError::Session(format!(
-                "aggregated PSBT input {idx} has at most {max_for_one_leaf} tap_script_sigs for any single leaf, below threshold {required_threshold}"
+                "aggregated PSBT input {idx} has more than one tap_scripts entry; ambiguous proposed leaf"
+            )));
+        }
+        let proposed_leaf = bitcoin::taproot::TapLeafHash::from_script(script, *leaf_version);
+        let matching = input
+            .tap_script_sigs
+            .keys()
+            .filter(|(_, leaf_hash)| *leaf_hash == proposed_leaf)
+            .count() as u32;
+        if matching < required_threshold {
+            return Err(FrostNetError::Session(format!(
+                "aggregated PSBT input {idx} has {matching} tap_script_sigs for the proposed leaf, below threshold {required_threshold}"
             )));
         }
     }

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -3,6 +3,7 @@
 //! WDC PSBT coordination handlers (recovery tier / scriptpath spends).
 
 use std::collections::HashSet;
+use std::str::FromStr;
 
 use bitcoin::hashes::Hash;
 use nostr_sdk::prelude::*;
@@ -32,6 +33,12 @@ pub struct PsbtSessionSnapshot {
     pub network: String,
     pub threshold: u32,
     pub expected_signers_len: u32,
+    /// Per-output (address string, value sats) decoded from the PSBT's
+    /// unsigned transaction. Entries whose script does not yield a
+    /// network-valid address are rendered as a hex script prefixed with
+    /// `script:` so the UI surfaces *something* rather than dropping the
+    /// output silently.
+    pub outputs: Vec<(String, u64)>,
 }
 
 impl KfpNode {
@@ -50,6 +57,7 @@ impl KfpNode {
             .as_deref()
             .and_then(|l| l.network_for(&self.group_pubkey, &descriptor_hash))
             .unwrap_or_else(|| "unknown".to_string());
+        let outputs = decode_psbt_outputs(session.proposal_psbt(), &network);
         Some(PsbtSessionSnapshot {
             session_id: *session.session_id(),
             tier_index: session.tier_index(),
@@ -60,8 +68,32 @@ impl KfpNode {
             network,
             threshold: session.required_threshold(),
             expected_signers_len: session.expected_signers().len() as u32,
+            outputs,
         })
     }
+    /// Return the proposal PSBT bytes for the given session, or `None` if
+    /// the session is unknown. Used by responders to reconstruct the
+    /// script-spend sighash before forwarding it to a NIP-46 signer.
+    pub fn psbt_session_proposal_psbt(&self, session_id: &[u8; 32]) -> Option<Vec<u8>> {
+        self.psbt_sessions
+            .read()
+            .get_session(session_id)
+            .map(|s| s.proposal_psbt().to_vec())
+    }
+
+    /// Return `(initiator_pubkey, descriptor_hash, tier_index)` for the given
+    /// PSBT session, or `None` if the session is unknown or has no recorded
+    /// initiator.
+    pub fn psbt_session_routing(
+        &self,
+        session_id: &[u8; 32],
+    ) -> Option<(PublicKey, [u8; 32], u32)> {
+        let sessions = self.psbt_sessions.read();
+        let session = sessions.get_session(session_id)?;
+        let initiator = *session.initiator()?;
+        Some((initiator, *session.descriptor_hash(), session.tier_index()))
+    }
+
     /// Propose a PSBT for a recovery tier spend. Publishes `PsbtPropose` to all
     /// expected signers over NIP-44 encrypted channel.
     ///
@@ -1050,6 +1082,35 @@ fn decode_psbt_for_snapshot(psbt_bytes: &[u8]) -> Option<([u8; 32], u32, Option<
     Some((psbt_hash, output_count, fee_sats))
 }
 
+/// Decode each output of `psbt_bytes` into a `(display_string, value_sats)`
+/// pair. Addresses are rendered for the canonical network when known; outputs
+/// whose script does not resolve to a network-valid address fall back to
+/// `script:<hex>` so the UI never silently drops a destination.
+///
+/// Returns an empty vector on decode failure (fail-closed; callers that need
+/// destinations to gate approval must treat empty as "no preview available").
+fn decode_psbt_outputs(psbt_bytes: &[u8], network_str: &str) -> Vec<(String, u64)> {
+    use bitcoin::Address;
+    let Ok(psbt) = bitcoin::psbt::Psbt::deserialize(psbt_bytes) else {
+        return Vec::new();
+    };
+    let network = bitcoin::Network::from_str(network_str).ok();
+    psbt.unsigned_tx
+        .output
+        .iter()
+        .map(|o| {
+            let s = match network {
+                Some(net) => match Address::from_script(&o.script_pubkey, net) {
+                    Ok(addr) => addr.to_string(),
+                    Err(_) => format!("script:{}", hex::encode(o.script_pubkey.as_bytes())),
+                },
+                None => format!("script:{}", hex::encode(o.script_pubkey.as_bytes())),
+            };
+            (s, o.value.to_sat())
+        })
+        .collect()
+}
+
 /// Combine every signer's merged PSBT with the proposal PSBT using
 /// `Psbt::combine`. Fails if any partial is undecodable, combination fails,
 /// or fewer than `required_threshold` distinct tap_script / partial
@@ -1278,5 +1339,32 @@ mod snapshot_decode_tests {
     fn decode_psbt_garbage_returns_none() {
         assert!(decode_psbt_for_snapshot(&[0u8, 1, 2, 3]).is_none());
         assert!(decode_psbt_for_snapshot(&[]).is_none());
+    }
+
+    #[test]
+    fn decode_outputs_emits_address_per_output_on_known_network() {
+        let bytes = fixture_psbt(true);
+        let outs = super::decode_psbt_outputs(&bytes, "regtest");
+        assert_eq!(outs.len(), 1);
+        let (addr, sats) = &outs[0];
+        assert_eq!(*sats, 50_000);
+        assert!(
+            addr.starts_with("bcrt1p"),
+            "expected regtest p2tr bech32m address, got {addr}"
+        );
+    }
+
+    #[test]
+    fn decode_outputs_unknown_network_falls_back_to_script_hex() {
+        let bytes = fixture_psbt(true);
+        let outs = super::decode_psbt_outputs(&bytes, "no-such-network");
+        assert_eq!(outs.len(), 1);
+        assert!(outs[0].0.starts_with("script:"));
+    }
+
+    #[test]
+    fn decode_outputs_garbage_returns_empty() {
+        let outs = super::decode_psbt_outputs(&[0u8, 1, 2], "regtest");
+        assert!(outs.is_empty());
     }
 }

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -1195,10 +1195,25 @@ fn aggregate_partial_psbts(
             )));
         }
         let proposed_leaf = bitcoin::taproot::TapLeafHash::from_script(script, *leaf_version);
+        // Collect the x-only keys actually committed inside the leaf script so
+        // that signatures for keys not present in the leaf cannot be counted
+        // toward the threshold.
+        let mut committed_keys = HashSet::new();
+        for instr in script.instructions_minimal() {
+            if let Ok(bitcoin::blockdata::script::Instruction::PushBytes(push)) = instr {
+                if push.len() == 32 {
+                    if let Ok(xonly) =
+                        bitcoin::secp256k1::XOnlyPublicKey::from_slice(push.as_bytes())
+                    {
+                        committed_keys.insert(xonly);
+                    }
+                }
+            }
+        }
         let matching = input
             .tap_script_sigs
             .keys()
-            .filter(|(_, leaf_hash)| *leaf_hash == proposed_leaf)
+            .filter(|(pk, leaf_hash)| *leaf_hash == proposed_leaf && committed_keys.contains(pk))
             .count() as u32;
         if matching < required_threshold {
             return Err(FrostNetError::Session(format!(

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -1191,7 +1191,7 @@ fn aggregate_partial_psbts(
                 return Ok(txout);
             }
             if let Some(tx) = input.non_witness_utxo.as_ref() {
-                let vout = aggregated
+                let prevout = aggregated
                     .unsigned_tx
                     .input
                     .get(i)
@@ -1200,8 +1200,18 @@ fn aggregate_partial_psbts(
                             "aggregated PSBT input {i} has no matching unsigned_tx input"
                         ))
                     })?
-                    .previous_output
-                    .vout as usize;
+                    .previous_output;
+                // Bind the non_witness_utxo to the input's previous_output.txid
+                // before trusting its value/script. Without this a malicious
+                // partial PSBT could supply an unrelated transaction whose
+                // output at this vout carries an altered value/script, changing
+                // the sighash recomputed below.
+                if tx.compute_txid() != prevout.txid {
+                    return Err(FrostNetError::Session(format!(
+                        "aggregated PSBT input {i} non_witness_utxo txid does not match previous_output"
+                    )));
+                }
+                let vout = prevout.vout as usize;
                 return tx.output.get(vout).cloned().ok_or_else(|| {
                     FrostNetError::Session(format!(
                         "aggregated PSBT input {i} non_witness_utxo has no output at index {vout}"

--- a/keep-frost-net/src/peer.rs
+++ b/keep-frost-net/src/peer.rs
@@ -125,8 +125,16 @@ impl PeerManager {
         self
     }
 
-    pub fn add_peer(&mut self, peer: Peer) {
+    pub fn add_peer(&mut self, mut peer: Peer) {
         if peer.share_index != self.our_share_index {
+            // PeerAnnounce carries no recovery xpubs; preserve any previously
+            // announced (and replay-validated) xpubs across re-announcements so
+            // a duplicate PeerAnnounce does not wipe stored recovery xpubs.
+            if peer.recovery_xpubs.is_empty() {
+                if let Some(existing) = self.peers.get(&peer.share_index) {
+                    peer.recovery_xpubs = existing.recovery_xpubs.clone();
+                }
+            }
             self.peers.insert(peer.share_index, peer);
         }
     }

--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -600,6 +600,9 @@ impl KfpMessage {
                     if !seen_xpubs.insert(&xpub.xpub) {
                         return Err("Duplicate recovery xpub");
                     }
+                    if xpub.xpub.parse::<bitcoin::bip32::Xpub>().is_err() {
+                        return Err("Recovery xpub is not a valid extended public key");
+                    }
                     if !is_valid_fingerprint(&xpub.fingerprint) {
                         return Err(
                             "Recovery fingerprint must be exactly 8 lowercase hex characters",

--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -600,7 +600,12 @@ impl KfpMessage {
                     if !seen_xpubs.insert(&xpub.xpub) {
                         return Err("Duplicate recovery xpub");
                     }
-                    if xpub.xpub.parse::<bitcoin::bip32::Xpub>().is_err() {
+                    // rust-bitcoin only parses standard BIP32 version bytes
+                    // (xpub/tpub); SLIP-132 Vpub/Upub keys are validated by
+                    // prefix+length above and accepted by the descriptor flow.
+                    if (xpub.xpub.starts_with("xpub") || xpub.xpub.starts_with("tpub"))
+                        && xpub.xpub.parse::<bitcoin::bip32::Xpub>().is_err()
+                    {
                         return Err("Recovery xpub is not a valid extended public key");
                     }
                     if !is_valid_fingerprint(&xpub.fingerprint) {

--- a/keep-frost-net/src/psbt_session.rs
+++ b/keep-frost-net/src/psbt_session.rs
@@ -303,30 +303,6 @@ impl PsbtSession {
         Ok(())
     }
 
-    /// Roll back a locally-recorded signature. Intended for the caller that
-    /// optimistically committed a contribution under `add_signature` and
-    /// then saw the wire send fail; keeps local state consistent with what
-    /// other peers have observed. If the rollback empties the signature set
-    /// the session transitions back to `Proposed`.
-    pub fn remove_signature(&mut self, signer: &SignerId) -> bool {
-        let removed = self.received_sigs.remove(signer);
-        self.partial_psbts.remove(signer);
-        if removed {
-            // current_psbt is snapshot-display only; after a rollback we can't
-            // deterministically choose a "representative" partial, so always
-            // fall back to the proposal PSBT. Aggregation at finalize time
-            // uses the full partial_psbts map regardless.
-            self.current_psbt = self.proposal_psbt.clone();
-            if self.received_sigs.is_empty() {
-                self.first_sig_at = None;
-                if matches!(self.state, PsbtSessionState::Signing) {
-                    self.state = PsbtSessionState::Proposed;
-                }
-            }
-        }
-        removed
-    }
-
     /// Atomic claim-to-finalize check, intended to gate a single caller when
     /// concurrent signatures cross the threshold. Returns `true` exactly once
     /// per session: when the session is in `Signing`, threshold is met, and

--- a/keep-frost-net/src/recovery_signers.rs
+++ b/keep-frost-net/src/recovery_signers.rs
@@ -56,14 +56,13 @@ impl InMemoryRecoverySignerRegistry {
     }
 
     /// Insert or replace the handle for `fingerprint`. Fingerprint matching
-    /// is case-insensitive; the key is stored lowercase.
-    pub fn insert(&self, fingerprint: &str, label: String, bunker_uri: String) {
+    /// is case-insensitive; the key is stored lowercase. The bunker URI is
+    /// taken as `Zeroizing<String>` so callers can preserve the wrapper end-
+    /// to-end and avoid a plain-`String` hop across the boundary.
+    pub fn insert(&self, fingerprint: &str, label: String, bunker_uri: Zeroizing<String>) {
         self.entries.write().insert(
             fingerprint.to_ascii_lowercase(),
-            RecoverySignerHandle {
-                label,
-                bunker_uri: Zeroizing::new(bunker_uri),
-            },
+            RecoverySignerHandle { label, bunker_uri },
         );
     }
 
@@ -94,7 +93,11 @@ mod tests {
     #[test]
     fn resolve_is_case_insensitive() {
         let reg = InMemoryRecoverySignerRegistry::new();
-        reg.insert("ABCDEF01", "coldcard-backup".into(), "bunker://x".into());
+        reg.insert(
+            "ABCDEF01",
+            "coldcard-backup".into(),
+            Zeroizing::new("bunker://x".into()),
+        );
         let h = reg.resolve("abcdef01").expect("resolves lowercase");
         assert_eq!(h.label, "coldcard-backup");
         assert_eq!(&*h.bunker_uri, "bunker://x");
@@ -105,7 +108,11 @@ mod tests {
     #[test]
     fn remove_returns_handle_and_clears() {
         let reg = InMemoryRecoverySignerRegistry::new();
-        reg.insert("a1b2c3d4", "sig".into(), "bunker://y".into());
+        reg.insert(
+            "a1b2c3d4",
+            "sig".into(),
+            Zeroizing::new("bunker://y".into()),
+        );
         let removed = reg.remove("A1B2C3D4").expect("removed");
         assert_eq!(removed.label, "sig");
         assert!(reg.resolve("a1b2c3d4").is_none());

--- a/keep-frost-net/src/recovery_signers.rs
+++ b/keep-frost-net/src/recovery_signers.rs
@@ -61,7 +61,7 @@ impl InMemoryRecoverySignerRegistry {
     /// to-end and avoid a plain-`String` hop across the boundary.
     pub fn insert(&self, fingerprint: &str, label: String, bunker_uri: Zeroizing<String>) {
         self.entries.write().insert(
-            fingerprint.to_ascii_lowercase(),
+            fingerprint.trim().to_ascii_lowercase(),
             RecoverySignerHandle { label, bunker_uri },
         );
     }
@@ -69,7 +69,7 @@ impl InMemoryRecoverySignerRegistry {
     pub fn remove(&self, fingerprint: &str) -> Option<RecoverySignerHandle> {
         self.entries
             .write()
-            .remove(&fingerprint.to_ascii_lowercase())
+            .remove(&fingerprint.trim().to_ascii_lowercase())
     }
 
     pub fn fingerprints(&self) -> Vec<String> {
@@ -81,7 +81,7 @@ impl RecoverySignerRegistry for InMemoryRecoverySignerRegistry {
     fn resolve(&self, fingerprint: &str) -> Option<RecoverySignerHandle> {
         self.entries
             .read()
-            .get(&fingerprint.to_ascii_lowercase())
+            .get(&fingerprint.trim().to_ascii_lowercase())
             .cloned()
     }
 }

--- a/keep-frost-net/src/recovery_signers.rs
+++ b/keep-frost-net/src/recovery_signers.rs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: (C) 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+//! Registry mapping recovery-tier xpub fingerprints to external NIP-46 signers.
+//!
+//! When a recovery tier contains `KeySlot::External { fingerprint, .. }` slots,
+//! the keep node holding the descriptor needs to know which physical signer
+//! holds the secret for each fingerprint. This module defines a small trait
+//! (`RecoverySignerRegistry`) plus a default in-memory implementation; the
+//! actual NIP-46 client invocation that consumes the resolved
+//! `RecoverySignerHandle` lives in the application layer (cli/desktop/mobile)
+//! to keep `keep-frost-net` free of a `keep-nip46` dependency.
+
+use std::collections::HashMap;
+
+use parking_lot::RwLock;
+use zeroize::Zeroizing;
+
+/// A resolved external recovery signer. The bunker URI is wrapped in
+/// `Zeroizing` because it may embed a single-use connect secret.
+#[derive(Clone)]
+pub struct RecoverySignerHandle {
+    /// Friendly label set at registration time (e.g. `"coldcard-backup"`).
+    pub label: String,
+    /// Bunker URI (`bunker://...?relay=...&secret=...`) to connect to.
+    pub bunker_uri: Zeroizing<String>,
+}
+
+impl std::fmt::Debug for RecoverySignerHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RecoverySignerHandle")
+            .field("label", &self.label)
+            .field("bunker_uri", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Resolves an xpub fingerprint to a signer connection. Implementations are
+/// expected to be cheap to call and safe to invoke from any thread.
+pub trait RecoverySignerRegistry: Send + Sync {
+    /// Returns the signer handle for `fingerprint` (case-insensitive,
+    /// 8-hex-char BIP-32 master fingerprint), or `None` if the application
+    /// has not registered an external signer for that key.
+    fn resolve(&self, fingerprint: &str) -> Option<RecoverySignerHandle>;
+}
+
+/// In-memory `RecoverySignerRegistry` backed by a `HashMap`.
+#[derive(Default)]
+pub struct InMemoryRecoverySignerRegistry {
+    entries: RwLock<HashMap<String, RecoverySignerHandle>>,
+}
+
+impl InMemoryRecoverySignerRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or replace the handle for `fingerprint`. Fingerprint matching
+    /// is case-insensitive; the key is stored lowercase.
+    pub fn insert(&self, fingerprint: &str, label: String, bunker_uri: String) {
+        self.entries.write().insert(
+            fingerprint.to_ascii_lowercase(),
+            RecoverySignerHandle {
+                label,
+                bunker_uri: Zeroizing::new(bunker_uri),
+            },
+        );
+    }
+
+    pub fn remove(&self, fingerprint: &str) -> Option<RecoverySignerHandle> {
+        self.entries
+            .write()
+            .remove(&fingerprint.to_ascii_lowercase())
+    }
+
+    pub fn fingerprints(&self) -> Vec<String> {
+        self.entries.read().keys().cloned().collect()
+    }
+}
+
+impl RecoverySignerRegistry for InMemoryRecoverySignerRegistry {
+    fn resolve(&self, fingerprint: &str) -> Option<RecoverySignerHandle> {
+        self.entries
+            .read()
+            .get(&fingerprint.to_ascii_lowercase())
+            .cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_is_case_insensitive() {
+        let reg = InMemoryRecoverySignerRegistry::new();
+        reg.insert("ABCDEF01", "coldcard-backup".into(), "bunker://x".into());
+        let h = reg.resolve("abcdef01").expect("resolves lowercase");
+        assert_eq!(h.label, "coldcard-backup");
+        assert_eq!(&*h.bunker_uri, "bunker://x");
+        assert!(reg.resolve("ABCDef01").is_some());
+        assert!(reg.resolve("not-registered").is_none());
+    }
+
+    #[test]
+    fn remove_returns_handle_and_clears() {
+        let reg = InMemoryRecoverySignerRegistry::new();
+        reg.insert("a1b2c3d4", "sig".into(), "bunker://y".into());
+        let removed = reg.remove("A1B2C3D4").expect("removed");
+        assert_eq!(removed.label, "sig");
+        assert!(reg.resolve("a1b2c3d4").is_none());
+    }
+
+    #[test]
+    fn handle_debug_redacts_uri() {
+        let h = RecoverySignerHandle {
+            label: "lbl".into(),
+            bunker_uri: Zeroizing::new("bunker://secret?secret=topsecret".into()),
+        };
+        let s = format!("{h:?}");
+        assert!(s.contains("redacted"));
+        assert!(!s.contains("topsecret"));
+    }
+}

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -707,11 +707,14 @@ async fn test_psbt_recovery_spend_end_to_end() {
     // live NIP-46 signer; the responder's `KfpNode` only sees the xpub +
     // fingerprint.
     let secp = Secp256k1::new();
-    let responder_xpriv = bitcoin::bip32::Xpriv::new_master(Network::Signet, &[7u8; 32])
-        .expect("xpriv master");
+    let responder_xpriv =
+        bitcoin::bip32::Xpriv::new_master(Network::Signet, &[7u8; 32]).expect("xpriv master");
     let responder_xpub = Xpub::from_priv(&secp, &responder_xpriv);
     let responder_xpub_str = responder_xpub.to_string();
-    let responder_fp = responder_xpub.fingerprint().to_string().to_ascii_lowercase();
+    let responder_fp = responder_xpub
+        .fingerprint()
+        .to_string()
+        .to_ascii_lowercase();
     let responder_xonly_bytes = responder_xpub.to_x_only_pub().serialize();
     let responder_xonly =
         XOnlyPublicKey::from_slice(&responder_xonly_bytes).expect("xonly from slice");
@@ -747,12 +750,9 @@ async fn test_psbt_recovery_spend_end_to_end() {
     };
     let policy_hash = keep_frost_net::derive_policy_hash(&policy);
 
-    let export = DescriptorExport::from_frost_wallet(
-        &group_pubkey,
-        Some(&recovery_config),
-        Network::Signet,
-    )
-    .expect("descriptor export");
+    let export =
+        DescriptorExport::from_frost_wallet(&group_pubkey, Some(&recovery_config), Network::Signet)
+            .expect("descriptor export");
     let external_desc = export.external_descriptor().to_string();
     let internal_desc = export.internal_descriptor().expect("internal descriptor");
 
@@ -925,6 +925,7 @@ async fn test_psbt_recovery_spend_end_to_end() {
         sighashes[0].input_index,
         responder_xonly,
         sighashes[0].leaf_hash,
+        &sighashes[0].sighash,
         schnorr_bytes,
     )
     .expect("merge sig");
@@ -945,10 +946,15 @@ async fn test_psbt_recovery_spend_end_to_end() {
     let finalized = timeout(Duration::from_secs(15), async {
         loop {
             match rx1.recv().await {
-                Ok(KfpNodeEvent::PsbtFinalized { session_id: sid, .. }) if sid == session_id => {
+                Ok(KfpNodeEvent::PsbtFinalized {
+                    session_id: sid, ..
+                }) if sid == session_id => {
                     return;
                 }
-                Ok(KfpNodeEvent::PsbtAborted { session_id: sid, reason }) if sid == session_id => {
+                Ok(KfpNodeEvent::PsbtAborted {
+                    session_id: sid,
+                    reason,
+                }) if sid == session_id => {
                     panic!("session aborted: {reason}");
                 }
                 Ok(_) => {}
@@ -989,10 +995,8 @@ async fn test_psbt_recovery_spend_end_to_end() {
         script_pubkey: recovery_output.address.script_pubkey(),
     };
     let mut cache = SighashCache::new(&final_tx);
-    let leaf_hash = TapLeafHash::from_script(
-        &recovery_output.tiers[0].script,
-        LeafVersion::TapScript,
-    );
+    let leaf_hash =
+        TapLeafHash::from_script(&recovery_output.tiers[0].script, LeafVersion::TapScript);
     let sighash = cache
         .taproot_script_spend_signature_hash(
             0,

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -819,8 +819,16 @@ async fn test_psbt_recovery_spend_end_to_end() {
         let mut n2 = 0u32;
         loop {
             tokio::select! {
-                Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx1.recv() => n1 += 1,
-                Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx2.recv() => n2 += 1,
+                ev = rx1.recv() => {
+                    if let Ok(KfpNodeEvent::PeerDiscovered { .. }) = ev {
+                        n1 += 1;
+                    }
+                }
+                ev = rx2.recv() => {
+                    if let Ok(KfpNodeEvent::PeerDiscovered { .. }) = ev {
+                        n2 += 1;
+                    }
+                }
             }
             if n1 >= 1 && n2 >= 1 {
                 return;
@@ -861,6 +869,29 @@ async fn test_psbt_recovery_spend_end_to_end() {
         graceful_shutdown(shutdown1, node1_handle).await;
         graceful_shutdown(shutdown2, node2_handle).await;
         panic!("did not receive responder's XpubAnnounce");
+    }
+
+    // The XpubAnnounced event only signals the announce was ingested; under load
+    // the peer's stored xpub may lag the event observer. Poll node1's peer view
+    // until the responder fingerprint is present so target_peers filtering by
+    // fingerprint deterministically succeeds before we propose.
+    let xpub_stored = timeout(Duration::from_secs(15), async {
+        loop {
+            if node1
+                .get_peer_recovery_xpubs(2)
+                .map(|xpubs| xpubs.iter().any(|x| x.fingerprint == responder_fp))
+                .unwrap_or(false)
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await;
+    if xpub_stored.is_err() {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        panic!("node1 did not store responder's recovery xpub");
     }
 
     // Build an unsigned recovery-spend PSBT for a 1-input/1-output tx against

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -640,6 +640,399 @@ async fn test_descriptor_coordination_flow() {
     graceful_shutdown(shutdown2, node2_handle).await;
 }
 
+/// In-process `PersistedDescriptorLookup` backed by a single `WalletDescriptor`
+/// for use by the recovery-tier PSBT integration test.
+struct StaticDescriptorLookup {
+    descriptor: keep_core::wallet::WalletDescriptor,
+}
+
+impl keep_frost_net::PersistedDescriptorLookup for StaticDescriptorLookup {
+    fn find_by_hash(&self, group: &[u8; 32], hash: &[u8; 32]) -> bool {
+        &self.descriptor.group_pubkey == group && &self.descriptor.canonical_hash() == hash
+    }
+    fn network_for(&self, group: &[u8; 32], hash: &[u8; 32]) -> Option<String> {
+        if self.find_by_hash(group, hash) {
+            Some(self.descriptor.network.clone())
+        } else {
+            None
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_psbt_recovery_spend_end_to_end() {
+    use std::sync::Arc;
+
+    use bitcoin::bip32::Xpub;
+    use bitcoin::hashes::Hash as _;
+    use bitcoin::psbt::Psbt;
+    use bitcoin::secp256k1::{Keypair, Secp256k1};
+    use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
+    use bitcoin::taproot::{LeafVersion, Signature as TaprootSignature, TapLeafHash};
+    use bitcoin::{
+        absolute::LockTime, transaction::Version, Amount, Network, OutPoint, ScriptBuf, Sequence,
+        Transaction, TxIn, TxOut, Witness, XOnlyPublicKey,
+    };
+    use keep_bitcoin::recovery::{
+        RecoveryConfig, RecoveryTier as BitcoinRecoveryTier, SpendingTier,
+    };
+    use keep_bitcoin::{
+        merge_tap_script_sig, script_spend_sighashes, DescriptorExport, RecoveryTxBuilder,
+    };
+    use keep_frost_net::{SignerId, WalletPolicy};
+
+    let mock_relay = MockRelay::run().await.expect("Failed to start mock relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let config = ThresholdConfig::two_of_three();
+    let dealer = TrustedDealer::new(config);
+    let (mut shares, _pubkey_pkg) = dealer.generate("test-psbt-recovery").unwrap();
+
+    let share1 = shares.remove(0);
+    let share2 = shares.remove(0);
+
+    let mut node1 = KfpNode::new(share1, vec![relay.clone()])
+        .await
+        .expect("Failed to create node 1 (initiator)");
+
+    let mut node2 = KfpNode::new(share2, vec![relay])
+        .await
+        .expect("Failed to create node 2 (responder)");
+
+    let group_pubkey = *node1.group_pubkey();
+
+    // Responder controls a known external xpub. We derive it from a fixed seed
+    // so the test has access to the secret key for inline signing in lieu of a
+    // live NIP-46 signer; the responder's `KfpNode` only sees the xpub +
+    // fingerprint.
+    let secp = Secp256k1::new();
+    let responder_xpriv = bitcoin::bip32::Xpriv::new_master(Network::Signet, &[7u8; 32])
+        .expect("xpriv master");
+    let responder_xpub = Xpub::from_priv(&secp, &responder_xpriv);
+    let responder_xpub_str = responder_xpub.to_string();
+    let responder_fp = responder_xpub.fingerprint().to_string().to_ascii_lowercase();
+    let responder_xonly_bytes = responder_xpub.to_x_only_pub().serialize();
+    let responder_xonly =
+        XOnlyPublicKey::from_slice(&responder_xonly_bytes).expect("xonly from slice");
+    let responder_sk = responder_xpriv.private_key.secret_bytes();
+
+    // Build a recovery config with a single recovery tier holding ONE external
+    // key (threshold 1). Single-signer keeps the test deterministic and lets
+    // the initiator auto-finalize as soon as the responder contributes.
+    let recovery_config = RecoveryConfig {
+        primary: SpendingTier {
+            keys: vec![group_pubkey],
+            threshold: 1,
+        },
+        recovery_tiers: vec![BitcoinRecoveryTier {
+            keys: vec![responder_xonly_bytes],
+            threshold: 1,
+            timelock_months: 6,
+        }],
+        network: Network::Signet,
+    };
+    let recovery_output = recovery_config.build().expect("build recovery output");
+    let builder = RecoveryTxBuilder::new(recovery_output.clone());
+
+    let policy = WalletPolicy {
+        recovery_tiers: vec![keep_frost_net::PolicyTier {
+            threshold: 1,
+            key_slots: vec![keep_frost_net::KeySlot::External {
+                xpub: responder_xpub_str.clone(),
+                fingerprint: responder_fp.clone(),
+            }],
+            timelock_months: 6,
+        }],
+    };
+    let policy_hash = keep_frost_net::derive_policy_hash(&policy);
+
+    let export = DescriptorExport::from_frost_wallet(
+        &group_pubkey,
+        Some(&recovery_config),
+        Network::Signet,
+    )
+    .expect("descriptor export");
+    let external_desc = export.external_descriptor().to_string();
+    let internal_desc = export.internal_descriptor().expect("internal descriptor");
+
+    let policy_value = serde_json::to_value(&policy).ok();
+    let wallet_descriptor = keep_core::wallet::WalletDescriptor {
+        group_pubkey,
+        external_descriptor: external_desc.clone(),
+        internal_descriptor: internal_desc.clone(),
+        network: "signet".to_string(),
+        created_at: 0,
+        device_registrations: Vec::new(),
+        policy_hash,
+        policy: policy_value,
+    };
+    let descriptor_hash = wallet_descriptor.canonical_hash();
+    let lookup: Arc<dyn keep_frost_net::PersistedDescriptorLookup> =
+        Arc::new(StaticDescriptorLookup {
+            descriptor: wallet_descriptor.clone(),
+        });
+
+    node1 = node1.with_descriptor_lookup(lookup.clone());
+    node2 = node2.with_descriptor_lookup(lookup);
+
+    let node1_pubkey = node1.pubkey();
+
+    let mut rx1 = node1.subscribe();
+    let mut rx2 = node2.subscribe();
+
+    let shutdown1 = node1.take_shutdown_handle();
+    let shutdown2 = node2.take_shutdown_handle();
+
+    let node1 = Arc::new(node1);
+    let node2 = Arc::new(node2);
+    let node1_run = Arc::clone(&node1);
+    let node2_run = Arc::clone(&node2);
+
+    let node1_handle = tokio::spawn(async move {
+        let _ = node1_run.run().await;
+    });
+    let node2_handle = tokio::spawn(async move {
+        let _ = node2_run.run().await;
+    });
+
+    // Both nodes announce so they discover each other; node2 also announces
+    // its external recovery xpub so the initiator can target it by fingerprint.
+    node1.announce().await.expect("node1 announce");
+    node2.announce().await.expect("node2 announce");
+
+    let discovery = timeout(Duration::from_secs(45), async {
+        let mut n1 = 0u32;
+        let mut n2 = 0u32;
+        loop {
+            tokio::select! {
+                Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx1.recv() => n1 += 1,
+                Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx2.recv() => n2 += 1,
+            }
+            if n1 >= 1 && n2 >= 1 {
+                return;
+            }
+        }
+    })
+    .await;
+    if discovery.is_err() {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        panic!("peer discovery timed out");
+    }
+
+    // After mutual peer discovery, announce the responder's external xpub so
+    // the initiator can target it by fingerprint when proposing.
+    node2
+        .announce_xpubs(vec![keep_frost_net::AnnouncedXpub {
+            xpub: responder_xpub_str.clone(),
+            fingerprint: responder_fp.clone(),
+            label: Some("test-responder".into()),
+        }])
+        .await
+        .expect("node2 announce_xpubs");
+
+    // Wait for node1 to ingest node2's XpubAnnounce so target_peers filtering
+    // by fingerprint succeeds when we propose.
+    let xpub_seen = timeout(Duration::from_secs(15), async {
+        loop {
+            if let Ok(KfpNodeEvent::XpubAnnounced { share_index, .. }) = rx1.recv().await {
+                if share_index == 2 {
+                    return;
+                }
+            }
+        }
+    })
+    .await;
+    if xpub_seen.is_err() {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        panic!("did not receive responder's XpubAnnounce");
+    }
+
+    // Build an unsigned recovery-spend PSBT for a 1-input/1-output tx against
+    // a synthetic UTXO that uses our recovery address as the prev script.
+    let utxo = OutPoint {
+        txid: bitcoin::Txid::all_zeros(),
+        vout: 0,
+    };
+    let utxo_value: u64 = 100_000;
+    let fee: u64 = 1_000;
+    let dest_kp = Keypair::from_seckey_slice(&secp, &[9u8; 32]).expect("dest keypair");
+    let dest_xonly = dest_kp.x_only_public_key().0;
+    let dest_script = ScriptBuf::new_p2tr(&secp, dest_xonly, None);
+
+    let unsigned_psbt = builder
+        .build_recovery_psbt(0, utxo, utxo_value, &dest_script, fee)
+        .expect("build_recovery_psbt");
+    let unsigned_bytes = unsigned_psbt.serialize();
+
+    // Initiator proposes the PSBT, expecting the responder's fingerprint to
+    // contribute the script-spend signature.
+    let session_id = node1
+        .request_psbt_spend(
+            descriptor_hash,
+            0,
+            unsigned_bytes.clone(),
+            fee,
+            1,
+            Vec::new(),
+            vec![responder_fp.clone()],
+            Vec::new(),
+            Vec::new(),
+            Some(60),
+        )
+        .await
+        .expect("request_psbt_spend");
+
+    // Responder side: receive PsbtSignatureNeeded, then perform the same chain
+    // the production approve path runs — compute sighash, sign (in lieu of
+    // NIP-46), merge, contribute.
+    let need = timeout(Duration::from_secs(15), async {
+        loop {
+            if let Ok(KfpNodeEvent::PsbtSignatureNeeded {
+                session_id: sid,
+                initiator_pubkey,
+                ..
+            }) = rx2.recv().await
+            {
+                if sid == session_id {
+                    return initiator_pubkey;
+                }
+            }
+        }
+    })
+    .await
+    .expect("PsbtSignatureNeeded on responder");
+    assert_eq!(need, node1_pubkey);
+
+    let proposal_bytes = node2
+        .psbt_session_proposal_psbt(&session_id)
+        .expect("responder has proposal psbt");
+    let mut responder_psbt = Psbt::deserialize(&proposal_bytes).expect("decode proposal");
+    let sighashes = script_spend_sighashes(&responder_psbt).expect("compute sighashes");
+    assert_eq!(sighashes.len(), 1);
+
+    // In-process "NIP-46 signer": sign the sighash directly with the known
+    // secret key. This stands in for a real bunker round-trip.
+    let kp = Keypair::from_seckey_slice(&secp, &responder_sk).expect("responder kp");
+    let msg = bitcoin::secp256k1::Message::from_digest(sighashes[0].sighash);
+    let aux = [0u8; 32];
+    let schnorr_sig = secp.sign_schnorr_with_aux_rand(&msg, &kp, &aux);
+    let schnorr_bytes: [u8; 64] = schnorr_sig.serialize();
+    merge_tap_script_sig(
+        &mut responder_psbt,
+        sighashes[0].input_index,
+        responder_xonly,
+        sighashes[0].leaf_hash,
+        schnorr_bytes,
+    )
+    .expect("merge sig");
+    let merged_bytes = responder_psbt.serialize();
+
+    node2
+        .contribute_psbt_signature(
+            session_id,
+            &need,
+            SignerId::Fingerprint(responder_fp.clone()),
+            merged_bytes,
+        )
+        .await
+        .expect("contribute_psbt_signature");
+
+    // Initiator auto-finalizes once threshold (1) is met. Wait for the event
+    // and validate the produced PSBT's witness verifies on the prevout.
+    let finalized = timeout(Duration::from_secs(15), async {
+        loop {
+            match rx1.recv().await {
+                Ok(KfpNodeEvent::PsbtFinalized { session_id: sid, .. }) if sid == session_id => {
+                    return;
+                }
+                Ok(KfpNodeEvent::PsbtAborted { session_id: sid, reason }) if sid == session_id => {
+                    panic!("session aborted: {reason}");
+                }
+                Ok(_) => {}
+                Err(_) => panic!("event channel closed"),
+            }
+        }
+    })
+    .await;
+    if finalized.is_err() {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        panic!("did not receive PsbtFinalized");
+    }
+
+    // Independently reconstruct the same merged PSBT and finalize it via the
+    // RecoveryTxBuilder so we can verify the script-spend signature is valid
+    // and produces a well-formed witness for the recovery tier.
+    let mut verify_psbt = Psbt::deserialize(&unsigned_bytes).expect("decode unsigned");
+    let verify_sighashes = script_spend_sighashes(&verify_psbt).expect("verify sighashes");
+    let v_msg = bitcoin::secp256k1::Message::from_digest(verify_sighashes[0].sighash);
+    let v_sig = secp.sign_schnorr_with_aux_rand(&v_msg, &kp, &aux);
+    verify_psbt.inputs[0].tap_script_sigs.insert(
+        (responder_xonly, verify_sighashes[0].leaf_hash),
+        TaprootSignature {
+            signature: v_sig,
+            sighash_type: TapSighashType::Default,
+        },
+    );
+
+    let final_tx = builder
+        .finalize_recovery(&mut verify_psbt, 0)
+        .expect("finalize_recovery");
+    assert!(!final_tx.input[0].witness.is_empty());
+
+    // Verify the schnorr signature against the sighash using the prevout.
+    let prevout = TxOut {
+        value: Amount::from_sat(utxo_value),
+        script_pubkey: recovery_output.address.script_pubkey(),
+    };
+    let mut cache = SighashCache::new(&final_tx);
+    let leaf_hash = TapLeafHash::from_script(
+        &recovery_output.tiers[0].script,
+        LeafVersion::TapScript,
+    );
+    let sighash = cache
+        .taproot_script_spend_signature_hash(
+            0,
+            &Prevouts::All(&[prevout]),
+            leaf_hash,
+            TapSighashType::Default,
+        )
+        .expect("verify sighash");
+    let verify_msg = bitcoin::secp256k1::Message::from_digest(sighash.to_byte_array());
+    secp.verify_schnorr(&v_sig, &verify_msg, &responder_xonly)
+        .expect("schnorr verify");
+
+    // Sanity: ensure the unused stack-cells / script / control-block are at
+    // the expected witness positions for a 1-of-1 recovery tier.
+    let witness = &final_tx.input[0].witness;
+    assert!(witness.len() >= 3, "witness should have sig + script + cb");
+
+    // Silence unused locals.
+    let _ = (
+        &external_desc,
+        &internal_desc,
+        Version::TWO,
+        LockTime::ZERO,
+        TxIn {
+            previous_output: utxo,
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+        },
+        Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![],
+            output: vec![],
+        },
+    );
+
+    graceful_shutdown(shutdown1, node1_handle).await;
+    graceful_shutdown(shutdown2, node2_handle).await;
+}
+
 #[tokio::test]
 async fn test_request_descriptor_fails_with_no_peers() {
     let mock_relay = MockRelay::run().await.expect("Failed to start mock relay");

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -706,11 +706,14 @@ async fn test_psbt_recovery_spend_end_to_end() {
     // live NIP-46 signer; the responder's `KfpNode` only sees the xpub +
     // fingerprint.
     let secp = Secp256k1::new();
-    let responder_xpriv = bitcoin::bip32::Xpriv::new_master(Network::Signet, &[7u8; 32])
-        .expect("xpriv master");
+    let responder_xpriv =
+        bitcoin::bip32::Xpriv::new_master(Network::Signet, &[7u8; 32]).expect("xpriv master");
     let responder_xpub = Xpub::from_priv(&secp, &responder_xpriv);
     let responder_xpub_str = responder_xpub.to_string();
-    let responder_fp = responder_xpub.fingerprint().to_string().to_ascii_lowercase();
+    let responder_fp = responder_xpub
+        .fingerprint()
+        .to_string()
+        .to_ascii_lowercase();
     let responder_xonly_bytes = responder_xpub.to_x_only_pub().serialize();
     let responder_xonly =
         XOnlyPublicKey::from_slice(&responder_xonly_bytes).expect("xonly from slice");
@@ -746,12 +749,9 @@ async fn test_psbt_recovery_spend_end_to_end() {
     };
     let policy_hash = keep_frost_net::derive_policy_hash(&policy);
 
-    let export = DescriptorExport::from_frost_wallet(
-        &group_pubkey,
-        Some(&recovery_config),
-        Network::Signet,
-    )
-    .expect("descriptor export");
+    let export =
+        DescriptorExport::from_frost_wallet(&group_pubkey, Some(&recovery_config), Network::Signet)
+            .expect("descriptor export");
     let external_desc = export.external_descriptor().to_string();
     let internal_desc = export.internal_descriptor().expect("internal descriptor");
 
@@ -924,6 +924,7 @@ async fn test_psbt_recovery_spend_end_to_end() {
         sighashes[0].input_index,
         responder_xonly,
         sighashes[0].leaf_hash,
+        &sighashes[0].sighash,
         schnorr_bytes,
     )
     .expect("merge sig");
@@ -944,10 +945,15 @@ async fn test_psbt_recovery_spend_end_to_end() {
     let finalized = timeout(Duration::from_secs(15), async {
         loop {
             match rx1.recv().await {
-                Ok(KfpNodeEvent::PsbtFinalized { session_id: sid, .. }) if sid == session_id => {
+                Ok(KfpNodeEvent::PsbtFinalized {
+                    session_id: sid, ..
+                }) if sid == session_id => {
                     return;
                 }
-                Ok(KfpNodeEvent::PsbtAborted { session_id: sid, reason }) if sid == session_id => {
+                Ok(KfpNodeEvent::PsbtAborted {
+                    session_id: sid,
+                    reason,
+                }) if sid == session_id => {
                     panic!("session aborted: {reason}");
                 }
                 Ok(_) => {}
@@ -988,10 +994,8 @@ async fn test_psbt_recovery_spend_end_to_end() {
         script_pubkey: recovery_output.address.script_pubkey(),
     };
     let mut cache = SighashCache::new(&final_tx);
-    let leaf_hash = TapLeafHash::from_script(
-        &recovery_output.tiers[0].script,
-        LeafVersion::TapScript,
-    );
+    let leaf_hash =
+        TapLeafHash::from_script(&recovery_output.tiers[0].script, LeafVersion::TapScript);
     let sighash = cache
         .taproot_script_spend_signature_hash(
             0,

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -658,6 +658,16 @@ impl keep_frost_net::PersistedDescriptorLookup for StaticDescriptorLookup {
             None
         }
     }
+    fn latest_version_for(
+        &self,
+        group: &[u8; 32],
+    ) -> std::result::Result<Option<u32>, keep_frost_net::DescriptorLookupUnavailable> {
+        if &self.descriptor.group_pubkey == group {
+            Ok(Some(self.descriptor.version))
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 #[tokio::test]
@@ -747,6 +757,7 @@ async fn test_psbt_recovery_spend_end_to_end() {
             }],
             timelock_months: 6,
         }],
+        version: 1,
     };
     let policy_hash = keep_frost_net::derive_policy_hash(&policy);
 
@@ -765,6 +776,8 @@ async fn test_psbt_recovery_spend_end_to_end() {
         created_at: 0,
         device_registrations: Vec::new(),
         policy_hash,
+        version: 1,
+        previous_descriptor_hash: None,
         policy: policy_value,
     };
     let descriptor_hash = wallet_descriptor.canonical_hash();

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -641,6 +641,399 @@ async fn test_descriptor_coordination_flow() {
     graceful_shutdown(shutdown2, node2_handle).await;
 }
 
+/// In-process `PersistedDescriptorLookup` backed by a single `WalletDescriptor`
+/// for use by the recovery-tier PSBT integration test.
+struct StaticDescriptorLookup {
+    descriptor: keep_core::wallet::WalletDescriptor,
+}
+
+impl keep_frost_net::PersistedDescriptorLookup for StaticDescriptorLookup {
+    fn find_by_hash(&self, group: &[u8; 32], hash: &[u8; 32]) -> bool {
+        &self.descriptor.group_pubkey == group && &self.descriptor.canonical_hash() == hash
+    }
+    fn network_for(&self, group: &[u8; 32], hash: &[u8; 32]) -> Option<String> {
+        if self.find_by_hash(group, hash) {
+            Some(self.descriptor.network.clone())
+        } else {
+            None
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_psbt_recovery_spend_end_to_end() {
+    use std::sync::Arc;
+
+    use bitcoin::bip32::Xpub;
+    use bitcoin::hashes::Hash as _;
+    use bitcoin::psbt::Psbt;
+    use bitcoin::secp256k1::{Keypair, Secp256k1};
+    use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
+    use bitcoin::taproot::{LeafVersion, Signature as TaprootSignature, TapLeafHash};
+    use bitcoin::{
+        absolute::LockTime, transaction::Version, Amount, Network, OutPoint, ScriptBuf, Sequence,
+        Transaction, TxIn, TxOut, Witness, XOnlyPublicKey,
+    };
+    use keep_bitcoin::recovery::{
+        RecoveryConfig, RecoveryTier as BitcoinRecoveryTier, SpendingTier,
+    };
+    use keep_bitcoin::{
+        merge_tap_script_sig, script_spend_sighashes, DescriptorExport, RecoveryTxBuilder,
+    };
+    use keep_frost_net::{SignerId, WalletPolicy};
+
+    let mock_relay = MockRelay::run().await.expect("Failed to start mock relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let config = ThresholdConfig::two_of_three();
+    let dealer = TrustedDealer::new(config);
+    let (mut shares, _pubkey_pkg) = dealer.generate("test-psbt-recovery").unwrap();
+
+    let share1 = shares.remove(0);
+    let share2 = shares.remove(0);
+
+    let mut node1 = KfpNode::new(share1, vec![relay.clone()])
+        .await
+        .expect("Failed to create node 1 (initiator)");
+
+    let mut node2 = KfpNode::new(share2, vec![relay])
+        .await
+        .expect("Failed to create node 2 (responder)");
+
+    let group_pubkey = *node1.group_pubkey();
+
+    // Responder controls a known external xpub. We derive it from a fixed seed
+    // so the test has access to the secret key for inline signing in lieu of a
+    // live NIP-46 signer; the responder's `KfpNode` only sees the xpub +
+    // fingerprint.
+    let secp = Secp256k1::new();
+    let responder_xpriv = bitcoin::bip32::Xpriv::new_master(Network::Signet, &[7u8; 32])
+        .expect("xpriv master");
+    let responder_xpub = Xpub::from_priv(&secp, &responder_xpriv);
+    let responder_xpub_str = responder_xpub.to_string();
+    let responder_fp = responder_xpub.fingerprint().to_string().to_ascii_lowercase();
+    let responder_xonly_bytes = responder_xpub.to_x_only_pub().serialize();
+    let responder_xonly =
+        XOnlyPublicKey::from_slice(&responder_xonly_bytes).expect("xonly from slice");
+    let responder_sk = responder_xpriv.private_key.secret_bytes();
+
+    // Build a recovery config with a single recovery tier holding ONE external
+    // key (threshold 1). Single-signer keeps the test deterministic and lets
+    // the initiator auto-finalize as soon as the responder contributes.
+    let recovery_config = RecoveryConfig {
+        primary: SpendingTier {
+            keys: vec![group_pubkey],
+            threshold: 1,
+        },
+        recovery_tiers: vec![BitcoinRecoveryTier {
+            keys: vec![responder_xonly_bytes],
+            threshold: 1,
+            timelock_months: 6,
+        }],
+        network: Network::Signet,
+    };
+    let recovery_output = recovery_config.build().expect("build recovery output");
+    let builder = RecoveryTxBuilder::new(recovery_output.clone());
+
+    let policy = WalletPolicy {
+        recovery_tiers: vec![keep_frost_net::PolicyTier {
+            threshold: 1,
+            key_slots: vec![keep_frost_net::KeySlot::External {
+                xpub: responder_xpub_str.clone(),
+                fingerprint: responder_fp.clone(),
+            }],
+            timelock_months: 6,
+        }],
+    };
+    let policy_hash = keep_frost_net::derive_policy_hash(&policy);
+
+    let export = DescriptorExport::from_frost_wallet(
+        &group_pubkey,
+        Some(&recovery_config),
+        Network::Signet,
+    )
+    .expect("descriptor export");
+    let external_desc = export.external_descriptor().to_string();
+    let internal_desc = export.internal_descriptor().expect("internal descriptor");
+
+    let policy_value = serde_json::to_value(&policy).ok();
+    let wallet_descriptor = keep_core::wallet::WalletDescriptor {
+        group_pubkey,
+        external_descriptor: external_desc.clone(),
+        internal_descriptor: internal_desc.clone(),
+        network: "signet".to_string(),
+        created_at: 0,
+        device_registrations: Vec::new(),
+        policy_hash,
+        policy: policy_value,
+    };
+    let descriptor_hash = wallet_descriptor.canonical_hash();
+    let lookup: Arc<dyn keep_frost_net::PersistedDescriptorLookup> =
+        Arc::new(StaticDescriptorLookup {
+            descriptor: wallet_descriptor.clone(),
+        });
+
+    node1 = node1.with_descriptor_lookup(lookup.clone());
+    node2 = node2.with_descriptor_lookup(lookup);
+
+    let node1_pubkey = node1.pubkey();
+
+    let mut rx1 = node1.subscribe();
+    let mut rx2 = node2.subscribe();
+
+    let shutdown1 = node1.take_shutdown_handle();
+    let shutdown2 = node2.take_shutdown_handle();
+
+    let node1 = Arc::new(node1);
+    let node2 = Arc::new(node2);
+    let node1_run = Arc::clone(&node1);
+    let node2_run = Arc::clone(&node2);
+
+    let node1_handle = tokio::spawn(async move {
+        let _ = node1_run.run().await;
+    });
+    let node2_handle = tokio::spawn(async move {
+        let _ = node2_run.run().await;
+    });
+
+    // Both nodes announce so they discover each other; node2 also announces
+    // its external recovery xpub so the initiator can target it by fingerprint.
+    node1.announce().await.expect("node1 announce");
+    node2.announce().await.expect("node2 announce");
+
+    let discovery = timeout(Duration::from_secs(45), async {
+        let mut n1 = 0u32;
+        let mut n2 = 0u32;
+        loop {
+            tokio::select! {
+                Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx1.recv() => n1 += 1,
+                Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx2.recv() => n2 += 1,
+            }
+            if n1 >= 1 && n2 >= 1 {
+                return;
+            }
+        }
+    })
+    .await;
+    if discovery.is_err() {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        panic!("peer discovery timed out");
+    }
+
+    // After mutual peer discovery, announce the responder's external xpub so
+    // the initiator can target it by fingerprint when proposing.
+    node2
+        .announce_xpubs(vec![keep_frost_net::AnnouncedXpub {
+            xpub: responder_xpub_str.clone(),
+            fingerprint: responder_fp.clone(),
+            label: Some("test-responder".into()),
+        }])
+        .await
+        .expect("node2 announce_xpubs");
+
+    // Wait for node1 to ingest node2's XpubAnnounce so target_peers filtering
+    // by fingerprint succeeds when we propose.
+    let xpub_seen = timeout(Duration::from_secs(15), async {
+        loop {
+            if let Ok(KfpNodeEvent::XpubAnnounced { share_index, .. }) = rx1.recv().await {
+                if share_index == 2 {
+                    return;
+                }
+            }
+        }
+    })
+    .await;
+    if xpub_seen.is_err() {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        panic!("did not receive responder's XpubAnnounce");
+    }
+
+    // Build an unsigned recovery-spend PSBT for a 1-input/1-output tx against
+    // a synthetic UTXO that uses our recovery address as the prev script.
+    let utxo = OutPoint {
+        txid: bitcoin::Txid::all_zeros(),
+        vout: 0,
+    };
+    let utxo_value: u64 = 100_000;
+    let fee: u64 = 1_000;
+    let dest_kp = Keypair::from_seckey_slice(&secp, &[9u8; 32]).expect("dest keypair");
+    let dest_xonly = dest_kp.x_only_public_key().0;
+    let dest_script = ScriptBuf::new_p2tr(&secp, dest_xonly, None);
+
+    let unsigned_psbt = builder
+        .build_recovery_psbt(0, utxo, utxo_value, &dest_script, fee)
+        .expect("build_recovery_psbt");
+    let unsigned_bytes = unsigned_psbt.serialize();
+
+    // Initiator proposes the PSBT, expecting the responder's fingerprint to
+    // contribute the script-spend signature.
+    let session_id = node1
+        .request_psbt_spend(
+            descriptor_hash,
+            0,
+            unsigned_bytes.clone(),
+            fee,
+            1,
+            Vec::new(),
+            vec![responder_fp.clone()],
+            Vec::new(),
+            Vec::new(),
+            Some(60),
+        )
+        .await
+        .expect("request_psbt_spend");
+
+    // Responder side: receive PsbtSignatureNeeded, then perform the same chain
+    // the production approve path runs — compute sighash, sign (in lieu of
+    // NIP-46), merge, contribute.
+    let need = timeout(Duration::from_secs(15), async {
+        loop {
+            if let Ok(KfpNodeEvent::PsbtSignatureNeeded {
+                session_id: sid,
+                initiator_pubkey,
+                ..
+            }) = rx2.recv().await
+            {
+                if sid == session_id {
+                    return initiator_pubkey;
+                }
+            }
+        }
+    })
+    .await
+    .expect("PsbtSignatureNeeded on responder");
+    assert_eq!(need, node1_pubkey);
+
+    let proposal_bytes = node2
+        .psbt_session_proposal_psbt(&session_id)
+        .expect("responder has proposal psbt");
+    let mut responder_psbt = Psbt::deserialize(&proposal_bytes).expect("decode proposal");
+    let sighashes = script_spend_sighashes(&responder_psbt).expect("compute sighashes");
+    assert_eq!(sighashes.len(), 1);
+
+    // In-process "NIP-46 signer": sign the sighash directly with the known
+    // secret key. This stands in for a real bunker round-trip.
+    let kp = Keypair::from_seckey_slice(&secp, &responder_sk).expect("responder kp");
+    let msg = bitcoin::secp256k1::Message::from_digest(sighashes[0].sighash);
+    let aux = [0u8; 32];
+    let schnorr_sig = secp.sign_schnorr_with_aux_rand(&msg, &kp, &aux);
+    let schnorr_bytes: [u8; 64] = schnorr_sig.serialize();
+    merge_tap_script_sig(
+        &mut responder_psbt,
+        sighashes[0].input_index,
+        responder_xonly,
+        sighashes[0].leaf_hash,
+        schnorr_bytes,
+    )
+    .expect("merge sig");
+    let merged_bytes = responder_psbt.serialize();
+
+    node2
+        .contribute_psbt_signature(
+            session_id,
+            &need,
+            SignerId::Fingerprint(responder_fp.clone()),
+            merged_bytes,
+        )
+        .await
+        .expect("contribute_psbt_signature");
+
+    // Initiator auto-finalizes once threshold (1) is met. Wait for the event
+    // and validate the produced PSBT's witness verifies on the prevout.
+    let finalized = timeout(Duration::from_secs(15), async {
+        loop {
+            match rx1.recv().await {
+                Ok(KfpNodeEvent::PsbtFinalized { session_id: sid, .. }) if sid == session_id => {
+                    return;
+                }
+                Ok(KfpNodeEvent::PsbtAborted { session_id: sid, reason }) if sid == session_id => {
+                    panic!("session aborted: {reason}");
+                }
+                Ok(_) => {}
+                Err(_) => panic!("event channel closed"),
+            }
+        }
+    })
+    .await;
+    if finalized.is_err() {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        panic!("did not receive PsbtFinalized");
+    }
+
+    // Independently reconstruct the same merged PSBT and finalize it via the
+    // RecoveryTxBuilder so we can verify the script-spend signature is valid
+    // and produces a well-formed witness for the recovery tier.
+    let mut verify_psbt = Psbt::deserialize(&unsigned_bytes).expect("decode unsigned");
+    let verify_sighashes = script_spend_sighashes(&verify_psbt).expect("verify sighashes");
+    let v_msg = bitcoin::secp256k1::Message::from_digest(verify_sighashes[0].sighash);
+    let v_sig = secp.sign_schnorr_with_aux_rand(&v_msg, &kp, &aux);
+    verify_psbt.inputs[0].tap_script_sigs.insert(
+        (responder_xonly, verify_sighashes[0].leaf_hash),
+        TaprootSignature {
+            signature: v_sig,
+            sighash_type: TapSighashType::Default,
+        },
+    );
+
+    let final_tx = builder
+        .finalize_recovery(&mut verify_psbt, 0)
+        .expect("finalize_recovery");
+    assert!(!final_tx.input[0].witness.is_empty());
+
+    // Verify the schnorr signature against the sighash using the prevout.
+    let prevout = TxOut {
+        value: Amount::from_sat(utxo_value),
+        script_pubkey: recovery_output.address.script_pubkey(),
+    };
+    let mut cache = SighashCache::new(&final_tx);
+    let leaf_hash = TapLeafHash::from_script(
+        &recovery_output.tiers[0].script,
+        LeafVersion::TapScript,
+    );
+    let sighash = cache
+        .taproot_script_spend_signature_hash(
+            0,
+            &Prevouts::All(&[prevout]),
+            leaf_hash,
+            TapSighashType::Default,
+        )
+        .expect("verify sighash");
+    let verify_msg = bitcoin::secp256k1::Message::from_digest(sighash.to_byte_array());
+    secp.verify_schnorr(&v_sig, &verify_msg, &responder_xonly)
+        .expect("schnorr verify");
+
+    // Sanity: ensure the unused stack-cells / script / control-block are at
+    // the expected witness positions for a 1-of-1 recovery tier.
+    let witness = &final_tx.input[0].witness;
+    assert!(witness.len() >= 3, "witness should have sig + script + cb");
+
+    // Silence unused locals.
+    let _ = (
+        &external_desc,
+        &internal_desc,
+        Version::TWO,
+        LockTime::ZERO,
+        TxIn {
+            previous_output: utxo,
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+        },
+        Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![],
+            output: vec![],
+        },
+    );
+
+    graceful_shutdown(shutdown1, node1_handle).await;
+    graceful_shutdown(shutdown2, node2_handle).await;
+}
+
 #[tokio::test]
 async fn test_request_descriptor_fails_with_no_peers() {
     let mock_relay = MockRelay::run().await.expect("Failed to start mock relay");

--- a/keep-frost-net/tests/property_tests.rs
+++ b/keep-frost-net/tests/property_tests.rs
@@ -9,8 +9,15 @@ use keep_frost_net::{
 };
 use proptest::prelude::*;
 
-const TEST_XPUB: &str = "xpub661MyMwAqRbcGczjuMoRm6dXaLDEhW1u34gKenbeYqAix21mdUKJyuyu5F1rzYGVxy5eYgMRkvksmGH3BPAxxxxxxxxxxxxxxxxxxxxxxxx";
-const TEST_TPUB: &str = "tpub661MyMwAqRbcGczjuMoRm6dXaLDEhW1u34gKenbeYqAix21mdUKJyuyu5F1rzYGVxy5eYgMRkvksmGH3BPAxxxxxxxxxxxxxxxxxxxxxxxx";
+const TEST_XPUBS: &[&str] = &[
+    "xpub68E4m4SzytZD9PJBwUjEk7s86ZnsLBS8yUmkewPaPFGCAfZz65rB4CnaEvmtFSxECi2oxEHxoEhzt7mue7TdZtrcfmFJfjtSJSdQzQsj6Wq",
+    "xpub68E4m4SzytZDB5dS961HDkDSY6HrjFgjfPcuyjkNURXMiTKb44rWeDY7ZSbzMgrZkhPXkFaB6hR6BBUzNCTroSd1ewTw6JRdB8cq2vkjSH1",
+    "xpub68E4m4SzytZDDWGUyToUTSAut4zeTPT8jchUXSETF4qer2ydy2oGHYrquHCjjGsnHjwGby8vCVg1aMxrWQxv7D2MKan6yW6zotuejYJ5xo2",
+    "xpub68E4m4SzytZDFXvZ3ef7TaNeyRwHpPVjxQVTNm3Byi5VPZYYDF9BZJGNsTR9d1Q86HTL2BY91sJTHLJ36KvkZx6kuSDLoG2YxQRwU1XbTSS",
+    "xpub68E4m4SzytZDJmnj987w1PrY4qsz62CCZUsnkqQtq6hbzZvw14i9Hj7wXtk2N15AzwUftoQhVU7Tixaakv1DMwehkLFr9FWbuJ1e3DdZwFv",
+];
+const TEST_XPUB: &str = TEST_XPUBS[0];
+const TEST_TPUB: &str = "tpubD8bhHJGghAWfRBV3PfiKx3CVRgtXKZwCX7N41VSijA25uxEhAJhGCeTQUxrfmwuTzcZiZooqLLY3aJGX2yJsTLJujMzcMGYftQDpkS2iZz8";
 
 fn roundtrip(msg: KfpMessage) -> KfpMessage {
     let json = msg.to_json().unwrap();
@@ -177,7 +184,7 @@ proptest! {
         let fingerprint = format!("{fingerprint_byte:08x}");
         let xpubs: Vec<AnnouncedXpub> = (0..xpub_count)
             .map(|i| AnnouncedXpub {
-                xpub: format!("{TEST_XPUB}{i:02}"),
+                xpub: TEST_XPUBS[i].into(),
                 fingerprint: fingerprint.clone(),
                 label: None,
             })

--- a/keep-frost-net/tests/property_tests.rs
+++ b/keep-frost-net/tests/property_tests.rs
@@ -18,6 +18,8 @@ const TEST_XPUBS: &[&str] = &[
 ];
 const TEST_XPUB: &str = TEST_XPUBS[0];
 const TEST_TPUB: &str = "tpubD8bhHJGghAWfRBV3PfiKx3CVRgtXKZwCX7N41VSijA25uxEhAJhGCeTQUxrfmwuTzcZiZooqLLY3aJGX2yJsTLJujMzcMGYftQDpkS2iZz8";
+// SLIP-132 P2WSH-multisig extended key; accepted by prefix+length, not BIP32-parsed.
+const TEST_SLIP132_XPUB: &str = "Vpub5fTdGxqcFV2csN5LDRcyA21vURYEfJ8jTXNz1QsM11LqgeWSMAuKuCLE1DpBp4sHctsBKs6xm8PQEiAYVwnZ7uc5mYxruKiTeimzoDrSihv";
 
 fn roundtrip(msg: KfpMessage) -> KfpMessage {
     let json = msg.to_json().unwrap();
@@ -352,6 +354,11 @@ fn valid_xpub_announce_passes_validation() {
             xpub: TEST_TPUB.into(),
             fingerprint: "00112233".into(),
             label: None,
+        },
+        AnnouncedXpub {
+            xpub: TEST_SLIP132_XPUB.into(),
+            fingerprint: "44556677".into(),
+            label: Some("p2wsh".into()),
         },
     ];
     let payload = XpubAnnouncePayload::new([1u8; 32], 1, xpubs);

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1999,10 +1999,14 @@ impl KeepMobile {
             } else {
                 Some(hex::encode(wd.policy_hash))
             };
-            let policy_json = wd
-                .policy
-                .as_ref()
-                .and_then(|v| serde_json::to_string(v).ok());
+            let policy_json = match wd.policy.as_ref() {
+                Some(v) => Some(serde_json::to_string(v).map_err(|e| {
+                    KeepMobileError::BackupError {
+                        msg: format!("failed to serialize descriptor policy: {e}"),
+                    }
+                })?),
+                None => None,
+            };
             prepared_descriptors.push(WalletDescriptorInfo {
                 group_pubkey: hex::encode(wd.group_pubkey),
                 external_descriptor: wd.external_descriptor.clone(),
@@ -2783,7 +2787,26 @@ impl KeepMobile {
                             version,
                             policy,
                         }) => {
-                            let policy_json = serde_json::to_string(&policy).ok();
+                            let policy_json = match serde_json::to_string(&policy) {
+                                Ok(s) => Some(s),
+                                Err(e) => {
+                                    tracing::error!("Failed to serialize descriptor policy: {e}");
+                                    clear_descriptor_state(
+                                        &desc.networks,
+                                        &desc.pending,
+                                        &session_id,
+                                    );
+                                    if let Some(cb) = desc.callbacks.read().await.as_ref() {
+                                        if let Err(e2) = cb.on_failed(
+                                            hex::encode(session_id),
+                                            format!("Failed to serialize descriptor policy: {e}"),
+                                        ) {
+                                            tracing::error!("Descriptor callback error: {e2}");
+                                        }
+                                    }
+                                    continue;
+                                }
+                            };
                             if let Ok(mut p) = desc.pending.lock() {
                                 p.remove(&session_id);
                             }

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1797,6 +1797,10 @@ impl KeepMobile {
                 }
                 None => None,
             };
+            let policy = d
+                .policy_json
+                .as_deref()
+                .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok());
             core_descriptors.push(keep_core::wallet::WalletDescriptor {
                 group_pubkey,
                 external_descriptor: d.external_descriptor.clone(),
@@ -1807,6 +1811,7 @@ impl KeepMobile {
                 policy_hash,
                 version: d.version,
                 previous_descriptor_hash,
+                policy,
             });
         }
 
@@ -1990,6 +1995,7 @@ impl KeepMobile {
             } else {
                 Some(hex::encode(wd.policy_hash))
             };
+            let policy_json = wd.policy.as_ref().and_then(|v| serde_json::to_string(v).ok());
             prepared_descriptors.push(WalletDescriptorInfo {
                 group_pubkey: hex::encode(wd.group_pubkey),
                 external_descriptor: wd.external_descriptor.clone(),
@@ -2012,6 +2018,7 @@ impl KeepMobile {
                 policy_hash_hex,
                 version: wd.version,
                 previous_descriptor_hash_hex: wd.previous_descriptor_hash.map(hex::encode),
+                policy_json,
             });
         }
 
@@ -2767,7 +2774,9 @@ impl KeepMobile {
                             network,
                             policy_hash,
                             version,
+                            policy,
                         }) => {
+                            let policy_json = serde_json::to_string(&policy).ok();
                             if let Ok(mut p) = desc.pending.lock() {
                                 p.remove(&session_id);
                             }
@@ -2796,6 +2805,7 @@ impl KeepMobile {
                                 internal_descriptor,
                                 policy_hash,
                                 version,
+                                policy_json,
                             )
                             .await;
                         }
@@ -2892,6 +2902,7 @@ impl KeepMobile {
         internal_descriptor: String,
         policy_hash: [u8; 32],
         version: u32,
+        policy_json: Option<String>,
     ) {
         let group_pubkey = hex::encode(node.group_pubkey());
         let created_at = std::time::SystemTime::now()
@@ -3008,6 +3019,7 @@ impl KeepMobile {
             },
             version,
             previous_descriptor_hash_hex,
+            policy_json,
         };
 
         if let Err(e) = persistence::persist_descriptor(storage, &info) {

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1995,7 +1995,10 @@ impl KeepMobile {
             } else {
                 Some(hex::encode(wd.policy_hash))
             };
-            let policy_json = wd.policy.as_ref().and_then(|v| serde_json::to_string(v).ok());
+            let policy_json = wd
+                .policy
+                .as_ref()
+                .and_then(|v| serde_json::to_string(v).ok());
             prepared_descriptors.push(WalletDescriptorInfo {
                 group_pubkey: hex::encode(wd.group_pubkey),
                 external_descriptor: wd.external_descriptor.clone(),

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1785,6 +1785,10 @@ impl KeepMobile {
                 }
                 None => [0u8; 32],
             };
+            let policy = d
+                .policy_json
+                .as_deref()
+                .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok());
             core_descriptors.push(keep_core::wallet::WalletDescriptor {
                 group_pubkey,
                 external_descriptor: d.external_descriptor.clone(),
@@ -1793,6 +1797,7 @@ impl KeepMobile {
                 created_at: d.created_at,
                 device_registrations,
                 policy_hash,
+                policy,
             });
         }
 
@@ -1976,6 +1981,7 @@ impl KeepMobile {
             } else {
                 Some(hex::encode(wd.policy_hash))
             };
+            let policy_json = wd.policy.as_ref().and_then(|v| serde_json::to_string(v).ok());
             prepared_descriptors.push(WalletDescriptorInfo {
                 group_pubkey: hex::encode(wd.group_pubkey),
                 external_descriptor: wd.external_descriptor.clone(),
@@ -1996,6 +2002,7 @@ impl KeepMobile {
                     })
                     .collect(),
                 policy_hash_hex,
+                policy_json,
             });
         }
 
@@ -2747,7 +2754,9 @@ impl KeepMobile {
                             internal_descriptor,
                             network,
                             policy_hash,
+                            policy,
                         }) => {
+                            let policy_json = serde_json::to_string(&policy).ok();
                             if let Ok(mut p) = desc.pending.lock() {
                                 p.remove(&session_id);
                             }
@@ -2775,6 +2784,7 @@ impl KeepMobile {
                                 external_descriptor,
                                 internal_descriptor,
                                 policy_hash,
+                                policy_json,
                             )
                             .await;
                         }
@@ -2870,6 +2880,7 @@ impl KeepMobile {
         external_descriptor: String,
         internal_descriptor: String,
         policy_hash: [u8; 32],
+        policy_json: Option<String>,
     ) {
         let group_pubkey = hex::encode(node.group_pubkey());
         let created_at = std::time::SystemTime::now()
@@ -2889,6 +2900,7 @@ impl KeepMobile {
             } else {
                 Some(hex::encode(policy_hash))
             },
+            policy_json,
         };
 
         if let Err(e) = persistence::persist_descriptor(storage, &info) {

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1797,10 +1797,14 @@ impl KeepMobile {
                 }
                 None => None,
             };
-            let policy = d
-                .policy_json
-                .as_deref()
-                .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok());
+            let policy = match d.policy_json.as_deref() {
+                Some(s) => Some(serde_json::from_str::<serde_json::Value>(s).map_err(|e| {
+                    KeepMobileError::BackupError {
+                        msg: format!("descriptor policy_json is not valid JSON: {e}"),
+                    }
+                })?),
+                None => None,
+            };
             core_descriptors.push(keep_core::wallet::WalletDescriptor {
                 group_pubkey,
                 external_descriptor: d.external_descriptor.clone(),

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1981,7 +1981,10 @@ impl KeepMobile {
             } else {
                 Some(hex::encode(wd.policy_hash))
             };
-            let policy_json = wd.policy.as_ref().and_then(|v| serde_json::to_string(v).ok());
+            let policy_json = wd
+                .policy
+                .as_ref()
+                .and_then(|v| serde_json::to_string(v).ok());
             prepared_descriptors.push(WalletDescriptorInfo {
                 group_pubkey: hex::encode(wd.group_pubkey),
                 external_descriptor: wd.external_descriptor.clone(),

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1999,14 +1999,15 @@ impl KeepMobile {
             } else {
                 Some(hex::encode(wd.policy_hash))
             };
-            let policy_json = match wd.policy.as_ref() {
-                Some(v) => Some(serde_json::to_string(v).map_err(|e| {
-                    KeepMobileError::BackupError {
-                        msg: format!("failed to serialize descriptor policy: {e}"),
-                    }
-                })?),
-                None => None,
-            };
+            let policy_json =
+                match wd.policy.as_ref() {
+                    Some(v) => Some(serde_json::to_string(v).map_err(|e| {
+                        KeepMobileError::BackupError {
+                            msg: format!("failed to serialize descriptor policy: {e}"),
+                        }
+                    })?),
+                    None => None,
+                };
             prepared_descriptors.push(WalletDescriptorInfo {
                 group_pubkey: hex::encode(wd.group_pubkey),
                 external_descriptor: wd.external_descriptor.clone(),

--- a/keep-mobile/src/persistence.rs
+++ b/keep-mobile/src/persistence.rs
@@ -224,6 +224,10 @@ struct StoredDescriptor {
     /// written before the field was introduced; new records always set it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     policy_hash_hex: Option<String>,
+    /// JSON-encoded `WalletPolicy`. Persisted as a string for FFI simplicity;
+    /// older records deserialize with `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    policy_json: Option<String>,
 }
 
 /// At-rest schema for a hardware-signer registration record.
@@ -403,6 +407,7 @@ fn stored_to_info(stored: StoredDescriptor) -> WalletDescriptorInfo {
         created_at: stored.created_at,
         device_registrations,
         policy_hash_hex: stored.policy_hash_hex,
+        policy_json: stored.policy_json,
     }
 }
 
@@ -414,6 +419,7 @@ fn info_to_stored(info: &WalletDescriptorInfo) -> StoredDescriptor {
         network: info.network.clone(),
         created_at: info.created_at,
         policy_hash_hex: info.policy_hash_hex.clone(),
+        policy_json: info.policy_json.clone(),
         device_registrations: info
             .device_registrations
             .iter()

--- a/keep-mobile/src/persistence.rs
+++ b/keep-mobile/src/persistence.rs
@@ -232,6 +232,10 @@ struct StoredDescriptor {
     /// supersedes. `None` for initial descriptors and legacy records.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     previous_descriptor_hash_hex: Option<String>,
+    /// JSON-encoded `WalletPolicy`. Persisted as a string for FFI simplicity;
+    /// older records deserialize with `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    policy_json: Option<String>,
 }
 
 fn default_stored_version() -> u32 {
@@ -422,6 +426,7 @@ fn stored_to_info(stored: StoredDescriptor) -> WalletDescriptorInfo {
         policy_hash_hex: stored.policy_hash_hex,
         version: stored.version,
         previous_descriptor_hash_hex: stored.previous_descriptor_hash_hex,
+        policy_json: stored.policy_json,
     }
 }
 
@@ -433,6 +438,7 @@ fn info_to_stored(info: &WalletDescriptorInfo) -> StoredDescriptor {
         network: info.network.clone(),
         created_at: info.created_at,
         policy_hash_hex: info.policy_hash_hex.clone(),
+        policy_json: info.policy_json.clone(),
         device_registrations: info
             .device_registrations
             .iter()

--- a/keep-mobile/src/types.rs
+++ b/keep-mobile/src/types.rs
@@ -89,6 +89,7 @@ pub struct WalletDescriptorInfo {
     /// supersedes, when this is a migration. `None` for the initial
     /// descriptor or for legacy records persisted before versioning.
     pub previous_descriptor_hash_hex: Option<String>,
+    pub policy_json: Option<String>,
 }
 
 impl std::fmt::Debug for WalletDescriptorInfo {

--- a/keep-mobile/src/types.rs
+++ b/keep-mobile/src/types.rs
@@ -82,6 +82,7 @@ pub struct WalletDescriptorInfo {
     pub created_at: u64,
     pub device_registrations: Vec<DeviceRegistrationInfo>,
     pub policy_hash_hex: Option<String>,
+    pub policy_json: Option<String>,
 }
 
 impl std::fmt::Debug for WalletDescriptorInfo {

--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -22,9 +22,11 @@ const REGISTER_WALLET_TIMEOUT: Duration = Duration::from_secs(180);
 /// silent or hostile signer cannot stall registration UX. Callers that need to
 /// override (e.g. a known-slow device) can wrap with their own `tokio::time::timeout`.
 pub const GET_DEVICE_INFO_TIMEOUT: Duration = Duration::from_secs(8);
+const SIGN_TAP_SCRIPT_TIMEOUT: Duration = Duration::from_secs(180);
 const MAX_RESPONSE_SIZE: usize = 64 * 1024;
 const MAX_HMAC_HEX_LEN: usize = 128;
 const HMAC_SHA256_LEN: usize = 32;
+const SCHNORR_SIG_LEN: usize = 64;
 pub const MAX_WALLET_NAME_LEN: usize = 64;
 pub const MAX_DESCRIPTOR_LEN: usize = 4096;
 /// Size cap on the JSON result string returned by `get_device_info`.
@@ -34,6 +36,7 @@ pub const MAX_DEVICE_KIND_LEN: usize = 32;
 pub const MAX_FIRMWARE_VERSION_LEN: usize = 64;
 pub const MAX_CAPABILITIES: usize = 32;
 pub const MAX_CAPABILITY_LEN: usize = 32;
+pub const MAX_TAP_SCRIPT_LEN: usize = 10_000;
 
 /// Reject signer-supplied strings that contain control characters. Strings are
 /// surfaced verbatim in CLI/UI output, so any C0/C1 control codes would corrupt
@@ -429,6 +432,85 @@ impl Nip46Client {
             validate_metadata_field("capability label", cap, 1, MAX_CAPABILITY_LEN)?;
         }
         Ok(info)
+    }
+
+    /// Request a taproot script-spend signature from the remote signer for a
+    /// recovery-tier PSBT input. The signer is expected to:
+    ///   1. Look up the descriptor it has previously registered (the descriptor
+    ///      string is passed for display/confirmation; it MUST match a record).
+    ///   2. Locate the secret key matching `xonly_pubkey` (e.g. by deriving
+    ///      every script-path key in its registered policy).
+    ///   3. Display the script and leaf hash for user confirmation.
+    ///   4. Schnorr-sign `sighash` under that key.
+    ///
+    /// All five params are hex-encoded except `descriptor`.
+    pub async fn sign_tap_script(
+        &self,
+        sighash: &[u8; 32],
+        xonly_pubkey: &[u8; 32],
+        leaf_hash: &[u8; 32],
+        script_bytes: &[u8],
+        descriptor: &str,
+    ) -> Result<[u8; SCHNORR_SIG_LEN]> {
+        if script_bytes.len() > MAX_TAP_SCRIPT_LEN {
+            return Err(KeepError::InvalidInput(format!(
+                "tap script exceeds {MAX_TAP_SCRIPT_LEN} bytes"
+            )));
+        }
+        if descriptor.is_empty() {
+            return Err(KeepError::InvalidInput(
+                "descriptor must not be empty".into(),
+            ));
+        }
+        if descriptor.len() > MAX_DESCRIPTOR_LEN {
+            return Err(KeepError::InvalidInput(format!(
+                "descriptor exceeds {MAX_DESCRIPTOR_LEN} bytes"
+            )));
+        }
+
+        let id = new_request_id();
+        let mut response = self
+            .request_with_timeout(
+                &id,
+                "sign_tap_script",
+                vec![
+                    Zeroizing::new(hex::encode(sighash)),
+                    Zeroizing::new(hex::encode(xonly_pubkey)),
+                    Zeroizing::new(hex::encode(leaf_hash)),
+                    Zeroizing::new(hex::encode(script_bytes)),
+                    Zeroizing::new(descriptor.to_string()),
+                ],
+                SIGN_TAP_SCRIPT_TIMEOUT,
+            )
+            .await?;
+
+        if let Some(err) = response.error {
+            return Err(
+                NetworkError::response(format!("sign_tap_script rejected: {err}")).into(),
+            );
+        }
+
+        let hex_str = response.result.as_mut().ok_or_else(|| {
+            NetworkError::response("sign_tap_script returned no result".to_string())
+        })?;
+        let trimmed_len = hex_str.trim().len();
+        if trimmed_len != SCHNORR_SIG_LEN * 2 {
+            hex_str.zeroize();
+            return Err(KeepError::InvalidInput(format!(
+                "sign_tap_script signature must be {} hex chars, got {}",
+                SCHNORR_SIG_LEN * 2,
+                trimmed_len
+            )));
+        }
+        let decode_result = hex::decode(hex_str.trim());
+        hex_str.zeroize();
+        let decoded = decode_result.map_err(|e| {
+            StorageError::invalid_format(format!("sign_tap_script signature hex: {e}"))
+        })?;
+        let sig: [u8; SCHNORR_SIG_LEN] = decoded.as_slice().try_into().map_err(|_| {
+            KeepError::InvalidInput("sign_tap_script signature wrong length".into())
+        })?;
+        Ok(sig)
     }
 
     async fn request(

--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -444,6 +444,20 @@ impl Nip46Client {
     ///   4. Schnorr-sign `sighash` under that key.
     ///
     /// All five params are hex-encoded except `descriptor`.
+    ///
+    /// # Trust assumption
+    ///
+    /// This call relays a 32-byte sighash to the remote bunker and trusts the
+    /// returned 64-byte Schnorr signature is a sig over THAT sighash by the
+    /// secret matching `xonly_pubkey`. The bunker is responsible for any
+    /// user-facing confirmation; this method does NOT itself prompt or
+    /// rate-limit. Callers MUST verify the returned signature against the
+    /// sighash and xonly_pubkey before merging it into a PSBT (see
+    /// `keep_bitcoin::merge_tap_script_sig`, which does this verification),
+    /// and MUST verify the PSBT input being signed is bound to a UTXO they
+    /// control (see `keep_bitcoin::verify_script_spend_input_binding`).
+    /// Without those two checks, this method is a signing oracle and any
+    /// caller that wraps it is too.
     pub async fn sign_tap_script(
         &self,
         sighash: &[u8; 32],
@@ -485,9 +499,7 @@ impl Nip46Client {
             .await?;
 
         if let Some(err) = response.error {
-            return Err(
-                NetworkError::response(format!("sign_tap_script rejected: {err}")).into(),
-            );
+            return Err(NetworkError::response(format!("sign_tap_script rejected: {err}")).into());
         }
 
         let hex_str = response.result.as_mut().ok_or_else(|| {


### PR DESCRIPTION
Recovery-tier PSBT signing flow across keep-bitcoin, keep-frost-net, keep-nip46, keep-cli, and keep-desktop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end "Review & Approve" PSBT flow: CLI subcommand + desktop UI to approve recovery PSBTs via external signers (NIP‑46 tap‑script signing).
  * Remote/partial taproot signing helpers and merge/verify utilities for responder workflows.
  * Wallet policy persisted/exchanged as JSON; UI shows PSBT output previews (address + sats).
  * Signer registry to resolve external signer endpoints.

* **Bug Fixes / Hardening**
  * Stronger PSBT validation, script‑spend binding checks, taproot dust enforcement, and tighter finalization guards.
  * NIP‑46 signer: tap‑script signing with payload limits and strict signature validation.

* **Tests**
  * New end‑to‑end PSBT recovery signing integration test.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->