### PR TITLE
Nonce pre-exchange for instant signing

### DIFF
--- a/keep-frost-net/src/event.rs
+++ b/keep-frost-net/src/event.rs
@@ -80,6 +80,30 @@ impl KfpEventBuilder {
             .map_err(|e| FrostNetError::Nostr(e.to_string()))
     }
 
+    pub fn nonce_commitment(
+        keys: &Keys,
+        recipient: &PublicKey,
+        payload: NonceCommitmentPayload,
+    ) -> Result<Event> {
+        let group_pubkey = payload.group_pubkey;
+        let msg = KfpMessage::NonceCommitment(payload);
+        let content = msg.to_json()?;
+
+        let encrypted = nip44::encrypt(keys.secret_key(), recipient, &content, nip44::Version::V2)
+            .map_err(|e| FrostNetError::Crypto(e.to_string()))?;
+
+        EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), encrypted)
+            .custom_created_at(Timestamp::tweaked(TIMESTAMP_TWEAK_RANGE))
+            .tag(Tag::public_key(*recipient))
+            .tag(Tag::custom(
+                TagKind::custom("g"),
+                [hex::encode(group_pubkey)],
+            ))
+            .tag(Tag::custom(TagKind::custom("t"), ["nonce_commitment"]))
+            .sign_with_keys(keys)
+            .map_err(|e| FrostNetError::Nostr(e.to_string()))
+    }
+
     pub fn commitment(
         keys: &Keys,
         recipient: &PublicKey,

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -65,6 +65,7 @@ mod ecdh;
 mod error;
 mod event;
 mod node;
+mod nonce_pool;
 mod nonce_store;
 mod peer;
 pub mod proof;
@@ -95,26 +96,28 @@ pub use node::{
     NoOpHooks, PeerPolicy, PersistedDescriptorLookup, PsbtSessionSnapshot, SessionInfo,
     SigningHooks,
 };
+pub use nonce_pool::{NonceId, NoncePool, DEFAULT_POOL_TARGET, MAX_POOL_ENTRIES};
 pub use nonce_store::{FileNonceStore, MemoryNonceStore, NonceStore};
 pub use peer::{AttestationStatus, Peer, PeerManager, PeerStatus};
 pub use protocol::{
     AnnouncePayload, AnnouncedXpub, CommitmentPayload, DescriptorAckPayload,
     DescriptorContributePayload, DescriptorFinalizePayload, DescriptorNackPayload,
     DescriptorProposePayload, EcdhCompletePayload, EcdhRequestPayload, EcdhSharePayload,
-    EnclaveAttestation, ErrorPayload, KeySlot, KfpMessage, PingPayload, PolicyTier, PongPayload,
-    PsbtAbortPayload, PsbtFinalizePayload, PsbtInputInfo, PsbtOutputInfo, PsbtProposePayload,
-    PsbtSignPayload, RefreshCompletePayload, RefreshRequestPayload, RefreshRound1Payload,
-    RefreshRound2Payload, SignRequestPayload, SignatureCompletePayload, SignatureSharePayload,
-    WalletPolicy, XpubAnnouncePayload, DEFAULT_REPLAY_WINDOW_SECS,
-    DESCRIPTOR_ACK_PHASE_TIMEOUT_SECS, DESCRIPTOR_ACK_TIMEOUT_SECS,
-    DESCRIPTOR_CONTRIBUTION_TIMEOUT_SECS, DESCRIPTOR_FINALIZE_TIMEOUT_SECS,
-    DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS, DESCRIPTOR_SESSION_TIMEOUT_SECS, KFP_EVENT_KIND,
-    KFP_VERSION, MAX_CAPABILITIES, MAX_CAPABILITY_LENGTH, MAX_COMMITMENT_SIZE,
-    MAX_DESCRIPTOR_LENGTH, MAX_ERROR_CODE_LENGTH, MAX_ERROR_MESSAGE_LENGTH, MAX_FINGERPRINT_LENGTH,
-    MAX_KEYS_PER_TIER, MAX_MESSAGE_SIZE, MAX_MESSAGE_TYPE_LENGTH, MAX_NACK_REASON_LENGTH,
-    MAX_NAME_LENGTH, MAX_PARTICIPANTS, MAX_PSBT_ADDRESS_LENGTH, MAX_PSBT_INPUTS, MAX_PSBT_OUTPUTS,
-    MAX_PSBT_SIZE, MAX_RECOVERY_TIERS, MAX_RECOVERY_XPUBS, MAX_SIGNATURE_SHARE_SIZE,
-    MAX_XPUB_LABEL_LENGTH, MAX_XPUB_LENGTH, MIN_XPUB_LENGTH, PSBT_FINALIZE_PHASE_TIMEOUT_SECS,
+    EnclaveAttestation, ErrorPayload, KeySlot, KfpMessage, NonceCommitmentPayload, NonceRef,
+    PingPayload, PolicyTier, PongPayload, PreExchangedCommitment, PsbtAbortPayload,
+    PsbtFinalizePayload, PsbtInputInfo, PsbtOutputInfo, PsbtProposePayload, PsbtSignPayload,
+    RefreshCompletePayload, RefreshRequestPayload, RefreshRound1Payload, RefreshRound2Payload,
+    SignRequestPayload, SignatureCompletePayload, SignatureSharePayload, WalletPolicy,
+    XpubAnnouncePayload, DEFAULT_REPLAY_WINDOW_SECS, DESCRIPTOR_ACK_PHASE_TIMEOUT_SECS,
+    DESCRIPTOR_ACK_TIMEOUT_SECS, DESCRIPTOR_CONTRIBUTION_TIMEOUT_SECS,
+    DESCRIPTOR_FINALIZE_TIMEOUT_SECS, DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS,
+    DESCRIPTOR_SESSION_TIMEOUT_SECS, KFP_EVENT_KIND, KFP_VERSION, MAX_CAPABILITIES,
+    MAX_CAPABILITY_LENGTH, MAX_COMMITMENT_SIZE, MAX_DESCRIPTOR_LENGTH, MAX_ERROR_CODE_LENGTH,
+    MAX_ERROR_MESSAGE_LENGTH, MAX_FINGERPRINT_LENGTH, MAX_KEYS_PER_TIER, MAX_MESSAGE_SIZE,
+    MAX_MESSAGE_TYPE_LENGTH, MAX_NACK_REASON_LENGTH, MAX_NAME_LENGTH, MAX_NONCE_COMMITMENTS,
+    MAX_PARTICIPANTS, MAX_PSBT_ADDRESS_LENGTH, MAX_PSBT_INPUTS, MAX_PSBT_OUTPUTS, MAX_PSBT_SIZE,
+    MAX_RECOVERY_TIERS, MAX_RECOVERY_XPUBS, MAX_SIGNATURE_SHARE_SIZE, MAX_XPUB_LABEL_LENGTH,
+    MAX_XPUB_LENGTH, MIN_XPUB_LENGTH, PSBT_FINALIZE_PHASE_TIMEOUT_SECS,
     PSBT_SESSION_MAX_TIMEOUT_SECS, PSBT_SESSION_TIMEOUT_SECS, PSBT_SIGNING_PHASE_TIMEOUT_SECS,
     VALID_NETWORKS, VALID_XPUB_PREFIXES,
 };

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -555,6 +555,13 @@ pub struct KfpNode {
     pub(crate) audit_log: Arc<SigningAuditLog>,
     expected_pcrs: Option<ExpectedPcrs>,
     pub(crate) seen_xpub_announces: RwLock<HashSet<(u16, u64, [u8; 32])>>,
+    /// Per-peer de-duplication for `NonceCommitment` broadcasts, keyed by
+    /// `(share_index, content_hash)` where `content_hash` covers the sorted
+    /// nonce_id/commitment set. Keying on content rather than the sender
+    /// controlled `created_at` avoids dropping distinct same-second batches and
+    /// stops a peer forcing repeated secp256k1 deserialization by perturbing the
+    /// timestamp. Value is `created_at` for time-based retention.
+    pub(crate) seen_nonce_commitments: RwLock<HashMap<(u16, [u8; 32]), u64>>,
     /// Per-session de-duplication for `DescriptorMigrate` link broadcasts.
     /// Keyed by `(session_id, new_descriptor_hash)` so an attacker cannot
     /// bypass dedupe by perturbing `created_at`. Value is `created_at` for
@@ -729,6 +736,7 @@ impl KfpNode {
             audit_log,
             expected_pcrs: None,
             seen_xpub_announces: RwLock::new(HashSet::new()),
+            seen_nonce_commitments: RwLock::new(HashMap::new()),
             seen_descriptor_migrates: RwLock::new(HashMap::new()),
             descriptor_proposers: RwLock::new(HashSet::new()),
             psbt_proposers: RwLock::new(HashSet::new()),
@@ -1174,6 +1182,9 @@ impl KfpNode {
                         self.seen_xpub_announces.write().retain(|&(_, ts, _)| {
                             now.saturating_sub(window) <= ts
                         });
+                        self.seen_nonce_commitments.write().retain(|_, ts| {
+                            now.saturating_sub(window) <= *ts
+                        });
                         self.seen_descriptor_migrates.write().retain(|_, ts| {
                             now.saturating_sub(window) <= *ts
                         });
@@ -1323,6 +1334,39 @@ impl KfpNode {
                     message = %payload.message,
                     "Received error from peer"
                 );
+                // A session-scoped error from a participant means that peer
+                // cannot continue the session (e.g. it no longer holds a
+                // referenced pre-exchanged nonce). Surface it so an in-flight
+                // `request_signature` fails fast instead of waiting for timeout.
+                if let Some(session_id) = payload.session_id {
+                    let is_participant = {
+                        let sessions = self.sessions.read();
+                        match sessions.get_session(&session_id) {
+                            Some(session) => {
+                                let peers = self.peers.read();
+                                session.participants().iter().any(|&idx| {
+                                    peers
+                                        .get_peer(idx)
+                                        .map(|p| p.pubkey == event.pubkey)
+                                        .unwrap_or(false)
+                                })
+                            }
+                            None => false,
+                        }
+                    };
+                    if is_participant {
+                        // Future improvement: on `stale_nonce` /
+                        // `incomplete_pre_exchange` the requester could retry
+                        // this session with a fresh interactive commitment round
+                        // instead of failing, since these are recoverable
+                        // pre-exchange misses rather than fatal errors. For now
+                        // we fail fast so the caller can decide to retry.
+                        let _ = self.event_tx.send(KfpNodeEvent::SigningFailed {
+                            session_id,
+                            error: format!("Peer reported error: {}", payload.code),
+                        });
+                    }
+                }
             }
         }
 
@@ -1398,6 +1442,8 @@ impl KfpNode {
 
         peer = peer.with_attestation_status(attestation_status);
 
+        let is_new_peer = self.peers.read().get_peer(payload.share_index).is_none();
+
         let name_clone = peer.name.clone();
         self.peers.write().add_peer(peer);
 
@@ -1411,6 +1457,15 @@ impl KfpNode {
             share_index: payload.share_index,
             name: name_clone,
         });
+
+        // A newly discovered peer may have come online after we last replenished
+        // (whose broadcast only carries freshly generated commitments). Send it
+        // our currently available pool so it can instant-sign with us right away.
+        if is_new_peer && self.can_send_to(&pubkey) {
+            if let Err(e) = self.send_nonce_pool_to(&pubkey).await {
+                warn!(peer = %pubkey, error = %e, "Failed to send nonce pool to new peer");
+            }
+        }
 
         Ok(())
     }

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -32,6 +32,7 @@ use crate::descriptor_session::DescriptorSessionManager;
 use crate::ecdh::EcdhSessionManager;
 use crate::error::{FrostNetError, Result};
 use crate::event::KfpEventBuilder;
+use crate::nonce_pool::{NonceId, NoncePool};
 use crate::nonce_store::{FileNonceStore, NonceStore};
 use crate::peer::{AttestationStatus, Peer, PeerManager, PeerStatus};
 use crate::protocol::*;
@@ -540,6 +541,7 @@ pub struct KfpNode {
     pub(crate) share: SharePackage,
     pub(crate) group_pubkey: [u8; 32],
     pub(crate) sessions: Arc<RwLock<SessionManager>>,
+    pub(crate) nonce_pool: NoncePool,
     pub(crate) ecdh_sessions: Arc<RwLock<EcdhSessionManager>>,
     pub(crate) descriptor_sessions: Arc<RwLock<DescriptorSessionManager>>,
     pub(crate) psbt_sessions: Arc<RwLock<PsbtSessionManager>>,
@@ -713,6 +715,7 @@ impl KfpNode {
             share,
             group_pubkey,
             sessions: Arc::new(RwLock::new(session_manager)),
+            nonce_pool: NoncePool::new(),
             ecdh_sessions: Arc::new(RwLock::new(ecdh_manager)),
             descriptor_sessions: Arc::new(RwLock::new(descriptor_manager)),
             psbt_sessions: Arc::new(RwLock::new(psbt_manager)),
@@ -823,6 +826,16 @@ impl KfpNode {
 
     pub fn online_peers(&self) -> usize {
         self.peers.read().online_count()
+    }
+
+    /// Number of our own pre-generated nonces currently available in the pool.
+    pub fn nonce_pool_own_available(&self) -> usize {
+        self.nonce_pool.own_available()
+    }
+
+    /// Number of pre-exchanged commitments pooled for the given peer.
+    pub fn nonce_pool_peer_available(&self, share_index: u16) -> usize {
+        self.nonce_pool.peer_available(share_index)
     }
 
     pub fn peer_status(&self) -> Vec<(u16, PeerStatus, Option<String>, PublicKey)> {
@@ -1115,6 +1128,9 @@ impl KfpNode {
         let mut cleanup_interval = tokio::time::interval(Duration::from_secs(120));
         cleanup_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
+        let mut replenish_interval = tokio::time::interval(Duration::from_secs(30));
+        replenish_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
         loop {
             tokio::select! {
                 _ = shutdown_rx.recv() => {
@@ -1124,6 +1140,13 @@ impl KfpNode {
                 _ = announce_interval.tick() => {
                     if let Err(e) = self.announce().await {
                         warn!(error = %e, "Failed to re-announce");
+                    }
+                }
+                _ = replenish_interval.tick() => {
+                    if self.nonce_pool.own_deficit() > 0 {
+                        if let Err(e) = self.replenish_nonce_pool().await {
+                            warn!(error = %e, "Failed to replenish nonce pool");
+                        }
                     }
                 }
                 _ = cleanup_interval.tick() => {
@@ -1220,6 +1243,9 @@ impl KfpNode {
             }
             KfpMessage::SignRequest(payload) => {
                 self.handle_sign_request(event.pubkey, payload).await?;
+            }
+            KfpMessage::NonceCommitment(payload) => {
+                self.handle_nonce_commitment(event.pubkey, payload).await?;
             }
             KfpMessage::Commitment(payload) => {
                 self.handle_commitment(event.pubkey, payload).await?;

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use frost_secp256k1_tr::rand_core::OsRng;
 use nostr_sdk::prelude::*;
+use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
 
 use crate::audit::SigningOperation;
@@ -105,6 +106,54 @@ impl KfpNode {
         Ok(())
     }
 
+    /// Send all currently available own commitments directly to one peer. Used
+    /// when a peer is newly discovered after the pool was already replenished,
+    /// so it does not have to wait for the next replenish broadcast (which only
+    /// carries freshly generated commitments) to enable instant signing.
+    pub(crate) async fn send_nonce_pool_to(&self, pubkey: &PublicKey) -> Result<()> {
+        let available = self.nonce_pool.own_commitments();
+        if available.is_empty() {
+            return Ok(());
+        }
+
+        let mut commitments = Vec::with_capacity(available.len());
+        for (nonce_id, commitment) in available {
+            commitments.push(PreExchangedCommitment {
+                nonce_id,
+                commitment: serialize_commitment(&commitment)?,
+            });
+        }
+
+        let payload = NonceCommitmentPayload::new(
+            self.group_pubkey,
+            self.share.metadata.identifier,
+            commitments,
+        );
+        let event = KfpEventBuilder::nonce_commitment(&self.keys, pubkey, payload)?;
+        self.client
+            .send_event(&event)
+            .await
+            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Build and send a session-scoped error event to a single peer.
+    async fn send_session_error(
+        &self,
+        to: &PublicKey,
+        code: &str,
+        message: &str,
+        session_id: [u8; 32],
+    ) -> Result<()> {
+        let event = KfpEventBuilder::error(&self.keys, to, code, message, Some(session_id))?;
+        self.client
+            .send_event(&event)
+            .await
+            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+        Ok(())
+    }
+
     pub(crate) async fn handle_nonce_commitment(
         &self,
         from: PublicKey,
@@ -114,24 +163,65 @@ impl KfpNode {
             return Ok(());
         }
 
-        self.verify_peer_share_index(from, payload.share_index)?;
-
+        // A NonceCommitment is an unsolicited fire-and-forget broadcast, so a
+        // stale, off-policy, or spoofed one is dropped silently rather than
+        // erroring. Gate order mirrors `handle_sign_request`: replay window and
+        // receive policy before peer-identity verification.
         if !payload.is_within_replay_window(self.replay_window_secs) {
-            warn!(
+            debug!(
                 share_index = payload.share_index,
                 created_at = payload.created_at,
-                "Rejecting nonce commitment: outside replay window"
+                "Dropping nonce commitment: outside replay window"
             );
-            return Err(FrostNetError::ReplayDetected(format!(
-                "Nonce commitment created_at {} outside {} second window",
-                payload.created_at, self.replay_window_secs
-            )));
+            return Ok(());
         }
 
         if !self.can_receive_from(&from) {
-            return Err(FrostNetError::PolicyViolation(format!(
-                "Peer {from} not allowed to send nonce commitments"
-            )));
+            return Ok(());
+        }
+
+        if self
+            .verify_peer_share_index(from, payload.share_index)
+            .is_err()
+        {
+            return Ok(());
+        }
+
+        // De-duplicate repeated batches from a peer within the replay window so
+        // a misbehaving peer cannot impose unbounded deserialization work by
+        // re-sending the same commitments. Key on a content hash of the sorted
+        // commitment set rather than the sender-controlled timestamp: distinct
+        // same-second batches stay distinct, and perturbing `created_at` cannot
+        // bypass the dedup to force repeated secp256k1 deserialization.
+        let content_hash = {
+            let mut entries: Vec<&PreExchangedCommitment> = payload.commitments.iter().collect();
+            entries.sort_by(|a, b| {
+                a.nonce_id
+                    .cmp(&b.nonce_id)
+                    .then(a.commitment.cmp(&b.commitment))
+            });
+            let mut hasher = Sha256::new();
+            hasher.update(b"keep-nonce-commitment-dedup-v1");
+            hasher.update(payload.share_index.to_be_bytes());
+            for entry in entries {
+                hasher.update(entry.nonce_id);
+                hasher.update((entry.commitment.len() as u32).to_be_bytes());
+                hasher.update(&entry.commitment);
+            }
+            let digest: [u8; 32] = hasher.finalize().into();
+            digest
+        };
+        if self
+            .seen_nonce_commitments
+            .write()
+            .insert((payload.share_index, content_hash), payload.created_at)
+            .is_some()
+        {
+            debug!(
+                share_index = payload.share_index,
+                "Dropping duplicate nonce commitment batch"
+            );
+            return Ok(());
         }
 
         let mut stored = 0usize;
@@ -275,17 +365,45 @@ impl KfpNode {
         hooks.pre_sign(&session_info)?;
 
         // Locate the requester's reference to our own pre-exchanged nonce, if
-        // any. Pre-exchange applies only when we still hold the referenced
-        // single-use secret nonce; check availability without consuming so the
-        // nonce_refs can be fully validated before the nonce is burned.
+        // any. The sentinel id ([0u8; 32]) marks the requester's echo-only
+        // commitment, never our consumable nonce, so it is excluded here.
+        // Pre-exchange applies only when we still hold the referenced single-use
+        // secret nonce; check availability without consuming so the nonce_refs
+        // can be fully validated before the nonce is burned.
         let own_nonce_id = request
             .nonce_refs
             .iter()
-            .find(|nref| nref.share_index == self.share.metadata.identifier)
+            .find(|nref| {
+                nref.share_index == self.share.metadata.identifier && nref.nonce_id != [0u8; 32]
+            })
             .map(|nref| nref.nonce_id);
         let used_pre_exchange = own_nonce_id
             .map(|id| self.nonce_pool.contains_own(&id))
             .unwrap_or(false);
+
+        // The requester reserved one of our pooled commitments and already
+        // embedded it in its own session, skipping the interactive commitment
+        // round. If we no longer hold the referenced secret nonce (consumed,
+        // evicted, or lost on restart), we cannot reproduce that commitment:
+        // sending a fresh one would collide on the requester as a duplicate and
+        // hang it until timeout. Signal the requester so it fails fast.
+        if let Some(missing) = own_nonce_id {
+            if !used_pre_exchange {
+                warn!(
+                    session_id = %hex::encode(request.session_id),
+                    nonce_id = %hex::encode(missing),
+                    "Referenced pre-exchanged nonce unavailable; signaling requester"
+                );
+                self.send_session_error(
+                    &from,
+                    "stale_nonce",
+                    "Referenced pre-exchanged nonce no longer available",
+                    request.session_id,
+                )
+                .await?;
+                return Ok(());
+            }
+        }
 
         // When pre-exchange is used, the requester includes every participant's
         // commitment (including its own) in `nonce_refs`. Validate and
@@ -331,7 +449,31 @@ impl KfpNode {
             }
         }
 
-        let (commitment, proceed_to_round2) = {
+        // A pre-exchange request must carry the full commitment set. If the
+        // validated refs plus our own commitment fall short of threshold we can
+        // neither instant-sign nor safely fall back: the requester already
+        // embedded our pooled commitment in its session and would reject a fresh
+        // one as a duplicate. Signal it to fall back rather than letting it hang,
+        // and avoid burning our pooled nonce on a session that cannot complete.
+        if used_pre_exchange && peer_refs.len() + 1 < self.share.metadata.threshold as usize {
+            warn!(
+                session_id = %hex::encode(request.session_id),
+                "Pre-exchange request below threshold; signaling requester"
+            );
+            self.send_session_error(
+                &from,
+                "incomplete_pre_exchange",
+                "Pre-exchange request did not cover threshold participants",
+                request.session_id,
+            )
+            .await?;
+            return Ok(());
+        }
+
+        // `None` signals that the pre-exchange path required a pooled nonce that
+        // vanished (consumed, evicted, or lost on restart) between validation
+        // and consume, so the session cannot proceed and must be torn down.
+        let commit_result = {
             let mut sessions = self.sessions.write();
 
             let session = sessions.get_or_create_session(
@@ -341,46 +483,75 @@ impl KfpNode {
                 request.participants.clone(),
             )?;
 
-            // All nonce_refs have now been validated above. The single-use own
-            // nonce is consumed only here, so neither session creation nor a
-            // poisoned/invalid commitment set can burn it.
+            // All nonce_refs have now been validated above, and a pre-exchange
+            // request that reaches here covers the full threshold set. The
+            // single-use own nonce is consumed only here, so neither session
+            // creation nor a poisoned commitment set can burn it.
             let pooled_nonces = if used_pre_exchange {
                 own_nonce_id.and_then(|nonce_id| self.nonce_pool.consume_own(&nonce_id))
             } else {
                 None
             };
-            let used_pre_exchange = pooled_nonces.is_some();
 
-            if used_pre_exchange {
-                debug!(
+            // We cannot reproduce the commitment the requester already embedded,
+            // so a fresh one would collide as a duplicate and hang it. Bail out
+            // and signal stale_nonce after dropping the session lock.
+            if used_pre_exchange && pooled_nonces.is_none() {
+                None
+            } else {
+                let used_pre_exchange = pooled_nonces.is_some();
+
+                if used_pre_exchange {
+                    debug!(
+                        session_id = %hex::encode(request.session_id),
+                        "Using pre-exchanged nonce for sign request"
+                    );
+                }
+
+                let (nonces, commitment) = match pooled_nonces {
+                    Some(nonces) => {
+                        let commitment = *nonces.commitments();
+                        (nonces, commitment)
+                    }
+                    None => {
+                        frost_secp256k1_tr::round1::commit(key_package.signing_share(), &mut OsRng)
+                    }
+                };
+
+                session.set_our_nonces(nonces);
+                session.set_our_commitment(commitment);
+                session.add_commitment(self.share.metadata.identifier, commitment)?;
+
+                if used_pre_exchange {
+                    for (share_index, c) in &peer_refs {
+                        session.add_commitment(*share_index, *c)?;
+                    }
+                }
+
+                let proceed = used_pre_exchange && session.has_all_commitments();
+
+                sessions.record_nonce_consumption(&request.session_id)?;
+
+                Some((commitment, proceed))
+            }
+        };
+
+        let (commitment, proceed_to_round2) = match commit_result {
+            Some(ready) => ready,
+            None => {
+                warn!(
                     session_id = %hex::encode(request.session_id),
-                    "Using pre-exchanged nonce for sign request"
+                    "Referenced pre-exchanged nonce vanished before consume; signaling requester"
                 );
+                self.send_session_error(
+                    &from,
+                    "stale_nonce",
+                    "Referenced pre-exchanged nonce no longer available",
+                    request.session_id,
+                )
+                .await?;
+                return Ok(());
             }
-
-            let (nonces, commitment) = match pooled_nonces {
-                Some(nonces) => {
-                    let commitment = *nonces.commitments();
-                    (nonces, commitment)
-                }
-                None => frost_secp256k1_tr::round1::commit(key_package.signing_share(), &mut OsRng),
-            };
-
-            session.set_our_nonces(nonces);
-            session.set_our_commitment(commitment);
-            session.add_commitment(self.share.metadata.identifier, commitment)?;
-
-            if used_pre_exchange {
-                for (share_index, c) in &peer_refs {
-                    session.add_commitment(*share_index, *c)?;
-                }
-            }
-
-            let proceed = used_pre_exchange && session.has_all_commitments();
-
-            sessions.record_nonce_consumption(&request.session_id)?;
-
-            (commitment, proceed)
         };
 
         let commit_bytes = serialize_commitment(&commitment)?;

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -13,9 +13,121 @@ use crate::event::KfpEventBuilder;
 use crate::protocol::*;
 use crate::session::derive_session_id;
 
-use super::{KfpNode, KfpNodeEvent, SessionInfo};
+use super::{KfpNode, KfpNodeEvent, NonceId, SessionInfo};
 
 impl KfpNode {
+    /// Generate fresh round-1 nonces to top the local pool back up to its
+    /// target and broadcast the matching commitments to online peers. Secret
+    /// nonces are stored in memory only; only commitments leave this node.
+    pub async fn replenish_nonce_pool(&self) -> Result<()> {
+        let deficit = self.nonce_pool.own_deficit();
+        if deficit == 0 {
+            return Ok(());
+        }
+
+        let key_package = self.share.key_package()?;
+        let mut commitments = Vec::with_capacity(deficit);
+        for _ in 0..deficit {
+            let nonce_id: NonceId = keep_core::crypto::random_bytes::<32>();
+            let (nonces, commitment) =
+                frost_secp256k1_tr::round1::commit(key_package.signing_share(), &mut OsRng);
+
+            let commit_bytes = commitment
+                .serialize()
+                .map_err(|e| FrostNetError::Crypto(format!("Serialize commitment: {e}")))?;
+
+            self.nonce_pool.store_own(nonce_id, nonces);
+            commitments.push(PreExchangedCommitment {
+                nonce_id,
+                commitment: commit_bytes.to_vec(),
+            });
+        }
+
+        let payload = NonceCommitmentPayload::new(
+            self.group_pubkey,
+            self.share.metadata.identifier,
+            commitments,
+        );
+
+        let peer_pubkeys: Vec<PublicKey> = self
+            .peers
+            .read()
+            .get_online_peers()
+            .iter()
+            .map(|p| p.pubkey)
+            .collect();
+
+        for pubkey in peer_pubkeys {
+            let event = KfpEventBuilder::nonce_commitment(&self.keys, &pubkey, payload.clone())?;
+            self.client
+                .send_event(&event)
+                .await
+                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+        }
+
+        debug!(
+            count = payload.commitments.len(),
+            "Broadcast pre-exchanged nonce commitments"
+        );
+
+        Ok(())
+    }
+
+    pub(crate) async fn handle_nonce_commitment(
+        &self,
+        from: PublicKey,
+        payload: NonceCommitmentPayload,
+    ) -> Result<()> {
+        if payload.group_pubkey != self.group_pubkey {
+            return Ok(());
+        }
+
+        self.verify_peer_share_index(from, payload.share_index)?;
+
+        if !payload.is_within_replay_window(self.replay_window_secs) {
+            warn!(
+                share_index = payload.share_index,
+                created_at = payload.created_at,
+                "Rejecting nonce commitment: outside replay window"
+            );
+            return Err(FrostNetError::ReplayDetected(format!(
+                "Nonce commitment created_at {} outside {} second window",
+                payload.created_at, self.replay_window_secs
+            )));
+        }
+
+        if !self.can_receive_from(&from) {
+            return Err(FrostNetError::PolicyViolation(format!(
+                "Peer {from} not allowed to send nonce commitments"
+            )));
+        }
+
+        let mut stored = 0usize;
+        for entry in payload.commitments {
+            let commitment = match frost_secp256k1_tr::round1::SigningCommitments::deserialize(
+                &entry.commitment,
+            ) {
+                Ok(c) => c,
+                Err(e) => {
+                    debug!(error = %e, "Skipping invalid pre-exchanged commitment");
+                    continue;
+                }
+            };
+            self.nonce_pool
+                .store_peer(payload.share_index, entry.nonce_id, commitment);
+            stored += 1;
+        }
+
+        self.peers.write().update_last_seen(payload.share_index);
+
+        debug!(
+            share_index = payload.share_index,
+            stored, "Stored pre-exchanged commitments from peer"
+        );
+
+        Ok(())
+    }
+
     pub(crate) async fn handle_sign_request(
         &self,
         from: PublicKey,
@@ -115,7 +227,25 @@ impl KfpNode {
         let hooks = self.hooks.read().clone();
         hooks.pre_sign(&session_info)?;
 
-        let commitment = {
+        // If the requester referenced a pre-exchanged nonce of ours, consume it
+        // (single-use, removed from the pool). If it is missing — e.g. the pool
+        // was rebuilt after a restart — fall back to a fresh interactive nonce.
+        let pooled_nonces = request
+            .nonce_refs
+            .iter()
+            .find(|nref| nref.share_index == self.share.metadata.identifier)
+            .and_then(|nref| self.nonce_pool.consume_own(&nref.nonce_id));
+
+        if pooled_nonces.is_some() {
+            debug!(
+                session_id = %hex::encode(request.session_id),
+                "Using pre-exchanged nonce for sign request"
+            );
+        }
+
+        let used_pre_exchange = pooled_nonces.is_some();
+
+        let (commitment, proceed_to_round2) = {
             let mut sessions = self.sessions.write();
 
             let session = sessions.get_or_create_session(
@@ -125,16 +255,44 @@ impl KfpNode {
                 request.participants.clone(),
             )?;
 
-            let (nonces, commitment) =
-                frost_secp256k1_tr::round1::commit(key_package.signing_share(), &mut OsRng);
+            let (nonces, commitment) = match pooled_nonces {
+                Some(nonces) => {
+                    let commitment = *nonces.commitments();
+                    (nonces, commitment)
+                }
+                None => frost_secp256k1_tr::round1::commit(key_package.signing_share(), &mut OsRng),
+            };
 
             session.set_our_nonces(nonces);
             session.set_our_commitment(commitment);
             session.add_commitment(self.share.metadata.identifier, commitment)?;
 
+            // When pre-exchange is used, the requester includes every
+            // participant's commitment (including its own) in `nonce_refs`. Add
+            // them so the session is complete from this single message, with no
+            // dependence on commitment-event ordering. Our own ref was already
+            // applied above; skip it and any malformed entries.
+            if used_pre_exchange {
+                for nref in &request.nonce_refs {
+                    if nref.share_index == self.share.metadata.identifier {
+                        continue;
+                    }
+                    match frost_secp256k1_tr::round1::SigningCommitments::deserialize(
+                        &nref.commitment,
+                    ) {
+                        Ok(c) => session.add_commitment(nref.share_index, c)?,
+                        Err(e) => {
+                            debug!(error = %e, share_index = nref.share_index, "Skipping invalid nonce ref commitment");
+                        }
+                    }
+                }
+            }
+
+            let proceed = used_pre_exchange && session.has_all_commitments();
+
             sessions.record_nonce_consumption(&request.session_id)?;
 
-            commitment
+            (commitment, proceed)
         };
 
         let commit_bytes = commitment
@@ -166,6 +324,15 @@ impl KfpNode {
             self.share.metadata.identifier,
             SigningOperation::CommitmentSent,
         );
+
+        // With pre-exchange, the full commitment set arrived in this request, so
+        // we can move straight to round 2 without waiting for commitment events.
+        if proceed_to_round2 {
+            if let Err(e) = self.generate_and_send_share(&request.session_id).await {
+                self.sessions.write().complete_session(&request.session_id);
+                return Err(e);
+            }
+        }
 
         Ok(())
     }
@@ -474,13 +641,55 @@ impl KfpNode {
             SigningOperation::SignRequestInitiated,
         );
 
+        let key_package = self.share.key_package()?;
+        let (nonces, our_commitment) =
+            frost_secp256k1_tr::round1::commit(key_package.signing_share(), &mut OsRng);
+
+        // Try to use pre-exchanged commitments for the selected peers. If every
+        // peer has a pooled commitment, reserve them (single-use; removed from
+        // the pool) so the interactive commitment round can be skipped.
+        let peer_indices: Vec<u16> = participant_peers.iter().map(|(idx, _)| *idx).collect();
+        let reserved = self.nonce_pool.reserve_for(&peer_indices);
+
+        let our_commit_bytes = our_commitment
+            .serialize()
+            .map_err(|e| FrostNetError::Crypto(format!("Serialize commitment: {e}")))?;
+
+        let mut nonce_refs: Vec<NonceRef> = Vec::new();
+        let mut reserved_commitments: Vec<(u16, frost_secp256k1_tr::round1::SigningCommitments)> =
+            Vec::new();
+        if let Some(entries) = &reserved {
+            for (idx, nonce_id, commitment) in entries {
+                let commit_bytes = commitment
+                    .serialize()
+                    .map_err(|e| FrostNetError::Crypto(format!("Serialize commitment: {e}")))?;
+                nonce_refs.push(NonceRef {
+                    share_index: *idx,
+                    nonce_id: *nonce_id,
+                    commitment: commit_bytes.to_vec(),
+                });
+                reserved_commitments.push((*idx, *commitment));
+            }
+            // Include the requester's own commitment so each participant has the
+            // complete commitment set from the single sign request, removing any
+            // dependence on commitment-event ordering. The zero `nonce_id` is a
+            // sentinel: participants never consume the requester's nonce, they
+            // only read the commitment.
+            nonce_refs.push(NonceRef {
+                share_index: self.share.metadata.identifier,
+                nonce_id: [0u8; 32],
+                commitment: our_commit_bytes.clone(),
+            });
+        }
+
         let request = SignRequestPayload::new(
             session_id,
             self.group_pubkey,
             message.clone(),
             message_type,
             participants.clone(),
-        );
+        )
+        .with_nonce_refs(nonce_refs);
 
         let session_info = SessionInfo {
             session_id,
@@ -491,10 +700,6 @@ impl KfpNode {
         };
         let hooks = self.hooks.read().clone();
         hooks.pre_sign(&session_info)?;
-
-        let key_package = self.share.key_package()?;
-        let (nonces, our_commitment) =
-            frost_secp256k1_tr::round1::commit(key_package.signing_share(), &mut OsRng);
 
         {
             let mut sessions = self.sessions.write();
@@ -509,16 +714,20 @@ impl KfpNode {
             session.set_our_commitment(our_commitment);
             session.add_commitment(self.share.metadata.identifier, our_commitment)?;
 
+            for (idx, commitment) in &reserved_commitments {
+                session.add_commitment(*idx, *commitment)?;
+            }
+
             sessions.record_nonce_consumption(&session_id)?;
         }
 
-        let our_commit_bytes = our_commitment
-            .serialize()
-            .map_err(|e| FrostNetError::Crypto(format!("Serialize commitment: {e}")))?;
+        // When pre-exchange is used the sign request already carries the full
+        // commitment set, so the separate interactive commitment is redundant.
+        let using_pre_exchange = reserved.is_some();
         let our_commit_payload = CommitmentPayload::new(
             session_id,
             self.share.metadata.identifier,
-            our_commit_bytes.to_vec(),
+            our_commit_bytes.clone(),
         );
 
         for (share_index, pubkey) in participant_peers {
@@ -528,20 +737,24 @@ impl KfpNode {
                 .await
                 .map_err(|e| FrostNetError::Transport(e.to_string()))?;
 
-            let commit_event =
-                KfpEventBuilder::commitment(&self.keys, &pubkey, our_commit_payload.clone())?;
-            self.client
-                .send_event(&commit_event)
-                .await
-                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+            if !using_pre_exchange {
+                let commit_event =
+                    KfpEventBuilder::commitment(&self.keys, &pubkey, our_commit_payload.clone())?;
+                self.client
+                    .send_event(&commit_event)
+                    .await
+                    .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+            }
 
-            debug!(share_index, "Sent sign request and commitment");
+            debug!(share_index, using_pre_exchange, "Sent sign request");
         }
 
         let mut rx = self.event_tx.subscribe();
 
-        // For single-participant (threshold=1), all commitments are already present.
-        // Must subscribe before generating share so we don't miss SignatureComplete.
+        // All commitments may already be present: for single-participant
+        // (threshold=1), or when peer commitments were pre-exchanged and
+        // reserved above. Must subscribe before generating share so we don't
+        // miss SignatureComplete.
         let all_committed = {
             let sessions = self.sessions.read();
             sessions

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -49,7 +49,54 @@ impl Drop for ReservationGuard<'_> {
     }
 }
 
+/// Content hash over a peer's nonce commitment batch, used to de-duplicate
+/// repeated broadcasts without trusting the sender-controlled timestamp. The
+/// set is sorted so reordering cannot bypass the dedup, and the length prefix
+/// keeps distinct commitments from colliding under concatenation.
+fn nonce_commitment_content_hash(
+    share_index: u16,
+    commitments: &[PreExchangedCommitment],
+) -> [u8; 32] {
+    let mut entries: Vec<&PreExchangedCommitment> = commitments.iter().collect();
+    entries.sort_by(|a, b| {
+        a.nonce_id
+            .cmp(&b.nonce_id)
+            .then(a.commitment.cmp(&b.commitment))
+    });
+    let mut hasher = Sha256::new();
+    hasher.update(b"keep-nonce-commitment-dedup-v1");
+    hasher.update(share_index.to_be_bytes());
+    for entry in entries {
+        hasher.update(entry.nonce_id);
+        hasher.update((entry.commitment.len() as u32).to_be_bytes());
+        hasher.update(&entry.commitment);
+    }
+    hasher.finalize().into()
+}
+
 impl KfpNode {
+    /// Build a [`NonceCommitmentPayload`] from a set of pooled commitments,
+    /// serializing each into wire bytes.
+    fn build_nonce_commitment_payload(
+        &self,
+        commitments: impl IntoIterator<Item = (NonceId, frost_secp256k1_tr::round1::SigningCommitments)>,
+    ) -> Result<NonceCommitmentPayload> {
+        let commitments = commitments
+            .into_iter()
+            .map(|(nonce_id, commitment)| {
+                Ok(PreExchangedCommitment {
+                    nonce_id,
+                    commitment: serialize_commitment(&commitment)?,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(NonceCommitmentPayload::new(
+            self.group_pubkey,
+            self.share.metadata.identifier,
+            commitments,
+        ))
+    }
+
     /// Generate fresh round-1 nonces to top the local pool back up to its
     /// target and broadcast the matching commitments to online peers. Secret
     /// nonces are stored in memory only; only commitments leave this node.
@@ -60,26 +107,16 @@ impl KfpNode {
         }
 
         let key_package = self.share.key_package()?;
-        let mut commitments = Vec::with_capacity(deficit);
+        let mut fresh = Vec::with_capacity(deficit);
         for _ in 0..deficit {
             let nonce_id: NonceId = keep_core::crypto::random_bytes::<32>();
             let (nonces, commitment) =
                 frost_secp256k1_tr::round1::commit(key_package.signing_share(), &mut OsRng);
-
-            let commit_bytes = serialize_commitment(&commitment)?;
-
             self.nonce_pool.store_own(nonce_id, nonces);
-            commitments.push(PreExchangedCommitment {
-                nonce_id,
-                commitment: commit_bytes,
-            });
+            fresh.push((nonce_id, commitment));
         }
 
-        let payload = NonceCommitmentPayload::new(
-            self.group_pubkey,
-            self.share.metadata.identifier,
-            commitments,
-        );
+        let payload = self.build_nonce_commitment_payload(fresh)?;
 
         let peer_pubkeys: Vec<PublicKey> = self
             .peers
@@ -116,19 +153,7 @@ impl KfpNode {
             return Ok(());
         }
 
-        let mut commitments = Vec::with_capacity(available.len());
-        for (nonce_id, commitment) in available {
-            commitments.push(PreExchangedCommitment {
-                nonce_id,
-                commitment: serialize_commitment(&commitment)?,
-            });
-        }
-
-        let payload = NonceCommitmentPayload::new(
-            self.group_pubkey,
-            self.share.metadata.identifier,
-            commitments,
-        );
+        let payload = self.build_nonce_commitment_payload(available)?;
         let event = KfpEventBuilder::nonce_commitment(&self.keys, pubkey, payload)?;
         self.client
             .send_event(&event)
@@ -193,24 +218,8 @@ impl KfpNode {
         // commitment set rather than the sender-controlled timestamp: distinct
         // same-second batches stay distinct, and perturbing `created_at` cannot
         // bypass the dedup to force repeated secp256k1 deserialization.
-        let content_hash = {
-            let mut entries: Vec<&PreExchangedCommitment> = payload.commitments.iter().collect();
-            entries.sort_by(|a, b| {
-                a.nonce_id
-                    .cmp(&b.nonce_id)
-                    .then(a.commitment.cmp(&b.commitment))
-            });
-            let mut hasher = Sha256::new();
-            hasher.update(b"keep-nonce-commitment-dedup-v1");
-            hasher.update(payload.share_index.to_be_bytes());
-            for entry in entries {
-                hasher.update(entry.nonce_id);
-                hasher.update((entry.commitment.len() as u32).to_be_bytes());
-                hasher.update(&entry.commitment);
-            }
-            let digest: [u8; 32] = hasher.finalize().into();
-            digest
-        };
+        let content_hash =
+            nonce_commitment_content_hash(payload.share_index, &payload.commitments);
         if self
             .seen_nonce_commitments
             .write()
@@ -497,6 +506,10 @@ impl KfpNode {
             // so a fresh one would collide as a duplicate and hang it. Bail out
             // and signal stale_nonce after dropping the session lock.
             if used_pre_exchange && pooled_nonces.is_none() {
+                // Drop the session we just created so a vanished-nonce request
+                // cannot leave dead sessions filling the active slot cap. Not
+                // marked completed so a legitimate retry is not flagged replay.
+                sessions.abandon_session(&request.session_id);
                 None
             } else {
                 let used_pre_exchange = pooled_nonces.is_some();

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -104,6 +104,12 @@ impl KfpNode {
 
         let mut stored = 0usize;
         for entry in payload.commitments {
+            if self
+                .nonce_pool
+                .contains_peer(payload.share_index, &entry.nonce_id)
+            {
+                continue;
+            }
             let commitment = match frost_secp256k1_tr::round1::SigningCommitments::deserialize(
                 &entry.commitment,
             ) {

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -218,8 +218,7 @@ impl KfpNode {
         // commitment set rather than the sender-controlled timestamp: distinct
         // same-second batches stay distinct, and perturbing `created_at` cannot
         // bypass the dedup to force repeated secp256k1 deserialization.
-        let content_hash =
-            nonce_commitment_content_hash(payload.share_index, &payload.commitments);
+        let content_hash = nonce_commitment_content_hash(payload.share_index, &payload.commitments);
         if self
             .seen_nonce_commitments
             .write()
@@ -434,6 +433,16 @@ impl KfpNode {
                 if !request.participants.contains(&nref.share_index) {
                     return Err(FrostNetError::Protocol(format!(
                         "Nonce ref for non-participant share_index {}",
+                        nref.share_index
+                    )));
+                }
+                // The sentinel (echo-only, unauthenticated against our pool) is
+                // legitimate only for the requester's own commitment. Reject it
+                // for any other share_index so a requester cannot substitute a
+                // forged commitment for an honest peer by bypassing matches_peer.
+                if nref.nonce_id == [0u8; 32] && nref.share_index != requester {
+                    return Err(FrostNetError::Protocol(format!(
+                        "Sentinel nonce ref allowed only for requester, got share_index {}",
                         nref.share_index
                     )));
                 }
@@ -1012,23 +1021,38 @@ impl KfpNode {
             our_commit_bytes.clone(),
         );
 
-        for (share_index, pubkey) in participant_peers {
-            let event = KfpEventBuilder::sign_request(&self.keys, &pubkey, request.clone())?;
-            self.client
-                .send_event(&event)
-                .await
-                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
-
-            if !using_pre_exchange {
-                let commit_event =
-                    KfpEventBuilder::commitment(&self.keys, &pubkey, our_commit_payload.clone())?;
+        // Reservations are already consumed and committed to the live session,
+        // so on a send failure tear the session down (matching the timeout and
+        // share-generation paths below) rather than leaving it active until it
+        // expires.
+        let send_result: Result<()> = async {
+            for (share_index, pubkey) in participant_peers {
+                let event = KfpEventBuilder::sign_request(&self.keys, &pubkey, request.clone())?;
                 self.client
-                    .send_event(&commit_event)
+                    .send_event(&event)
                     .await
                     .map_err(|e| FrostNetError::Transport(e.to_string()))?;
-            }
 
-            debug!(share_index, using_pre_exchange, "Sent sign request");
+                if !using_pre_exchange {
+                    let commit_event = KfpEventBuilder::commitment(
+                        &self.keys,
+                        &pubkey,
+                        our_commit_payload.clone(),
+                    )?;
+                    self.client
+                        .send_event(&commit_event)
+                        .await
+                        .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+                }
+
+                debug!(share_index, using_pre_exchange, "Sent sign request");
+            }
+            Ok(())
+        }
+        .await;
+        if let Err(e) = send_result {
+            self.sessions.write().complete_session(&session_id);
+            return Err(e);
         }
 
         let mut rx = self.event_tx.subscribe();

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -14,7 +14,7 @@ use crate::protocol::*;
 use crate::session::derive_session_id;
 
 use super::{KfpNode, KfpNodeEvent, NonceId, SessionInfo};
-use crate::nonce_pool::NoncePool;
+use crate::nonce_pool::{serialize_commitment, NoncePool};
 
 /// Restores peer commitments reserved from the [`NoncePool`] back into the pool
 /// if a signing request aborts before the reservation is committed to a live
@@ -65,14 +65,12 @@ impl KfpNode {
             let (nonces, commitment) =
                 frost_secp256k1_tr::round1::commit(key_package.signing_share(), &mut OsRng);
 
-            let commit_bytes = commitment
-                .serialize()
-                .map_err(|e| FrostNetError::Crypto(format!("Serialize commitment: {e}")))?;
+            let commit_bytes = serialize_commitment(&commitment)?;
 
             self.nonce_pool.store_own(nonce_id, nonces);
             commitments.push(PreExchangedCommitment {
                 nonce_id,
-                commitment: commit_bytes.to_vec(),
+                commitment: commit_bytes,
             });
         }
 
@@ -142,6 +140,17 @@ impl KfpNode {
                 .nonce_pool
                 .contains_peer(payload.share_index, &entry.nonce_id)
             {
+                if !self.nonce_pool.matches_peer(
+                    payload.share_index,
+                    &entry.nonce_id,
+                    &entry.commitment,
+                ) {
+                    warn!(
+                        share_index = payload.share_index,
+                        nonce_id = %hex::encode(entry.nonce_id),
+                        "Conflicting commitment for existing nonce_id; keeping first-write-wins value (possible equivocation)"
+                    );
+                }
                 continue;
             }
             let commitment = match frost_secp256k1_tr::round1::SigningCommitments::deserialize(
@@ -223,14 +232,12 @@ impl KfpNode {
                 session_id = %hex::encode(request.session_id),
                 "Resending existing commitment for session"
             );
-            let commit_bytes = existing
-                .serialize()
-                .map_err(|e| FrostNetError::Crypto(format!("Serialize commitment: {e}")))?;
+            let commit_bytes = serialize_commitment(&existing)?;
 
             let payload = CommitmentPayload::new(
                 request.session_id,
                 self.share.metadata.identifier,
-                commit_bytes.to_vec(),
+                commit_bytes,
             );
 
             let event = KfpEventBuilder::commitment(&self.keys, &from, payload)?;
@@ -268,14 +275,61 @@ impl KfpNode {
         hooks.pre_sign(&session_info)?;
 
         // Locate the requester's reference to our own pre-exchanged nonce, if
-        // any. The secret nonce is consumed only AFTER the session is validated
-        // and created below, so a session-creation failure cannot burn the
-        // single-use nonce.
+        // any. Pre-exchange applies only when we still hold the referenced
+        // single-use secret nonce; check availability without consuming so the
+        // nonce_refs can be fully validated before the nonce is burned.
         let own_nonce_id = request
             .nonce_refs
             .iter()
             .find(|nref| nref.share_index == self.share.metadata.identifier)
             .map(|nref| nref.nonce_id);
+        let used_pre_exchange = own_nonce_id
+            .map(|id| self.nonce_pool.contains_own(&id))
+            .unwrap_or(false);
+
+        // When pre-exchange is used, the requester includes every participant's
+        // commitment (including its own) in `nonce_refs`. Validate and
+        // deserialize all of them BEFORE consuming our single-use own nonce, so
+        // a malicious requester cannot drain our own-nonce pool by sending a
+        // valid own_nonce_id alongside bogus peer commitments.
+        //
+        // Each non-self, non-sentinel commitment is cross-checked against our
+        // own authenticated pool: the echoed bytes must match the commitment we
+        // received directly from that peer via `handle_nonce_commitment`. The
+        // requester's own commitment (sentinel nonce_id == [0u8; 32]) is
+        // legitimately absent from the pool and accepted echo-only.
+        let mut peer_refs: Vec<(u16, frost_secp256k1_tr::round1::SigningCommitments)> = Vec::new();
+        if used_pre_exchange {
+            for nref in &request.nonce_refs {
+                if nref.share_index == self.share.metadata.identifier {
+                    continue;
+                }
+                if !request.participants.contains(&nref.share_index) {
+                    return Err(FrostNetError::Protocol(format!(
+                        "Nonce ref for non-participant share_index {}",
+                        nref.share_index
+                    )));
+                }
+                let c =
+                    frost_secp256k1_tr::round1::SigningCommitments::deserialize(&nref.commitment)
+                        .map_err(|e| {
+                        FrostNetError::Crypto(format!("Deserialize nonce ref commitment: {e}"))
+                    })?;
+                if nref.nonce_id != [0u8; 32]
+                    && !self.nonce_pool.matches_peer(
+                        nref.share_index,
+                        &nref.nonce_id,
+                        &nref.commitment,
+                    )
+                {
+                    return Err(FrostNetError::Protocol(format!(
+                        "Echoed commitment for share_index {} does not match our pooled commitment",
+                        nref.share_index
+                    )));
+                }
+                peer_refs.push((nref.share_index, c));
+            }
+        }
 
         let (commitment, proceed_to_round2) = {
             let mut sessions = self.sessions.write();
@@ -287,8 +341,14 @@ impl KfpNode {
                 request.participants.clone(),
             )?;
 
-            let pooled_nonces =
-                own_nonce_id.and_then(|nonce_id| self.nonce_pool.consume_own(&nonce_id));
+            // All nonce_refs have now been validated above. The single-use own
+            // nonce is consumed only here, so neither session creation nor a
+            // poisoned/invalid commitment set can burn it.
+            let pooled_nonces = if used_pre_exchange {
+                own_nonce_id.and_then(|nonce_id| self.nonce_pool.consume_own(&nonce_id))
+            } else {
+                None
+            };
             let used_pre_exchange = pooled_nonces.is_some();
 
             if used_pre_exchange {
@@ -310,50 +370,9 @@ impl KfpNode {
             session.set_our_commitment(commitment);
             session.add_commitment(self.share.metadata.identifier, commitment)?;
 
-            // When pre-exchange is used, the requester includes every
-            // participant's commitment (including its own) in `nonce_refs`. Add
-            // them so the session is complete from this single message, with no
-            // dependence on commitment-event ordering. Our own ref was already
-            // applied above.
-            //
-            // Each non-self, non-sentinel commitment is cross-checked against
-            // our own authenticated pool: the echoed bytes must match the
-            // commitment we received directly from that peer via
-            // `handle_nonce_commitment`. This prevents a malicious requester
-            // from poisoning the session with arbitrary commitments and burning
-            // our single-use nonce on a session that can never aggregate. The
-            // requester's own commitment (sentinel nonce_id == [0u8; 32]) is
-            // legitimately absent from the pool and accepted echo-only.
             if used_pre_exchange {
-                for nref in &request.nonce_refs {
-                    if nref.share_index == self.share.metadata.identifier {
-                        continue;
-                    }
-                    if !request.participants.contains(&nref.share_index) {
-                        return Err(FrostNetError::Protocol(format!(
-                            "Nonce ref for non-participant share_index {}",
-                            nref.share_index
-                        )));
-                    }
-                    let c = frost_secp256k1_tr::round1::SigningCommitments::deserialize(
-                        &nref.commitment,
-                    )
-                    .map_err(|e| {
-                        FrostNetError::Crypto(format!("Deserialize nonce ref commitment: {e}"))
-                    })?;
-                    if nref.nonce_id != [0u8; 32]
-                        && !self.nonce_pool.matches_peer(
-                            nref.share_index,
-                            &nref.nonce_id,
-                            &nref.commitment,
-                        )
-                    {
-                        return Err(FrostNetError::Protocol(format!(
-                            "Echoed commitment for share_index {} does not match our pooled commitment",
-                            nref.share_index
-                        )));
-                    }
-                    session.add_commitment(nref.share_index, c)?;
+                for (share_index, c) in &peer_refs {
+                    session.add_commitment(*share_index, *c)?;
                 }
             }
 
@@ -364,14 +383,12 @@ impl KfpNode {
             (commitment, proceed)
         };
 
-        let commit_bytes = commitment
-            .serialize()
-            .map_err(|e| FrostNetError::Crypto(format!("Serialize commitment: {e}")))?;
+        let commit_bytes = serialize_commitment(&commitment)?;
 
         let payload = CommitmentPayload::new(
             request.session_id,
             self.share.metadata.identifier,
-            commit_bytes.to_vec(),
+            commit_bytes,
         );
 
         let event = KfpEventBuilder::commitment(&self.keys, &from, payload)?;
@@ -397,6 +414,14 @@ impl KfpNode {
         // With pre-exchange, the full commitment set arrived in this request, so
         // we can move straight to round 2 without waiting for commitment events.
         if proceed_to_round2 {
+            info!(
+                session_id = %hex::encode(request.session_id),
+                "Instant-signing: full commitment set pre-exchanged, proceeding to round 2"
+            );
+            // The own nonce was already consumed (single-use) and used to
+            // compute the signature share, which may have been partially sent.
+            // Do NOT restore it on send failure: reusing a nonce that produced
+            // a share is a key-leak risk. Tear down the session instead.
             if let Err(e) = self.generate_and_send_share(&request.session_id).await {
                 self.sessions.write().complete_session(&request.session_id);
                 return Err(e);
@@ -723,22 +748,18 @@ impl KfpNode {
         // must go back into the pool so they are not leaked permanently.
         let mut reservation_guard = ReservationGuard::new(&self.nonce_pool, reserved.clone());
 
-        let our_commit_bytes = our_commitment
-            .serialize()
-            .map_err(|e| FrostNetError::Crypto(format!("Serialize commitment: {e}")))?;
+        let our_commit_bytes = serialize_commitment(&our_commitment)?;
 
         let mut nonce_refs: Vec<NonceRef> = Vec::new();
         let mut reserved_commitments: Vec<(u16, frost_secp256k1_tr::round1::SigningCommitments)> =
             Vec::new();
         if let Some(entries) = &reserved {
             for (idx, nonce_id, commitment) in entries {
-                let commit_bytes = commitment
-                    .serialize()
-                    .map_err(|e| FrostNetError::Crypto(format!("Serialize commitment: {e}")))?;
+                let commit_bytes = serialize_commitment(commitment)?;
                 nonce_refs.push(NonceRef {
                     share_index: *idx,
                     nonce_id: *nonce_id,
-                    commitment: commit_bytes.to_vec(),
+                    commitment: commit_bytes,
                 });
                 reserved_commitments.push((*idx, *commitment));
             }

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -87,6 +87,7 @@ impl KfpNode {
             .read()
             .get_online_peers()
             .iter()
+            .filter(|p| self.can_send_to(&p.pubkey))
             .map(|p| p.pubkey)
             .collect();
 

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -14,6 +14,39 @@ use crate::protocol::*;
 use crate::session::derive_session_id;
 
 use super::{KfpNode, KfpNodeEvent, NonceId, SessionInfo};
+use crate::nonce_pool::NoncePool;
+
+/// Restores peer commitments reserved from the [`NoncePool`] back into the pool
+/// if a signing request aborts before the reservation is committed to a live
+/// session. Disarm once the commitments are recorded so successful flows do not
+/// re-insert consumed entries.
+struct ReservationGuard<'a> {
+    pool: &'a NoncePool,
+    reserved: Option<Vec<(u16, NonceId, frost_secp256k1_tr::round1::SigningCommitments)>>,
+}
+
+impl<'a> ReservationGuard<'a> {
+    fn new(
+        pool: &'a NoncePool,
+        reserved: Option<Vec<(u16, NonceId, frost_secp256k1_tr::round1::SigningCommitments)>>,
+    ) -> Self {
+        Self { pool, reserved }
+    }
+
+    fn disarm(&mut self) {
+        self.reserved = None;
+    }
+}
+
+impl Drop for ReservationGuard<'_> {
+    fn drop(&mut self) {
+        if let Some(entries) = self.reserved.take() {
+            for (idx, nonce_id, commitment) in entries {
+                self.pool.store_peer(idx, nonce_id, commitment);
+            }
+        }
+    }
+}
 
 impl KfpNode {
     /// Generate fresh round-1 nonces to top the local pool back up to its
@@ -59,10 +92,10 @@ impl KfpNode {
 
         for pubkey in peer_pubkeys {
             let event = KfpEventBuilder::nonce_commitment(&self.keys, &pubkey, payload.clone())?;
-            self.client
-                .send_event(&event)
-                .await
-                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+            if let Err(e) = self.client.send_event(&event).await {
+                warn!(peer = %pubkey, error = %e, "Failed to broadcast nonce commitment to peer");
+                continue;
+            }
         }
 
         debug!(
@@ -233,23 +266,15 @@ impl KfpNode {
         let hooks = self.hooks.read().clone();
         hooks.pre_sign(&session_info)?;
 
-        // If the requester referenced a pre-exchanged nonce of ours, consume it
-        // (single-use, removed from the pool). If it is missing — e.g. the pool
-        // was rebuilt after a restart — fall back to a fresh interactive nonce.
-        let pooled_nonces = request
+        // Locate the requester's reference to our own pre-exchanged nonce, if
+        // any. The secret nonce is consumed only AFTER the session is validated
+        // and created below, so a session-creation failure cannot burn the
+        // single-use nonce.
+        let own_nonce_id = request
             .nonce_refs
             .iter()
             .find(|nref| nref.share_index == self.share.metadata.identifier)
-            .and_then(|nref| self.nonce_pool.consume_own(&nref.nonce_id));
-
-        if pooled_nonces.is_some() {
-            debug!(
-                session_id = %hex::encode(request.session_id),
-                "Using pre-exchanged nonce for sign request"
-            );
-        }
-
-        let used_pre_exchange = pooled_nonces.is_some();
+            .map(|nref| nref.nonce_id);
 
         let (commitment, proceed_to_round2) = {
             let mut sessions = self.sessions.write();
@@ -260,6 +285,17 @@ impl KfpNode {
                 self.share.metadata.threshold,
                 request.participants.clone(),
             )?;
+
+            let pooled_nonces =
+                own_nonce_id.and_then(|nonce_id| self.nonce_pool.consume_own(&nonce_id));
+            let used_pre_exchange = pooled_nonces.is_some();
+
+            if used_pre_exchange {
+                debug!(
+                    session_id = %hex::encode(request.session_id),
+                    "Using pre-exchanged nonce for sign request"
+                );
+            }
 
             let (nonces, commitment) = match pooled_nonces {
                 Some(nonces) => {
@@ -277,20 +313,46 @@ impl KfpNode {
             // participant's commitment (including its own) in `nonce_refs`. Add
             // them so the session is complete from this single message, with no
             // dependence on commitment-event ordering. Our own ref was already
-            // applied above; skip it and any malformed entries.
+            // applied above.
+            //
+            // Each non-self, non-sentinel commitment is cross-checked against
+            // our own authenticated pool: the echoed bytes must match the
+            // commitment we received directly from that peer via
+            // `handle_nonce_commitment`. This prevents a malicious requester
+            // from poisoning the session with arbitrary commitments and burning
+            // our single-use nonce on a session that can never aggregate. The
+            // requester's own commitment (sentinel nonce_id == [0u8; 32]) is
+            // legitimately absent from the pool and accepted echo-only.
             if used_pre_exchange {
                 for nref in &request.nonce_refs {
                     if nref.share_index == self.share.metadata.identifier {
                         continue;
                     }
-                    match frost_secp256k1_tr::round1::SigningCommitments::deserialize(
-                        &nref.commitment,
-                    ) {
-                        Ok(c) => session.add_commitment(nref.share_index, c)?,
-                        Err(e) => {
-                            debug!(error = %e, share_index = nref.share_index, "Skipping invalid nonce ref commitment");
-                        }
+                    if !request.participants.contains(&nref.share_index) {
+                        return Err(FrostNetError::Protocol(format!(
+                            "Nonce ref for non-participant share_index {}",
+                            nref.share_index
+                        )));
                     }
+                    let c = frost_secp256k1_tr::round1::SigningCommitments::deserialize(
+                        &nref.commitment,
+                    )
+                    .map_err(|e| {
+                        FrostNetError::Crypto(format!("Deserialize nonce ref commitment: {e}"))
+                    })?;
+                    if nref.nonce_id != [0u8; 32]
+                        && !self.nonce_pool.matches_peer(
+                            nref.share_index,
+                            &nref.nonce_id,
+                            &nref.commitment,
+                        )
+                    {
+                        return Err(FrostNetError::Protocol(format!(
+                            "Echoed commitment for share_index {} does not match our pooled commitment",
+                            nref.share_index
+                        )));
+                    }
+                    session.add_commitment(nref.share_index, c)?;
                 }
             }
 
@@ -656,6 +718,9 @@ impl KfpNode {
         // the pool) so the interactive commitment round can be skipped.
         let peer_indices: Vec<u16> = participant_peers.iter().map(|(idx, _)| *idx).collect();
         let reserved = self.nonce_pool.reserve_for(&peer_indices);
+        // If any step below fails after reservation, the reserved commitments
+        // must go back into the pool so they are not leaked permanently.
+        let mut reservation_guard = ReservationGuard::new(&self.nonce_pool, reserved.clone());
 
         let our_commit_bytes = our_commitment
             .serialize()
@@ -726,6 +791,11 @@ impl KfpNode {
 
             sessions.record_nonce_consumption(&session_id)?;
         }
+
+        // Reserved commitments are now committed into the live session; they are
+        // no longer the pool's responsibility, so the guard must not restore
+        // them if a later send fails.
+        reservation_guard.disarm();
 
         // When pre-exchange is used the sign request already carries the full
         // commitment set, so the separate interactive commitment is redundant.

--- a/keep-frost-net/src/nonce_pool.rs
+++ b/keep-frost-net/src/nonce_pool.rs
@@ -138,6 +138,11 @@ impl NoncePool {
             .count()
     }
 
+    /// Whether the pool already holds a commitment for `(share_index, nonce_id)`.
+    pub fn contains_peer(&self, share_index: u16, nonce_id: &NonceId) -> bool {
+        self.inner.lock().peer.contains_key(&(share_index, *nonce_id))
+    }
+
     /// Consume a peer's pre-exchanged commitment, removing it from the pool.
     ///
     /// Returns `None` if no matching commitment is available.

--- a/keep-frost-net/src/nonce_pool.rs
+++ b/keep-frost-net/src/nonce_pool.rs
@@ -12,9 +12,11 @@
 //! are rebuilt by idle replenishment after a restart. Commitments are public
 //! and may be shared freely.
 //!
-//! Single-use is strictly enforced. Both the local secret nonces and the
-//! received peer commitments are *removed* on consume; there is no
-//! peek-without-consume in the signing path.
+//! Single-use is strictly enforced for secret material: the local secret
+//! nonces are *removed* on consume. Peer commitments are public and may be
+//! authenticated against an echoed copy without consuming (see
+//! [`NoncePool::matches_peer`]); they are removed on reservation/consume so a
+//! given pooled commitment is bound to one session.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -103,28 +105,17 @@ impl NoncePool {
         Some(nonces)
     }
 
-    /// Record a peer's pre-exchanged commitment. Evicts the oldest commitment
-    /// for that peer if it exceeds [`MAX_POOL_ENTRIES`].
+    /// Record a peer's pre-exchanged commitment. Evicts the oldest stored
+    /// commitment (across all peers) if the total exceeds [`MAX_POOL_ENTRIES`].
     pub fn store_peer(&self, share_index: u16, nonce_id: NonceId, commitment: SigningCommitments) {
         let mut inner = self.inner.lock();
         let key = (share_index, nonce_id);
         if inner.peer.insert(key, commitment).is_none() {
             inner.peer_order.push(key);
         }
-        let count = inner
-            .peer_order
-            .iter()
-            .filter(|(idx, _)| *idx == share_index)
-            .count();
-        if count > MAX_POOL_ENTRIES {
-            if let Some(pos) = inner
-                .peer_order
-                .iter()
-                .position(|(idx, _)| *idx == share_index)
-            {
-                let evict = inner.peer_order.remove(pos);
-                inner.peer.remove(&evict);
-            }
+        while inner.peer_order.len() > MAX_POOL_ENTRIES {
+            let evict = inner.peer_order.remove(0);
+            inner.peer.remove(&evict);
         }
     }
 
@@ -140,7 +131,30 @@ impl NoncePool {
 
     /// Whether the pool already holds a commitment for `(share_index, nonce_id)`.
     pub fn contains_peer(&self, share_index: u16, nonce_id: &NonceId) -> bool {
-        self.inner.lock().peer.contains_key(&(share_index, *nonce_id))
+        self.inner
+            .lock()
+            .peer
+            .contains_key(&(share_index, *nonce_id))
+    }
+
+    /// Whether the pool holds a commitment for `(share_index, nonce_id)` whose
+    /// serialized bytes equal `commitment_bytes`. Used to authenticate echoed
+    /// commitments against what the peer actually advertised to us, without
+    /// consuming the pooled entry.
+    pub fn matches_peer(
+        &self,
+        share_index: u16,
+        nonce_id: &NonceId,
+        commitment_bytes: &[u8],
+    ) -> bool {
+        let inner = self.inner.lock();
+        match inner.peer.get(&(share_index, *nonce_id)) {
+            Some(c) => c
+                .serialize()
+                .map(|b| b.as_slice() == commitment_bytes)
+                .unwrap_or(false),
+            None => false,
+        }
     }
 
     /// Consume a peer's pre-exchanged commitment, removing it from the pool.
@@ -167,13 +181,13 @@ impl NoncePool {
         let mut chosen: Vec<(u16, NonceId)> = Vec::with_capacity(peers.len());
         for &idx in peers {
             let next = inner
-                .peer
-                .keys()
-                .find(|(i, _)| *i == idx)
-                .map(|(i, id)| (*i, *id));
+                .peer_order
+                .iter()
+                .find(|(i, id)| *i == idx && !chosen.contains(&(*i, *id)))
+                .copied();
             match next {
-                Some(key) if !chosen.contains(&key) => chosen.push(key),
-                _ => return None,
+                Some(key) => chosen.push(key),
+                None => return None,
             }
         }
 
@@ -257,6 +271,47 @@ mod tests {
         // Reserved commitments are removed (single-use).
         assert_eq!(pool.peer_available(2), 0);
         assert_eq!(pool.peer_available(3), 0);
+    }
+
+    #[test]
+    fn matches_peer_authenticates_echoed_commitment() {
+        let pool = NoncePool::new();
+        let (_n, commitment) = make_pair();
+        let id = [5u8; 32];
+        let bytes = commitment.serialize().unwrap().to_vec();
+        pool.store_peer(2, id, commitment);
+
+        assert!(pool.matches_peer(2, &id, &bytes));
+        // Wrong bytes, wrong id, and wrong index all fail.
+        assert!(!pool.matches_peer(2, &id, &[0u8; 33]));
+        assert!(!pool.matches_peer(2, &[6u8; 32], &bytes));
+        assert!(!pool.matches_peer(3, &id, &bytes));
+    }
+
+    #[test]
+    fn peer_eviction_bounds_total_memory() {
+        let pool = NoncePool::new();
+        for i in 0..(MAX_POOL_ENTRIES + 10) {
+            let mut id = [0u8; 32];
+            id[..8].copy_from_slice(&(i as u64).to_be_bytes());
+            let idx = (i % 4) as u16 + 1;
+            let (_n, c) = make_pair();
+            pool.store_peer(idx, id, c);
+        }
+        let total: usize = (1..=4).map(|idx| pool.peer_available(idx)).sum();
+        assert_eq!(total, MAX_POOL_ENTRIES);
+    }
+
+    #[test]
+    fn reserve_consumes_oldest_first() {
+        let pool = NoncePool::new();
+        let (_n1, c1) = make_pair();
+        let (_n2, c2) = make_pair();
+        pool.store_peer(2, [1u8; 32], c1);
+        pool.store_peer(2, [2u8; 32], c2);
+
+        let reserved = pool.reserve_for(&[2]).expect("peer available");
+        assert_eq!(reserved[0].1, [1u8; 32]);
     }
 
     #[test]

--- a/keep-frost-net/src/nonce_pool.rs
+++ b/keep-frost-net/src/nonce_pool.rs
@@ -24,15 +24,31 @@ use std::sync::Arc;
 use frost_secp256k1_tr::round1::{SigningCommitments, SigningNonces};
 use parking_lot::Mutex;
 
+use crate::error::{FrostNetError, Result};
+
 /// Identifier for a single pre-exchanged nonce/commitment pair.
 pub type NonceId = [u8; 32];
+
+/// Serialize a FROST round-1 commitment into wire bytes, mapping the library
+/// error into a [`FrostNetError`].
+pub fn serialize_commitment(commitment: &SigningCommitments) -> Result<Vec<u8>> {
+    commitment
+        .serialize()
+        .map(|b| b.to_vec())
+        .map_err(|e| FrostNetError::Crypto(format!("Serialize commitment: {e}")))
+}
 
 /// Default number of nonces a node keeps pre-generated and available.
 pub const DEFAULT_POOL_TARGET: usize = 16;
 
-/// Hard cap on stored entries (own nonces or per-peer commitments) to bound
+/// Hard cap on stored entries (own nonces or total peer commitments) to bound
 /// memory against a misbehaving or chatty peer.
 pub const MAX_POOL_ENTRIES: usize = 256;
+
+/// Per-peer cap on stored commitments. Bounds how much of the shared peer pool
+/// a single peer can occupy so one chatty or hostile peer cannot evict every
+/// other peer's pre-exchanged commitments (soft DoS on instant signing).
+pub const MAX_POOL_ENTRIES_PER_PEER: usize = 32;
 
 #[derive(Default)]
 struct PoolInner {
@@ -93,6 +109,13 @@ impl NoncePool {
         self.target.saturating_sub(self.own_available())
     }
 
+    /// Whether an own nonce with `nonce_id` is currently available, without
+    /// consuming it. Used to validate a sign request before burning the
+    /// single-use secret nonce.
+    pub fn contains_own(&self, nonce_id: &NonceId) -> bool {
+        self.inner.lock().own.contains_key(nonce_id)
+    }
+
     /// Consume our own pre-generated nonce, removing it from the pool.
     ///
     /// Returns `None` if no nonce with `nonce_id` is available (already
@@ -105,13 +128,32 @@ impl NoncePool {
         Some(nonces)
     }
 
-    /// Record a peer's pre-exchanged commitment. Evicts the oldest stored
-    /// commitment (across all peers) if the total exceeds [`MAX_POOL_ENTRIES`].
+    /// Record a peer's pre-exchanged commitment. Enforces a per-peer cap
+    /// ([`MAX_POOL_ENTRIES_PER_PEER`]) so one peer cannot crowd out others, then
+    /// the global cap ([`MAX_POOL_ENTRIES`]); oldest entries are evicted first.
     pub fn store_peer(&self, share_index: u16, nonce_id: NonceId, commitment: SigningCommitments) {
         let mut inner = self.inner.lock();
         let key = (share_index, nonce_id);
         if inner.peer.insert(key, commitment).is_none() {
             inner.peer_order.push(key);
+        }
+        while inner
+            .peer_order
+            .iter()
+            .filter(|(idx, _)| *idx == share_index)
+            .count()
+            > MAX_POOL_ENTRIES_PER_PEER
+        {
+            if let Some(pos) = inner
+                .peer_order
+                .iter()
+                .position(|(idx, _)| *idx == share_index)
+            {
+                let evict = inner.peer_order.remove(pos);
+                inner.peer.remove(&evict);
+            } else {
+                break;
+            }
         }
         while inner.peer_order.len() > MAX_POOL_ENTRIES {
             let evict = inner.peer_order.remove(0);
@@ -290,16 +332,37 @@ mod tests {
 
     #[test]
     fn peer_eviction_bounds_total_memory() {
+        // Spread entries across enough peers that the global cap binds before
+        // the per-peer cap (16 peers * 32 per-peer = 512 > 256 global).
         let pool = NoncePool::new();
         for i in 0..(MAX_POOL_ENTRIES + 10) {
             let mut id = [0u8; 32];
             id[..8].copy_from_slice(&(i as u64).to_be_bytes());
-            let idx = (i % 4) as u16 + 1;
+            let idx = (i % 16) as u16 + 1;
             let (_n, c) = make_pair();
             pool.store_peer(idx, id, c);
         }
-        let total: usize = (1..=4).map(|idx| pool.peer_available(idx)).sum();
+        let total: usize = (1..=16).map(|idx| pool.peer_available(idx)).sum();
         assert_eq!(total, MAX_POOL_ENTRIES);
+    }
+
+    #[test]
+    fn per_peer_cap_prevents_one_peer_crowding_out() {
+        let pool = NoncePool::new();
+        // One peer floods well past the per-peer cap.
+        for i in 0..(MAX_POOL_ENTRIES_PER_PEER + 50) {
+            let mut id = [0u8; 32];
+            id[..8].copy_from_slice(&(i as u64).to_be_bytes());
+            let (_n, c) = make_pair();
+            pool.store_peer(2, id, c);
+        }
+        assert_eq!(pool.peer_available(2), MAX_POOL_ENTRIES_PER_PEER);
+
+        // A second peer's commitments are unaffected by the first peer's flood.
+        let (_n, c) = make_pair();
+        pool.store_peer(3, [255u8; 32], c);
+        assert_eq!(pool.peer_available(3), 1);
+        assert_eq!(pool.peer_available(2), MAX_POOL_ENTRIES_PER_PEER);
     }
 
     #[test]

--- a/keep-frost-net/src/nonce_pool.rs
+++ b/keep-frost-net/src/nonce_pool.rs
@@ -1,0 +1,277 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+//! Pre-exchanged FROST round-1 nonce pool.
+//!
+//! To avoid the interactive commitment round on every signing request, each
+//! participant can pre-generate FROST round-1 nonces and broadcast the matching
+//! commitments to peers ahead of time. A pooled commitment is identified by a
+//! random `nonce_id`.
+//!
+//! Secret [`SigningNonces`] live in memory only and are never persisted: pools
+//! are rebuilt by idle replenishment after a restart. Commitments are public
+//! and may be shared freely.
+//!
+//! Single-use is strictly enforced. Both the local secret nonces and the
+//! received peer commitments are *removed* on consume; there is no
+//! peek-without-consume in the signing path.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use frost_secp256k1_tr::round1::{SigningCommitments, SigningNonces};
+use parking_lot::Mutex;
+
+/// Identifier for a single pre-exchanged nonce/commitment pair.
+pub type NonceId = [u8; 32];
+
+/// Default number of nonces a node keeps pre-generated and available.
+pub const DEFAULT_POOL_TARGET: usize = 16;
+
+/// Hard cap on stored entries (own nonces or per-peer commitments) to bound
+/// memory against a misbehaving or chatty peer.
+pub const MAX_POOL_ENTRIES: usize = 256;
+
+#[derive(Default)]
+struct PoolInner {
+    /// Our own secret nonces, keyed by the `nonce_id` we advertised.
+    own: HashMap<NonceId, SigningNonces>,
+    /// Order in which our own nonces were generated, for FIFO eviction.
+    own_order: Vec<NonceId>,
+    /// Commitments received from peers, keyed by `(share_index, nonce_id)`.
+    peer: HashMap<(u16, NonceId), SigningCommitments>,
+    /// Order in which peer commitments were received, for FIFO eviction.
+    peer_order: Vec<(u16, NonceId)>,
+}
+
+/// In-memory pool of pre-exchanged FROST round-1 material.
+#[derive(Clone)]
+pub struct NoncePool {
+    inner: Arc<Mutex<PoolInner>>,
+    target: usize,
+}
+
+impl NoncePool {
+    pub fn new() -> Self {
+        Self::with_target(DEFAULT_POOL_TARGET)
+    }
+
+    pub fn with_target(target: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(PoolInner::default())),
+            target: target.min(MAX_POOL_ENTRIES),
+        }
+    }
+
+    /// Target number of available own nonces.
+    pub fn target(&self) -> usize {
+        self.target
+    }
+
+    /// Store a freshly generated own nonce under `nonce_id`. Evicts the oldest
+    /// own nonce if the pool exceeds [`MAX_POOL_ENTRIES`].
+    pub fn store_own(&self, nonce_id: NonceId, nonces: SigningNonces) {
+        let mut inner = self.inner.lock();
+        if inner.own.insert(nonce_id, nonces).is_none() {
+            inner.own_order.push(nonce_id);
+        }
+        while inner.own_order.len() > MAX_POOL_ENTRIES {
+            let oldest = inner.own_order.remove(0);
+            inner.own.remove(&oldest);
+        }
+    }
+
+    /// Number of own nonces currently available (not yet consumed).
+    pub fn own_available(&self) -> usize {
+        self.inner.lock().own.len()
+    }
+
+    /// How many additional own nonces should be generated to reach the target.
+    pub fn own_deficit(&self) -> usize {
+        self.target.saturating_sub(self.own_available())
+    }
+
+    /// Consume our own pre-generated nonce, removing it from the pool.
+    ///
+    /// Returns `None` if no nonce with `nonce_id` is available (already
+    /// consumed or never stored), in which case the caller must fall back to
+    /// the interactive round.
+    pub fn consume_own(&self, nonce_id: &NonceId) -> Option<SigningNonces> {
+        let mut inner = self.inner.lock();
+        let nonces = inner.own.remove(nonce_id)?;
+        inner.own_order.retain(|id| id != nonce_id);
+        Some(nonces)
+    }
+
+    /// Record a peer's pre-exchanged commitment. Evicts the oldest commitment
+    /// for that peer if it exceeds [`MAX_POOL_ENTRIES`].
+    pub fn store_peer(&self, share_index: u16, nonce_id: NonceId, commitment: SigningCommitments) {
+        let mut inner = self.inner.lock();
+        let key = (share_index, nonce_id);
+        if inner.peer.insert(key, commitment).is_none() {
+            inner.peer_order.push(key);
+        }
+        let count = inner
+            .peer_order
+            .iter()
+            .filter(|(idx, _)| *idx == share_index)
+            .count();
+        if count > MAX_POOL_ENTRIES {
+            if let Some(pos) = inner
+                .peer_order
+                .iter()
+                .position(|(idx, _)| *idx == share_index)
+            {
+                let evict = inner.peer_order.remove(pos);
+                inner.peer.remove(&evict);
+            }
+        }
+    }
+
+    /// Number of pooled commitments available for a given peer.
+    pub fn peer_available(&self, share_index: u16) -> usize {
+        self.inner
+            .lock()
+            .peer
+            .keys()
+            .filter(|(idx, _)| *idx == share_index)
+            .count()
+    }
+
+    /// Consume a peer's pre-exchanged commitment, removing it from the pool.
+    ///
+    /// Returns `None` if no matching commitment is available.
+    pub fn consume_peer(&self, share_index: u16, nonce_id: &NonceId) -> Option<SigningCommitments> {
+        let mut inner = self.inner.lock();
+        let key = (share_index, *nonce_id);
+        let commitment = inner.peer.remove(&key)?;
+        inner.peer_order.retain(|k| k != &key);
+        Some(commitment)
+    }
+
+    /// Reserve one available commitment per requested peer for a signing
+    /// request, returning the chosen `nonce_id`s. The commitments are *removed*
+    /// from the pool so they cannot be reused.
+    ///
+    /// Returns `None` (consuming nothing) unless every requested peer has at
+    /// least one pooled commitment, so the caller can cleanly fall back to the
+    /// interactive round.
+    pub fn reserve_for(&self, peers: &[u16]) -> Option<Vec<(u16, NonceId, SigningCommitments)>> {
+        let mut inner = self.inner.lock();
+
+        let mut chosen: Vec<(u16, NonceId)> = Vec::with_capacity(peers.len());
+        for &idx in peers {
+            let next = inner
+                .peer
+                .keys()
+                .find(|(i, _)| *i == idx)
+                .map(|(i, id)| (*i, *id));
+            match next {
+                Some(key) if !chosen.contains(&key) => chosen.push(key),
+                _ => return None,
+            }
+        }
+
+        let mut reserved = Vec::with_capacity(chosen.len());
+        for key in chosen {
+            if let Some(commitment) = inner.peer.remove(&key) {
+                inner.peer_order.retain(|k| k != &key);
+                reserved.push((key.0, key.1, commitment));
+            } else {
+                return None;
+            }
+        }
+        Some(reserved)
+    }
+}
+
+impl Default for NoncePool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use frost_secp256k1_tr::keys::{generate_with_dealer, IdentifierList, KeyPackage};
+    use frost_secp256k1_tr::rand_core::OsRng;
+
+    fn make_pair() -> (SigningNonces, SigningCommitments) {
+        let (shares, _pubkeys) =
+            generate_with_dealer(2, 2, IdentifierList::Default, OsRng).unwrap();
+        let secret = shares.into_values().next().unwrap();
+        let kp = KeyPackage::try_from(secret).unwrap();
+        frost_secp256k1_tr::round1::commit(kp.signing_share(), &mut OsRng)
+    }
+
+    #[test]
+    fn own_store_and_single_use_consume() {
+        let pool = NoncePool::new();
+        let (nonces, _commitment) = make_pair();
+        let id = [7u8; 32];
+
+        pool.store_own(id, nonces);
+        assert_eq!(pool.own_available(), 1);
+
+        assert!(pool.consume_own(&id).is_some());
+        assert_eq!(pool.own_available(), 0);
+        // Strict single-use: second consume yields nothing.
+        assert!(pool.consume_own(&id).is_none());
+    }
+
+    #[test]
+    fn peer_store_and_single_use_consume() {
+        let pool = NoncePool::new();
+        let (_n, commitment) = make_pair();
+        let id = [9u8; 32];
+
+        pool.store_peer(2, id, commitment);
+        assert_eq!(pool.peer_available(2), 1);
+
+        assert!(pool.consume_peer(2, &id).is_some());
+        assert_eq!(pool.peer_available(2), 0);
+        assert!(pool.consume_peer(2, &id).is_none());
+    }
+
+    #[test]
+    fn reserve_requires_all_peers() {
+        let pool = NoncePool::new();
+        let (_n, c1) = make_pair();
+        pool.store_peer(2, [1u8; 32], c1);
+
+        // Peer 3 has nothing: reservation fails and consumes nothing.
+        assert!(pool.reserve_for(&[2, 3]).is_none());
+        assert_eq!(pool.peer_available(2), 1);
+
+        let (_n2, c2) = make_pair();
+        pool.store_peer(3, [2u8; 32], c2);
+
+        let reserved = pool.reserve_for(&[2, 3]).expect("both peers available");
+        assert_eq!(reserved.len(), 2);
+        // Reserved commitments are removed (single-use).
+        assert_eq!(pool.peer_available(2), 0);
+        assert_eq!(pool.peer_available(3), 0);
+    }
+
+    #[test]
+    fn deficit_tracks_target() {
+        let pool = NoncePool::with_target(4);
+        assert_eq!(pool.own_deficit(), 4);
+        let (nonces, _c) = make_pair();
+        pool.store_own([1u8; 32], nonces);
+        assert_eq!(pool.own_deficit(), 3);
+    }
+
+    #[test]
+    fn own_eviction_bounds_memory() {
+        let pool = NoncePool::with_target(MAX_POOL_ENTRIES);
+        for i in 0..(MAX_POOL_ENTRIES + 10) {
+            let mut id = [0u8; 32];
+            id[..8].copy_from_slice(&(i as u64).to_be_bytes());
+            let (nonces, _c) = make_pair();
+            pool.store_own(id, nonces);
+        }
+        assert_eq!(pool.own_available(), MAX_POOL_ENTRIES);
+    }
+}

--- a/keep-frost-net/src/nonce_pool.rs
+++ b/keep-frost-net/src/nonce_pool.rs
@@ -104,6 +104,19 @@ impl NoncePool {
         self.inner.lock().own.len()
     }
 
+    /// Commitments for all currently available own nonces, in generation order.
+    /// Used to (re)broadcast the pool to a peer that comes online after the
+    /// pool was last replenished. Only public commitments are exposed; secret
+    /// nonces never leave the pool.
+    pub fn own_commitments(&self) -> Vec<(NonceId, SigningCommitments)> {
+        let inner = self.inner.lock();
+        inner
+            .own_order
+            .iter()
+            .filter_map(|id| inner.own.get(id).map(|n| (*id, *n.commitments())))
+            .collect()
+    }
+
     /// How many additional own nonces should be generated to reach the target.
     pub fn own_deficit(&self) -> usize {
         self.target.saturating_sub(self.own_available())

--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -239,9 +239,20 @@ impl KfpMessage {
                 if p.nonce_refs.len() > MAX_PARTICIPANTS {
                     return Err("Nonce refs exceed maximum size");
                 }
+                let mut seen_refs: HashSet<u16> = HashSet::new();
+                let mut sentinel_refs = 0usize;
                 for nref in &p.nonce_refs {
                     if nref.commitment.len() > MAX_COMMITMENT_SIZE {
                         return Err("Nonce ref commitment exceeds maximum size");
+                    }
+                    if !seen_refs.insert(nref.share_index) {
+                        return Err("Duplicate share_index in nonce_refs");
+                    }
+                    if nref.nonce_id == [0u8; 32] {
+                        sentinel_refs += 1;
+                        if sentinel_refs > 1 {
+                            return Err("Multiple sentinel nonce_refs");
+                        }
                     }
                 }
             }

--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -239,20 +239,32 @@ impl KfpMessage {
                 if p.nonce_refs.len() > MAX_PARTICIPANTS {
                     return Err("Nonce refs exceed maximum size");
                 }
-                let mut seen_refs: HashSet<u16> = HashSet::new();
-                let mut sentinel_refs = 0usize;
-                for nref in &p.nonce_refs {
-                    if nref.commitment.len() > MAX_COMMITMENT_SIZE {
-                        return Err("Nonce ref commitment exceeds maximum size");
+                if !p.nonce_refs.is_empty() {
+                    if p.nonce_refs.len() != p.participants.len() {
+                        return Err("Nonce refs must cover all participants");
                     }
-                    if !seen_refs.insert(nref.share_index) {
-                        return Err("Duplicate share_index in nonce_refs");
-                    }
-                    if nref.nonce_id == [0u8; 32] {
-                        sentinel_refs += 1;
-                        if sentinel_refs > 1 {
-                            return Err("Multiple sentinel nonce_refs");
+                    let expected: HashSet<u16> = p.participants.iter().copied().collect();
+                    let mut seen_refs: HashSet<u16> = HashSet::new();
+                    let mut sentinel_refs = 0usize;
+                    for nref in &p.nonce_refs {
+                        if nref.commitment.len() > MAX_COMMITMENT_SIZE {
+                            return Err("Nonce ref commitment exceeds maximum size");
                         }
+                        if !seen_refs.insert(nref.share_index) {
+                            return Err("Duplicate share_index in nonce_refs");
+                        }
+                        if !expected.contains(&nref.share_index) {
+                            return Err("Nonce ref share_index not in participants");
+                        }
+                        if nref.nonce_id == [0u8; 32] {
+                            sentinel_refs += 1;
+                        }
+                    }
+                    if seen_refs != expected {
+                        return Err("Nonce refs must match participant share indices");
+                    }
+                    if sentinel_refs != 1 {
+                        return Err("Nonce refs must contain exactly one sentinel");
                     }
                 }
             }

--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -245,6 +245,9 @@ impl KfpMessage {
                     }
                     let expected: HashSet<u16> = p.participants.iter().copied().collect();
                     let mut seen_refs: HashSet<u16> = HashSet::new();
+                    // An all-zero `nonce_id` is the sentinel marking the
+                    // requester's own commitment (echo-only, never consumed).
+                    // Exactly one ref must carry it.
                     let mut sentinel_refs = 0usize;
                     for nref in &p.nonce_refs {
                         if nref.commitment.len() > MAX_COMMITMENT_SIZE {

--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -12,6 +12,8 @@ pub const DEFAULT_REPLAY_WINDOW_SECS: u64 = 300;
 
 pub const MAX_MESSAGE_SIZE: usize = 65536;
 pub const MAX_COMMITMENT_SIZE: usize = 128;
+/// Maximum number of pre-exchanged commitments in a single `NonceCommitment`.
+pub const MAX_NONCE_COMMITMENTS: usize = 256;
 pub const MAX_SIGNATURE_SHARE_SIZE: usize = 64;
 pub const MAX_PARTICIPANTS: usize = 255;
 pub const MAX_NAME_LENGTH: usize = 256;
@@ -83,6 +85,7 @@ pub(crate) fn is_valid_fingerprint(fp: &str) -> bool {
 pub enum KfpMessage {
     Announce(AnnouncePayload),
     SignRequest(SignRequestPayload),
+    NonceCommitment(NonceCommitmentPayload),
     Commitment(CommitmentPayload),
     SignatureShare(SignatureSharePayload),
     SignatureComplete(SignatureCompletePayload),
@@ -114,6 +117,7 @@ impl KfpMessage {
         match self {
             KfpMessage::Announce(_) => "announce",
             KfpMessage::SignRequest(_) => "sign_request",
+            KfpMessage::NonceCommitment(_) => "nonce_commitment",
             KfpMessage::Commitment(_) => "commitment",
             KfpMessage::SignatureShare(_) => "signature_share",
             KfpMessage::SignatureComplete(_) => "signature_complete",
@@ -173,6 +177,7 @@ impl KfpMessage {
         match self {
             KfpMessage::Announce(p) => Some(&p.group_pubkey),
             KfpMessage::SignRequest(p) => Some(&p.group_pubkey),
+            KfpMessage::NonceCommitment(p) => Some(&p.group_pubkey),
             KfpMessage::EcdhRequest(p) => Some(&p.group_pubkey),
             KfpMessage::RefreshRequest(p) => Some(&p.group_pubkey),
             KfpMessage::DescriptorPropose(p) => Some(&p.group_pubkey),
@@ -230,6 +235,27 @@ impl KfpMessage {
                 }
                 if p.participants.len() > MAX_PARTICIPANTS {
                     return Err("Participants list exceeds maximum size");
+                }
+                if p.nonce_refs.len() > MAX_PARTICIPANTS {
+                    return Err("Nonce refs exceed maximum size");
+                }
+                for nref in &p.nonce_refs {
+                    if nref.commitment.len() > MAX_COMMITMENT_SIZE {
+                        return Err("Nonce ref commitment exceeds maximum size");
+                    }
+                }
+            }
+            KfpMessage::NonceCommitment(p) => {
+                if p.share_index == 0 {
+                    return Err("share_index must be non-zero");
+                }
+                if p.commitments.len() > MAX_NONCE_COMMITMENTS {
+                    return Err("Too many nonce commitments");
+                }
+                for c in &p.commitments {
+                    if c.commitment.len() > MAX_COMMITMENT_SIZE {
+                        return Err("Commitment exceeds maximum size");
+                    }
                 }
             }
             KfpMessage::Commitment(p) => {
@@ -775,6 +801,29 @@ pub struct SignRequestPayload {
     pub created_at: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
+    /// Optional references to pre-exchanged round-1 nonces, one per participant.
+    /// When present, each referenced participant consumes the matching pooled
+    /// nonce instead of running the interactive commitment round. An empty (or
+    /// absent) list falls back to the interactive round. Kept `#[serde(default)]`
+    /// for wire compatibility with peers that predate nonce pre-exchange.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub nonce_refs: Vec<NonceRef>,
+}
+
+/// A reference to a single pre-exchanged nonce/commitment pair.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct NonceRef {
+    /// Participant the reference applies to.
+    pub share_index: u16,
+    /// Identifier of the pooled nonce the participant must consume. A zero id
+    /// is a sentinel meaning "commitment only" (e.g. the requester's own
+    /// commitment), which participants read but never consume.
+    #[serde(with = "hex_bytes")]
+    pub nonce_id: [u8; 32],
+    /// The participant's pre-exchanged commitment, echoed so the requester's
+    /// signing package is self-contained.
+    #[serde(with = "hex_vec")]
+    pub commitment: Vec<u8>,
 }
 
 impl SignRequestPayload {
@@ -793,11 +842,17 @@ impl SignRequestPayload {
             participants,
             created_at: Timestamp::now().as_secs(),
             metadata: None,
+            nonce_refs: Vec::new(),
         }
     }
 
     pub fn with_metadata(mut self, metadata: serde_json::Value) -> Self {
         self.metadata = Some(metadata);
+        self
+    }
+
+    pub fn with_nonce_refs(mut self, nonce_refs: Vec<NonceRef>) -> Self {
+        self.nonce_refs = nonce_refs;
         self
     }
 
@@ -822,6 +877,45 @@ impl CommitmentPayload {
             share_index,
             commitment,
         }
+    }
+}
+
+/// A single pre-exchanged commitment entry within a `NonceCommitment` broadcast.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PreExchangedCommitment {
+    #[serde(with = "hex_bytes")]
+    pub nonce_id: [u8; 32],
+    #[serde(with = "hex_vec")]
+    pub commitment: Vec<u8>,
+}
+
+/// Broadcast of pre-generated round-1 commitments offered for future signing
+/// sessions. Secret nonces remain local; only commitments are shared.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct NonceCommitmentPayload {
+    #[serde(with = "hex_bytes")]
+    pub group_pubkey: [u8; 32],
+    pub share_index: u16,
+    pub commitments: Vec<PreExchangedCommitment>,
+    pub created_at: u64,
+}
+
+impl NonceCommitmentPayload {
+    pub fn new(
+        group_pubkey: [u8; 32],
+        share_index: u16,
+        commitments: Vec<PreExchangedCommitment>,
+    ) -> Self {
+        Self {
+            group_pubkey,
+            share_index,
+            commitments,
+            created_at: Timestamp::now().as_secs(),
+        }
+    }
+
+    pub fn is_within_replay_window(&self, window_secs: u64) -> bool {
+        within_replay_window(self.created_at, window_secs)
     }
 }
 
@@ -2443,5 +2537,98 @@ mod tests {
             }
             _ => panic!("expected Announce"),
         }
+    }
+
+    #[test]
+    fn test_sign_request_without_nonce_refs_omits_field() {
+        let payload =
+            SignRequestPayload::new([1u8; 32], [2u8; 32], b"msg".to_vec(), "raw", vec![1, 3]);
+        let msg = KfpMessage::SignRequest(payload);
+        let json = msg.to_json().unwrap();
+        // Wire compatibility: absent refs are not serialized.
+        assert!(!json.contains("nonce_refs"));
+    }
+
+    #[test]
+    fn test_sign_request_legacy_json_deserializes() {
+        // A payload produced by a peer predating nonce pre-exchange has no
+        // `nonce_refs` field at all; it must still parse to an empty list.
+        let legacy = r#"{"type":"sign_request","session_id":"0101010101010101010101010101010101010101010101010101010101010101","group_pubkey":"0202020202020202020202020202020202020202020202020202020202020202","message":"6d7367","message_type":"raw","participants":[1,3],"created_at":1700000000}"#;
+        let parsed = KfpMessage::from_json(legacy).unwrap();
+        match parsed {
+            KfpMessage::SignRequest(p) => assert!(p.nonce_refs.is_empty()),
+            _ => panic!("expected SignRequest"),
+        }
+    }
+
+    #[test]
+    fn test_sign_request_with_nonce_refs_roundtrip() {
+        let refs = vec![
+            NonceRef {
+                share_index: 1,
+                nonce_id: [9u8; 32],
+                commitment: vec![1, 2, 3],
+            },
+            NonceRef {
+                share_index: 3,
+                nonce_id: [0u8; 32],
+                commitment: vec![4, 5, 6],
+            },
+        ];
+        let payload =
+            SignRequestPayload::new([1u8; 32], [2u8; 32], b"msg".to_vec(), "raw", vec![1, 3])
+                .with_nonce_refs(refs.clone());
+        let msg = KfpMessage::SignRequest(payload);
+        let json = msg.to_json().unwrap();
+        let parsed = KfpMessage::from_json(&json).unwrap();
+        match parsed {
+            KfpMessage::SignRequest(p) => assert_eq!(p.nonce_refs, refs),
+            _ => panic!("expected SignRequest"),
+        }
+    }
+
+    #[test]
+    fn test_nonce_commitment_roundtrip() {
+        let payload = NonceCommitmentPayload::new(
+            [7u8; 32],
+            2,
+            vec![PreExchangedCommitment {
+                nonce_id: [5u8; 32],
+                commitment: vec![1, 2, 3, 4],
+            }],
+        );
+        let msg = KfpMessage::NonceCommitment(payload);
+        assert_eq!(msg.message_type(), "nonce_commitment");
+        assert_eq!(msg.group_pubkey(), Some(&[7u8; 32]));
+        assert_eq!(msg.session_id(), None);
+
+        let json = msg.to_json().unwrap();
+        let parsed = KfpMessage::from_json(&json).unwrap();
+        match parsed {
+            KfpMessage::NonceCommitment(p) => {
+                assert_eq!(p.share_index, 2);
+                assert_eq!(p.commitments.len(), 1);
+                assert_eq!(p.commitments[0].nonce_id, [5u8; 32]);
+            }
+            _ => panic!("expected NonceCommitment"),
+        }
+    }
+
+    #[test]
+    fn test_nonce_commitment_rejects_zero_share_index() {
+        let payload = NonceCommitmentPayload::new([7u8; 32], 0, vec![]);
+        assert!(KfpMessage::NonceCommitment(payload).validate().is_err());
+    }
+
+    #[test]
+    fn test_nonce_commitment_rejects_too_many() {
+        let commitments = (0..(MAX_NONCE_COMMITMENTS + 1))
+            .map(|_| PreExchangedCommitment {
+                nonce_id: [1u8; 32],
+                commitment: vec![1],
+            })
+            .collect();
+        let payload = NonceCommitmentPayload::new([7u8; 32], 1, commitments);
+        assert!(KfpMessage::NonceCommitment(payload).validate().is_err());
     }
 }

--- a/keep-frost-net/src/session.rs
+++ b/keep-frost-net/src/session.rs
@@ -633,6 +633,10 @@ impl SessionManager {
             .expect("just inserted"))
     }
 
+    pub fn abandon_session(&mut self, session_id: &[u8; 32]) {
+        self.active_sessions.remove(session_id);
+    }
+
     pub fn complete_session(&mut self, session_id: &[u8; 32]) {
         self.active_sessions.remove(session_id);
 

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -1120,3 +1120,144 @@ async fn test_request_descriptor_fails_with_no_peers() {
         "Expected 'No online peers' error, got: {err}"
     );
 }
+
+#[tokio::test]
+#[ignore] // Flaky in CI due to network timing - run with: cargo test -- --ignored
+async fn test_signing_flow_with_nonce_pre_exchange() {
+    use std::sync::Arc;
+
+    let mock_relay = MockRelay::run().await.expect("Failed to start mock relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let config = ThresholdConfig::two_of_three();
+    let dealer = TrustedDealer::new(config);
+    let (mut shares, _pubkey_pkg) = dealer.generate("test-nonce-pre-exchange").unwrap();
+
+    let share1 = shares.remove(0);
+    let share2 = shares.remove(0);
+    let share3 = shares.remove(0);
+
+    let mut node1 = KfpNode::new(share1, vec![relay.clone()])
+        .await
+        .expect("Failed to create node 1");
+    let mut node2 = KfpNode::new(share2, vec![relay.clone()])
+        .await
+        .expect("Failed to create node 2");
+    let mut node3 = KfpNode::new(share3, vec![relay])
+        .await
+        .expect("Failed to create node 3");
+
+    let mut rx3 = node3.subscribe();
+
+    let shutdown1 = node1.take_shutdown_handle();
+    let shutdown2 = node2.take_shutdown_handle();
+    let shutdown3 = node3.take_shutdown_handle();
+
+    let node1 = Arc::new(node1);
+    let node2 = Arc::new(node2);
+    let node3 = Arc::new(node3);
+
+    let n1 = Arc::clone(&node1);
+    let n2 = Arc::clone(&node2);
+    let n3 = Arc::clone(&node3);
+
+    let node1_handle = tokio::spawn(async move {
+        let _ = n1.run().await;
+    });
+    let node2_handle = tokio::spawn(async move {
+        let _ = n2.run().await;
+    });
+    let node3_handle = tokio::spawn(async move {
+        let _ = n3.run().await;
+    });
+
+    let mut peers_discovered = 0u32;
+    let discovery_timeout = timeout(Duration::from_secs(45), async {
+        while peers_discovered < 2 {
+            if let Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx3.recv().await {
+                peers_discovered += 1;
+            }
+        }
+    })
+    .await;
+
+    if discovery_timeout.is_err() {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        graceful_shutdown(shutdown3, node3_handle).await;
+        panic!("Peer discovery timed out: only {peers_discovered} peers discovered");
+    }
+
+    // Wait until node1 and node2 have also discovered node3, so their
+    // broadcasts will reach the signer.
+    let peers_ready = timeout(Duration::from_secs(45), async {
+        loop {
+            if node1.online_peers() >= 2 && node2.online_peers() >= 2 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await;
+
+    if peers_ready.is_err() {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        graceful_shutdown(shutdown3, node3_handle).await;
+        panic!("node1/node2 did not discover all peers");
+    }
+
+    // Each peer pre-exchanges round-1 commitments. node3 (the signer) needs
+    // pooled commitments from node1 and node2.
+    node1.replenish_nonce_pool().await.expect("node1 replenish");
+    node2.replenish_nonce_pool().await.expect("node2 replenish");
+
+    // Allow the broadcast NonceCommitment events to propagate to node3.
+    let pool_ready = timeout(Duration::from_secs(20), async {
+        loop {
+            if node3.nonce_pool_peer_available(1) > 0 && node3.nonce_pool_peer_available(2) > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await;
+
+    if pool_ready.is_err() {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        graceful_shutdown(shutdown3, node3_handle).await;
+        panic!("Pre-exchanged commitments did not propagate to signer");
+    }
+
+    let before_1 = node3.nonce_pool_peer_available(1);
+    let before_2 = node3.nonce_pool_peer_available(2);
+
+    let message = b"pre-exchanged nonce signing".to_vec();
+    let sign_result = timeout(Duration::from_secs(60), async {
+        node3.request_signature(message, "raw").await
+    })
+    .await;
+
+    // The signer should have consumed exactly one pooled commitment per peer.
+    let after_1 = node3.nonce_pool_peer_available(1);
+    let after_2 = node3.nonce_pool_peer_available(2);
+
+    graceful_shutdown(shutdown1, node1_handle).await;
+    graceful_shutdown(shutdown2, node2_handle).await;
+    graceful_shutdown(shutdown3, node3_handle).await;
+
+    match sign_result {
+        Ok(Ok(signature)) => assert_eq!(signature.len(), 64),
+        Ok(Err(e)) => panic!("Signing failed: {e:?}"),
+        Err(_) => panic!("Signing timed out after 60 seconds"),
+    }
+
+    // A 2-of-3 signing selects exactly one peer besides the requester, so
+    // exactly one pooled commitment must have been consumed (single-use).
+    let consumed = (before_1 - after_1) + (before_2 - after_2);
+    assert_eq!(
+        consumed, 1,
+        "expected exactly one pooled commitment consumed across selected peers"
+    );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-exchanged nonce commitment support and a pooled in-memory nonce store with reservation, FIFO eviction, and availability queries.
  * Nodes automatically rebalance/send pooled nonces to peers and can fast‑path signing when pre‑exchanged nonces are available.
  * New protocol message for broadcasting nonce commitments and ability to include pre‑exchanged refs in sign requests.
* **Tests**
  * Integration test validating pre‑exchange and consumption behavior (ignored in CI).
* **Behavior**
  * Nodes emit session-scoped signing failure events and can abandon sessions without marking them complete.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/390?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->