### PR TITLE
Automated fund sweep on descriptor migration

### DIFF
--- a/keep-bitcoin/src/descriptor.rs
+++ b/keep-bitcoin/src/descriptor.rs
@@ -202,6 +202,27 @@ pub fn address_at(descriptor: &str, index: u32, network: Network) -> Result<bitc
         .map_err(|e| BitcoinError::Descriptor(format!("address derivation failed: {e}")))
 }
 
+/// Derive the `script_pubkey` for a descriptor string. Ranged descriptors are
+/// resolved at `index`; definite (non-ranged) descriptors ignore `index` and
+/// yield their single output. Used to bind a supplied [`crate::RecoveryOutput`]
+/// to the descriptor identified by a canonical hash before sweeping its coins.
+pub fn descriptor_script_pubkey(descriptor: &str, index: u32) -> Result<bitcoin::ScriptBuf> {
+    let body = descriptor.split('#').next().unwrap_or(descriptor);
+    let parsed: Descriptor<DescriptorPublicKey> = body
+        .parse()
+        .map_err(|e| BitcoinError::Descriptor(format!("invalid descriptor: {e}")))?;
+    let definite = if parsed.has_wildcard() {
+        parsed
+            .at_derivation_index(index)
+            .map_err(|e| BitcoinError::Descriptor(format!("derivation index {index}: {e}")))?
+    } else {
+        parsed
+            .at_derivation_index(0)
+            .map_err(|e| BitcoinError::Descriptor(format!("definite descriptor: {e}")))?
+    };
+    Ok(definite.script_pubkey())
+}
+
 fn canonicalize_descriptor(body: &str) -> Result<(String, String)> {
     let body = body.split('#').next().unwrap_or(body);
     let parsed: Descriptor<DescriptorPublicKey> = body

--- a/keep-bitcoin/src/descriptor.rs
+++ b/keep-bitcoin/src/descriptor.rs
@@ -177,43 +177,38 @@ pub fn multipath_from_external(external: &str) -> Result<String> {
     Ok(canonical)
 }
 
-/// Derive the receive address at `index` from a ranged external descriptor
-/// string (e.g. `tr(...)/0/*`). Used to pick a fresh destination on the new
-/// descriptor when sweeping funds after a migration.
-///
-/// The descriptor must be ranged (contain a wildcard `*`); a definite
-/// descriptor with no wildcard is rejected so callers don't silently reuse a
-/// single address.
-pub fn address_at(descriptor: &str, index: u32, network: Network) -> Result<bitcoin::Address> {
-    let parsed = parse_descriptor_body(descriptor)?;
-    if !parsed.has_wildcard() {
-        return Err(BitcoinError::Descriptor(
-            "descriptor has no wildcard; cannot derive a ranged receive address".into(),
-        ));
-    }
-    parsed
-        .at_derivation_index(index)
-        .map_err(|e| BitcoinError::Descriptor(format!("derivation index {index}: {e}")))?
-        .address(network)
-        .map_err(|e| BitcoinError::Descriptor(format!("address derivation failed: {e}")))
-}
-
 /// Derive the `script_pubkey` for a definite (non-ranged) descriptor string.
 /// Used to bind a supplied [`crate::RecoveryOutput`] to the descriptor
 /// identified by a canonical hash before sweeping its coins. A recovery output
 /// is by definition a single, non-ranged output, so a ranged descriptor is
 /// rejected rather than silently resolved at an arbitrary index.
 pub fn descriptor_script_pubkey(descriptor: &str) -> Result<bitcoin::ScriptBuf> {
+    let parsed = parse_definite_descriptor(descriptor)?;
+    Ok(parsed.script_pubkey())
+}
+
+/// Derive the address for a definite (non-ranged) descriptor string on
+/// `network`. Used to pick the sweep destination from a finalized FROST wallet
+/// descriptor, which is definite (`tr(<xonly>,<tree>)`, no wildcard).
+pub fn descriptor_address(descriptor: &str, network: Network) -> Result<bitcoin::Address> {
+    let parsed = parse_definite_descriptor(descriptor)?;
+    parsed
+        .address(network)
+        .map_err(|e| BitcoinError::Descriptor(format!("address derivation failed: {e}")))
+}
+
+fn parse_definite_descriptor(
+    descriptor: &str,
+) -> Result<Descriptor<miniscript::DefiniteDescriptorKey>> {
     let parsed = parse_descriptor_body(descriptor)?;
     if parsed.has_wildcard() {
         return Err(BitcoinError::Descriptor(
-            "descriptor is ranged; expected a definite recovery output".into(),
+            "descriptor is ranged; expected a definite output".into(),
         ));
     }
-    let definite = parsed
+    parsed
         .at_derivation_index(0)
-        .map_err(|e| BitcoinError::Descriptor(format!("definite descriptor: {e}")))?;
-    Ok(definite.script_pubkey())
+        .map_err(|e| BitcoinError::Descriptor(format!("definite descriptor: {e}")))
 }
 
 fn parse_descriptor_body(descriptor: &str) -> Result<Descriptor<DescriptorPublicKey>> {
@@ -252,24 +247,40 @@ mod tests {
     }
 
     #[test]
-    fn test_address_at_derives_distinct_ranged_addresses() {
-        let secret = [7u8; 32];
-        let derivation = AddressDerivation::new(&secret, Network::Testnet).unwrap();
-        let export = DescriptorExport::from_derivation(&derivation, 0).unwrap();
+    fn test_descriptor_address_for_definite_frost_wallet() {
+        use crate::recovery::{RecoveryTier, SpendingTier};
 
-        let a0 = address_at(&export.descriptor, 0, Network::Testnet).unwrap();
-        let a1 = address_at(&export.descriptor, 1, Network::Testnet).unwrap();
-        assert_ne!(a0, a1);
-        assert!(a0.to_string().starts_with("tb1p"));
+        let group = test_group_pubkey();
+        let config = RecoveryConfig {
+            primary: SpendingTier {
+                keys: vec![test_keypair(1)],
+                threshold: 1,
+            },
+            recovery_tiers: vec![RecoveryTier {
+                keys: vec![test_keypair(2)],
+                threshold: 1,
+                timelock_months: 6,
+            }],
+            network: Network::Testnet,
+        };
+        // Real wallet descriptors are definite: tr(<xonly>,<tree>), no wildcard.
+        let export =
+            DescriptorExport::from_frost_wallet(&group, Some(&config), Network::Testnet).unwrap();
+
+        let addr = descriptor_address(&export.descriptor, Network::Testnet).unwrap();
+        assert!(addr.to_string().starts_with("tb1p"));
+
+        let spk = descriptor_script_pubkey(&export.descriptor).unwrap();
+        assert_eq!(addr.script_pubkey(), spk);
     }
 
     #[test]
-    fn test_address_at_rejects_non_ranged_descriptor() {
-        let group = test_group_pubkey();
-        // tr(<xonly>) has no wildcard.
-        let export = DescriptorExport::from_frost_wallet(&group, None, Network::Testnet).unwrap();
-        let err = address_at(&export.descriptor, 0, Network::Testnet).unwrap_err();
-        assert!(err.to_string().contains("wildcard"));
+    fn test_descriptor_address_rejects_ranged_descriptor() {
+        let secret = [7u8; 32];
+        let derivation = AddressDerivation::new(&secret, Network::Testnet).unwrap();
+        let export = DescriptorExport::from_derivation(&derivation, 0).unwrap();
+        let err = descriptor_address(&export.descriptor, Network::Testnet).unwrap_err();
+        assert!(err.to_string().contains("ranged"));
     }
 
     #[test]

--- a/keep-bitcoin/src/descriptor.rs
+++ b/keep-bitcoin/src/descriptor.rs
@@ -218,10 +218,7 @@ fn parse_descriptor_body(descriptor: &str) -> Result<Descriptor<DescriptorPublic
 }
 
 fn canonicalize_descriptor(body: &str) -> Result<(String, String)> {
-    let body = body.split('#').next().unwrap_or(body);
-    let parsed: Descriptor<DescriptorPublicKey> = body
-        .parse()
-        .map_err(|e| BitcoinError::Descriptor(format!("invalid descriptor: {e}")))?;
+    let parsed = parse_descriptor_body(body)?;
     let canonical = parsed.to_string();
     let (_, checksum) = canonical.rsplit_once('#').ok_or_else(|| {
         BitcoinError::Descriptor("rust-miniscript returned descriptor without checksum".into())

--- a/keep-bitcoin/src/descriptor.rs
+++ b/keep-bitcoin/src/descriptor.rs
@@ -267,8 +267,7 @@ mod tests {
     fn test_address_at_rejects_non_ranged_descriptor() {
         let group = test_group_pubkey();
         // tr(<xonly>) has no wildcard.
-        let export =
-            DescriptorExport::from_frost_wallet(&group, None, Network::Testnet).unwrap();
+        let export = DescriptorExport::from_frost_wallet(&group, None, Network::Testnet).unwrap();
         let err = address_at(&export.descriptor, 0, Network::Testnet).unwrap_err();
         assert!(err.to_string().contains("wildcard"));
     }

--- a/keep-bitcoin/src/descriptor.rs
+++ b/keep-bitcoin/src/descriptor.rs
@@ -185,42 +185,41 @@ pub fn multipath_from_external(external: &str) -> Result<String> {
 /// descriptor with no wildcard is rejected so callers don't silently reuse a
 /// single address.
 pub fn address_at(descriptor: &str, index: u32, network: Network) -> Result<bitcoin::Address> {
-    let body = descriptor.split('#').next().unwrap_or(descriptor);
-    let parsed: Descriptor<DescriptorPublicKey> = body
-        .parse()
-        .map_err(|e| BitcoinError::Descriptor(format!("invalid descriptor: {e}")))?;
+    let parsed = parse_descriptor_body(descriptor)?;
     if !parsed.has_wildcard() {
         return Err(BitcoinError::Descriptor(
             "descriptor has no wildcard; cannot derive a ranged receive address".into(),
         ));
     }
-    let definite = parsed
+    parsed
         .at_derivation_index(index)
-        .map_err(|e| BitcoinError::Descriptor(format!("derivation index {index}: {e}")))?;
-    definite
+        .map_err(|e| BitcoinError::Descriptor(format!("derivation index {index}: {e}")))?
         .address(network)
         .map_err(|e| BitcoinError::Descriptor(format!("address derivation failed: {e}")))
 }
 
-/// Derive the `script_pubkey` for a descriptor string. Ranged descriptors are
-/// resolved at `index`; definite (non-ranged) descriptors ignore `index` and
-/// yield their single output. Used to bind a supplied [`crate::RecoveryOutput`]
-/// to the descriptor identified by a canonical hash before sweeping its coins.
-pub fn descriptor_script_pubkey(descriptor: &str, index: u32) -> Result<bitcoin::ScriptBuf> {
-    let body = descriptor.split('#').next().unwrap_or(descriptor);
-    let parsed: Descriptor<DescriptorPublicKey> = body
-        .parse()
-        .map_err(|e| BitcoinError::Descriptor(format!("invalid descriptor: {e}")))?;
-    let definite = if parsed.has_wildcard() {
-        parsed
-            .at_derivation_index(index)
-            .map_err(|e| BitcoinError::Descriptor(format!("derivation index {index}: {e}")))?
-    } else {
-        parsed
-            .at_derivation_index(0)
-            .map_err(|e| BitcoinError::Descriptor(format!("definite descriptor: {e}")))?
-    };
+/// Derive the `script_pubkey` for a definite (non-ranged) descriptor string.
+/// Used to bind a supplied [`crate::RecoveryOutput`] to the descriptor
+/// identified by a canonical hash before sweeping its coins. A recovery output
+/// is by definition a single, non-ranged output, so a ranged descriptor is
+/// rejected rather than silently resolved at an arbitrary index.
+pub fn descriptor_script_pubkey(descriptor: &str) -> Result<bitcoin::ScriptBuf> {
+    let parsed = parse_descriptor_body(descriptor)?;
+    if parsed.has_wildcard() {
+        return Err(BitcoinError::Descriptor(
+            "descriptor is ranged; expected a definite recovery output".into(),
+        ));
+    }
+    let definite = parsed
+        .at_derivation_index(0)
+        .map_err(|e| BitcoinError::Descriptor(format!("definite descriptor: {e}")))?;
     Ok(definite.script_pubkey())
+}
+
+fn parse_descriptor_body(descriptor: &str) -> Result<Descriptor<DescriptorPublicKey>> {
+    let body = descriptor.split('#').next().unwrap_or(descriptor);
+    body.parse()
+        .map_err(|e| BitcoinError::Descriptor(format!("invalid descriptor: {e}")))
 }
 
 fn canonicalize_descriptor(body: &str) -> Result<(String, String)> {

--- a/keep-bitcoin/src/descriptor.rs
+++ b/keep-bitcoin/src/descriptor.rs
@@ -177,6 +177,31 @@ pub fn multipath_from_external(external: &str) -> Result<String> {
     Ok(canonical)
 }
 
+/// Derive the receive address at `index` from a ranged external descriptor
+/// string (e.g. `tr(...)/0/*`). Used to pick a fresh destination on the new
+/// descriptor when sweeping funds after a migration.
+///
+/// The descriptor must be ranged (contain a wildcard `*`); a definite
+/// descriptor with no wildcard is rejected so callers don't silently reuse a
+/// single address.
+pub fn address_at(descriptor: &str, index: u32, network: Network) -> Result<bitcoin::Address> {
+    let body = descriptor.split('#').next().unwrap_or(descriptor);
+    let parsed: Descriptor<DescriptorPublicKey> = body
+        .parse()
+        .map_err(|e| BitcoinError::Descriptor(format!("invalid descriptor: {e}")))?;
+    if !parsed.has_wildcard() {
+        return Err(BitcoinError::Descriptor(
+            "descriptor has no wildcard; cannot derive a ranged receive address".into(),
+        ));
+    }
+    let definite = parsed
+        .at_derivation_index(index)
+        .map_err(|e| BitcoinError::Descriptor(format!("derivation index {index}: {e}")))?;
+    definite
+        .address(network)
+        .map_err(|e| BitcoinError::Descriptor(format!("address derivation failed: {e}")))
+}
+
 fn canonicalize_descriptor(body: &str) -> Result<(String, String)> {
     let body = body.split('#').next().unwrap_or(body);
     let parsed: Descriptor<DescriptorPublicKey> = body
@@ -204,6 +229,28 @@ mod tests {
         assert!(export.descriptor.contains("tr("));
         assert!(export.descriptor.contains("86'/1'/0'"));
         assert!(export.descriptor.contains("#"));
+    }
+
+    #[test]
+    fn test_address_at_derives_distinct_ranged_addresses() {
+        let secret = [7u8; 32];
+        let derivation = AddressDerivation::new(&secret, Network::Testnet).unwrap();
+        let export = DescriptorExport::from_derivation(&derivation, 0).unwrap();
+
+        let a0 = address_at(&export.descriptor, 0, Network::Testnet).unwrap();
+        let a1 = address_at(&export.descriptor, 1, Network::Testnet).unwrap();
+        assert_ne!(a0, a1);
+        assert!(a0.to_string().starts_with("tb1p"));
+    }
+
+    #[test]
+    fn test_address_at_rejects_non_ranged_descriptor() {
+        let group = test_group_pubkey();
+        // tr(<xonly>) has no wildcard.
+        let export =
+            DescriptorExport::from_frost_wallet(&group, None, Network::Testnet).unwrap();
+        let err = address_at(&export.descriptor, 0, Network::Testnet).unwrap_err();
+        assert!(err.to_string().contains("wildcard"));
     }
 
     #[test]

--- a/keep-bitcoin/src/lib.rs
+++ b/keep-bitcoin/src/lib.rs
@@ -13,7 +13,10 @@ pub mod recovery_tx;
 mod signer;
 
 pub use address::{AddressDerivation, DerivedAddress};
-pub use descriptor::{address_at, multipath_from_external, xpub_to_x_only, DescriptorExport};
+pub use descriptor::{
+    address_at, descriptor_script_pubkey, multipath_from_external, xpub_to_x_only,
+    DescriptorExport,
+};
 pub use error::{BitcoinError, Result};
 pub use key_proof::{build_key_proof_psbt, sign_key_proof, verify_key_proof};
 pub use psbt::{PsbtAnalysis, PsbtSigner};

--- a/keep-bitcoin/src/lib.rs
+++ b/keep-bitcoin/src/lib.rs
@@ -14,8 +14,7 @@ mod signer;
 
 pub use address::{AddressDerivation, DerivedAddress};
 pub use descriptor::{
-    address_at, descriptor_script_pubkey, multipath_from_external, xpub_to_x_only,
-    DescriptorExport,
+    address_at, descriptor_script_pubkey, multipath_from_external, xpub_to_x_only, DescriptorExport,
 };
 pub use error::{BitcoinError, Result};
 pub use key_proof::{build_key_proof_psbt, sign_key_proof, verify_key_proof};

--- a/keep-bitcoin/src/lib.rs
+++ b/keep-bitcoin/src/lib.rs
@@ -13,7 +13,7 @@ pub mod recovery_tx;
 mod signer;
 
 pub use address::{AddressDerivation, DerivedAddress};
-pub use descriptor::{multipath_from_external, xpub_to_x_only, DescriptorExport};
+pub use descriptor::{address_at, multipath_from_external, xpub_to_x_only, DescriptorExport};
 pub use error::{BitcoinError, Result};
 pub use key_proof::{build_key_proof_psbt, sign_key_proof, verify_key_proof};
 pub use psbt::{PsbtAnalysis, PsbtSigner};
@@ -22,7 +22,7 @@ pub use recovery::{
 };
 pub use recovery_tx::{
     merge_tap_script_sig, script_spend_sighashes, verify_all_script_spend_input_bindings,
-    verify_script_spend_input_binding, RecoveryTxBuilder, ScriptSpendSighash,
+    verify_script_spend_input_binding, RecoveryTxBuilder, ScriptSpendSighash, SweepUtxo,
     TAPROOT_DUST_LIMIT_SATS,
 };
 pub use signer::BitcoinSigner;

--- a/keep-bitcoin/src/lib.rs
+++ b/keep-bitcoin/src/lib.rs
@@ -14,7 +14,8 @@ mod signer;
 
 pub use address::{AddressDerivation, DerivedAddress};
 pub use descriptor::{
-    address_at, descriptor_script_pubkey, multipath_from_external, xpub_to_x_only, DescriptorExport,
+    descriptor_address, descriptor_script_pubkey, multipath_from_external, xpub_to_x_only,
+    DescriptorExport,
 };
 pub use error::{BitcoinError, Result};
 pub use key_proof::{build_key_proof_psbt, sign_key_proof, verify_key_proof};

--- a/keep-bitcoin/src/recovery_tx.rs
+++ b/keep-bitcoin/src/recovery_tx.rs
@@ -17,9 +17,13 @@ const MAX_FEE_SATS: u64 = 100_000_000; // 1 BTC
 /// Bitcoin Core's default dust threshold for taproot (P2TR) outputs in sats.
 /// Outputs smaller than this are non-standard and unlikely to relay.
 pub const TAPROOT_DUST_LIMIT_SATS: u64 = 330;
-/// Maximum number of inputs in a single consolidating sweep. A larger tx would
-/// exceed standardness limits and fail to relay, so reject it at build time.
-pub const MAX_SWEEP_INPUTS: usize = 500;
+/// Maximum number of inputs in a single consolidating sweep. Taproot
+/// script-path inputs carry a sizable witness (signature, leaf script, control
+/// block), so a large input count both risks the ~100 kvB standardness weight
+/// limit and is costly to sign (one sighash per input per signer). Bound it
+/// conservatively; callers needing to consolidate more must batch into
+/// multiple sweeps.
+pub const MAX_SWEEP_INPUTS: usize = 100;
 
 /// A single UTXO under the recovery output being consolidated by
 /// [`RecoveryTxBuilder::build_sweep_psbt`].
@@ -334,10 +338,27 @@ impl RecoveryTxBuilder {
     }
 
     fn get_tier(&self, index: usize) -> Result<&TierInfo> {
-        self.recovery_output
+        let tier = self
+            .recovery_output
             .tiers
             .get(index)
-            .ok_or_else(|| BitcoinError::Recovery(format!("tier {index} not found")))
+            .ok_or_else(|| BitcoinError::Recovery(format!("tier {index} not found")))?;
+        if tier.keys.is_empty() {
+            return Err(BitcoinError::Recovery(format!("tier {index} has no keys")));
+        }
+        if tier.threshold < 1 {
+            return Err(BitcoinError::Recovery(format!(
+                "tier {index} threshold must be at least 1"
+            )));
+        }
+        if tier.threshold as usize > tier.keys.len() {
+            return Err(BitcoinError::Recovery(format!(
+                "tier {index} threshold {} exceeds key count {}",
+                tier.threshold,
+                tier.keys.len()
+            )));
+        }
+        Ok(tier)
     }
 
     fn control_block(&self, tier: &TierInfo) -> Result<ControlBlock> {

--- a/keep-bitcoin/src/recovery_tx.rs
+++ b/keep-bitcoin/src/recovery_tx.rs
@@ -17,6 +17,9 @@ const MAX_FEE_SATS: u64 = 100_000_000; // 1 BTC
 /// Bitcoin Core's default dust threshold for taproot (P2TR) outputs in sats.
 /// Outputs smaller than this are non-standard and unlikely to relay.
 pub const TAPROOT_DUST_LIMIT_SATS: u64 = 330;
+/// Maximum number of inputs in a single consolidating sweep. A larger tx would
+/// exceed standardness limits and fail to relay, so reject it at build time.
+pub const MAX_SWEEP_INPUTS: usize = 500;
 
 /// A single UTXO under the recovery output being consolidated by
 /// [`RecoveryTxBuilder::build_sweep_psbt`].
@@ -122,6 +125,12 @@ impl RecoveryTxBuilder {
             return Err(BitcoinError::Recovery(
                 "sweep requires at least one UTXO".into(),
             ));
+        }
+        if utxos.len() > MAX_SWEEP_INPUTS {
+            return Err(BitcoinError::Recovery(format!(
+                "sweep input count {} exceeds maximum {MAX_SWEEP_INPUTS}",
+                utxos.len()
+            )));
         }
         if fee_sats > MAX_FEE_SATS {
             return Err(BitcoinError::Recovery(format!(

--- a/keep-bitcoin/src/recovery_tx.rs
+++ b/keep-bitcoin/src/recovery_tx.rs
@@ -18,6 +18,14 @@ const MAX_FEE_SATS: u64 = 100_000_000; // 1 BTC
 /// Outputs smaller than this are non-standard and unlikely to relay.
 pub const TAPROOT_DUST_LIMIT_SATS: u64 = 330;
 
+/// A single UTXO under the recovery output being consolidated by
+/// [`RecoveryTxBuilder::build_sweep_psbt`].
+#[derive(Clone, Debug)]
+pub struct SweepUtxo {
+    pub outpoint: OutPoint,
+    pub value_sats: u64,
+}
+
 pub struct RecoveryTxBuilder {
     recovery_output: RecoveryOutput,
     secp: Secp256k1<All>,
@@ -88,6 +96,103 @@ impl RecoveryTxBuilder {
         psbt.inputs[0]
             .tap_scripts
             .insert(control_block, (tier.script.clone(), LeafVersion::TapScript));
+
+        Ok(psbt)
+    }
+
+    /// Build a consolidating sweep PSBT that spends every UTXO in `utxos`
+    /// (all under this recovery output, via the same `tier_index` scriptpath)
+    /// into a single output paying `destination`. The output value is the sum
+    /// of all UTXO values minus `fee_sats`.
+    ///
+    /// Every input is tagged with the tier's `tap_scripts` entry and
+    /// `witness_utxo`, so each can be signed via [`script_spend_sighashes`] and
+    /// aggregated by the PSBT coordination layer. `utxos` must be non-empty and
+    /// contain no duplicate outpoints.
+    pub fn build_sweep_psbt(
+        &self,
+        tier_index: usize,
+        utxos: &[SweepUtxo],
+        destination: &ScriptBuf,
+        fee_sats: u64,
+    ) -> Result<Psbt> {
+        let tier = self.get_tier(tier_index)?;
+
+        if utxos.is_empty() {
+            return Err(BitcoinError::Recovery(
+                "sweep requires at least one UTXO".into(),
+            ));
+        }
+        if fee_sats > MAX_FEE_SATS {
+            return Err(BitcoinError::Recovery(format!(
+                "fee {fee_sats} sats exceeds maximum {MAX_FEE_SATS} sats"
+            )));
+        }
+
+        let mut seen = std::collections::HashSet::new();
+        let mut total_in: u64 = 0;
+        for utxo in utxos {
+            if !seen.insert(utxo.outpoint) {
+                return Err(BitcoinError::Recovery(format!(
+                    "duplicate UTXO {} in sweep",
+                    utxo.outpoint
+                )));
+            }
+            total_in = total_in.checked_add(utxo.value_sats).ok_or_else(|| {
+                BitcoinError::Recovery("sweep input value overflow".into())
+            })?;
+        }
+
+        if total_in <= fee_sats {
+            return Err(BitcoinError::Recovery("insufficient funds".into()));
+        }
+        let output_value = total_in - fee_sats;
+        if output_value < TAPROOT_DUST_LIMIT_SATS {
+            return Err(BitcoinError::Recovery(format!(
+                "sweep output below dust threshold ({TAPROOT_DUST_LIMIT_SATS} sats)"
+            )));
+        }
+
+        let sequence = match tier.timelock_blocks {
+            Some(timelock_blocks) => crate::recovery::recovery_sequence(timelock_blocks)?,
+            None => Sequence::ENABLE_RBF_NO_LOCKTIME,
+        };
+
+        let input: Vec<TxIn> = utxos
+            .iter()
+            .map(|u| TxIn {
+                previous_output: u.outpoint,
+                script_sig: ScriptBuf::new(),
+                sequence,
+                witness: Witness::default(),
+            })
+            .collect();
+
+        let tx = Transaction {
+            version: bitcoin::transaction::Version(2),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input,
+            output: vec![TxOut {
+                value: Amount::from_sat(output_value),
+                script_pubkey: destination.clone(),
+            }],
+        };
+
+        let mut psbt =
+            Psbt::from_unsigned_tx(tx).map_err(|e| BitcoinError::Recovery(e.to_string()))?;
+
+        let control_block = self.control_block(tier)?;
+        let spk = self.recovery_output.address.script_pubkey();
+        for (i, utxo) in utxos.iter().enumerate() {
+            psbt.inputs[i].witness_utxo = Some(TxOut {
+                value: Amount::from_sat(utxo.value_sats),
+                script_pubkey: spk.clone(),
+            });
+            psbt.inputs[i].tap_scripts.insert(
+                control_block.clone(),
+                (tier.script.clone(), LeafVersion::TapScript),
+            );
+        }
 
         Ok(psbt)
     }
@@ -559,6 +664,131 @@ mod tests {
 
         let tx = builder.finalize_recovery(&mut psbt, 0).unwrap();
         assert!(!tx.input[0].witness.is_empty());
+    }
+
+    #[test]
+    fn test_build_sweep_psbt_consolidates_utxos() {
+        let (_, pk1) = test_keypair_full(1);
+        let (_, pk2) = test_keypair_full(2);
+        let secp = Secp256k1::new();
+
+        let config = RecoveryConfig {
+            primary: SpendingTier {
+                keys: vec![pk1],
+                threshold: 1,
+            },
+            recovery_tiers: vec![RecoveryTier {
+                keys: vec![pk2],
+                threshold: 1,
+                timelock_months: 6,
+            }],
+            network: Network::Testnet,
+        };
+
+        let output = config.build().unwrap();
+        let builder = RecoveryTxBuilder::new(output);
+
+        let utxos = vec![
+            SweepUtxo {
+                outpoint: OutPoint {
+                    txid: bitcoin::Txid::all_zeros(),
+                    vout: 0,
+                },
+                value_sats: 100_000,
+            },
+            SweepUtxo {
+                outpoint: OutPoint {
+                    txid: bitcoin::Txid::all_zeros(),
+                    vout: 1,
+                },
+                value_sats: 50_000,
+            },
+        ];
+
+        let xonly_pk1 = XOnlyPublicKey::from_slice(&pk1).unwrap();
+        let dest = ScriptBuf::new_p2tr(&secp, xonly_pk1, None);
+
+        let psbt = builder.build_sweep_psbt(0, &utxos, &dest, 2_000).unwrap();
+
+        assert_eq!(psbt.unsigned_tx.input.len(), 2);
+        assert_eq!(psbt.unsigned_tx.output.len(), 1);
+        assert_eq!(psbt.unsigned_tx.output[0].value.to_sat(), 148_000);
+        for input in &psbt.inputs {
+            assert!(input.witness_utxo.is_some());
+            assert_eq!(input.tap_scripts.len(), 1);
+        }
+        assert!(psbt.unsigned_tx.input[0].sequence.is_relative_lock_time());
+    }
+
+    #[test]
+    fn test_build_sweep_psbt_rejects_empty_and_duplicate() {
+        let (_, pk1) = test_keypair_full(1);
+        let (_, pk2) = test_keypair_full(2);
+        let secp = Secp256k1::new();
+        let config = RecoveryConfig {
+            primary: SpendingTier {
+                keys: vec![pk1],
+                threshold: 1,
+            },
+            recovery_tiers: vec![RecoveryTier {
+                keys: vec![pk2],
+                threshold: 1,
+                timelock_months: 6,
+            }],
+            network: Network::Testnet,
+        };
+        let builder = RecoveryTxBuilder::new(config.build().unwrap());
+        let xonly_pk1 = XOnlyPublicKey::from_slice(&pk1).unwrap();
+        let dest = ScriptBuf::new_p2tr(&secp, xonly_pk1, None);
+
+        assert!(builder.build_sweep_psbt(0, &[], &dest, 1_000).is_err());
+
+        let op = OutPoint {
+            txid: bitcoin::Txid::all_zeros(),
+            vout: 0,
+        };
+        let dup = vec![
+            SweepUtxo {
+                outpoint: op,
+                value_sats: 100_000,
+            },
+            SweepUtxo {
+                outpoint: op,
+                value_sats: 100_000,
+            },
+        ];
+        let err = builder.build_sweep_psbt(0, &dup, &dest, 1_000).unwrap_err();
+        assert!(err.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn test_build_sweep_psbt_insufficient_funds() {
+        let (_, pk1) = test_keypair_full(1);
+        let (_, pk2) = test_keypair_full(2);
+        let secp = Secp256k1::new();
+        let config = RecoveryConfig {
+            primary: SpendingTier {
+                keys: vec![pk1],
+                threshold: 1,
+            },
+            recovery_tiers: vec![RecoveryTier {
+                keys: vec![pk2],
+                threshold: 1,
+                timelock_months: 6,
+            }],
+            network: Network::Testnet,
+        };
+        let builder = RecoveryTxBuilder::new(config.build().unwrap());
+        let xonly_pk1 = XOnlyPublicKey::from_slice(&pk1).unwrap();
+        let dest = ScriptBuf::new_p2tr(&secp, xonly_pk1, None);
+        let utxos = vec![SweepUtxo {
+            outpoint: OutPoint {
+                txid: bitcoin::Txid::all_zeros(),
+                vout: 0,
+            },
+            value_sats: 500,
+        }];
+        assert!(builder.build_sweep_psbt(0, &utxos, &dest, 1_000).is_err());
     }
 
     #[test]

--- a/keep-bitcoin/src/recovery_tx.rs
+++ b/keep-bitcoin/src/recovery_tx.rs
@@ -147,9 +147,9 @@ impl RecoveryTxBuilder {
                     utxo.outpoint
                 )));
             }
-            total_in = total_in.checked_add(utxo.value_sats).ok_or_else(|| {
-                BitcoinError::Recovery("sweep input value overflow".into())
-            })?;
+            total_in = total_in
+                .checked_add(utxo.value_sats)
+                .ok_or_else(|| BitcoinError::Recovery("sweep input value overflow".into()))?;
         }
 
         if total_in <= fee_sats {

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -32,7 +32,7 @@ fn descriptor_lookup_for(
 > {
     keep_frost_net::KeepDescriptorLookup::new(move || {
         let guard = keep.lock().ok()?;
-        guard.list_wallet_descriptors().ok()
+        guard.list_all_wallet_descriptor_versions().ok()
     })
 }
 

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -26,7 +26,7 @@ fn descriptor_lookup_for(
 > {
     keep_frost_net::KeepDescriptorLookup::new(move || {
         let guard = keep.lock().ok()?;
-        guard.list_wallet_descriptors().ok()
+        guard.list_all_wallet_descriptor_versions().ok()
     })
 }
 

--- a/keep-desktop/src/frost.rs
+++ b/keep-desktop/src/frost.rs
@@ -43,7 +43,7 @@ pub(crate) fn descriptor_lookup_for(
     keep_frost_net::KeepDescriptorLookup::new(move || {
         let guard = keep.lock().ok()?;
         let keep = guard.as_ref()?;
-        keep.list_wallet_descriptors().ok()
+        keep.list_all_wallet_descriptor_versions().ok()
     })
 }
 

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -76,6 +76,15 @@ pub trait PersistedDescriptorLookup: Send + Sync {
         None
     }
 
+    /// Return the external (receive) descriptor string of the persisted
+    /// descriptor whose group + canonical hash match, if any. Used by the
+    /// migration sweep to bind a supplied recovery output to the persisted OLD
+    /// descriptor, so the source of truth survives session reaping/restart.
+    fn external_for(&self, group: &[u8; 32], hash: &[u8; 32]) -> Option<String> {
+        let _ = (group, hash);
+        None
+    }
+
     /// Return the largest persisted descriptor version for the given group,
     /// `Ok(None)` if no descriptor exists, or `Err(DescriptorLookupUnavailable)`
     /// if the underlying store could not be queried (e.g. vault locked). Used
@@ -143,6 +152,10 @@ where
 
     fn network_for(&self, group: &[u8; 32], hash: &[u8; 32]) -> Option<String> {
         self.lookup(|d| Some(d.network.clone()), group, hash)
+    }
+
+    fn external_for(&self, group: &[u8; 32], hash: &[u8; 32]) -> Option<String> {
+        self.lookup(|d| Some(d.external_descriptor.clone()), group, hash)
     }
 
     fn latest_version_for(

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1753,4 +1753,49 @@ mod tests {
         let node = result.unwrap();
         assert_eq!(node.share_index(), 1);
     }
+
+    fn descriptor_version(
+        group: [u8; 32],
+        external: &str,
+        version: u32,
+    ) -> keep_core::wallet::WalletDescriptor {
+        keep_core::wallet::WalletDescriptor {
+            group_pubkey: group,
+            external_descriptor: external.to_string(),
+            internal_descriptor: String::new(),
+            network: "regtest".to_string(),
+            created_at: 0,
+            device_registrations: Vec::new(),
+            policy_hash: [0u8; 32],
+            version,
+            previous_descriptor_hash: None,
+            policy: None,
+        }
+    }
+
+    #[test]
+    fn external_for_resolves_superseded_version() {
+        let group = [3u8; 32];
+        let old = descriptor_version(group, "tr(old_external)", 1);
+        let new = descriptor_version(group, "tr(new_external)", 2);
+        let old_hash = old.canonical_hash();
+        let new_hash = new.canonical_hash();
+        assert_ne!(old_hash, new_hash);
+
+        let rows = vec![old.clone(), new.clone()];
+        let lookup = KeepDescriptorLookup::new(move || Some(rows.clone()));
+
+        assert_eq!(
+            lookup.external_for(&group, &old_hash).as_deref(),
+            Some("tr(old_external)"),
+            "migration sweep must resolve the superseded OLD descriptor across all versions",
+        );
+        assert_eq!(
+            lookup.external_for(&group, &new_hash).as_deref(),
+            Some("tr(new_external)"),
+        );
+        assert_eq!(lookup.latest_version_for(&group), Ok(Some(2)));
+        assert!(lookup.find_by_hash(&group, &old_hash));
+        assert!(lookup.find_by_hash(&group, &new_hash));
+    }
 }

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -112,6 +112,174 @@ impl KfpNode {
         )
     }
 
+    /// Propose a migration sweep: consolidate every UTXO under the OLD
+    /// descriptor (spent via the `tier_index` recovery scriptpath) into a
+    /// single output paying a fresh receive address derived from the NEW
+    /// descriptor of the completed migration `session_id`.
+    ///
+    /// Preconditions, enforced fail-closed:
+    ///   - the migration session must be `Complete` with a finalized descriptor;
+    ///   - the NEW descriptor must be persisted and version-linked, i.e. its
+    ///     canonical hash resolves via the configured `descriptor_lookup`
+    ///     (the `previous_descriptor_hash` chain is written when the migrate
+    ///     link is processed);
+    ///   - the supplied `old_recovery` must build a P2TR output whose hash
+    ///     equals `old_descriptor_hash`.
+    ///
+    /// The sweep is driven through the existing [`Self::request_psbt_spend`]
+    /// coordination keyed on `old_descriptor_hash`, so peers correlate it with
+    /// the descriptor bump via the migrate link that already references the
+    /// same migration `session_id`.
+    ///
+    /// Returns the derived PSBT session id.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn request_descriptor_migration_sweep(
+        &self,
+        migration_session_id: [u8; 32],
+        old_descriptor_hash: [u8; 32],
+        old_recovery: &keep_bitcoin::RecoveryOutput,
+        tier_index: u32,
+        utxos: Vec<keep_bitcoin::SweepUtxo>,
+        new_receive_index: u32,
+        fee_sats: u64,
+        required_threshold: u32,
+        expected_share_signers: Vec<u16>,
+        expected_fingerprints: Vec<String>,
+        timeout_secs: Option<u64>,
+    ) -> Result<[u8; 32]> {
+        if utxos.is_empty() {
+            return Err(FrostNetError::Session(
+                "migration sweep requires at least one UTXO".into(),
+            ));
+        }
+
+        // 1. Resolve the completed migration session and its finalized NEW
+        //    descriptor. Require Complete state so we never sweep into a
+        //    descriptor the group has not fully validated.
+        let (new_external, new_network, new_policy_hash, new_version) = {
+            let sessions = self.descriptor_sessions.read();
+            let session = sessions.get_session(&migration_session_id).ok_or_else(|| {
+                FrostNetError::Session("unknown migration session".into())
+            })?;
+            if session.group_pubkey() != &self.group_pubkey {
+                return Err(FrostNetError::Session(
+                    "migration session belongs to a different group".into(),
+                ));
+            }
+            if !matches!(
+                session.state(),
+                crate::descriptor_session::DescriptorSessionState::Complete
+            ) {
+                return Err(FrostNetError::Session(
+                    "migration session is not Complete; refusing to sweep into an unfinalized descriptor".into(),
+                ));
+            }
+            let finalized = session.descriptor().ok_or_else(|| {
+                FrostNetError::Session("migration session has no finalized descriptor".into())
+            })?;
+            (
+                finalized.external.clone(),
+                session.network().to_string(),
+                finalized.policy_hash,
+                session.policy().version,
+            )
+        };
+
+        // 2. Require the NEW descriptor be persisted + version-linked. The hash
+        //    is recomputed from the finalized session data and must resolve via
+        //    the descriptor lookup (which reads the same store the migrate link
+        //    writes `previous_descriptor_hash` lineage into).
+        let new_internal = {
+            let sessions = self.descriptor_sessions.read();
+            let session = sessions.get_session(&migration_session_id).ok_or_else(|| {
+                FrostNetError::Session("migration session vanished".into())
+            })?;
+            session
+                .descriptor()
+                .map(|d| d.internal.clone())
+                .ok_or_else(|| {
+                    FrostNetError::Session("migration session has no finalized descriptor".into())
+                })?
+        };
+        let new_descriptor_hash = keep_core::wallet::canonical_descriptor_hash(
+            &new_external,
+            &new_internal,
+            &new_policy_hash,
+            new_version,
+        )
+        .map_err(|e| FrostNetError::Session(format!("canonical descriptor hash failed: {e}")))?;
+        let lookup = self.descriptor_lookup.as_deref().ok_or_else(|| {
+            FrostNetError::Session(
+                "no descriptor lookup configured; cannot confirm the new descriptor is persisted before sweeping".into(),
+            )
+        })?;
+        if !lookup.find_by_hash(&self.group_pubkey, &new_descriptor_hash) {
+            return Err(FrostNetError::Session(
+                "new descriptor is not persisted (version-linked); finalize and store it before proposing a sweep".into(),
+            ));
+        }
+
+        // 3. Derive the fresh NEW receive address. old_descriptor_hash is
+        //    re-verified against the persisted store inside request_psbt_spend,
+        //    so a caller cannot sweep an unrelated descriptor's coins through
+        //    this migration's coordination.
+        let network = bitcoin::Network::from_str(&new_network).map_err(|e| {
+            FrostNetError::Session(format!("invalid network {new_network}: {e}"))
+        })?;
+        let destination = keep_bitcoin::address_at(&new_external, new_receive_index, network)
+            .map_err(|e| FrostNetError::Session(format!("new receive address: {e}")))?
+            .script_pubkey();
+
+        // 4. Build the consolidating sweep PSBT under the OLD recovery tier.
+        let builder = keep_bitcoin::RecoveryTxBuilder::new(old_recovery.clone());
+        let psbt = builder
+            .build_sweep_psbt(tier_index as usize, &utxos, &destination, fee_sats)
+            .map_err(|e| FrostNetError::Session(format!("sweep PSBT build failed: {e}")))?;
+        let psbt_bytes = psbt.serialize();
+
+        let inputs: Vec<PsbtInputInfo> = utxos
+            .iter()
+            .enumerate()
+            .map(|(i, u)| PsbtInputInfo {
+                index: i as u32,
+                value_sats: u.value_sats,
+                address: None,
+            })
+            .collect();
+        let total_in: u64 = utxos.iter().map(|u| u.value_sats).sum();
+        let outputs = vec![PsbtOutputInfo {
+            index: 0,
+            value_sats: total_in.saturating_sub(fee_sats),
+            address: keep_bitcoin::address_at(&new_external, new_receive_index, network)
+                .ok()
+                .map(|a| a.to_string()),
+            is_change: false,
+        }];
+
+        info!(
+            migration_session_id = %hex::encode(migration_session_id),
+            old_descriptor_hash = %hex::encode(old_descriptor_hash),
+            new_descriptor_hash = %hex::encode(new_descriptor_hash),
+            utxos = utxos.len(),
+            "Proposing migration sweep"
+        );
+
+        // 5. Drive through the existing PSBT propose/sign coordination.
+        self.request_psbt_spend(
+            old_descriptor_hash,
+            tier_index,
+            psbt_bytes,
+            fee_sats,
+            required_threshold,
+            expected_share_signers,
+            expected_fingerprints,
+            inputs,
+            outputs,
+            timeout_secs,
+        )
+        .await
+    }
+
     /// Propose a PSBT for a recovery tier spend. Publishes `PsbtPropose` to all
     /// expected signers over NIP-44 encrypted channel.
     ///

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -41,6 +41,17 @@ pub struct PsbtSessionSnapshot {
     pub outputs: Vec<(String, u64)>,
 }
 
+/// Maximum receive index accepted for a migration sweep destination. Bounds
+/// the BIP-44 style gap: a sweep must pay an address within a sane window of
+/// the new descriptor's used range, not an arbitrarily deep index.
+const MAX_SWEEP_RECEIVE_INDEX: u32 = 1_000;
+
+/// Reject a sweep whose fee exceeds this fraction of total input value. Guards
+/// against a fee-griefing proposal that burns swept funds while still passing
+/// the absolute `MAX_FEE_SATS` cap in the builder.
+const MAX_SWEEP_FEE_NUMERATOR: u64 = 1;
+const MAX_SWEEP_FEE_DENOMINATOR: u64 = 4;
+
 impl KfpNode {
     /// Return a display-safe snapshot for the given PSBT session. Returns
     /// `None` if the session does not exist or the stored PSBT fails to
@@ -123,8 +134,11 @@ impl KfpNode {
     ///     canonical hash resolves via the configured `descriptor_lookup`
     ///     (the `previous_descriptor_hash` chain is written when the migrate
     ///     link is processed);
-    ///   - the supplied `old_recovery` must build a P2TR output whose hash
-    ///     equals `old_descriptor_hash`.
+    ///   - the supplied `old_recovery` must resolve to the descriptor
+    ///     identified by `old_descriptor_hash`: the recovery output's
+    ///     `script_pubkey` is compared against the finalized OLD descriptor's
+    ///     output script and a mismatch is rejected, so a proposer cannot
+    ///     sweep coins from an unrelated recovery output.
     ///
     /// The sweep is driven through the existing [`Self::request_psbt_spend`]
     /// coordination keyed on `old_descriptor_hash`, so peers correlate it with
@@ -152,11 +166,17 @@ impl KfpNode {
                 "migration sweep requires at least one UTXO".into(),
             ));
         }
+        if new_receive_index > MAX_SWEEP_RECEIVE_INDEX {
+            return Err(FrostNetError::Session(format!(
+                "new receive index {new_receive_index} exceeds gap limit {MAX_SWEEP_RECEIVE_INDEX}"
+            )));
+        }
 
         // 1. Resolve the completed migration session and its finalized NEW
-        //    descriptor. Require Complete state so we never sweep into a
-        //    descriptor the group has not fully validated.
-        let (new_external, new_network, new_policy_hash, new_version) = {
+        //    descriptor in a single lock scope so every field derives from one
+        //    consistent snapshot. Require Complete state so we never sweep into
+        //    a descriptor the group has not fully validated.
+        let (new_external, new_internal, new_network, new_policy_hash, new_version) = {
             let sessions = self.descriptor_sessions.read();
             let session = sessions.get_session(&migration_session_id).ok_or_else(|| {
                 FrostNetError::Session("unknown migration session".into())
@@ -179,6 +199,7 @@ impl KfpNode {
             })?;
             (
                 finalized.external.clone(),
+                finalized.internal.clone(),
                 session.network().to_string(),
                 finalized.policy_hash,
                 session.policy().version,
@@ -189,18 +210,6 @@ impl KfpNode {
         //    is recomputed from the finalized session data and must resolve via
         //    the descriptor lookup (which reads the same store the migrate link
         //    writes `previous_descriptor_hash` lineage into).
-        let new_internal = {
-            let sessions = self.descriptor_sessions.read();
-            let session = sessions.get_session(&migration_session_id).ok_or_else(|| {
-                FrostNetError::Session("migration session vanished".into())
-            })?;
-            session
-                .descriptor()
-                .map(|d| d.internal.clone())
-                .ok_or_else(|| {
-                    FrostNetError::Session("migration session has no finalized descriptor".into())
-                })?
-        };
         let new_descriptor_hash = keep_core::wallet::canonical_descriptor_hash(
             &new_external,
             &new_internal,
@@ -219,18 +228,55 @@ impl KfpNode {
             ));
         }
 
-        // 3. Derive the fresh NEW receive address. old_descriptor_hash is
-        //    re-verified against the persisted store inside request_psbt_spend,
-        //    so a caller cannot sweep an unrelated descriptor's coins through
-        //    this migration's coordination.
         let network = bitcoin::Network::from_str(&new_network).map_err(|e| {
             FrostNetError::Session(format!("invalid network {new_network}: {e}"))
         })?;
-        let destination = keep_bitcoin::address_at(&new_external, new_receive_index, network)
-            .map_err(|e| FrostNetError::Session(format!("new receive address: {e}")))?
-            .script_pubkey();
 
-        // 4. Build the consolidating sweep PSBT under the OLD recovery tier.
+        // 3. Bind `old_recovery` to `old_descriptor_hash`. The PSBT body
+        //    (witness_utxo script, tap_scripts, control blocks) is built
+        //    entirely from `old_recovery`, while authorization keys only on
+        //    `old_descriptor_hash`. Without this check a proposer could sweep
+        //    coins from an unrelated recovery output that the group never
+        //    finalized. Resolve the finalized OLD descriptor by hash and require
+        //    its output script equal the recovery output's script_pubkey.
+        let old_external = self
+            .external_descriptor_for_hash(&old_descriptor_hash)?
+            .ok_or_else(|| {
+                FrostNetError::Session(
+                    "old_descriptor_hash does not resolve to a finalized descriptor for this group"
+                        .into(),
+                )
+            })?;
+        let old_spk = keep_bitcoin::descriptor_script_pubkey(&old_external, 0)
+            .map_err(|e| FrostNetError::Session(format!("old descriptor script_pubkey: {e}")))?;
+        if old_spk != old_recovery.address.script_pubkey() {
+            return Err(FrostNetError::Session(
+                "old_recovery output does not match the descriptor identified by old_descriptor_hash"
+                    .into(),
+            ));
+        }
+
+        // 4. Derive the fresh NEW receive address once and reuse it for both the
+        //    PSBT destination and the display output so they cannot diverge.
+        let dest_addr = keep_bitcoin::address_at(&new_external, new_receive_index, network)
+            .map_err(|e| FrostNetError::Session(format!("new receive address: {e}")))?;
+        let destination = dest_addr.script_pubkey();
+
+        // 5. Bound the fee relative to total input value before building, so a
+        //    fee-griefing proposal is rejected ahead of the looser absolute cap
+        //    enforced inside the builder.
+        let total_in: u64 = utxos
+            .iter()
+            .try_fold(0u64, |acc, u| acc.checked_add(u.value_sats))
+            .ok_or_else(|| FrostNetError::Session("sweep input value overflow".into()))?;
+        let fee_cap = total_in.saturating_mul(MAX_SWEEP_FEE_NUMERATOR) / MAX_SWEEP_FEE_DENOMINATOR;
+        if fee_sats > fee_cap {
+            return Err(FrostNetError::Session(format!(
+                "sweep fee {fee_sats} exceeds {MAX_SWEEP_FEE_NUMERATOR}/{MAX_SWEEP_FEE_DENOMINATOR} of total input {total_in}"
+            )));
+        }
+
+        // 6. Build the consolidating sweep PSBT under the OLD recovery tier.
         let builder = keep_bitcoin::RecoveryTxBuilder::new(old_recovery.clone());
         let psbt = builder
             .build_sweep_psbt(tier_index as usize, &utxos, &destination, fee_sats)
@@ -246,13 +292,10 @@ impl KfpNode {
                 address: None,
             })
             .collect();
-        let total_in: u64 = utxos.iter().map(|u| u.value_sats).sum();
         let outputs = vec![PsbtOutputInfo {
             index: 0,
             value_sats: total_in.saturating_sub(fee_sats),
-            address: keep_bitcoin::address_at(&new_external, new_receive_index, network)
-                .ok()
-                .map(|a| a.to_string()),
+            address: Some(dest_addr.to_string()),
             is_change: false,
         }];
 
@@ -724,6 +767,32 @@ impl KfpNode {
             )));
         }
         Ok(())
+    }
+
+    /// Resolve the external descriptor string of the finalized descriptor whose
+    /// canonical hash equals `descriptor_hash`, scanning in-memory sessions for
+    /// this group. Returns `None` if no finalized descriptor matches.
+    fn external_descriptor_for_hash(&self, descriptor_hash: &[u8; 32]) -> Result<Option<String>> {
+        let sessions = self.descriptor_sessions.read();
+        for (_, session) in sessions.iter_sessions() {
+            if session.group_pubkey() != &self.group_pubkey {
+                continue;
+            }
+            let Some(finalized) = session.descriptor() else {
+                continue;
+            };
+            let expected = keep_core::wallet::canonical_descriptor_hash(
+                &finalized.external,
+                &finalized.internal,
+                &finalized.policy_hash,
+                session.policy().version,
+            )
+            .map_err(|e| FrostNetError::Session(format!("canonical descriptor hash failed: {e}")))?;
+            if &expected == descriptor_hash {
+                return Ok(Some(finalized.external.clone()));
+            }
+        }
+        Ok(None)
     }
 
     fn verify_descriptor_hash_against_stored(&self, descriptor_hash: &[u8; 32]) -> Result<()> {

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -177,9 +177,9 @@ impl KfpNode {
         //    a descriptor the group has not fully validated.
         let (new_external, new_internal, new_network, new_policy_hash, new_version) = {
             let sessions = self.descriptor_sessions.read();
-            let session = sessions.get_session(&migration_session_id).ok_or_else(|| {
-                FrostNetError::Session("unknown migration session".into())
-            })?;
+            let session = sessions
+                .get_session(&migration_session_id)
+                .ok_or_else(|| FrostNetError::Session("unknown migration session".into()))?;
             if session.group_pubkey() != &self.group_pubkey {
                 return Err(FrostNetError::Session(
                     "migration session belongs to a different group".into(),
@@ -227,9 +227,8 @@ impl KfpNode {
             ));
         }
 
-        let network = bitcoin::Network::from_str(&new_network).map_err(|e| {
-            FrostNetError::Session(format!("invalid network {new_network}: {e}"))
-        })?;
+        let network = bitcoin::Network::from_str(&new_network)
+            .map_err(|e| FrostNetError::Session(format!("invalid network {new_network}: {e}")))?;
 
         // 3. Bind `old_recovery` to `old_descriptor_hash`. The PSBT body
         //    (witness_utxo script, tap_scripts, control blocks) is built
@@ -786,7 +785,9 @@ impl KfpNode {
                 &finalized.policy_hash,
                 session.policy().version,
             )
-            .map_err(|e| FrostNetError::Session(format!("canonical descriptor hash failed: {e}")))?;
+            .map_err(|e| {
+                FrostNetError::Session(format!("canonical descriptor hash failed: {e}"))
+            })?;
             if &expected == descriptor_hash {
                 return Ok(Some(finalized.external.clone()));
             }

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -46,11 +46,10 @@ pub struct PsbtSessionSnapshot {
 /// the new descriptor's used range, not an arbitrarily deep index.
 const MAX_SWEEP_RECEIVE_INDEX: u32 = 1_000;
 
-/// Reject a sweep whose fee exceeds this fraction of total input value. Guards
-/// against a fee-griefing proposal that burns swept funds while still passing
-/// the absolute `MAX_FEE_SATS` cap in the builder.
-const MAX_SWEEP_FEE_NUMERATOR: u64 = 1;
-const MAX_SWEEP_FEE_DENOMINATOR: u64 = 4;
+/// Reject a sweep whose fee exceeds `1 / MAX_SWEEP_FEE_FRACTION` of total input
+/// value. Guards against a fee-griefing proposal that burns swept funds while
+/// still passing the absolute `MAX_FEE_SATS` cap in the builder.
+const MAX_SWEEP_FEE_FRACTION: u64 = 4;
 
 impl KfpNode {
     /// Return a display-safe snapshot for the given PSBT session. Returns
@@ -247,7 +246,7 @@ impl KfpNode {
                         .into(),
                 )
             })?;
-        let old_spk = keep_bitcoin::descriptor_script_pubkey(&old_external, 0)
+        let old_spk = keep_bitcoin::descriptor_script_pubkey(&old_external)
             .map_err(|e| FrostNetError::Session(format!("old descriptor script_pubkey: {e}")))?;
         if old_spk != old_recovery.address.script_pubkey() {
             return Err(FrostNetError::Session(
@@ -269,10 +268,10 @@ impl KfpNode {
             .iter()
             .try_fold(0u64, |acc, u| acc.checked_add(u.value_sats))
             .ok_or_else(|| FrostNetError::Session("sweep input value overflow".into()))?;
-        let fee_cap = total_in.saturating_mul(MAX_SWEEP_FEE_NUMERATOR) / MAX_SWEEP_FEE_DENOMINATOR;
+        let fee_cap = total_in / MAX_SWEEP_FEE_FRACTION;
         if fee_sats > fee_cap {
             return Err(FrostNetError::Session(format!(
-                "sweep fee {fee_sats} exceeds {MAX_SWEEP_FEE_NUMERATOR}/{MAX_SWEEP_FEE_DENOMINATOR} of total input {total_in}"
+                "sweep fee {fee_sats} exceeds 1/{MAX_SWEEP_FEE_FRACTION} of total input {total_in}"
             )));
         }
 
@@ -307,7 +306,7 @@ impl KfpNode {
             "Proposing migration sweep"
         );
 
-        // 5. Drive through the existing PSBT propose/sign coordination.
+        // 7. Drive through the existing PSBT propose/sign coordination.
         self.request_psbt_spend(
             old_descriptor_hash,
             tier_index,

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -41,11 +41,6 @@ pub struct PsbtSessionSnapshot {
     pub outputs: Vec<(String, u64)>,
 }
 
-/// Maximum receive index accepted for a migration sweep destination. Bounds
-/// the BIP-44 style gap: a sweep must pay an address within a sane window of
-/// the new descriptor's used range, not an arbitrarily deep index.
-const MAX_SWEEP_RECEIVE_INDEX: u32 = 1_000;
-
 /// Reject a sweep whose fee exceeds `1 / MAX_SWEEP_FEE_FRACTION` of total input
 /// value. Guards against a fee-griefing proposal that burns swept funds while
 /// still passing the absolute `MAX_FEE_SATS` cap in the builder.
@@ -124,8 +119,8 @@ impl KfpNode {
 
     /// Propose a migration sweep: consolidate every UTXO under the OLD
     /// descriptor (spent via the `tier_index` recovery scriptpath) into a
-    /// single output paying a fresh receive address derived from the NEW
-    /// descriptor of the completed migration `session_id`.
+    /// single output paying the address of the NEW (definite) descriptor of the
+    /// completed migration `session_id`.
     ///
     /// Preconditions, enforced fail-closed:
     ///   - the migration session must be `Complete` with a finalized descriptor;
@@ -153,7 +148,6 @@ impl KfpNode {
         old_recovery: &keep_bitcoin::RecoveryOutput,
         tier_index: u32,
         utxos: Vec<keep_bitcoin::SweepUtxo>,
-        new_receive_index: u32,
         fee_sats: u64,
         required_threshold: u32,
         expected_share_signers: Vec<u16>,
@@ -164,11 +158,6 @@ impl KfpNode {
             return Err(FrostNetError::Session(
                 "migration sweep requires at least one UTXO".into(),
             ));
-        }
-        if new_receive_index > MAX_SWEEP_RECEIVE_INDEX {
-            return Err(FrostNetError::Session(format!(
-                "new receive index {new_receive_index} exceeds gap limit {MAX_SWEEP_RECEIVE_INDEX}"
-            )));
         }
 
         // 1. Resolve the completed migration session and its finalized NEW
@@ -235,13 +224,15 @@ impl KfpNode {
         //    entirely from `old_recovery`, while authorization keys only on
         //    `old_descriptor_hash`. Without this check a proposer could sweep
         //    coins from an unrelated recovery output that the group never
-        //    finalized. Resolve the finalized OLD descriptor by hash and require
-        //    its output script equal the recovery output's script_pubkey.
-        let old_external = self
-            .external_descriptor_for_hash(&old_descriptor_hash)?
+        //    finalized. Resolve the finalized OLD descriptor by hash through the
+        //    same persisted lookup used for the new one, so the source of truth
+        //    is consistent and survives session reaping/restart. Require its
+        //    output script equal the recovery output's script_pubkey.
+        let old_external = lookup
+            .external_for(&self.group_pubkey, &old_descriptor_hash)
             .ok_or_else(|| {
                 FrostNetError::Session(
-                    "old_descriptor_hash does not resolve to a finalized descriptor for this group"
+                    "old_descriptor_hash does not resolve to a persisted descriptor for this group"
                         .into(),
                 )
             })?;
@@ -253,10 +244,29 @@ impl KfpNode {
                     .into(),
             ));
         }
+        if !old_recovery
+            .address
+            .as_unchecked()
+            .is_valid_for_network(network)
+        {
+            return Err(FrostNetError::Session(format!(
+                "old_recovery address is not valid for network {network}"
+            )));
+        }
 
-        // 4. Derive the fresh NEW receive address once and reuse it for both the
-        //    PSBT destination and the display output so they cannot diverge.
-        let dest_addr = keep_bitcoin::address_at(&new_external, new_receive_index, network)
+        // 4. Derive the NEW destination address from the finalized descriptor.
+        //    FROST wallet descriptors are definite (`tr(<xonly>,<tree>)`, no
+        //    wildcard), so derive the single address directly and reuse it for
+        //    both the PSBT destination and the display output.
+        //
+        // NOTE: this destination derivation is proposer-side only. The sweep
+        // rides the generic `request_psbt_spend` path keyed on the OLD
+        // descriptor hash, and responders currently sign the proposed
+        // destination without re-deriving/validating it against the NEW
+        // descriptor. Responder-side destination re-derivation is a broader
+        // change to the general signing path (keep-desktop/keep-cli signing
+        // UIs) and is tracked separately.
+        let dest_addr = keep_bitcoin::descriptor_address(&new_external, network)
             .map_err(|e| FrostNetError::Session(format!("new receive address: {e}")))?;
         let destination = dest_addr.script_pubkey();
 
@@ -292,7 +302,7 @@ impl KfpNode {
             .collect();
         let outputs = vec![PsbtOutputInfo {
             index: 0,
-            value_sats: total_in.saturating_sub(fee_sats),
+            value_sats: psbt.unsigned_tx.output[0].value.to_sat(),
             address: Some(dest_addr.to_string()),
             is_change: false,
         }];
@@ -765,34 +775,6 @@ impl KfpNode {
             )));
         }
         Ok(())
-    }
-
-    /// Resolve the external descriptor string of the finalized descriptor whose
-    /// canonical hash equals `descriptor_hash`, scanning in-memory sessions for
-    /// this group. Returns `None` if no finalized descriptor matches.
-    fn external_descriptor_for_hash(&self, descriptor_hash: &[u8; 32]) -> Result<Option<String>> {
-        let sessions = self.descriptor_sessions.read();
-        for (_, session) in sessions.iter_sessions() {
-            if session.group_pubkey() != &self.group_pubkey {
-                continue;
-            }
-            let Some(finalized) = session.descriptor() else {
-                continue;
-            };
-            let expected = keep_core::wallet::canonical_descriptor_hash(
-                &finalized.external,
-                &finalized.internal,
-                &finalized.policy_hash,
-                session.policy().version,
-            )
-            .map_err(|e| {
-                FrostNetError::Session(format!("canonical descriptor hash failed: {e}"))
-            })?;
-            if &expected == descriptor_hash {
-                return Ok(Some(finalized.external.clone()));
-            }
-        }
-        Ok(None)
     }
 
     fn verify_descriptor_hash_against_stored(&self, descriptor_hash: &[u8; 32]) -> Result<()> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Derive addresses and script pubkeys from definite descriptors (index 0) and expose deterministic descriptor-derived outputs.
  * Construct single-output PSBT sweeps to consolidate multiple UTXOs with input limits, fee/dust checks, and duplicate/outpoint validation.
  * Coordinate descriptor migration sweeps that validate old/new descriptors, enforce fee bounds, and produce sweep proposals.
  * Descriptor lookups now consider all descriptor versions when resolving receive descriptors.

* **Tests**
  * Added/updated unit tests for descriptor derivation, sweep construction, and related error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->