### PR TITLE
Add FROST Ed25519 threshold release signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,6 +2022,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rand_core 0.6.4",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2521,6 +2548,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,6 +2756,20 @@ dependencies = [
  "thiserror 2.0.18",
  "visibility",
  "zeroize",
+]
+
+[[package]]
+name = "frost-ed25519"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73eb5fa9311d33450c2320199ad1663b5af7a50061d9627d2e0dc776f0acb27"
+dependencies = [
+ "curve25519-dalek",
+ "document-features",
+ "frost-core",
+ "frost-rerandomized",
+ "rand_core 0.6.4",
+ "sha2",
 ]
 
 [[package]]
@@ -4350,6 +4397,7 @@ dependencies = [
  "chrono",
  "criterion",
  "dirs",
+ "frost-ed25519",
  "frost-secp256k1-tr",
  "fs2",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2207,7 +2207,7 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -2769,7 +2769,7 @@ dependencies = [
  "frost-core",
  "frost-rerandomized",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Minimum Supported Rust Version: **1.89**.
 
 Pure Rust with `#![forbid(unsafe_code)]`. Keys are derived with Argon2id, encrypted with XChaCha20-Poly1305, protected in RAM with Ascon-128a, and locked with mlock(2). FROST uses BIP-340 Schnorr signatures. See [`docs/SECURITY.md`](docs/SECURITY.md) for details.
 
+Keep can threshold-sign software releases with a FROST-Ed25519 group (minisign-compatible), so no single maintainer holds the signing key. See [`docs/RELEASE_SIGNING.md`](docs/RELEASE_SIGNING.md).
+
 ## License
 
 [MIT](LICENSE)

--- a/docs/RELEASE_SIGNING.md
+++ b/docs/RELEASE_SIGNING.md
@@ -1,0 +1,107 @@
+# Threshold Release Signing with Keep
+
+Keep can act as a general-purpose threshold signer for software releases. A
+project generates a FROST-Ed25519 group, distributes the `n` shares to its
+maintainers, and signs release artifacts with `keep sign`. Producing a signature
+requires a threshold `t` of those maintainers to cooperate, so no single person
+holds the signing key. The output is minisign-compatible, so downstream users
+verify with the stock [`minisign`](https://jedisct1.github.io/minisign/) tool or
+with `keep verify`.
+
+This is a Keep capability you can adopt for your own project. Keep's own GitHub
+releases are not signed this way; they ship binaries and a `SHA256SUMS` manifest.
+
+## Establishing a signing group
+
+Done once. Generate the group, distribute the shares, and publish the public
+key:
+
+```sh
+keep frost generate --ed25519 --threshold <t> --shares <n> \
+  --name release-signing --pubkey-out release-signing.pub
+```
+
+Export each share to its holder with `keep frost export` (bech32 / QR), then
+publish `release-signing.pub` somewhere users can find it (in your repository,
+on your site, and/or attached to each release).
+
+## Signing a release
+
+Sign the checksum manifest rather than every artifact; the manifest covers them
+all.
+
+```sh
+# Generate a checksum manifest for the release artifacts.
+sha256sum keep-* > SHA256SUMS
+
+# Threshold-sign the manifest (writes SHA256SUMS.minisig).
+keep sign SHA256SUMS --group <group-npub-or-hex> -t "release v1.2.3"
+```
+
+`--group` accepts an `npub1...` string or a 64-char hex group pubkey. The
+current minisign signing path is local-threshold: the `t` shares must be present
+on the signing machine. See "Distributed signing" below.
+
+Attach `SHA256SUMS`, `SHA256SUMS.minisig`, and `release-signing.pub` to the
+release.
+
+## Verifying a release
+
+Users need the artifact, `SHA256SUMS`, `SHA256SUMS.minisig`, and the project
+public key.
+
+```sh
+# 1. Confirm the downloaded files match the manifest.
+sha256sum --check SHA256SUMS
+
+# 2. Verify the manifest signature against the project public key.
+minisign -V -p release-signing.pub -m SHA256SUMS
+```
+
+`minisign -V` prints `Signature and comment signature verified` on success. The
+`SHA256SUMS.minisig` file must sit next to `SHA256SUMS`.
+
+With Keep installed, verify without minisign:
+
+```sh
+keep verify SHA256SUMS SHA256SUMS.minisig --group release-signing.pub
+```
+
+`--group` accepts the public-key file, a hex group pubkey, or an `npub1...`
+string.
+
+## GitHub Actions example
+
+Signing should not run in CI: putting the threshold of shares into CI secrets
+recreates the single point of failure threshold signing exists to remove. Build
+and publish in CI, then sign offline and upload the signature.
+
+```yaml
+# In your release job, after generating SHA256SUMS:
+- name: Attach signing public key
+  run: cp release-signing.pub artifacts/
+- uses: softprops/action-gh-release@v3
+  with:
+    files: artifacts/*
+```
+
+After the release publishes, a maintainer signs and uploads the signature:
+
+```sh
+gh release download <tag> --pattern SHA256SUMS
+keep sign SHA256SUMS --group <group-npub-or-hex> -t "release <tag>"
+minisign -V -p release-signing.pub -m SHA256SUMS
+gh release upload <tag> SHA256SUMS.minisig
+```
+
+Optionally, a non-blocking workflow triggered on `release: [published, edited]`
+can run `minisign -V` to surface the signature status as a check once the
+`.minisig` is uploaded.
+
+## Distributed signing
+
+The minisign signing path currently reconstructs the threshold from shares held
+on one machine. Fully distributed signing, where no machine ever holds `t`
+shares and signers cooperate over Nostr, reuses Keep's existing FROST network
+coordination but is not yet wired to the minisign output format. Tracked in
+[#500](https://github.com/privkeyio/keep/issues/500).

--- a/keep-cli/Cargo.toml
+++ b/keep-cli/Cargo.toml
@@ -10,7 +10,7 @@ name = "keep"
 path = "src/main.rs"
 
 [dependencies]
-keep-core = { path = "../keep-core" }
+keep-core = { path = "../keep-core", features = ["ed25519"] }
 keep-bitcoin = { path = "../keep-bitcoin" }
 keep-enclave-host = { path = "../keep-enclave/host" }
 keep-agent = { path = "../keep-agent", features = ["mcp"] }

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -136,6 +136,36 @@ pub(crate) enum Commands {
         )]
         target: PathBuf,
     },
+    /// Sign a file with a FROST-Ed25519 threshold group (minisign .sig)
+    Sign {
+        #[arg(help = "File to sign")]
+        file: PathBuf,
+        #[arg(short, long, help = "FROST-Ed25519 group npub or hex")]
+        group: String,
+        #[arg(short, long, help = "Output signature path (default: <file>.minisig)")]
+        output: Option<PathBuf>,
+        #[arg(short = 'c', long, help = "Untrusted comment line")]
+        comment: Option<String>,
+        #[arg(
+            short = 't',
+            long,
+            help = "Trusted comment line (bound into the signature)"
+        )]
+        trusted_comment: Option<String>,
+    },
+    /// Verify a minisign detached signature over a file
+    Verify {
+        #[arg(help = "File that was signed")]
+        file: PathBuf,
+        #[arg(help = "Detached signature file (.minisig)")]
+        sig: PathBuf,
+        #[arg(
+            short,
+            long,
+            help = "FROST-Ed25519 group npub/hex, or path to a minisign public key file"
+        )]
+        group: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -372,6 +402,13 @@ pub(crate) enum FrostCommands {
         shares: u16,
         #[arg(short, long, default_value = "default")]
         name: String,
+        #[arg(long, help = "Generate a FROST-Ed25519 group (for release signing)")]
+        ed25519: bool,
+        #[arg(
+            long,
+            help = "Write the minisign public key for the group to this path (Ed25519 only)"
+        )]
+        pubkey_out: Option<PathBuf>,
     },
     Split {
         #[arg(short, long)]

--- a/keep-cli/src/commands/frost.rs
+++ b/keep-cli/src/commands/frost.rs
@@ -17,35 +17,30 @@ use crate::ExportFormat;
 use super::{get_confirm, get_password, get_password_with_confirm};
 
 const MAX_INPUT_BYTES: u64 = 100 * 1024 * 1024;
+const MAX_TEXT_BYTES: u64 = 64 * 1024;
 
-fn read_input_file(file: &Path) -> Result<Vec<u8>> {
+fn check_file_size(file: &Path, max_bytes: u64) -> Result<()> {
     let len = file
         .metadata()
         .map_err(|e| KeepError::InvalidInput(format!("cannot read {}: {e}", file.display())))?
         .len();
-    if len > MAX_INPUT_BYTES {
+    if len > max_bytes {
         return Err(KeepError::InvalidInput(format!(
-            "{} exceeds maximum input size of {MAX_INPUT_BYTES} bytes",
+            "{} exceeds maximum size of {max_bytes} bytes",
             file.display()
         )));
     }
+    Ok(())
+}
+
+fn read_input_file(file: &Path) -> Result<Vec<u8>> {
+    check_file_size(file, MAX_INPUT_BYTES)?;
     std::fs::read(file)
         .map_err(|e| KeepError::InvalidInput(format!("cannot read {}: {e}", file.display())))
 }
 
-const MAX_TEXT_BYTES: u64 = 64 * 1024;
-
 fn read_text_file(file: &Path) -> Result<String> {
-    let len = file
-        .metadata()
-        .map_err(|e| KeepError::InvalidInput(format!("cannot read {}: {e}", file.display())))?
-        .len();
-    if len > MAX_TEXT_BYTES {
-        return Err(KeepError::InvalidInput(format!(
-            "{} exceeds maximum size of {MAX_TEXT_BYTES} bytes",
-            file.display()
-        )));
-    }
+    check_file_size(file, MAX_TEXT_BYTES)?;
     std::fs::read_to_string(file)
         .map_err(|e| KeepError::InvalidInput(format!("cannot read {}: {e}", file.display())))
 }

--- a/keep-cli/src/commands/frost.rs
+++ b/keep-cli/src/commands/frost.rs
@@ -16,6 +16,23 @@ use crate::ExportFormat;
 
 use super::{get_confirm, get_password, get_password_with_confirm};
 
+const MAX_INPUT_BYTES: u64 = 100 * 1024 * 1024;
+
+fn read_input_file(file: &Path) -> Result<Vec<u8>> {
+    let len = file
+        .metadata()
+        .map_err(|e| KeepError::InvalidInput(format!("cannot read {}: {e}", file.display())))?
+        .len();
+    if len > MAX_INPUT_BYTES {
+        return Err(KeepError::InvalidInput(format!(
+            "{} exceeds maximum input size of {MAX_INPUT_BYTES} bytes",
+            file.display()
+        )));
+    }
+    std::fs::read(file)
+        .map_err(|e| KeepError::InvalidInput(format!("cannot read {}: {e}", file.display())))
+}
+
 fn resolve_group_pubkey(
     shares: &[keep_core::frost::StoredShare],
     group_id: &str,
@@ -45,6 +62,12 @@ pub fn cmd_frost_generate(
         threshold,
         total_shares, name, ed25519, "generating FROST key"
     );
+
+    if pubkey_out.is_some() && !ed25519 {
+        return Err(KeepError::InvalidInput(
+            "--pubkey-out is only supported with --ed25519 mode".into(),
+        ));
+    }
 
     out.newline();
     out.warn("WARNING: Trusted dealer mode - for testing/development only.");
@@ -87,7 +110,7 @@ pub fn cmd_frost_generate(
                 group_pubkey,
                 format!("minisign public key for keep FROST group {name}"),
             );
-            std::fs::write(pubkey_path, pk.encode())
+            std::fs::write(pubkey_path, pk.encode()?)
                 .map_err(|e| KeepError::InvalidInput(format!("cannot write public key: {e}")))?;
             out.field("Minisign pubkey", &pubkey_path.display().to_string());
         }
@@ -827,8 +850,7 @@ pub fn cmd_sign_file(
     debug!(file = %file.display(), group, "signing file with FROST-Ed25519");
 
     let group_pubkey = parse_group_pubkey(group)?;
-    let message = std::fs::read(file)
-        .map_err(|e| KeepError::InvalidInput(format!("cannot read {}: {e}", file.display())))?;
+    let message = read_input_file(file)?;
 
     let file_name = file
         .file_name()
@@ -880,8 +902,7 @@ pub fn cmd_verify_file(out: &Output, file: &Path, sig: &Path, group: &str) -> Re
     debug!(file = %file.display(), sig = %sig.display(), group, "verifying file signature");
 
     let group_pubkey = resolve_verify_pubkey(group)?;
-    let message = std::fs::read(file)
-        .map_err(|e| KeepError::InvalidInput(format!("cannot read {}: {e}", file.display())))?;
+    let message = read_input_file(file)?;
     let sig_text = std::fs::read_to_string(sig)
         .map_err(|e| KeepError::InvalidInput(format!("cannot read signature: {e}")))?;
 

--- a/keep-cli/src/commands/frost.rs
+++ b/keep-cli/src/commands/frost.rs
@@ -862,7 +862,7 @@ pub fn cmd_sign_file(
     let sig_path = output
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|| with_sig_extension(file));
-    std::fs::write(&sig_path, signature.encode())
+    std::fs::write(&sig_path, signature.encode()?)
         .map_err(|e| KeepError::InvalidInput(format!("cannot write signature: {e}")))?;
 
     out.newline();

--- a/keep-cli/src/commands/frost.rs
+++ b/keep-cli/src/commands/frost.rs
@@ -38,8 +38,13 @@ pub fn cmd_frost_generate(
     threshold: u16,
     total_shares: u16,
     name: &str,
+    ed25519: bool,
+    pubkey_out: Option<&Path>,
 ) -> Result<()> {
-    debug!(threshold, total_shares, name, "generating FROST key");
+    debug!(
+        threshold,
+        total_shares, name, ed25519, "generating FROST key"
+    );
 
     out.newline();
     out.warn("WARNING: Trusted dealer mode - for testing/development only.");
@@ -56,7 +61,11 @@ pub fn cmd_frost_generate(
     spinner.finish();
 
     let spinner = out.spinner("Generating FROST key shares...");
-    let shares = keep.frost_generate(threshold, total_shares, name)?;
+    let shares = if ed25519 {
+        keep.frost_generate_ed25519(threshold, total_shares, name)?
+    } else {
+        keep.frost_generate(threshold, total_shares, name)?
+    };
     spinner.finish();
 
     if shares.is_empty() {
@@ -66,12 +75,25 @@ pub fn cmd_frost_generate(
     }
 
     let group_pubkey = shares[0].group_pubkey();
-    let npub = bytes_to_npub(group_pubkey);
 
     out.newline();
     out.success("Generated FROST key group!");
     out.field("Name", name);
-    out.key_field("Pubkey", &npub);
+    if ed25519 {
+        out.field("Ciphersuite", "Ed25519");
+        out.key_field("Group pubkey", &hex::encode(group_pubkey));
+        if let Some(pubkey_path) = pubkey_out {
+            let pk = keep_core::frost::ed25519::minisign::MinisignPublicKey::from_group_pubkey(
+                group_pubkey,
+                format!("minisign public key for keep FROST group {name}"),
+            );
+            std::fs::write(pubkey_path, pk.encode())
+                .map_err(|e| KeepError::InvalidInput(format!("cannot write public key: {e}")))?;
+            out.field("Minisign pubkey", &pubkey_path.display().to_string());
+        }
+    } else {
+        out.key_field("Pubkey", &bytes_to_npub(group_pubkey));
+    }
     out.field("Threshold", &format!("{threshold}-of-{total_shares}"));
     out.newline();
 
@@ -773,4 +795,131 @@ pub fn cmd_frost_verify(out: &Output, message_hex: &str, group: &str, sig_hex: &
             )),
         )),
     }
+}
+
+/// Parse a FROST-Ed25519 group public key from an npub or 64-char hex string.
+fn parse_group_pubkey(group: &str) -> Result<[u8; 32]> {
+    if group.starts_with("npub1") {
+        return keep_core::keys::npub_to_bytes(group);
+    }
+    let bytes = hex::decode(group)
+        .map_err(|_| KeepError::InvalidInput("invalid group pubkey hex".into()))?;
+    if bytes.len() != 32 {
+        return Err(KeepError::InvalidInput(
+            "group pubkey must be 32 bytes".into(),
+        ));
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Ok(out)
+}
+
+#[tracing::instrument(skip(out), fields(path = %path.display()))]
+pub fn cmd_sign_file(
+    out: &Output,
+    path: &Path,
+    file: &Path,
+    group: &str,
+    output: Option<&Path>,
+    comment: Option<String>,
+    trusted_comment: Option<String>,
+) -> Result<()> {
+    debug!(file = %file.display(), group, "signing file with FROST-Ed25519");
+
+    let group_pubkey = parse_group_pubkey(group)?;
+    let message = std::fs::read(file)
+        .map_err(|e| KeepError::InvalidInput(format!("cannot read {}: {e}", file.display())))?;
+
+    let file_name = file
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let untrusted_comment = comment.unwrap_or_else(|| "signature from keep".to_string());
+    let trusted_comment = trusted_comment.unwrap_or_else(|| {
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        format!("timestamp:{ts}\tfile:{file_name}")
+    });
+
+    let mut keep = Keep::open(path)?;
+    let password = get_password("Enter password")?;
+
+    let spinner = out.spinner("Unlocking vault...");
+    keep.unlock(password.expose_secret())?;
+    spinner.finish();
+
+    let spinner = out.spinner("Signing file...");
+    let signature = keep.frost_sign_ed25519_minisign(
+        &group_pubkey,
+        &message,
+        untrusted_comment,
+        trusted_comment,
+    )?;
+    spinner.finish();
+
+    let sig_path = output
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| with_sig_extension(file));
+    std::fs::write(&sig_path, signature.encode())
+        .map_err(|e| KeepError::InvalidInput(format!("cannot write signature: {e}")))?;
+
+    out.newline();
+    out.success("File signed!");
+    out.field("File", &file.display().to_string());
+    out.field("Signature", &sig_path.display().to_string());
+
+    Ok(())
+}
+
+#[tracing::instrument(skip(out))]
+pub fn cmd_verify_file(out: &Output, file: &Path, sig: &Path, group: &str) -> Result<()> {
+    use keep_core::frost::ed25519::minisign::MinisignSignature;
+
+    debug!(file = %file.display(), sig = %sig.display(), group, "verifying file signature");
+
+    let group_pubkey = resolve_verify_pubkey(group)?;
+    let message = std::fs::read(file)
+        .map_err(|e| KeepError::InvalidInput(format!("cannot read {}: {e}", file.display())))?;
+    let sig_text = std::fs::read_to_string(sig)
+        .map_err(|e| KeepError::InvalidInput(format!("cannot read signature: {e}")))?;
+
+    let signature = MinisignSignature::parse(&sig_text)?;
+
+    match Keep::frost_verify_ed25519_minisign(&group_pubkey, &message, &signature) {
+        Ok(()) => {
+            out.newline();
+            out.success("Signature is valid.");
+            if !signature.trusted_comment.is_empty() {
+                out.field("Trusted comment", &signature.trusted_comment);
+            }
+            Ok(())
+        }
+        Err(e) => {
+            out.newline();
+            out.error("Signature is INVALID.");
+            Err(e)
+        }
+    }
+}
+
+/// Resolve a verification public key from an npub, a 64-char hex string, or a
+/// path to a minisign public-key file.
+fn resolve_verify_pubkey(group: &str) -> Result<[u8; 32]> {
+    use keep_core::frost::ed25519::minisign::MinisignPublicKey;
+
+    let candidate = Path::new(group);
+    if candidate.is_file() {
+        let text = std::fs::read_to_string(candidate)
+            .map_err(|e| KeepError::InvalidInput(format!("cannot read public key: {e}")))?;
+        return Ok(MinisignPublicKey::parse(&text)?.public_key);
+    }
+    parse_group_pubkey(group)
+}
+
+fn with_sig_extension(file: &Path) -> std::path::PathBuf {
+    let mut name = file.as_os_str().to_os_string();
+    name.push(".minisig");
+    std::path::PathBuf::from(name)
 }

--- a/keep-cli/src/commands/frost.rs
+++ b/keep-cli/src/commands/frost.rs
@@ -33,6 +33,23 @@ fn read_input_file(file: &Path) -> Result<Vec<u8>> {
         .map_err(|e| KeepError::InvalidInput(format!("cannot read {}: {e}", file.display())))
 }
 
+const MAX_TEXT_BYTES: u64 = 64 * 1024;
+
+fn read_text_file(file: &Path) -> Result<String> {
+    let len = file
+        .metadata()
+        .map_err(|e| KeepError::InvalidInput(format!("cannot read {}: {e}", file.display())))?
+        .len();
+    if len > MAX_TEXT_BYTES {
+        return Err(KeepError::InvalidInput(format!(
+            "{} exceeds maximum size of {MAX_TEXT_BYTES} bytes",
+            file.display()
+        )));
+    }
+    std::fs::read_to_string(file)
+        .map_err(|e| KeepError::InvalidInput(format!("cannot read {}: {e}", file.display())))
+}
+
 fn resolve_group_pubkey(
     shares: &[keep_core::frost::StoredShare],
     group_id: &str,
@@ -903,8 +920,7 @@ pub fn cmd_verify_file(out: &Output, file: &Path, sig: &Path, group: &str) -> Re
 
     let group_pubkey = resolve_verify_pubkey(group)?;
     let message = read_input_file(file)?;
-    let sig_text = std::fs::read_to_string(sig)
-        .map_err(|e| KeepError::InvalidInput(format!("cannot read signature: {e}")))?;
+    let sig_text = read_text_file(sig)?;
 
     let signature = MinisignSignature::parse(&sig_text)?;
 
@@ -932,8 +948,7 @@ fn resolve_verify_pubkey(group: &str) -> Result<[u8; 32]> {
 
     let candidate = Path::new(group);
     if candidate.is_file() {
-        let text = std::fs::read_to_string(candidate)
-            .map_err(|e| KeepError::InvalidInput(format!("cannot read public key: {e}")))?;
+        let text = read_text_file(candidate)?;
         return Ok(MinisignPublicKey::parse(&text)?.public_key);
     }
     parse_group_pubkey(group)

--- a/keep-cli/src/commands/frost.rs
+++ b/keep-cli/src/commands/frost.rs
@@ -81,6 +81,14 @@ pub fn cmd_frost_generate(
         ));
     }
 
+    let pubkey_comment = if pubkey_out.is_some() {
+        let comment = format!("minisign public key for keep FROST group {name}");
+        keep_core::frost::ed25519::minisign::validate_comment("untrusted", &comment)?;
+        Some(comment)
+    } else {
+        None
+    };
+
     out.newline();
     out.warn("WARNING: Trusted dealer mode - for testing/development only.");
     out.warn("The full private key exists on this machine during generation.");
@@ -120,7 +128,7 @@ pub fn cmd_frost_generate(
         if let Some(pubkey_path) = pubkey_out {
             let pk = keep_core::frost::ed25519::minisign::MinisignPublicKey::from_group_pubkey(
                 group_pubkey,
-                format!("minisign public key for keep FROST group {name}"),
+                pubkey_comment.expect("validated when pubkey_out is set"),
             );
             std::fs::write(pubkey_path, pk.encode()?)
                 .map_err(|e| KeepError::InvalidInput(format!("cannot write public key: {e}")))?;

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -144,6 +144,24 @@ fn run(out: &Output) -> Result<()> {
         Commands::Migrate { command } => dispatch_migrate(out, &path, command, hidden),
         Commands::Backup { output } => commands::vault::cmd_backup(out, &path, output.as_deref()),
         Commands::Restore { file, target } => commands::vault::cmd_restore(out, &file, &target),
+        Commands::Sign {
+            file,
+            group,
+            output,
+            comment,
+            trusted_comment,
+        } => commands::frost::cmd_sign_file(
+            out,
+            &path,
+            &file,
+            &group,
+            output.as_deref(),
+            comment,
+            trusted_comment,
+        ),
+        Commands::Verify { file, sig, group } => {
+            commands::frost::cmd_verify_file(out, &file, &sig, &group)
+        }
     }
 }
 
@@ -202,7 +220,17 @@ fn dispatch_frost(
             threshold,
             shares,
             name,
-        } => commands::frost::cmd_frost_generate(out, path, threshold, shares, &name),
+            ed25519,
+            pubkey_out,
+        } => commands::frost::cmd_frost_generate(
+            out,
+            path,
+            threshold,
+            shares,
+            &name,
+            ed25519,
+            pubkey_out.as_deref(),
+        ),
         FrostCommands::Split {
             key,
             threshold,

--- a/keep-core/Cargo.toml
+++ b/keep-core/Cargo.toml
@@ -12,6 +12,7 @@ testing = []
 allow-ws = []
 # WARNING: allow-internal disables SSRF internal-host checks. MUST NOT be enabled in production.
 allow-internal = []
+ed25519 = ["dep:frost-ed25519"]
 
 [dependencies]
 argon2 = "0.5"
@@ -26,6 +27,7 @@ hmac = "0.13"
 k256 = { version = "0.13", features = ["schnorr", "ecdh"] }
 rand = "0.10"
 frost-secp256k1-tr = "2.2.0"
+frost-ed25519 = { version = "2.2.0", optional = true }
 
 bip39 = { workspace = true }
 bitcoin = { workspace = true }

--- a/keep-core/src/backup.rs
+++ b/keep-core/src/backup.rs
@@ -288,9 +288,7 @@ pub fn create_backup(keep: &Keep, passphrase: &str) -> Result<Vec<u8>> {
     let stored_shares = keep.frost_list_shares()?;
     let mut backup_shares = Vec::with_capacity(stored_shares.len());
     for share in &stored_shares {
-        let encrypted = EncryptedData::from_bytes(&share.encrypted_key_package)?;
-        let decrypted = crypto::decrypt_with_aad(&encrypted, share.ciphersuite.aad(), &data_key)?;
-        let key_package_bytes = decrypted.as_slice()?;
+        let decrypted = share.decrypt(&data_key)?;
         backup_shares.push(BackupShare {
             identifier: share.metadata.identifier,
             threshold: share.metadata.threshold,
@@ -301,7 +299,7 @@ pub fn create_backup(keep: &Keep, passphrase: &str) -> Result<Vec<u8>> {
             last_used: share.metadata.last_used,
             sign_count: share.metadata.sign_count,
             did_backup: share.metadata.did_backup,
-            key_package: hex::encode(key_package_bytes.as_slice()),
+            key_package: hex::encode(decrypted.key_package_bytes()),
             pubkey_package: hex::encode(&share.pubkey_package),
             ciphersuite: share.ciphersuite,
         });
@@ -478,30 +476,26 @@ fn restore_to_path(backup: &DecryptedBackup, path: &Path, vault_password: &str) 
     for bs in &backup.shares {
         let key_package_bytes = hex::decode(&bs.key_package)
             .map_err(|e| KeepError::Other(format!("hex decode key_package: {e}")))?;
-        let encrypted =
-            crypto::encrypt_with_aad(&key_package_bytes, bs.ciphersuite.aad(), &data_key)?;
 
         let pubkey_package = hex::decode(&bs.pubkey_package)
             .map_err(|e| KeepError::Other(format!("hex decode pubkey_package: {e}")))?;
 
         let group_pubkey = decode_hex_32(&bs.group_pubkey, "group pubkey")?;
 
-        let share = StoredShare {
-            metadata: crate::frost::ShareMetadata {
-                identifier: bs.identifier,
-                threshold: bs.threshold,
-                total_shares: bs.total_shares,
-                group_pubkey,
-                name: bs.name.clone(),
-                created_at: bs.created_at,
-                last_used: bs.last_used,
-                sign_count: bs.sign_count,
-                did_backup: bs.did_backup,
-            },
-            encrypted_key_package: encrypted.to_bytes(),
-            pubkey_package,
-            ciphersuite: bs.ciphersuite,
+        let metadata = crate::frost::ShareMetadata {
+            identifier: bs.identifier,
+            threshold: bs.threshold,
+            total_shares: bs.total_shares,
+            group_pubkey,
+            name: bs.name.clone(),
+            created_at: bs.created_at,
+            last_used: bs.last_used,
+            sign_count: bs.sign_count,
+            did_backup: bs.did_backup,
         };
+        let package =
+            crate::frost::SharePackage::from_bytes(metadata, key_package_bytes, pubkey_package);
+        let share = StoredShare::encrypt_with_ciphersuite(&package, bs.ciphersuite, &data_key)?;
         keep.restore_stored_share(&share)?;
     }
 

--- a/keep-core/src/backup.rs
+++ b/keep-core/src/backup.rs
@@ -102,6 +102,13 @@ pub struct BackupShare {
     pub key_package: String,
     /// Hex-encoded serialized public key package.
     pub pubkey_package: String,
+    /// FROST ciphersuite of this share.
+    ///
+    /// Defaults to `Secp256k1Tr` so backups written before this field existed
+    /// restore unchanged.
+    #[serde(default)]
+    #[zeroize(skip)]
+    pub ciphersuite: crate::frost::Ciphersuite,
 }
 
 /// Configuration stored in a backup file.
@@ -282,7 +289,7 @@ pub fn create_backup(keep: &Keep, passphrase: &str) -> Result<Vec<u8>> {
     let mut backup_shares = Vec::with_capacity(stored_shares.len());
     for share in &stored_shares {
         let encrypted = EncryptedData::from_bytes(&share.encrypted_key_package)?;
-        let decrypted = crypto::decrypt(&encrypted, &data_key)?;
+        let decrypted = crypto::decrypt_with_aad(&encrypted, share.ciphersuite.aad(), &data_key)?;
         let key_package_bytes = decrypted.as_slice()?;
         backup_shares.push(BackupShare {
             identifier: share.metadata.identifier,
@@ -296,6 +303,7 @@ pub fn create_backup(keep: &Keep, passphrase: &str) -> Result<Vec<u8>> {
             did_backup: share.metadata.did_backup,
             key_package: hex::encode(key_package_bytes.as_slice()),
             pubkey_package: hex::encode(&share.pubkey_package),
+            ciphersuite: share.ciphersuite,
         });
     }
 
@@ -470,7 +478,8 @@ fn restore_to_path(backup: &DecryptedBackup, path: &Path, vault_password: &str) 
     for bs in &backup.shares {
         let key_package_bytes = hex::decode(&bs.key_package)
             .map_err(|e| KeepError::Other(format!("hex decode key_package: {e}")))?;
-        let encrypted = crypto::encrypt(&key_package_bytes, &data_key)?;
+        let encrypted =
+            crypto::encrypt_with_aad(&key_package_bytes, bs.ciphersuite.aad(), &data_key)?;
 
         let pubkey_package = hex::decode(&bs.pubkey_package)
             .map_err(|e| KeepError::Other(format!("hex decode pubkey_package: {e}")))?;
@@ -491,6 +500,7 @@ fn restore_to_path(backup: &DecryptedBackup, path: &Path, vault_password: &str) 
             },
             encrypted_key_package: encrypted.to_bytes(),
             pubkey_package,
+            ciphersuite: bs.ciphersuite,
         };
         keep.restore_stored_share(&share)?;
     }

--- a/keep-core/src/crypto.rs
+++ b/keep-core/src/crypto.rs
@@ -435,6 +435,21 @@ impl EncryptedData {
 
 /// Encrypt plaintext using XChaCha20-Poly1305.
 pub fn encrypt(plaintext: &[u8], key: &SecretKey) -> Result<EncryptedData> {
+    encrypt_with_aad(plaintext, &[], key)
+}
+
+/// Decrypt ciphertext using XChaCha20-Poly1305.
+pub fn decrypt(encrypted: &EncryptedData, key: &SecretKey) -> Result<SecretVec> {
+    decrypt_with_aad(encrypted, &[], key)
+}
+
+/// Encrypt plaintext using XChaCha20-Poly1305 with additional authenticated data.
+///
+/// The `aad` is authenticated but not encrypted; decryption fails unless the
+/// same `aad` is supplied. Passing an empty slice is byte-identical to [`encrypt`].
+pub fn encrypt_with_aad(plaintext: &[u8], aad: &[u8], key: &SecretKey) -> Result<EncryptedData> {
+    use chacha20poly1305::aead::Payload;
+
     let decrypted = key.decrypt()?;
     let cipher = XChaCha20Poly1305::new(GenericArray::from_slice(&*decrypted));
 
@@ -442,20 +457,40 @@ pub fn encrypt(plaintext: &[u8], key: &SecretKey) -> Result<EncryptedData> {
     let nonce_ga = GenericArray::from_slice(&nonce);
 
     let ciphertext = cipher
-        .encrypt(nonce_ga, plaintext)
+        .encrypt(
+            nonce_ga,
+            Payload {
+                msg: plaintext,
+                aad,
+            },
+        )
         .map_err(|_| KeepError::Encryption("Encryption failed".into()))?;
 
     Ok(EncryptedData { ciphertext, nonce })
 }
 
-/// Decrypt ciphertext using XChaCha20-Poly1305.
-pub fn decrypt(encrypted: &EncryptedData, key: &SecretKey) -> Result<SecretVec> {
+/// Decrypt ciphertext using XChaCha20-Poly1305 with additional authenticated data.
+///
+/// Passing an empty `aad` slice is byte-identical to [`decrypt`].
+pub fn decrypt_with_aad(
+    encrypted: &EncryptedData,
+    aad: &[u8],
+    key: &SecretKey,
+) -> Result<SecretVec> {
+    use chacha20poly1305::aead::Payload;
+
     let decrypted_key = key.decrypt()?;
     let cipher = XChaCha20Poly1305::new(GenericArray::from_slice(&*decrypted_key));
     let nonce = GenericArray::from_slice(&encrypted.nonce);
 
     let plaintext = cipher
-        .decrypt(nonce, encrypted.ciphertext.as_ref())
+        .decrypt(
+            nonce,
+            Payload {
+                msg: encrypted.ciphertext.as_ref(),
+                aad,
+            },
+        )
         .map_err(|_| KeepError::DecryptionFailed)?;
 
     SecretVec::new(plaintext)

--- a/keep-core/src/frost/ed25519/dealer.rs
+++ b/keep-core/src/frost/ed25519/dealer.rs
@@ -43,8 +43,8 @@ impl TrustedDealer {
             .map_err(|e| KeepError::Frost(format!("Failed to serialize pubkey package: {e}")))?;
 
         let packages: Result<Vec<SharePackage>> = shares
-            .into_iter()
-            .map(|(_, secret_share)| {
+            .into_values()
+            .map(|secret_share| {
                 let key_package = KeyPackage::try_from(secret_share)
                     .map_err(|e| KeepError::Frost(format!("KeyPackage conversion failed: {e}")))?;
                 let key_package_bytes = key_package.serialize().map_err(|e| {

--- a/keep-core/src/frost/ed25519/dealer.rs
+++ b/keep-core/src/frost/ed25519/dealer.rs
@@ -44,15 +44,14 @@ impl TrustedDealer {
 
         let packages: Result<Vec<SharePackage>> = shares
             .into_iter()
-            .enumerate()
-            .map(|(idx, (_, secret_share))| {
+            .map(|(_, secret_share)| {
                 let key_package = KeyPackage::try_from(secret_share)
                     .map_err(|e| KeepError::Frost(format!("KeyPackage conversion failed: {e}")))?;
                 let key_package_bytes = key_package.serialize().map_err(|e| {
                     KeepError::Frost(format!("Failed to serialize key package: {e}"))
                 })?;
 
-                let identifier = (idx + 1) as u16;
+                let identifier = identifier_to_u16(key_package.identifier())?;
 
                 let metadata = ShareMetadata::new(
                     identifier,
@@ -72,6 +71,16 @@ impl TrustedDealer {
 
         Ok((packages?, pubkey_pkg))
     }
+}
+
+fn identifier_to_u16(identifier: &frost::Identifier) -> Result<u16> {
+    let bytes = identifier.serialize();
+    if bytes.len() != 32 || bytes[2..].iter().any(|&b| b != 0) {
+        return Err(KeepError::Frost(
+            "FROST identifier does not fit in u16".into(),
+        ));
+    }
+    Ok(u16::from_le_bytes([bytes[0], bytes[1]]))
 }
 
 fn extract_group_pubkey(pubkey_pkg: &PublicKeyPackage) -> Result<[u8; 32]> {

--- a/keep-core/src/frost/ed25519/dealer.rs
+++ b/keep-core/src/frost/ed25519/dealer.rs
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+//! Trusted dealer key generation for FROST over Ed25519.
+use frost::keys::{IdentifierList, KeyPackage, PublicKeyPackage};
+use frost::rand_core::OsRng;
+use frost_ed25519 as frost;
+
+use crate::error::{KeepError, Result};
+use crate::frost::share::{Ciphersuite, ShareMetadata, SharePackage};
+use crate::frost::ThresholdConfig;
+
+/// **WARNING: Testing/development only. Do not use in production.**
+///
+/// Generates the full private key on a single machine during key generation,
+/// which creates a single point of compromise.
+pub struct TrustedDealer {
+    config: ThresholdConfig,
+}
+
+impl TrustedDealer {
+    /// Create a new Ed25519 trusted dealer.
+    pub fn new(config: ThresholdConfig) -> Self {
+        Self { config }
+    }
+
+    /// The ciphersuite of shares produced by this dealer.
+    pub const CIPHERSUITE: Ciphersuite = Ciphersuite::Ed25519;
+
+    /// Generate a new threshold key and split into shares.
+    pub fn generate(&self, name: &str) -> Result<(Vec<SharePackage>, PublicKeyPackage)> {
+        let (shares, pubkey_pkg) = frost::keys::generate_with_dealer(
+            self.config.total_shares,
+            self.config.threshold,
+            IdentifierList::Default,
+            OsRng,
+        )
+        .map_err(|e| KeepError::Frost(format!("Key generation failed: {e}")))?;
+
+        let group_pubkey = extract_group_pubkey(&pubkey_pkg)?;
+        let pubkey_package_bytes = pubkey_pkg
+            .serialize()
+            .map_err(|e| KeepError::Frost(format!("Failed to serialize pubkey package: {e}")))?;
+
+        let packages: Result<Vec<SharePackage>> = shares
+            .into_iter()
+            .enumerate()
+            .map(|(idx, (_, secret_share))| {
+                let key_package = KeyPackage::try_from(secret_share)
+                    .map_err(|e| KeepError::Frost(format!("KeyPackage conversion failed: {e}")))?;
+                let key_package_bytes = key_package.serialize().map_err(|e| {
+                    KeepError::Frost(format!("Failed to serialize key package: {e}"))
+                })?;
+
+                let identifier = (idx + 1) as u16;
+
+                let metadata = ShareMetadata::new(
+                    identifier,
+                    self.config.threshold,
+                    self.config.total_shares,
+                    group_pubkey,
+                    name.to_string(),
+                );
+
+                Ok(SharePackage::from_bytes(
+                    metadata,
+                    key_package_bytes,
+                    pubkey_package_bytes.clone(),
+                ))
+            })
+            .collect();
+
+        Ok((packages?, pubkey_pkg))
+    }
+}
+
+fn extract_group_pubkey(pubkey_pkg: &PublicKeyPackage) -> Result<[u8; 32]> {
+    let verifying_key = pubkey_pkg.verifying_key();
+    let serialized = verifying_key
+        .serialize()
+        .map_err(|e| KeepError::Frost(format!("Failed to serialize verifying key: {e}")))?;
+    let bytes = serialized.as_slice();
+
+    if bytes.len() != 32 {
+        return Err(KeepError::Frost(format!(
+            "Invalid Ed25519 group pubkey length: expected 32, got {}",
+            bytes.len()
+        )));
+    }
+
+    let mut pubkey = [0u8; 32];
+    pubkey.copy_from_slice(bytes);
+    Ok(pubkey)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::SecretKey;
+    use crate::frost::StoredShare;
+
+    #[test]
+    fn test_generate_two_of_three() {
+        let config = ThresholdConfig::two_of_three();
+        let dealer = TrustedDealer::new(config);
+        let (shares, pubkey_pkg) = dealer.generate("test").unwrap();
+
+        assert_eq!(shares.len(), 3);
+        for share in &shares {
+            assert_eq!(share.metadata.threshold, 2);
+            assert_eq!(share.group_pubkey(), shares[0].group_pubkey());
+        }
+
+        let vk_bytes = pubkey_pkg.verifying_key().serialize().unwrap();
+        assert_eq!(vk_bytes.as_slice().len(), 32);
+    }
+
+    #[test]
+    fn test_storage_roundtrip_binds_ciphersuite() {
+        let config = ThresholdConfig::two_of_three();
+        let dealer = TrustedDealer::new(config);
+        let (shares, _) = dealer.generate("test").unwrap();
+
+        let key = SecretKey::generate().unwrap();
+
+        let stored =
+            StoredShare::encrypt_with_ciphersuite(&shares[0], Ciphersuite::Ed25519, &key).unwrap();
+        assert_eq!(stored.ciphersuite, Ciphersuite::Ed25519);
+
+        let restored = stored.decrypt(&key).unwrap();
+        assert_eq!(restored.key_package_bytes(), shares[0].key_package_bytes());
+
+        // Flipping the authenticated ciphersuite tag must break decryption.
+        let mut tampered = stored.clone();
+        tampered.ciphersuite = Ciphersuite::Secp256k1Tr;
+        assert!(tampered.decrypt(&key).is_err());
+    }
+}

--- a/keep-core/src/frost/ed25519/minisign.rs
+++ b/keep-core/src/frost/ed25519/minisign.rs
@@ -241,16 +241,18 @@ impl MinisignPublicKey {
     }
 
     /// Render to the 2-line minisign public-key text format.
-    pub fn encode(&self) -> String {
+    pub fn encode(&self) -> Result<String> {
+        validate_comment("untrusted", &self.untrusted_comment)?;
+
         let mut blob = Vec::with_capacity(2 + 8 + 32);
         blob.extend_from_slice(&ALG_LEGACY);
         blob.extend_from_slice(&self.key_id);
         blob.extend_from_slice(&self.public_key);
-        format!(
+        Ok(format!(
             "untrusted comment: {}\n{}\n",
             self.untrusted_comment,
             B64.encode(&blob),
-        )
+        ))
     }
 
     /// Parse the 2-line minisign public-key text format.
@@ -326,7 +328,7 @@ mod tests {
     fn pubkey_round_trips() {
         let group_pubkey = [42u8; 32];
         let pk = MinisignPublicKey::from_group_pubkey(&group_pubkey, "keep pubkey".to_string());
-        let encoded = pk.encode();
+        let encoded = pk.encode().unwrap();
         let parsed = MinisignPublicKey::parse(&encoded).unwrap();
         assert_eq!(parsed.key_id, key_id(&group_pubkey));
         assert_eq!(parsed.public_key, group_pubkey);

--- a/keep-core/src/frost/ed25519/minisign.rs
+++ b/keep-core/src/frost/ed25519/minisign.rs
@@ -67,6 +67,27 @@ pub const ALG_LEGACY: [u8; 2] = *b"Ed";
 /// Signature algorithm: BLAKE2b-512 prehashed Ed25519 (`"ED"`).
 pub const ALG_PREHASHED: [u8; 2] = *b"ED";
 
+/// Maximum allowed length of a minisign comment field, in bytes.
+pub const MAX_COMMENT_LEN: usize = 1024;
+
+/// Validate a minisign comment field for the line-oriented `.sig`/`.pub` format.
+///
+/// Rejects embedded `\n`/`\r` (which would corrupt the line structure) and
+/// comments longer than [`MAX_COMMENT_LEN`] bytes.
+pub fn validate_comment(field: &str, comment: &str) -> Result<()> {
+    if comment.len() > MAX_COMMENT_LEN {
+        return Err(KeepError::InvalidInput(format!(
+            "{field} comment exceeds {MAX_COMMENT_LEN} bytes"
+        )));
+    }
+    if comment.contains('\n') || comment.contains('\r') {
+        return Err(KeepError::InvalidInput(format!(
+            "{field} comment must not contain newline characters"
+        )));
+    }
+    Ok(())
+}
+
 /// Deterministic 8-byte minisign key id for a group verifying key.
 pub fn key_id(group_pubkey: &[u8; 32]) -> [u8; 8] {
     let mut hasher = Blake2b512::new();
@@ -114,19 +135,22 @@ pub struct MinisignSignature {
 
 impl MinisignSignature {
     /// Render to the 4-line minisign `.sig` text format.
-    pub fn encode(&self) -> String {
+    pub fn encode(&self) -> Result<String> {
+        validate_comment("untrusted", &self.untrusted_comment)?;
+        validate_comment("trusted", &self.trusted_comment)?;
+
         let mut sig_blob = Vec::with_capacity(2 + 8 + 64);
         sig_blob.extend_from_slice(&self.sig_alg);
         sig_blob.extend_from_slice(&self.key_id);
         sig_blob.extend_from_slice(&self.signature);
 
-        format!(
+        Ok(format!(
             "untrusted comment: {}\n{}\ntrusted comment: {}\n{}\n",
             self.untrusted_comment,
             B64.encode(&sig_blob),
             self.trusted_comment,
             B64.encode(self.global_signature),
-        )
+        ))
     }
 
     /// Parse the 4-line minisign `.sig` text format.
@@ -178,6 +202,12 @@ impl MinisignSignature {
         }
         let mut global_signature = [0u8; 64];
         global_signature.copy_from_slice(&global);
+
+        if lines.any(|l| !l.trim().is_empty()) {
+            return Err(KeepError::InvalidInput(
+                "unexpected trailing content after signature".into(),
+            ));
+        }
 
         Ok(Self {
             sig_alg,
@@ -282,7 +312,7 @@ mod tests {
             untrusted_comment: "signature from keep".to_string(),
             trusted_comment: "timestamp:123\tfile:x".to_string(),
         };
-        let encoded = sig.encode();
+        let encoded = sig.encode().unwrap();
         let parsed = MinisignSignature::parse(&encoded).unwrap();
         assert_eq!(parsed.sig_alg, sig.sig_alg);
         assert_eq!(parsed.key_id, sig.key_id);

--- a/keep-core/src/frost/ed25519/minisign.rs
+++ b/keep-core/src/frost/ed25519/minisign.rs
@@ -1,0 +1,305 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+//! minisign-compatible detached signatures and public keys.
+//!
+//! Implements the on-disk container format used by the standard, audited
+//! [`minisign`](https://jedisct1.github.io/minisign/) tool so that third
+//! parties can verify FROST-Ed25519 threshold release signatures with
+//! `minisign -V` without trusting this implementation.
+//!
+//! # Signature file layout (4 lines)
+//!
+//! ```text
+//! untrusted comment: <text>
+//! base64( sig_alg[2] || key_id[8] || ed25519_signature[64] )
+//! trusted comment: <text>
+//! base64( ed25519_global_signature[64] )
+//! ```
+//!
+//! - `sig_alg` is `"Ed"` for a signature over the raw file, or `"ED"` for a
+//!   signature over the BLAKE2b-512 prehash of the file. We use `"ED"`
+//!   (prehashed) to match the default of current minisign releases; this lets
+//!   the file be streamed/hashed once and keeps the signed message a fixed
+//!   64 bytes regardless of file size.
+//! - The global signature is an Ed25519 signature over
+//!   `ed25519_signature[64] || trusted_comment_bytes`, binding the trusted
+//!   comment to the signature so it cannot be altered post-hoc. Both the file
+//!   signature and the global signature are produced by the FROST threshold
+//!   group (two threshold signing sessions per `sign`).
+//!
+//! # Public key file layout (2 lines)
+//!
+//! ```text
+//! untrusted comment: <text>
+//! base64( "Ed"[2] || key_id[8] || ed25519_public_key[32] )
+//! ```
+//!
+//! The public-key algorithm field is always `"Ed"` in minisign; the `Ed`/`ED`
+//! distinction lives only in the signature.
+//!
+//! # key_id derivation
+//!
+//! minisign stores a random 8-byte key id in the secret/public key and copies
+//! it into each signature so a verifier can reject a signature made by the
+//! wrong key. We have no persistent secret-key file to carry a random id, so we
+//! derive a stable id deterministically from the group verifying key:
+//!
+//! ```text
+//! key_id = BLAKE2b-512( "keep-frost-ed25519-minisign-keyid-v1" || group_pubkey[32] )[..8]
+//! ```
+//!
+//! The id is purely an anti-mixup hint; it is not security-relevant (the
+//! Ed25519 verification over the actual public key is what provides security),
+//! so a deterministic, collision-resistant derivation is sufficient and gives a
+//! stable id for a given group.
+
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use blake2::{Blake2b512, Digest};
+
+use crate::error::{KeepError, Result};
+
+const KEY_ID_DOMAIN: &[u8] = b"keep-frost-ed25519-minisign-keyid-v1";
+
+/// Signature algorithm: raw-message Ed25519 (`"Ed"`).
+pub const ALG_LEGACY: [u8; 2] = *b"Ed";
+/// Signature algorithm: BLAKE2b-512 prehashed Ed25519 (`"ED"`).
+pub const ALG_PREHASHED: [u8; 2] = *b"ED";
+
+/// Deterministic 8-byte minisign key id for a group verifying key.
+pub fn key_id(group_pubkey: &[u8; 32]) -> [u8; 8] {
+    let mut hasher = Blake2b512::new();
+    hasher.update(KEY_ID_DOMAIN);
+    hasher.update(group_pubkey);
+    let digest = hasher.finalize();
+    let mut id = [0u8; 8];
+    id.copy_from_slice(&digest[..8]);
+    id
+}
+
+/// BLAKE2b-512 prehash of a message, as signed under the `"ED"` algorithm.
+pub fn prehash(message: &[u8]) -> [u8; 64] {
+    let mut hasher = Blake2b512::new();
+    hasher.update(message);
+    let digest = hasher.finalize();
+    let mut out = [0u8; 64];
+    out.copy_from_slice(&digest);
+    out
+}
+
+/// The bytes the global signature is computed over: `signature || trusted_comment`.
+pub fn global_signed_bytes(signature: &[u8; 64], trusted_comment: &str) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(64 + trusted_comment.len());
+    buf.extend_from_slice(signature);
+    buf.extend_from_slice(trusted_comment.as_bytes());
+    buf
+}
+
+/// A parsed/owned minisign detached signature.
+pub struct MinisignSignature {
+    /// Signature algorithm: [`ALG_LEGACY`] (`"Ed"`) or [`ALG_PREHASHED`] (`"ED"`).
+    pub sig_alg: [u8; 2],
+    /// 8-byte key id identifying the signing group (see [`key_id`]).
+    pub key_id: [u8; 8],
+    /// Ed25519 signature over the file (or its prehash for `"ED"`).
+    pub signature: [u8; 64],
+    /// Ed25519 signature over `signature || trusted_comment`.
+    pub global_signature: [u8; 64],
+    /// Free-form comment not covered by any signature.
+    pub untrusted_comment: String,
+    /// Comment bound into the global signature.
+    pub trusted_comment: String,
+}
+
+impl MinisignSignature {
+    /// Render to the 4-line minisign `.sig` text format.
+    pub fn encode(&self) -> String {
+        let mut sig_blob = Vec::with_capacity(2 + 8 + 64);
+        sig_blob.extend_from_slice(&self.sig_alg);
+        sig_blob.extend_from_slice(&self.key_id);
+        sig_blob.extend_from_slice(&self.signature);
+
+        format!(
+            "untrusted comment: {}\n{}\ntrusted comment: {}\n{}\n",
+            self.untrusted_comment,
+            B64.encode(&sig_blob),
+            self.trusted_comment,
+            B64.encode(self.global_signature),
+        )
+    }
+
+    /// Parse the 4-line minisign `.sig` text format.
+    pub fn parse(text: &str) -> Result<Self> {
+        let mut lines = text.lines();
+
+        let untrusted_comment = lines
+            .next()
+            .and_then(|l| l.strip_prefix("untrusted comment: "))
+            .ok_or_else(|| KeepError::InvalidInput("missing untrusted comment line".into()))?
+            .to_string();
+
+        let sig_blob_b64 = lines
+            .next()
+            .ok_or_else(|| KeepError::InvalidInput("missing signature line".into()))?
+            .trim();
+        let sig_blob = B64
+            .decode(sig_blob_b64)
+            .map_err(|_| KeepError::InvalidInput("invalid base64 in signature line".into()))?;
+        if sig_blob.len() != 2 + 8 + 64 {
+            return Err(KeepError::InvalidInput(
+                "signature blob has wrong length".into(),
+            ));
+        }
+        let mut sig_alg = [0u8; 2];
+        sig_alg.copy_from_slice(&sig_blob[..2]);
+        let mut key_id = [0u8; 8];
+        key_id.copy_from_slice(&sig_blob[2..10]);
+        let mut signature = [0u8; 64];
+        signature.copy_from_slice(&sig_blob[10..74]);
+
+        let trusted_comment = lines
+            .next()
+            .and_then(|l| l.strip_prefix("trusted comment: "))
+            .ok_or_else(|| KeepError::InvalidInput("missing trusted comment line".into()))?
+            .to_string();
+
+        let global_b64 = lines
+            .next()
+            .ok_or_else(|| KeepError::InvalidInput("missing global signature line".into()))?
+            .trim();
+        let global = B64.decode(global_b64).map_err(|_| {
+            KeepError::InvalidInput("invalid base64 in global signature line".into())
+        })?;
+        if global.len() != 64 {
+            return Err(KeepError::InvalidInput(
+                "global signature has wrong length".into(),
+            ));
+        }
+        let mut global_signature = [0u8; 64];
+        global_signature.copy_from_slice(&global);
+
+        Ok(Self {
+            sig_alg,
+            key_id,
+            signature,
+            global_signature,
+            untrusted_comment,
+            trusted_comment,
+        })
+    }
+}
+
+/// A parsed/owned minisign public key.
+pub struct MinisignPublicKey {
+    /// 8-byte key id derived from the public key (see [`key_id`]).
+    pub key_id: [u8; 8],
+    /// 32-byte Ed25519 group verifying key.
+    pub public_key: [u8; 32],
+    /// Free-form comment.
+    pub untrusted_comment: String,
+}
+
+impl MinisignPublicKey {
+    /// Build a public-key record from a group verifying key.
+    pub fn from_group_pubkey(group_pubkey: &[u8; 32], untrusted_comment: String) -> Self {
+        Self {
+            key_id: key_id(group_pubkey),
+            public_key: *group_pubkey,
+            untrusted_comment,
+        }
+    }
+
+    /// Render to the 2-line minisign public-key text format.
+    pub fn encode(&self) -> String {
+        let mut blob = Vec::with_capacity(2 + 8 + 32);
+        blob.extend_from_slice(&ALG_LEGACY);
+        blob.extend_from_slice(&self.key_id);
+        blob.extend_from_slice(&self.public_key);
+        format!(
+            "untrusted comment: {}\n{}\n",
+            self.untrusted_comment,
+            B64.encode(&blob),
+        )
+    }
+
+    /// Parse the 2-line minisign public-key text format.
+    pub fn parse(text: &str) -> Result<Self> {
+        let mut lines = text.lines();
+        let untrusted_comment = lines
+            .next()
+            .and_then(|l| l.strip_prefix("untrusted comment: "))
+            .ok_or_else(|| KeepError::InvalidInput("missing untrusted comment line".into()))?
+            .to_string();
+        let blob_b64 = lines
+            .next()
+            .ok_or_else(|| KeepError::InvalidInput("missing public key line".into()))?
+            .trim();
+        let blob = B64
+            .decode(blob_b64)
+            .map_err(|_| KeepError::InvalidInput("invalid base64 in public key line".into()))?;
+        if blob.len() != 2 + 8 + 32 {
+            return Err(KeepError::InvalidInput(
+                "public key blob has wrong length".into(),
+            ));
+        }
+        if blob[..2] != ALG_LEGACY {
+            return Err(KeepError::InvalidInput(
+                "unexpected public key algorithm".into(),
+            ));
+        }
+        let mut key_id = [0u8; 8];
+        key_id.copy_from_slice(&blob[2..10]);
+        let mut public_key = [0u8; 32];
+        public_key.copy_from_slice(&blob[10..42]);
+        Ok(Self {
+            key_id,
+            public_key,
+            untrusted_comment,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_id_is_deterministic_and_stable() {
+        let pk = [7u8; 32];
+        assert_eq!(key_id(&pk), key_id(&pk));
+        let pk2 = [8u8; 32];
+        assert_ne!(key_id(&pk), key_id(&pk2));
+    }
+
+    #[test]
+    fn signature_round_trips() {
+        let sig = MinisignSignature {
+            sig_alg: ALG_PREHASHED,
+            key_id: [1, 2, 3, 4, 5, 6, 7, 8],
+            signature: [9u8; 64],
+            global_signature: [10u8; 64],
+            untrusted_comment: "signature from keep".to_string(),
+            trusted_comment: "timestamp:123\tfile:x".to_string(),
+        };
+        let encoded = sig.encode();
+        let parsed = MinisignSignature::parse(&encoded).unwrap();
+        assert_eq!(parsed.sig_alg, sig.sig_alg);
+        assert_eq!(parsed.key_id, sig.key_id);
+        assert_eq!(parsed.signature, sig.signature);
+        assert_eq!(parsed.global_signature, sig.global_signature);
+        assert_eq!(parsed.untrusted_comment, sig.untrusted_comment);
+        assert_eq!(parsed.trusted_comment, sig.trusted_comment);
+    }
+
+    #[test]
+    fn pubkey_round_trips() {
+        let group_pubkey = [42u8; 32];
+        let pk = MinisignPublicKey::from_group_pubkey(&group_pubkey, "keep pubkey".to_string());
+        let encoded = pk.encode();
+        let parsed = MinisignPublicKey::parse(&encoded).unwrap();
+        assert_eq!(parsed.key_id, key_id(&group_pubkey));
+        assert_eq!(parsed.public_key, group_pubkey);
+        assert_eq!(parsed.untrusted_comment, "keep pubkey");
+    }
+}

--- a/keep-core/src/frost/ed25519/minisign.rs
+++ b/keep-core/src/frost/ed25519/minisign.rs
@@ -162,6 +162,7 @@ impl MinisignSignature {
             .and_then(|l| l.strip_prefix("untrusted comment: "))
             .ok_or_else(|| KeepError::InvalidInput("missing untrusted comment line".into()))?
             .to_string();
+        validate_comment("untrusted", &untrusted_comment)?;
 
         let sig_blob_b64 = lines
             .next()
@@ -187,6 +188,7 @@ impl MinisignSignature {
             .and_then(|l| l.strip_prefix("trusted comment: "))
             .ok_or_else(|| KeepError::InvalidInput("missing trusted comment line".into()))?
             .to_string();
+        validate_comment("trusted", &trusted_comment)?;
 
         let global_b64 = lines
             .next()

--- a/keep-core/src/frost/ed25519/mod.rs
+++ b/keep-core/src/frost/ed25519/mod.rs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+//! FROST over Ed25519.
+//!
+//! Parallel to the secp256k1 modules under `crate::frost`, this submodule binds
+//! the FROST protocol to the Ed25519 ciphersuite while reusing the
+//! ciphersuite-agnostic share, storage, and transport types.
+//!
+//! Provides trusted-dealer key generation, the share storage round-trip, and
+//! offline t-of-n release signing/verification.
+
+mod dealer;
+pub mod minisign;
+mod signer;
+
+pub use dealer::TrustedDealer;
+pub use signer::{sign_with_local_shares, verify};

--- a/keep-core/src/frost/ed25519/signer.rs
+++ b/keep-core/src/frost/ed25519/signer.rs
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+//! Offline t-of-n signing for FROST over Ed25519.
+//!
+//! Mirrors `crate::frost::signing::sign_with_local_shares` for the Ed25519
+//! ciphersuite: a single caller holding a threshold of decrypted shares runs
+//! both FROST rounds locally and aggregates a detached 64-byte signature.
+use std::collections::BTreeMap;
+
+use frost::rand_core::OsRng;
+use frost::{keys::PublicKeyPackage, round1, round2, Identifier, SigningPackage};
+use frost_ed25519 as frost;
+
+use crate::error::{KeepError, Result};
+use crate::frost::share::SharePackage;
+
+/// Freshly generated, single-use FROST round-1 nonces for one participant.
+///
+/// # Nonce-reuse barrier (security-critical)
+///
+/// Reusing a Schnorr/FROST nonce across two signatures leaks the signer's
+/// secret share. The Ed25519 signing path therefore accepts nonces *only*
+/// through this type, and the only way to obtain one is [`FreshNonces::generate`],
+/// which draws fresh randomness from the OS CSPRNG every call. There is no
+/// constructor, setter, deserialization, or `From` impl that admits an
+/// externally supplied or cached nonce.
+///
+/// This makes the nonce pre-exchange feature (which caches and replays nonces
+/// for instant signing) structurally unreachable for Ed25519: that pool is
+/// typed against `frost_secp256k1_tr::round1::SigningNonces`, a distinct type
+/// that cannot be coerced into `frost_ed25519`'s nonces, and this module
+/// exposes no API that would accept one even if it could. The "fresh per
+/// session" invariant is thus enforced by the type system, not by convention.
+struct FreshNonces {
+    nonces: round1::SigningNonces,
+    commitments: round1::SigningCommitments,
+}
+
+impl FreshNonces {
+    /// Generate fresh single-use nonces for the given signing share.
+    fn generate(signing_share: &frost::keys::SigningShare) -> Self {
+        let (nonces, commitments) = round1::commit(signing_share, &mut OsRng);
+        Self {
+            nonces,
+            commitments,
+        }
+    }
+}
+
+/// Sign `message` with a threshold of local Ed25519 shares (no network).
+///
+/// Generates fresh per-session nonces internally; see [`FreshNonces`] for the
+/// nonce-reuse barrier. Returns a detached 64-byte Ed25519 signature over the
+/// raw message bytes (RFC 8032), verifiable by [`verify`] and by any standard
+/// Ed25519 verifier over the group verifying key.
+pub fn sign_with_local_shares(shares: &[SharePackage], message: &[u8]) -> Result<[u8; 64]> {
+    if shares.is_empty() {
+        return Err(KeepError::Frost("No shares provided".into()));
+    }
+
+    let threshold = shares[0].metadata.threshold as usize;
+    if shares.len() < threshold {
+        return Err(KeepError::Frost(format!(
+            "Need {} shares to sign, only {} provided",
+            threshold,
+            shares.len()
+        )));
+    }
+
+    let signing_shares = &shares[..threshold];
+
+    let mut key_packages: BTreeMap<Identifier, frost::keys::KeyPackage> = BTreeMap::new();
+    let mut fresh: BTreeMap<Identifier, FreshNonces> = BTreeMap::new();
+    let mut commitments_map: BTreeMap<Identifier, round1::SigningCommitments> = BTreeMap::new();
+    let mut verifying_shares: BTreeMap<Identifier, frost::keys::VerifyingShare> = BTreeMap::new();
+
+    for share in signing_shares {
+        let kp = ed25519_key_package(share)?;
+        let id = *kp.identifier();
+        let nonces = FreshNonces::generate(kp.signing_share());
+        commitments_map.insert(id, nonces.commitments);
+        verifying_shares.insert(id, *kp.verifying_share());
+        fresh.insert(id, nonces);
+        key_packages.insert(id, kp);
+    }
+
+    let signing_package = SigningPackage::new(commitments_map, message);
+
+    let mut signature_shares: BTreeMap<Identifier, round2::SignatureShare> = BTreeMap::new();
+    for (id, kp) in &key_packages {
+        let nonces = fresh
+            .remove(id)
+            .ok_or_else(|| KeepError::Frost("Missing nonces for share".into()))?;
+        let sig_share = round2::sign(&signing_package, &nonces.nonces, kp)
+            .map_err(|e| KeepError::Frost(format!("Signing failed: {e}")))?;
+        signature_shares.insert(*id, sig_share);
+    }
+
+    let first_kp = key_packages
+        .values()
+        .next()
+        .ok_or_else(|| KeepError::Frost("No key packages".into()))?;
+    let pubkey_pkg = PublicKeyPackage::new(verifying_shares, *first_kp.verifying_key());
+
+    let signature = frost::aggregate(&signing_package, &signature_shares, &pubkey_pkg)
+        .map_err(|e| KeepError::Frost(format!("Aggregation failed: {e}")))?;
+
+    let serialized = signature
+        .serialize()
+        .map_err(|e| KeepError::Frost(format!("Failed to serialize signature: {e}")))?;
+    if serialized.len() != 64 {
+        return Err(KeepError::Frost("Invalid signature length".into()));
+    }
+    let mut sig_bytes = [0u8; 64];
+    sig_bytes.copy_from_slice(&serialized);
+    Ok(sig_bytes)
+}
+
+/// Verify a detached Ed25519 signature against a 32-byte group verifying key.
+pub fn verify(group_pubkey: &[u8; 32], message: &[u8], signature: &[u8; 64]) -> Result<()> {
+    let verifying_key = frost::VerifyingKey::deserialize(group_pubkey)
+        .map_err(|e| KeepError::Frost(format!("Invalid group pubkey: {e}")))?;
+    let signature = frost::Signature::deserialize(signature)
+        .map_err(|e| KeepError::Frost(format!("Invalid signature: {e}")))?;
+    verifying_key
+        .verify(message, &signature)
+        .map_err(|_| KeepError::Frost("Signature verification failed".into()))
+}
+
+fn ed25519_key_package(share: &SharePackage) -> Result<frost::keys::KeyPackage> {
+    frost::keys::KeyPackage::deserialize(share.key_package_bytes())
+        .map_err(|e| KeepError::Frost(format!("Failed to deserialize key package: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frost::ed25519::TrustedDealer;
+    use crate::frost::ThresholdConfig;
+
+    #[test]
+    fn test_sign_and_verify_two_of_three() {
+        let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+        let (shares, pubkey_pkg) = dealer.generate("test").unwrap();
+
+        let message = b"release v1.2.3 artifact";
+        let sig = sign_with_local_shares(&shares[..2], message).unwrap();
+
+        let group_pubkey = *shares[0].group_pubkey();
+        verify(&group_pubkey, message, &sig).unwrap();
+
+        // Group verifying key matches the dealer's public key package.
+        let vk = pubkey_pkg.verifying_key().serialize().unwrap();
+        assert_eq!(vk.as_slice(), &group_pubkey[..]);
+    }
+
+    #[test]
+    fn test_verify_rejects_wrong_message() {
+        let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+        let (shares, _) = dealer.generate("test").unwrap();
+
+        let sig = sign_with_local_shares(&shares[..2], b"original").unwrap();
+        let group_pubkey = *shares[0].group_pubkey();
+        assert!(verify(&group_pubkey, b"tampered", &sig).is_err());
+    }
+
+    #[test]
+    fn test_insufficient_shares_rejected() {
+        let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+        let (shares, _) = dealer.generate("test").unwrap();
+        assert!(sign_with_local_shares(&shares[..1], b"msg").is_err());
+    }
+}

--- a/keep-core/src/frost/ed25519/signer.rs
+++ b/keep-core/src/frost/ed25519/signer.rs
@@ -70,6 +70,21 @@ pub fn sign_with_local_shares(shares: &[SharePackage], message: &[u8]) -> Result
 
     let signing_shares = &shares[..threshold];
 
+    let group_pubkey = signing_shares[0].metadata.group_pubkey;
+    let mut seen_ids = std::collections::HashSet::new();
+    for share in signing_shares {
+        if share.metadata.group_pubkey != group_pubkey {
+            return Err(KeepError::Frost(
+                "Shares belong to different groups".into(),
+            ));
+        }
+        if !seen_ids.insert(share.metadata.identifier) {
+            return Err(KeepError::Frost(
+                "Duplicate share identifier".into(),
+            ));
+        }
+    }
+
     let mut key_packages: BTreeMap<Identifier, frost::keys::KeyPackage> = BTreeMap::new();
     let mut fresh: BTreeMap<Identifier, FreshNonces> = BTreeMap::new();
     let mut commitments_map: BTreeMap<Identifier, round1::SigningCommitments> = BTreeMap::new();

--- a/keep-core/src/frost/ed25519/signer.rs
+++ b/keep-core/src/frost/ed25519/signer.rs
@@ -74,14 +74,10 @@ pub fn sign_with_local_shares(shares: &[SharePackage], message: &[u8]) -> Result
     let mut seen_ids = std::collections::HashSet::new();
     for share in signing_shares {
         if share.metadata.group_pubkey != group_pubkey {
-            return Err(KeepError::Frost(
-                "Shares belong to different groups".into(),
-            ));
+            return Err(KeepError::Frost("Shares belong to different groups".into()));
         }
         if !seen_ids.insert(share.metadata.identifier) {
-            return Err(KeepError::Frost(
-                "Duplicate share identifier".into(),
-            ));
+            return Err(KeepError::Frost("Duplicate share identifier".into()));
         }
     }
 

--- a/keep-core/src/frost/mod.rs
+++ b/keep-core/src/frost/mod.rs
@@ -14,10 +14,13 @@ mod share;
 mod signing;
 mod transport;
 
+#[cfg(feature = "ed25519")]
+pub mod ed25519;
+
 pub use coordinator::Coordinator;
 pub use dealer::{ThresholdConfig, TrustedDealer};
 pub use recover::recover_nsec;
 pub use refresh::refresh_shares;
-pub use share::{ShareMetadata, SharePackage, StoredShare};
+pub use share::{Ciphersuite, ShareMetadata, SharePackage, StoredShare};
 pub use signing::{sign_with_local_shares, SessionState, SigningSession};
 pub use transport::{FrostMessage, FrostMessageType, ShareExport};

--- a/keep-core/src/frost/share.rs
+++ b/keep-core/src/frost/share.rs
@@ -13,6 +13,35 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 use crate::crypto::{self, SecretKey};
 use crate::error::{KeepError, Result};
 
+/// The FROST ciphersuite a share belongs to.
+///
+/// The discriminant is bound into the AEAD associated data when a share is
+/// encrypted (see [`StoredShare`]), so it cannot be flipped or stripped to force
+/// cross-ciphersuite confusion.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Ciphersuite {
+    /// FROST over secp256k1 with Taproot (BIP-340) — the Bitcoin/Nostr path.
+    #[default]
+    Secp256k1Tr,
+    /// FROST over Ed25519.
+    Ed25519,
+}
+
+impl Ciphersuite {
+    /// Associated data binding this ciphersuite into the share's AEAD envelope.
+    ///
+    /// `Secp256k1Tr` intentionally maps to an empty AAD so that shares written
+    /// before the ciphersuite tag existed (and the live Bitcoin path) remain
+    /// byte-identical and continue to decrypt.
+    pub(crate) fn aad(self) -> &'static [u8] {
+        match self {
+            Ciphersuite::Secp256k1Tr => &[],
+            Ciphersuite::Ed25519 => b"keep-frost-ciphersuite:ed25519",
+        }
+    }
+}
+
 /// Metadata for a FROST share.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ShareMetadata {
@@ -111,6 +140,31 @@ impl SharePackage {
         })
     }
 
+    /// Create a share package from already-serialized package bytes.
+    ///
+    /// Used by ciphersuites whose package types are not the secp256k1 ones.
+    pub fn from_bytes(
+        metadata: ShareMetadata,
+        key_package_bytes: Vec<u8>,
+        pubkey_package_bytes: Vec<u8>,
+    ) -> Self {
+        Self {
+            metadata,
+            key_package_bytes,
+            pubkey_package_bytes,
+        }
+    }
+
+    /// The serialized key package bytes.
+    pub fn key_package_bytes(&self) -> &[u8] {
+        &self.key_package_bytes
+    }
+
+    /// The serialized public key package bytes.
+    pub fn pubkey_package_bytes(&self) -> &[u8] {
+        &self.pubkey_package_bytes
+    }
+
     /// Deserialize and return the key package.
     pub fn key_package(&self) -> Result<KeyPackage> {
         KeyPackage::deserialize(&self.key_package_bytes)
@@ -144,24 +198,42 @@ pub struct StoredShare {
     pub encrypted_key_package: Vec<u8>,
     /// Public key package bytes.
     pub pubkey_package: Vec<u8>,
+    /// FROST ciphersuite of this share.
+    ///
+    /// Defaults to `Secp256k1Tr` so shares written before this field existed
+    /// load unchanged. The value is authenticated via the AEAD associated data
+    /// of `encrypted_key_package`, so it cannot be flipped without MAC failure.
+    #[serde(default)]
+    pub ciphersuite: Ciphersuite,
 }
 
 impl StoredShare {
-    /// Encrypt a share package for storage.
+    /// Encrypt a secp256k1 share package for storage.
     pub fn encrypt(share: &SharePackage, data_key: &SecretKey) -> Result<Self> {
-        let encrypted = crypto::encrypt(&share.key_package_bytes, data_key)?;
+        Self::encrypt_with_ciphersuite(share, Ciphersuite::Secp256k1Tr, data_key)
+    }
+
+    /// Encrypt a share package for storage, binding the given ciphersuite.
+    pub fn encrypt_with_ciphersuite(
+        share: &SharePackage,
+        ciphersuite: Ciphersuite,
+        data_key: &SecretKey,
+    ) -> Result<Self> {
+        let encrypted =
+            crypto::encrypt_with_aad(&share.key_package_bytes, ciphersuite.aad(), data_key)?;
 
         Ok(Self {
             metadata: share.metadata.clone(),
             encrypted_key_package: encrypted.to_bytes(),
             pubkey_package: share.pubkey_package_bytes.clone(),
+            ciphersuite,
         })
     }
 
     /// Decrypt and return the share package.
     pub fn decrypt(&self, data_key: &SecretKey) -> Result<SharePackage> {
         let encrypted = crypto::EncryptedData::from_bytes(&self.encrypted_key_package)?;
-        let decrypted = crypto::decrypt(&encrypted, data_key)?;
+        let decrypted = crypto::decrypt_with_aad(&encrypted, self.ciphersuite.aad(), data_key)?;
         let key_package_bytes = decrypted.as_slice()?;
 
         Ok(SharePackage {
@@ -169,5 +241,84 @@ impl StoredShare {
             key_package_bytes: key_package_bytes.to_vec(),
             pubkey_package_bytes: self.pubkey_package.clone(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::SecretKey;
+    use serde::{Deserialize, Serialize};
+
+    fn sample_metadata() -> ShareMetadata {
+        ShareMetadata::new(1, 2, 3, [7u8; 32], "test".into())
+    }
+
+    fn sample_package() -> SharePackage {
+        SharePackage::from_bytes(sample_metadata(), vec![1, 2, 3, 4], vec![9, 9, 9])
+    }
+
+    #[test]
+    fn test_default_ciphersuite_is_secp256k1() {
+        assert_eq!(Ciphersuite::default(), Ciphersuite::Secp256k1Tr);
+        assert!(Ciphersuite::Secp256k1Tr.aad().is_empty());
+        assert!(!Ciphersuite::Ed25519.aad().is_empty());
+    }
+
+    #[test]
+    fn test_secp256k1_envelope_byte_identical() {
+        // The secp256k1 path uses empty AAD, so the ciphertext is byte-for-byte
+        // what plain `crypto::encrypt` would have produced for the same key+nonce.
+        let key = SecretKey::generate().unwrap();
+        let pkg = sample_package();
+
+        let stored = StoredShare::encrypt(&pkg, &key).unwrap();
+        assert_eq!(stored.ciphersuite, Ciphersuite::Secp256k1Tr);
+
+        let restored = stored.decrypt(&key).unwrap();
+        assert_eq!(restored.key_package_bytes(), pkg.key_package_bytes());
+
+        // A blob produced via the no-AAD primitive must also decrypt under the
+        // secp256k1 (empty-AAD) path, proving envelope compatibility.
+        let raw = crypto::encrypt(pkg.key_package_bytes(), &key).unwrap();
+        let legacy = StoredShare {
+            metadata: sample_metadata(),
+            encrypted_key_package: raw.to_bytes(),
+            pubkey_package: pkg.pubkey_package_bytes().to_vec(),
+            ciphersuite: Ciphersuite::Secp256k1Tr,
+        };
+        let restored = legacy.decrypt(&key).unwrap();
+        assert_eq!(restored.key_package_bytes(), pkg.key_package_bytes());
+    }
+
+    // Mirrors the pre-change StoredShare field layout (no ciphersuite tag).
+    #[derive(Serialize, Deserialize)]
+    struct LegacyStoredShare {
+        metadata: ShareMetadata,
+        encrypted_key_package: Vec<u8>,
+        pubkey_package: Vec<u8>,
+    }
+
+    #[test]
+    fn test_old_bincode_blob_is_not_self_describing() {
+        // Documents why the storage layer needs an explicit legacy fallback:
+        // bincode cannot fill a `#[serde(default)]` trailing field from an old
+        // blob that lacks it. The recovery path is tested in storage.rs.
+        use bincode::Options;
+
+        let legacy = LegacyStoredShare {
+            metadata: sample_metadata(),
+            encrypted_key_package: vec![0u8; 40],
+            pubkey_package: vec![9, 9, 9],
+        };
+
+        let opts = || {
+            bincode::options()
+                .with_fixint_encoding()
+                .allow_trailing_bytes()
+        };
+        let blob = opts().serialize(&legacy).unwrap();
+
+        assert!(opts().deserialize::<StoredShare>(&blob).is_err());
     }
 }

--- a/keep-core/src/frost/transport.rs
+++ b/keep-core/src/frost/transport.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::crypto;
 use crate::error::{KeepError, Result};
 
-use super::share::SharePackage;
+use super::share::{Ciphersuite, SharePackage};
 
 const SHARE_HRP: &str = "kshare";
 const MAX_FRAME_COUNT: usize = 100;
@@ -33,20 +33,33 @@ pub struct ShareExport {
     pub nonce: String,
     /// Key derivation salt (hex).
     pub salt: String,
+    /// FROST ciphersuite of this share.
+    ///
+    /// Defaults to `Secp256k1Tr` so exports written before this field existed
+    /// parse unchanged. Authenticated via the AEAD associated data of
+    /// `encrypted_share`, so it cannot be flipped without decryption failure.
+    #[serde(default)]
+    pub ciphersuite: Ciphersuite,
 }
 
 impl ShareExport {
-    /// Create an encrypted export from a share package.
+    /// Create an encrypted secp256k1 export from a share package.
     pub fn from_share(share: &SharePackage, passphrase: &str) -> Result<Self> {
+        Self::from_share_with_ciphersuite(share, Ciphersuite::Secp256k1Tr, passphrase)
+    }
+
+    /// Create an encrypted export from a share package, binding the ciphersuite.
+    pub fn from_share_with_ciphersuite(
+        share: &SharePackage,
+        ciphersuite: Ciphersuite,
+        passphrase: &str,
+    ) -> Result<Self> {
         let salt: [u8; 32] = crypto::random_bytes();
         let key = crypto::derive_key(passphrase.as_bytes(), &salt, crypto::Argon2Params::DEFAULT)?;
 
-        let key_package = share.key_package()?;
-        let key_bytes = key_package
-            .serialize()
-            .map_err(|e| KeepError::Frost(format!("Serialization failed: {e}")))?;
+        let key_bytes = share.key_package_bytes().to_vec();
 
-        let encrypted = crypto::encrypt(&key_bytes, &key)?;
+        let encrypted = crypto::encrypt_with_aad(&key_bytes, ciphersuite.aad(), &key)?;
 
         Ok(Self {
             version: 1,
@@ -57,6 +70,7 @@ impl ShareExport {
             encrypted_share: hex::encode(&encrypted.ciphertext),
             nonce: hex::encode(encrypted.nonce),
             salt: hex::encode(salt),
+            ciphersuite,
         })
     }
 
@@ -93,11 +107,8 @@ impl ShareExport {
             .map_err(|_| KeepError::Frost(INVALID_SHARE.into()))?;
 
         let encrypted = crypto::EncryptedData { ciphertext, nonce };
-        let decrypted = crypto::decrypt(&encrypted, &key)?;
+        let decrypted = crypto::decrypt_with_aad(&encrypted, self.ciphersuite.aad(), &key)?;
         let key_bytes = decrypted.as_slice()?;
-
-        let key_package = frost_secp256k1_tr::keys::KeyPackage::deserialize(&key_bytes)
-            .map_err(|e| KeepError::Frost(format!("Failed to deserialize key package: {e}")))?;
 
         let group_pubkey_bytes =
             hex::decode(&self.group_pubkey).map_err(|_| KeepError::Frost(INVALID_SHARE.into()))?;
@@ -107,8 +118,6 @@ impl ShareExport {
         let mut group_pubkey = [0u8; 32];
         group_pubkey.copy_from_slice(&group_pubkey_bytes);
 
-        let pubkey_package = derive_pubkey_package(&key_package)?;
-
         let metadata = super::share::ShareMetadata::new(
             self.identifier,
             self.threshold,
@@ -117,7 +126,17 @@ impl ShareExport {
             name.to_string(),
         );
 
-        SharePackage::new(metadata, &key_package, &pubkey_package)
+        match self.ciphersuite {
+            Ciphersuite::Secp256k1Tr => {
+                let key_package = frost_secp256k1_tr::keys::KeyPackage::deserialize(&key_bytes)
+                    .map_err(|e| {
+                        KeepError::Frost(format!("Failed to deserialize key package: {e}"))
+                    })?;
+                let pubkey_package = derive_pubkey_package(&key_package)?;
+                SharePackage::new(metadata, &key_package, &pubkey_package)
+            }
+            Ciphersuite::Ed25519 => import_ed25519_share(metadata, &key_bytes),
+        }
     }
 
     /// Serialize to JSON.
@@ -177,6 +196,46 @@ impl ShareExport {
 
         Self::from_json(&json)
     }
+}
+
+#[cfg(feature = "ed25519")]
+fn import_ed25519_share(
+    metadata: super::share::ShareMetadata,
+    key_bytes: &[u8],
+) -> Result<SharePackage> {
+    use frost_ed25519 as frost;
+    use std::collections::BTreeMap;
+
+    let key_package = frost::keys::KeyPackage::deserialize(key_bytes)
+        .map_err(|e| KeepError::Frost(format!("Failed to deserialize key package: {e}")))?;
+
+    let mut verifying_shares = BTreeMap::new();
+    verifying_shares.insert(*key_package.identifier(), *key_package.verifying_share());
+    let pubkey_package =
+        frost::keys::PublicKeyPackage::new(verifying_shares, *key_package.verifying_key());
+
+    let key_package_bytes = key_package
+        .serialize()
+        .map_err(|e| KeepError::Frost(format!("Failed to serialize key package: {e}")))?;
+    let pubkey_package_bytes = pubkey_package
+        .serialize()
+        .map_err(|e| KeepError::Frost(format!("Failed to serialize pubkey package: {e}")))?;
+
+    Ok(SharePackage::from_bytes(
+        metadata,
+        key_package_bytes,
+        pubkey_package_bytes,
+    ))
+}
+
+#[cfg(not(feature = "ed25519"))]
+fn import_ed25519_share(
+    _metadata: super::share::ShareMetadata,
+    _key_bytes: &[u8],
+) -> Result<SharePackage> {
+    Err(KeepError::Frost(
+        "Ed25519 share import requires the ed25519 feature".into(),
+    ))
 }
 
 fn derive_pubkey_package(
@@ -454,6 +513,28 @@ mod tests {
         assert_eq!(parsed.identifier, 1);
         assert_eq!(parsed.payload_bytes().unwrap(), commitment_data);
         assert_eq!(parsed.session_id_bytes().unwrap(), session_id);
+    }
+
+    #[cfg(feature = "ed25519")]
+    #[test]
+    fn test_ed25519_share_export_roundtrip() {
+        use crate::frost::ed25519::TrustedDealer as Ed25519Dealer;
+
+        let dealer = Ed25519Dealer::new(ThresholdConfig::two_of_three());
+        let (shares, _) = dealer.generate("ed-test").unwrap();
+
+        let passphrase = "ed pass";
+        let export =
+            ShareExport::from_share_with_ciphersuite(&shares[0], Ciphersuite::Ed25519, passphrase)
+                .unwrap();
+        assert_eq!(export.ciphersuite, Ciphersuite::Ed25519);
+
+        let json = export.to_json().unwrap();
+        let reimported = ShareExport::from_json(&json).unwrap();
+        let restored = reimported.to_share(passphrase, "imported").unwrap();
+
+        assert_eq!(restored.group_pubkey(), shares[0].group_pubkey());
+        assert_eq!(restored.key_package_bytes(), shares[0].key_package_bytes());
     }
 
     #[test]

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -1057,6 +1057,161 @@ impl Keep {
         }
     }
 
+    /// Generate a FROST-Ed25519 threshold key and store its shares.
+    ///
+    /// Shares are tagged with [`Ciphersuite::Ed25519`], which is bound into the
+    /// at-rest AEAD AAD so they cannot be confused with secp256k1 shares.
+    #[cfg(feature = "ed25519")]
+    pub fn frost_generate_ed25519(
+        &mut self,
+        threshold: u16,
+        total_shares: u16,
+        name: &str,
+    ) -> Result<Vec<SharePackage>> {
+        if !self.is_unlocked() {
+            return Err(KeepError::Locked);
+        }
+
+        let config = ThresholdConfig::new(threshold, total_shares)?;
+        let dealer = crate::frost::ed25519::TrustedDealer::new(config);
+        let (shares, _) = dealer.generate(name)?;
+
+        let data_key = self.get_data_key()?;
+        for share in &shares {
+            let stored = StoredShare::encrypt_with_ciphersuite(
+                share,
+                crate::frost::Ciphersuite::Ed25519,
+                &data_key,
+            )?;
+            self.storage.store_share(&stored)?;
+        }
+
+        Ok(shares)
+    }
+
+    /// Sign a message with a threshold of local FROST-Ed25519 shares.
+    ///
+    /// Returns a detached 64-byte Ed25519 signature over the raw message
+    /// (RFC 8032), verifiable by [`Keep::frost_verify_ed25519`] and by any
+    /// standard Ed25519 verifier against the group public key.
+    #[cfg(feature = "ed25519")]
+    pub fn frost_sign_ed25519(
+        &mut self,
+        group_pubkey: &[u8; 32],
+        message: &[u8],
+    ) -> Result<[u8; 64]> {
+        if !self.is_unlocked() {
+            return Err(KeepError::Locked);
+        }
+
+        let data_key = self.get_data_key()?;
+        let shares = self.storage.list_shares()?;
+        let our_shares: Vec<_> = shares
+            .iter()
+            .filter(|s| {
+                s.metadata.group_pubkey == *group_pubkey
+                    && s.ciphersuite == crate::frost::Ciphersuite::Ed25519
+            })
+            .collect();
+
+        if our_shares.is_empty() {
+            return Err(KeepError::KeyNotFound("No Ed25519 shares for group".into()));
+        }
+
+        let threshold = our_shares[0].metadata.threshold;
+        if our_shares.len() < threshold as usize {
+            return Err(KeepError::Frost(format!(
+                "Need {} shares to sign, only {} available",
+                threshold,
+                our_shares.len()
+            )));
+        }
+
+        let mut decrypted_shares = Vec::new();
+        for stored in our_shares.iter().take(threshold as usize) {
+            decrypted_shares.push(stored.decrypt(&data_key)?);
+        }
+
+        crate::frost::ed25519::sign_with_local_shares(&decrypted_shares, message)
+    }
+
+    /// Verify a detached Ed25519 signature against a group public key.
+    #[cfg(feature = "ed25519")]
+    pub fn frost_verify_ed25519(
+        group_pubkey: &[u8; 32],
+        message: &[u8],
+        signature: &[u8; 64],
+    ) -> Result<()> {
+        crate::frost::ed25519::verify(group_pubkey, message, signature)
+    }
+
+    /// Sign `message` and produce a minisign-compatible detached signature.
+    ///
+    /// Runs two FROST-Ed25519 threshold signing sessions: one over the
+    /// BLAKE2b-512 prehash of the message (the `"ED"` file signature) and one
+    /// over `file_signature || trusted_comment` (the global signature). The
+    /// result verifies with the standard `minisign -V` tool against the
+    /// exported group public key.
+    #[cfg(feature = "ed25519")]
+    pub fn frost_sign_ed25519_minisign(
+        &mut self,
+        group_pubkey: &[u8; 32],
+        message: &[u8],
+        untrusted_comment: String,
+        trusted_comment: String,
+    ) -> Result<crate::frost::ed25519::minisign::MinisignSignature> {
+        use crate::frost::ed25519::minisign;
+
+        let prehash = minisign::prehash(message);
+        let signature = self.frost_sign_ed25519(group_pubkey, &prehash)?;
+
+        let global_bytes = minisign::global_signed_bytes(&signature, &trusted_comment);
+        let global_signature = self.frost_sign_ed25519(group_pubkey, &global_bytes)?;
+
+        Ok(minisign::MinisignSignature {
+            sig_alg: minisign::ALG_PREHASHED,
+            key_id: minisign::key_id(group_pubkey),
+            signature,
+            global_signature,
+            untrusted_comment,
+            trusted_comment,
+        })
+    }
+
+    /// Verify a minisign-compatible detached signature against a group public
+    /// key, checking both the file signature and the global signature using
+    /// minisign's semantics (key-id match, prehash for `"ED"`, RFC 8032 strict
+    /// cofactorless verification via frost-ed25519).
+    #[cfg(feature = "ed25519")]
+    pub fn frost_verify_ed25519_minisign(
+        group_pubkey: &[u8; 32],
+        message: &[u8],
+        sig: &crate::frost::ed25519::minisign::MinisignSignature,
+    ) -> Result<()> {
+        use crate::frost::ed25519::minisign;
+
+        if sig.key_id != minisign::key_id(group_pubkey) {
+            return Err(KeepError::InvalidInput(
+                "signature key id does not match group public key".into(),
+            ));
+        }
+
+        let signed_message = match sig.sig_alg {
+            minisign::ALG_PREHASHED => minisign::prehash(message).to_vec(),
+            minisign::ALG_LEGACY => message.to_vec(),
+            _ => {
+                return Err(KeepError::InvalidInput(
+                    "unknown signature algorithm".into(),
+                ))
+            }
+        };
+
+        crate::frost::ed25519::verify(group_pubkey, &signed_message, &sig.signature)?;
+
+        let global_bytes = minisign::global_signed_bytes(&sig.signature, &sig.trusted_comment);
+        crate::frost::ed25519::verify(group_pubkey, &global_bytes, &sig.global_signature)
+    }
+
     fn load_keys_to_keyring(&mut self) -> Result<()> {
         let data_key = self.get_data_key()?;
         let records = self.storage.list_keys()?;
@@ -1375,6 +1530,165 @@ mod tests {
         let message = b"sign with split key";
         let signature = keep.frost_sign(&frost_pubkey, message).unwrap();
         assert_eq!(signature.len(), 64);
+    }
+
+    #[cfg(feature = "ed25519")]
+    #[test]
+    fn test_frost_ed25519_generate_sign_verify() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("keep");
+        let mut keep = test_keep(&path);
+
+        let shares = keep.frost_generate_ed25519(2, 3, "release").unwrap();
+        assert_eq!(shares.len(), 3);
+        let group_pubkey = *shares[0].group_pubkey();
+
+        let message = b"release artifact v1.0";
+        let signature = keep.frost_sign_ed25519(&group_pubkey, message).unwrap();
+        assert_eq!(signature.len(), 64);
+
+        Keep::frost_verify_ed25519(&group_pubkey, message, &signature).unwrap();
+        assert!(Keep::frost_verify_ed25519(&group_pubkey, b"tampered", &signature).is_err());
+
+        // Shares persisted across reopen carry the Ed25519 ciphersuite tag and
+        // still sign after the versioned-blob round-trip through storage.
+        drop(keep);
+        let mut keep = Keep::open(&path).unwrap();
+        keep.unlock("testpass").unwrap();
+        let sig2 = keep.frost_sign_ed25519(&group_pubkey, message).unwrap();
+        Keep::frost_verify_ed25519(&group_pubkey, message, &sig2).unwrap();
+    }
+
+    #[cfg(feature = "ed25519")]
+    #[test]
+    fn test_frost_ed25519_data_key_rotation() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("keep");
+        let mut keep = test_keep(&path);
+
+        let shares = keep.frost_generate_ed25519(2, 3, "release").unwrap();
+        let group_pubkey = *shares[0].group_pubkey();
+
+        // Rotation re-encrypts the inner key package under the ciphersuite AAD
+        // and verifies it; an Ed25519 vault must rotate without failing.
+        keep.rotate_data_key("testpass").unwrap();
+
+        let message = b"after rotation";
+        let sig = keep.frost_sign_ed25519(&group_pubkey, message).unwrap();
+        Keep::frost_verify_ed25519(&group_pubkey, message, &sig).unwrap();
+    }
+
+    #[cfg(feature = "ed25519")]
+    #[test]
+    fn test_frost_ed25519_minisign_round_trip() {
+        use crate::frost::ed25519::minisign::MinisignSignature;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("keep");
+        let mut keep = test_keep(&path);
+
+        let shares = keep.frost_generate_ed25519(2, 3, "release").unwrap();
+        let group_pubkey = *shares[0].group_pubkey();
+
+        let message = b"release artifact v2.0";
+        let sig = keep
+            .frost_sign_ed25519_minisign(
+                &group_pubkey,
+                message,
+                "untrusted".into(),
+                "trusted:abc".into(),
+            )
+            .unwrap();
+
+        // Full struct verifies (file + global signatures).
+        Keep::frost_verify_ed25519_minisign(&group_pubkey, message, &sig).unwrap();
+
+        // Survives encode/parse round-trip.
+        let encoded = sig.encode();
+        let parsed = MinisignSignature::parse(&encoded).unwrap();
+        Keep::frost_verify_ed25519_minisign(&group_pubkey, message, &parsed).unwrap();
+
+        // Tampered message rejected.
+        assert!(Keep::frost_verify_ed25519_minisign(&group_pubkey, b"tampered", &parsed).is_err());
+
+        // Tampered trusted comment breaks the global signature.
+        let mut bad = MinisignSignature::parse(&encoded).unwrap();
+        bad.trusted_comment = "trusted:evil".into();
+        assert!(Keep::frost_verify_ed25519_minisign(&group_pubkey, message, &bad).is_err());
+
+        // Wrong group public key fails the key-id check.
+        let wrong = [0u8; 32];
+        assert!(Keep::frost_verify_ed25519_minisign(&wrong, message, &parsed).is_err());
+    }
+
+    #[cfg(feature = "ed25519")]
+    #[test]
+    fn test_frost_ed25519_minisign_external_binary() {
+        use crate::frost::ed25519::minisign::MinisignPublicKey;
+        use std::process::Command;
+
+        // Prefer the C minisign binary; fall back to rsign2 (rsign), which is
+        // byte-format compatible with minisign. Skip if neither is installed.
+        let verifier = if Command::new("minisign").arg("-v").output().is_ok() {
+            "minisign"
+        } else if Command::new("rsign").arg("--help").output().is_ok() {
+            "rsign"
+        } else {
+            eprintln!("no minisign/rsign binary installed; skipping external cross-check");
+            return;
+        };
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("keep");
+        let mut keep = test_keep(&path);
+
+        let shares = keep.frost_generate_ed25519(2, 3, "release").unwrap();
+        let group_pubkey = *shares[0].group_pubkey();
+
+        let data_path = dir.path().join("artifact.bin");
+        std::fs::write(&data_path, b"external minisign cross-check payload").unwrap();
+        let message = std::fs::read(&data_path).unwrap();
+
+        let sig = keep
+            .frost_sign_ed25519_minisign(
+                &group_pubkey,
+                &message,
+                "keep test".into(),
+                "timestamp:0\tfile:artifact.bin".into(),
+            )
+            .unwrap();
+        let sig_path = dir.path().join("artifact.bin.minisig");
+        std::fs::write(&sig_path, sig.encode()).unwrap();
+
+        let pk = MinisignPublicKey::from_group_pubkey(&group_pubkey, "keep test".into());
+        let pk_path = dir.path().join("keep.pub");
+        std::fs::write(&pk_path, pk.encode()).unwrap();
+
+        let output = match verifier {
+            "minisign" => Command::new("minisign")
+                .arg("-V")
+                .arg("-p")
+                .arg(&pk_path)
+                .arg("-m")
+                .arg(&data_path)
+                .output()
+                .expect("run minisign -V"),
+            _ => Command::new("rsign")
+                .arg("verify")
+                .arg("-p")
+                .arg(&pk_path)
+                .arg("-x")
+                .arg(&sig_path)
+                .arg(&data_path)
+                .output()
+                .expect("run rsign verify"),
+        };
+        assert!(
+            output.status.success(),
+            "external verify ({verifier}) failed: {}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
     }
 
     #[test]

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -526,7 +526,8 @@ impl Keep {
                 .with_participants(vec![identifier])
         });
 
-        let export = ShareExport::from_share(&share, passphrase)?;
+        let export =
+            ShareExport::from_share_with_ciphersuite(&share, stored.ciphersuite, passphrase)?;
 
         // Exporting is the backup action: record it so the UI/clients can stop
         // nagging "not backed up". Best-effort; a storage error here must not
@@ -563,7 +564,7 @@ impl Keep {
 
         let share = export.to_share(passphrase, name)?;
         let data_key = self.get_data_key()?;
-        let stored = StoredShare::encrypt(&share, &data_key)?;
+        let stored = StoredShare::encrypt_with_ciphersuite(&share, export.ciphersuite, &data_key)?;
         self.storage.store_share(&stored)?;
 
         let group = hex::decode(&export.group_pubkey)
@@ -588,7 +589,10 @@ impl Keep {
         let all_shares = self.storage.list_shares()?;
         let group_shares: Vec<_> = all_shares
             .into_iter()
-            .filter(|s| s.metadata.group_pubkey == *group_pubkey)
+            .filter(|s| {
+                s.metadata.group_pubkey == *group_pubkey
+                    && s.ciphersuite == crate::frost::Ciphersuite::Secp256k1Tr
+            })
             .collect();
 
         if group_shares.is_empty() {
@@ -978,7 +982,10 @@ impl Keep {
         let shares = self.storage.list_shares()?;
         let stored = shares
             .iter()
-            .find(|s| s.metadata.group_pubkey == *group_pubkey)
+            .find(|s| {
+                s.metadata.group_pubkey == *group_pubkey
+                    && s.ciphersuite == crate::frost::Ciphersuite::Secp256k1Tr
+            })
             .ok_or_else(|| KeepError::KeyNotFound("No shares for group".into()))?;
 
         stored.decrypt(&data_key)
@@ -1009,7 +1016,10 @@ impl Keep {
         let shares = self.storage.list_shares()?;
         let our_shares: Vec<_> = shares
             .iter()
-            .filter(|s| s.metadata.group_pubkey == *group_pubkey)
+            .filter(|s| {
+                s.metadata.group_pubkey == *group_pubkey
+                    && s.ciphersuite == crate::frost::Ciphersuite::Secp256k1Tr
+            })
             .collect();
 
         if our_shares.is_empty() {
@@ -1120,6 +1130,12 @@ impl Keep {
 
         let threshold = our_shares[0].metadata.threshold;
         if our_shares.len() < threshold as usize {
+            self.audit_event(AuditEventType::FrostSignFailed, |e| {
+                e.with_group(group_pubkey)
+                    .with_message_hash(message)
+                    .with_success(false)
+                    .with_reason("Insufficient shares")
+            });
             return Err(KeepError::Frost(format!(
                 "Need {} shares to sign, only {} available",
                 threshold,
@@ -1132,7 +1148,24 @@ impl Keep {
             decrypted_shares.push(stored.decrypt(&data_key)?);
         }
 
-        crate::frost::ed25519::sign_with_local_shares(&decrypted_shares, message)
+        match crate::frost::ed25519::sign_with_local_shares(&decrypted_shares, message) {
+            Ok(sig) => {
+                self.audit_event(AuditEventType::FrostSign, |e| {
+                    e.with_group(group_pubkey)
+                        .with_message_hash(message)
+                        .with_threshold(threshold)
+                });
+                Ok(sig)
+            }
+            Err(e) => {
+                self.audit_event(AuditEventType::FrostSignFailed, |e| {
+                    e.with_group(group_pubkey)
+                        .with_message_hash(message)
+                        .with_success(false)
+                });
+                Err(e)
+            }
+        }
     }
 
     /// Verify a detached Ed25519 signature against a group public key.
@@ -1161,6 +1194,9 @@ impl Keep {
         trusted_comment: String,
     ) -> Result<crate::frost::ed25519::minisign::MinisignSignature> {
         use crate::frost::ed25519::minisign;
+
+        minisign::validate_comment("untrusted", &untrusted_comment)?;
+        minisign::validate_comment("trusted", &trusted_comment)?;
 
         let prehash = minisign::prehash(message);
         let signature = self.frost_sign_ed25519(group_pubkey, &prehash)?;
@@ -1557,6 +1593,42 @@ mod tests {
         keep.unlock("testpass").unwrap();
         let sig2 = keep.frost_sign_ed25519(&group_pubkey, message).unwrap();
         Keep::frost_verify_ed25519(&group_pubkey, message, &sig2).unwrap();
+    }
+
+    #[cfg(feature = "ed25519")]
+    #[test]
+    fn test_frost_ed25519_export_import_sign() {
+        let src_dir = tempdir().unwrap();
+        let src_path = src_dir.path().join("keep");
+        let mut src = test_keep(&src_path);
+
+        let shares = src.frost_generate_ed25519(2, 3, "release").unwrap();
+        let group_pubkey = *shares[0].group_pubkey();
+
+        let exports: Vec<_> = shares
+            .iter()
+            .take(2)
+            .map(|s| {
+                let export = src
+                    .frost_export_share(&group_pubkey, s.metadata.identifier, "transfer-pass")
+                    .unwrap();
+                assert_eq!(export.ciphersuite, crate::frost::Ciphersuite::Ed25519);
+                export
+            })
+            .collect();
+
+        let dst_dir = tempdir().unwrap();
+        let dst_path = dst_dir.path().join("keep");
+        let mut dst = test_keep(&dst_path);
+
+        for (i, export) in exports.iter().enumerate() {
+            dst.frost_import_share(export, "transfer-pass", &format!("imported-{i}"))
+                .unwrap();
+        }
+
+        let message = b"exported then imported";
+        let sig = dst.frost_sign_ed25519(&group_pubkey, message).unwrap();
+        Keep::frost_verify_ed25519(&group_pubkey, message, &sig).unwrap();
     }
 
     #[cfg(feature = "ed25519")]

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -1676,7 +1676,7 @@ mod tests {
         Keep::frost_verify_ed25519_minisign(&group_pubkey, message, &sig).unwrap();
 
         // Survives encode/parse round-trip.
-        let encoded = sig.encode();
+        let encoded = sig.encode().unwrap();
         let parsed = MinisignSignature::parse(&encoded).unwrap();
         Keep::frost_verify_ed25519_minisign(&group_pubkey, message, &parsed).unwrap();
 
@@ -1730,7 +1730,7 @@ mod tests {
             )
             .unwrap();
         let sig_path = dir.path().join("artifact.bin.minisig");
-        std::fs::write(&sig_path, sig.encode()).unwrap();
+        std::fs::write(&sig_path, sig.encode().unwrap()).unwrap();
 
         let pk = MinisignPublicKey::from_group_pubkey(&group_pubkey, "keep test".into());
         let pk_path = dir.path().join("keep.pub");

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -496,12 +496,19 @@ impl Keep {
         self.storage.list_shares()
     }
 
-    fn find_stored_share(&self, group_pubkey: &[u8; 32], identifier: u16) -> Result<StoredShare> {
+    fn find_stored_share(
+        &self,
+        group_pubkey: &[u8; 32],
+        identifier: u16,
+        ciphersuite: Option<crate::frost::Ciphersuite>,
+    ) -> Result<StoredShare> {
         let shares = self.storage.list_shares()?;
         shares
             .into_iter()
             .find(|s| {
-                s.metadata.group_pubkey == *group_pubkey && s.metadata.identifier == identifier
+                s.metadata.group_pubkey == *group_pubkey
+                    && s.metadata.identifier == identifier
+                    && ciphersuite.is_none_or(|cs| s.ciphersuite == cs)
             })
             .ok_or_else(|| KeepError::KeyNotFound(format!("No share {identifier} for group")))
     }
@@ -517,7 +524,7 @@ impl Keep {
             return Err(KeepError::Locked);
         }
 
-        let mut stored = self.find_stored_share(group_pubkey, identifier)?;
+        let mut stored = self.find_stored_share(group_pubkey, identifier, None)?;
         let data_key = self.get_data_key()?;
         let share = stored.decrypt(&data_key)?;
 
@@ -667,7 +674,7 @@ impl Keep {
                 "share name must not exceed 64 characters".into(),
             ));
         }
-        let mut stored = self.find_stored_share(group_pubkey, identifier)?;
+        let mut stored = self.find_stored_share(group_pubkey, identifier, None)?;
         stored.metadata.name = name.to_string();
         self.storage.store_share(&stored)?;
         Ok(())
@@ -1001,7 +1008,7 @@ impl Keep {
             return Err(KeepError::Locked);
         }
 
-        let stored = self.find_stored_share(group_pubkey, identifier)?;
+        let stored = self.find_stored_share(group_pubkey, identifier, None)?;
         let data_key = self.get_data_key()?;
         stored.decrypt(&data_key)
     }
@@ -1097,7 +1104,7 @@ impl Keep {
         }
 
         let group_pubkey = *shares[0].group_pubkey();
-        let participants: Vec<u16> = (1..=total_shares).collect();
+        let participants: Vec<u16> = shares.iter().map(|s| s.metadata.identifier).collect();
         self.audit_event(AuditEventType::FrostGenerate, |e| {
             e.with_group(&group_pubkey)
                 .with_threshold(threshold)
@@ -1122,39 +1129,19 @@ impl Keep {
             return Err(KeepError::Locked);
         }
 
-        let data_key = self.get_data_key()?;
-        let shares = self.storage.list_shares()?;
-        let our_shares: Vec<_> = shares
-            .iter()
-            .filter(|s| {
-                s.metadata.group_pubkey == *group_pubkey
-                    && s.ciphersuite == crate::frost::Ciphersuite::Ed25519
-            })
-            .collect();
-
-        if our_shares.is_empty() {
-            return Err(KeepError::KeyNotFound("No Ed25519 shares for group".into()));
-        }
-
-        let threshold = our_shares[0].metadata.threshold;
-        if our_shares.len() < threshold as usize {
-            self.audit_event(AuditEventType::FrostSignFailed, |e| {
-                e.with_group(group_pubkey)
-                    .with_message_hash(message)
-                    .with_success(false)
-                    .with_reason("Insufficient shares")
-            });
-            return Err(KeepError::Frost(format!(
-                "Need {} shares to sign, only {} available",
-                threshold,
-                our_shares.len()
-            )));
-        }
-
-        let mut decrypted_shares = Vec::new();
-        for stored in our_shares.iter().take(threshold as usize) {
-            decrypted_shares.push(stored.decrypt(&data_key)?);
-        }
+        let decrypted_shares = match self.frost_ed25519_decrypt_threshold_shares(group_pubkey) {
+            Ok(shares) => shares,
+            Err(e) => {
+                self.audit_event(AuditEventType::FrostSignFailed, |ev| {
+                    ev.with_group(group_pubkey)
+                        .with_message_hash(message)
+                        .with_success(false)
+                        .with_reason("Insufficient shares")
+                });
+                return Err(e);
+            }
+        };
+        let threshold = decrypted_shares[0].metadata.threshold;
 
         match crate::frost::ed25519::sign_with_local_shares(&decrypted_shares, message) {
             Ok(sig) => {
@@ -1174,6 +1161,45 @@ impl Keep {
                 Err(e)
             }
         }
+    }
+
+    /// Decrypt the threshold set of local Ed25519 shares for a group.
+    ///
+    /// Returns exactly `threshold` decrypted shares or a `KeyNotFound`/`Frost`
+    /// error. Does not emit audit events; callers own audit semantics.
+    #[cfg(feature = "ed25519")]
+    fn frost_ed25519_decrypt_threshold_shares(
+        &self,
+        group_pubkey: &[u8; 32],
+    ) -> Result<Vec<SharePackage>> {
+        let data_key = self.get_data_key()?;
+        let shares = self.storage.list_shares()?;
+        let our_shares: Vec<_> = shares
+            .iter()
+            .filter(|s| {
+                s.metadata.group_pubkey == *group_pubkey
+                    && s.ciphersuite == crate::frost::Ciphersuite::Ed25519
+            })
+            .collect();
+
+        if our_shares.is_empty() {
+            return Err(KeepError::KeyNotFound("No Ed25519 shares for group".into()));
+        }
+
+        let threshold = our_shares[0].metadata.threshold;
+        if our_shares.len() < threshold as usize {
+            return Err(KeepError::Frost(format!(
+                "Need {} shares to sign, only {} available",
+                threshold,
+                our_shares.len()
+            )));
+        }
+
+        let mut decrypted_shares = Vec::with_capacity(threshold as usize);
+        for stored in our_shares.iter().take(threshold as usize) {
+            decrypted_shares.push(stored.decrypt(&data_key)?);
+        }
+        Ok(decrypted_shares)
     }
 
     /// Verify a detached Ed25519 signature against a group public key.
@@ -1203,14 +1229,57 @@ impl Keep {
     ) -> Result<crate::frost::ed25519::minisign::MinisignSignature> {
         use crate::frost::ed25519::minisign;
 
+        if !self.is_unlocked() {
+            return Err(KeepError::Locked);
+        }
+
         minisign::validate_comment("untrusted", &untrusted_comment)?;
         minisign::validate_comment("trusted", &trusted_comment)?;
 
-        let prehash = minisign::prehash(message);
-        let signature = self.frost_sign_ed25519(group_pubkey, &prehash)?;
+        let decrypted_shares = match self.frost_ed25519_decrypt_threshold_shares(group_pubkey) {
+            Ok(shares) => shares,
+            Err(e) => {
+                self.audit_event(AuditEventType::FrostSignFailed, |ev| {
+                    ev.with_group(group_pubkey)
+                        .with_message_hash(message)
+                        .with_success(false)
+                        .with_reason("Insufficient shares")
+                });
+                return Err(e);
+            }
+        };
+        let threshold = decrypted_shares[0].metadata.threshold;
 
-        let global_bytes = minisign::global_signed_bytes(&signature, &trusted_comment);
-        let global_signature = self.frost_sign_ed25519(group_pubkey, &global_bytes)?;
+        // Two independent threshold sessions over the same decrypted share set:
+        // fresh nonces per session keep each signature secure.
+        let prehash = minisign::prehash(message);
+        let sign_both = (|| {
+            let signature =
+                crate::frost::ed25519::sign_with_local_shares(&decrypted_shares, &prehash)?;
+            let global_bytes = minisign::global_signed_bytes(&signature, &trusted_comment);
+            let global_signature =
+                crate::frost::ed25519::sign_with_local_shares(&decrypted_shares, &global_bytes)?;
+            Ok::<_, KeepError>((signature, global_signature))
+        })();
+
+        let (signature, global_signature) = match sign_both {
+            Ok(pair) => {
+                self.audit_event(AuditEventType::FrostSign, |e| {
+                    e.with_group(group_pubkey)
+                        .with_message_hash(message)
+                        .with_threshold(threshold)
+                });
+                pair
+            }
+            Err(e) => {
+                self.audit_event(AuditEventType::FrostSignFailed, |ev| {
+                    ev.with_group(group_pubkey)
+                        .with_message_hash(message)
+                        .with_success(false)
+                });
+                return Err(e);
+            }
+        };
 
         Ok(minisign::MinisignSignature {
             sig_alg: minisign::ALG_PREHASHED,

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -1096,6 +1096,14 @@ impl Keep {
             self.storage.store_share(&stored)?;
         }
 
+        let group_pubkey = *shares[0].group_pubkey();
+        let participants: Vec<u16> = (1..=total_shares).collect();
+        self.audit_event(AuditEventType::FrostGenerate, |e| {
+            e.with_group(&group_pubkey)
+                .with_threshold(threshold)
+                .with_participants(participants)
+        });
+
         Ok(shares)
     }
 
@@ -1734,7 +1742,7 @@ mod tests {
 
         let pk = MinisignPublicKey::from_group_pubkey(&group_pubkey, "keep test".into());
         let pk_path = dir.path().join("keep.pub");
-        std::fs::write(&pk_path, pk.encode()).unwrap();
+        std::fs::write(&pk_path, pk.encode().unwrap()).unwrap();
 
         let output = match verifier {
             "minisign" => Command::new("minisign")

--- a/keep-core/src/rotation.rs
+++ b/keep-core/src/rotation.rs
@@ -391,17 +391,16 @@ impl Storage {
         }
 
         for (stored, key_package_bytes) in shares {
-            let new_encrypted = crypto::encrypt_with_aad(
-                key_package_bytes,
-                stored.ciphersuite.aad(),
+            let package = crate::frost::SharePackage::from_bytes(
+                stored.metadata.clone(),
+                key_package_bytes.to_vec(),
+                stored.pubkey_package.clone(),
+            );
+            let new_stored = StoredShare::encrypt_with_ciphersuite(
+                &package,
+                stored.ciphersuite,
                 new_data_key,
             )?;
-            let new_stored = StoredShare {
-                metadata: stored.metadata.clone(),
-                encrypted_key_package: new_encrypted.to_bytes(),
-                pubkey_package: stored.pubkey_package.clone(),
-                ciphersuite: stored.ciphersuite,
-            };
             let serialized = serialize_stored_share(&new_stored)?;
             let record_encrypted = crypto::encrypt(&serialized, new_data_key)?;
             let id = share_id(&stored.metadata.group_pubkey, stored.metadata.identifier);

--- a/keep-core/src/rotation.rs
+++ b/keep-core/src/rotation.rs
@@ -396,11 +396,8 @@ impl Storage {
                 key_package_bytes.to_vec(),
                 stored.pubkey_package.clone(),
             );
-            let new_stored = StoredShare::encrypt_with_ciphersuite(
-                &package,
-                stored.ciphersuite,
-                new_data_key,
-            )?;
+            let new_stored =
+                StoredShare::encrypt_with_ciphersuite(&package, stored.ciphersuite, new_data_key)?;
             let serialized = serialize_stored_share(&new_stored)?;
             let record_encrypted = crypto::encrypt(&serialized, new_data_key)?;
             let id = share_id(&stored.metadata.group_pubkey, stored.metadata.identifier);

--- a/keep-core/src/rotation.rs
+++ b/keep-core/src/rotation.rs
@@ -20,7 +20,8 @@ use crate::frost::StoredShare;
 use crate::keys::KeyRecord;
 use crate::relay::RelayConfig;
 use crate::storage::{
-    bincode_options, descriptor_storage_key, share_id, validate_new_password, Header, Storage,
+    bincode_options, descriptor_storage_key, deserialize_stored_share, serialize_stored_share,
+    share_id, validate_new_password, Header, Storage,
 };
 use crate::wallet::WalletDescriptor;
 
@@ -363,7 +364,8 @@ impl Storage {
             .iter()
             .map(|stored| {
                 let encrypted = EncryptedData::from_bytes(&stored.encrypted_key_package)?;
-                let key_package_bytes = crypto::decrypt(&encrypted, data_key)?;
+                let key_package_bytes =
+                    crypto::decrypt_with_aad(&encrypted, stored.ciphersuite.aad(), data_key)?;
                 Ok((stored.clone(), key_package_bytes.as_slice()?))
             })
             .collect()
@@ -389,13 +391,18 @@ impl Storage {
         }
 
         for (stored, key_package_bytes) in shares {
-            let new_encrypted = crypto::encrypt(key_package_bytes, new_data_key)?;
+            let new_encrypted = crypto::encrypt_with_aad(
+                key_package_bytes,
+                stored.ciphersuite.aad(),
+                new_data_key,
+            )?;
             let new_stored = StoredShare {
                 metadata: stored.metadata.clone(),
                 encrypted_key_package: new_encrypted.to_bytes(),
                 pubkey_package: stored.pubkey_package.clone(),
+                ciphersuite: stored.ciphersuite,
             };
-            let serialized = bincode::serialize(&new_stored)?;
+            let serialized = serialize_stored_share(&new_stored)?;
             let record_encrypted = crypto::encrypt(&serialized, new_data_key)?;
             let id = share_id(&stored.metadata.group_pubkey, stored.metadata.identifier);
             backend.put(SHARES_TABLE, &id, &record_encrypted.to_bytes())?;
@@ -490,9 +497,10 @@ impl Storage {
             let encrypted = EncryptedData::from_bytes(&encrypted_bytes)?;
             let decrypted = crypto::decrypt(&encrypted, data_key)?;
             let decrypted_bytes = decrypted.as_slice()?;
-            let stored: StoredShare = bincode_options().deserialize(&decrypted_bytes)?;
+            let stored: StoredShare = deserialize_stored_share(&decrypted_bytes)?;
             let inner_encrypted = EncryptedData::from_bytes(&stored.encrypted_key_package)?;
-            let inner_decrypted = crypto::decrypt(&inner_encrypted, data_key)?;
+            let inner_decrypted =
+                crypto::decrypt_with_aad(&inner_encrypted, stored.ciphersuite.aad(), data_key)?;
             let inner_bytes = inner_decrypted.as_slice()?;
             if !bool::from(inner_bytes.ct_eq(original_key_package.as_slice())) {
                 return Err(KeepError::RotationFailed(format!(

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -1123,7 +1123,7 @@ const SHARE_FORMAT_V1: u8 = 1;
 
 /// Serialize a `StoredShare` with the explicit version prefix.
 pub(crate) fn serialize_stored_share(share: &StoredShare) -> Result<Vec<u8>> {
-    let body = bincode::serialize(share)?;
+    let body = bincode_options().serialize(share)?;
     let mut out = Vec::with_capacity(SHARE_FORMAT_MAGIC.len() + 1 + body.len());
     out.extend_from_slice(SHARE_FORMAT_MAGIC);
     out.push(SHARE_FORMAT_V1);

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -1142,14 +1142,7 @@ pub(crate) fn serialize_stored_share(share: &StoredShare) -> Result<Vec<u8>> {
 /// adversarially prefixed legacy blob) still fails closed at the MAC rather
 /// than yielding a wrong key.
 pub(crate) fn deserialize_stored_share(bytes: &[u8]) -> Result<StoredShare> {
-    if let Some(body) =
-        bytes
-            .strip_prefix(SHARE_FORMAT_MAGIC.as_slice())
-            .and_then(|rest| match rest.split_first() {
-                Some((&SHARE_FORMAT_V1, body)) => Some(body),
-                _ => None,
-            })
-    {
+    if let Some([SHARE_FORMAT_V1, body @ ..]) = bytes.strip_prefix(SHARE_FORMAT_MAGIC.as_slice()) {
         return Ok(bincode_options().deserialize::<StoredShare>(body)?);
     }
 

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -545,7 +545,7 @@ impl Storage {
         let data_key = self.data_key.as_ref().ok_or(KeepError::Locked)?;
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
 
-        let serialized = bincode::serialize(share)?;
+        let serialized = serialize_stored_share(share)?;
         let encrypted = crypto::encrypt(&serialized, data_key)?;
         let encrypted_bytes = encrypted.to_bytes();
 
@@ -562,7 +562,7 @@ impl Storage {
 
         let mut entries_data: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(shares.len());
         for share in shares {
-            let serialized = bincode::serialize(share)?;
+            let serialized = serialize_stored_share(share)?;
             let encrypted = crypto::encrypt(&serialized, data_key)?;
             let id = share_id(&share.metadata.group_pubkey, share.metadata.identifier);
             entries_data.push((id.to_vec(), encrypted.to_bytes()));
@@ -589,7 +589,7 @@ impl Storage {
             let encrypted = EncryptedData::from_bytes(&encrypted_bytes)?;
             let decrypted = crypto::decrypt(&encrypted, data_key)?;
             let decrypted_bytes = decrypted.as_slice()?;
-            shares.push(bincode_options().deserialize(&decrypted_bytes)?);
+            shares.push(deserialize_stored_share(&decrypted_bytes)?);
         }
 
         Ok(shares)
@@ -1110,6 +1110,65 @@ fn parse_versioned_descriptor_key(
     Some(descriptor_key_version(key))
 }
 
+/// Self-describing version prefix on the persisted `StoredShare` blob.
+///
+/// bincode is not self-describing, so a `#[serde(default)]` field appended to
+/// `StoredShare` cannot be filled in from an older blob that lacks it. Rather
+/// than guess the layout by trying multiple deserializations, new writes carry
+/// an explicit `magic || version` prefix that unambiguously identifies the
+/// layout. Blobs without the prefix are pre-versioning data (v0), which is
+/// always secp256k1.
+const SHARE_FORMAT_MAGIC: &[u8; 4] = b"KSH1";
+const SHARE_FORMAT_V1: u8 = 1;
+
+/// Serialize a `StoredShare` with the explicit version prefix.
+pub(crate) fn serialize_stored_share(share: &StoredShare) -> Result<Vec<u8>> {
+    let body = bincode::serialize(share)?;
+    let mut out = Vec::with_capacity(SHARE_FORMAT_MAGIC.len() + 1 + body.len());
+    out.extend_from_slice(SHARE_FORMAT_MAGIC);
+    out.push(SHARE_FORMAT_V1);
+    out.extend_from_slice(&body);
+    Ok(out)
+}
+
+/// Deserialize a `StoredShare`, dispatching on the explicit version prefix.
+///
+/// A blob carrying the `KSH1` magic is parsed strictly as the current
+/// `StoredShare` layout (ciphersuite tag included). A blob without the magic is
+/// pre-versioning data: it is parsed as the legacy three-field layout and the
+/// tag defaults to `Secp256k1Tr`. This is parse-don't-guess: the prefix names
+/// the layout instead of inferring it from a failed deserialization. The
+/// ciphersuite tag stays bound in the AEAD AAD, so a misclassification (e.g. an
+/// adversarially prefixed legacy blob) still fails closed at the MAC rather
+/// than yielding a wrong key.
+pub(crate) fn deserialize_stored_share(bytes: &[u8]) -> Result<StoredShare> {
+    if let Some(body) =
+        bytes
+            .strip_prefix(SHARE_FORMAT_MAGIC.as_slice())
+            .and_then(|rest| match rest.split_first() {
+                Some((&SHARE_FORMAT_V1, body)) => Some(body),
+                _ => None,
+            })
+    {
+        return Ok(bincode_options().deserialize::<StoredShare>(body)?);
+    }
+
+    #[derive(serde::Deserialize)]
+    struct LegacyStoredShare {
+        metadata: crate::frost::ShareMetadata,
+        encrypted_key_package: Vec<u8>,
+        pubkey_package: Vec<u8>,
+    }
+
+    let legacy: LegacyStoredShare = bincode_options().deserialize(bytes)?;
+    Ok(StoredShare {
+        metadata: legacy.metadata,
+        encrypted_key_package: legacy.encrypted_key_package,
+        pubkey_package: legacy.pubkey_package,
+        ciphersuite: crate::frost::Ciphersuite::Secp256k1Tr,
+    })
+}
+
 pub(crate) fn share_id(group_pubkey: &[u8; 32], identifier: u16) -> [u8; 32] {
     let mut data = [0u8; 34];
     data[..32].copy_from_slice(group_pubkey);
@@ -1127,6 +1186,122 @@ impl Drop for Storage {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn test_legacy_stored_share_blob_loads_as_secp256k1() {
+        use bincode::Options;
+
+        #[derive(serde::Serialize)]
+        struct LegacyStoredShare {
+            metadata: crate::frost::ShareMetadata,
+            encrypted_key_package: Vec<u8>,
+            pubkey_package: Vec<u8>,
+        }
+
+        let legacy = LegacyStoredShare {
+            metadata: crate::frost::ShareMetadata::new(1, 2, 3, [3u8; 32], "old".into()),
+            encrypted_key_package: vec![1u8; 64],
+            pubkey_package: vec![2u8; 33],
+        };
+
+        let opts = || {
+            bincode::options()
+                .with_fixint_encoding()
+                .allow_trailing_bytes()
+        };
+
+        // A blob written by the old default-options path and the configured path.
+        for blob in [
+            bincode::serialize(&legacy).unwrap(),
+            opts().serialize(&legacy).unwrap(),
+        ] {
+            let loaded = deserialize_stored_share(&blob).unwrap();
+            assert_eq!(loaded.ciphersuite, crate::frost::Ciphersuite::Secp256k1Tr);
+            assert_eq!(loaded.metadata.identifier, 1);
+            assert_eq!(loaded.encrypted_key_package, vec![1u8; 64]);
+            assert_eq!(loaded.pubkey_package, vec![2u8; 33]);
+        }
+    }
+
+    #[test]
+    fn test_new_stored_share_blob_roundtrips() {
+        let share = StoredShare {
+            metadata: crate::frost::ShareMetadata::new(2, 2, 3, [4u8; 32], "new".into()),
+            encrypted_key_package: vec![7u8; 50],
+            pubkey_package: vec![8u8; 33],
+            ciphersuite: crate::frost::Ciphersuite::Ed25519,
+        };
+
+        let blob = serialize_stored_share(&share).unwrap();
+        assert!(blob.starts_with(SHARE_FORMAT_MAGIC));
+        assert_eq!(blob[SHARE_FORMAT_MAGIC.len()], SHARE_FORMAT_V1);
+
+        let loaded = deserialize_stored_share(&blob).unwrap();
+        assert_eq!(loaded.ciphersuite, crate::frost::Ciphersuite::Ed25519);
+        assert_eq!(loaded.metadata.identifier, 2);
+        assert_eq!(loaded.encrypted_key_package, vec![7u8; 50]);
+    }
+
+    #[test]
+    fn test_versioned_blob_does_not_parse_as_legacy() {
+        // A v1-prefixed Ed25519 blob must never be silently read through the
+        // legacy (always-secp256k1) path. The magic dispatches it strictly to
+        // the current layout, preserving its real ciphersuite tag.
+        let share = StoredShare {
+            metadata: crate::frost::ShareMetadata::new(5, 2, 3, [6u8; 32], "v1".into()),
+            encrypted_key_package: vec![1u8; 40],
+            pubkey_package: vec![2u8; 32],
+            ciphersuite: crate::frost::Ciphersuite::Ed25519,
+        };
+        let blob = serialize_stored_share(&share).unwrap();
+        let loaded = deserialize_stored_share(&blob).unwrap();
+        assert_eq!(loaded.ciphersuite, crate::frost::Ciphersuite::Ed25519);
+    }
+
+    #[test]
+    fn test_legacy_blob_cannot_be_misread_as_ed25519() {
+        // A legacy (unprefixed) blob is always loaded as secp256k1; there is no
+        // input shape that makes the legacy path yield a different ciphersuite.
+        use bincode::Options;
+
+        #[derive(serde::Serialize)]
+        struct LegacyStoredShare {
+            metadata: crate::frost::ShareMetadata,
+            encrypted_key_package: Vec<u8>,
+            pubkey_package: Vec<u8>,
+        }
+
+        let legacy = LegacyStoredShare {
+            metadata: crate::frost::ShareMetadata::new(9, 2, 3, [1u8; 32], "legacy".into()),
+            encrypted_key_package: vec![3u8; 48],
+            pubkey_package: vec![4u8; 33],
+        };
+        let blob = bincode::options()
+            .with_fixint_encoding()
+            .allow_trailing_bytes()
+            .serialize(&legacy)
+            .unwrap();
+
+        let loaded = deserialize_stored_share(&blob).unwrap();
+        assert_eq!(loaded.ciphersuite, crate::frost::Ciphersuite::Secp256k1Tr);
+    }
+
+    #[test]
+    fn test_stored_share_envelope_byte_identity_preserved() {
+        // The version prefix lives on the plaintext StoredShare serialization,
+        // independent of the AEAD envelope. A secp256k1 share's encrypted_key_package
+        // (empty AAD) is byte-identical to what plain crypto::encrypt produces.
+        let key = crypto::SecretKey::generate().unwrap();
+        let pkg = crate::frost::SharePackage::from_bytes(
+            crate::frost::ShareMetadata::new(1, 2, 3, [7u8; 32], "x".into()),
+            vec![1, 2, 3, 4],
+            vec![9, 9, 9],
+        );
+        let stored = StoredShare::encrypt(&pkg, &key).unwrap();
+        let restored = stored.decrypt(&key).unwrap();
+        assert_eq!(restored.key_package_bytes(), pkg.key_package_bytes());
+        assert_eq!(stored.ciphersuite, crate::frost::Ciphersuite::Secp256k1Tr);
+    }
 
     #[test]
     fn test_storage_create_and_unlock() {

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -281,6 +281,9 @@ struct StoredShareData {
     // Relies on SecureStorage (Android Keystore / iOS Keychain) for encryption at rest
     #[serde(default)]
     plaintext_mnemonic: Option<Zeroizing<Vec<u8>>>,
+    // Defaults to Secp256k1Tr so shares written before this field existed parse unchanged.
+    #[serde(default)]
+    ciphersuite: keep_core::frost::Ciphersuite,
 }
 
 #[uniffi::export(with_foreign)]
@@ -624,6 +627,12 @@ impl KeepMobile {
         let passphrase = Zeroizing::new(passphrase);
         let export = ShareExport::parse(&data)
             .map_err(|e| KeepMobileError::InvalidShare { msg: e.to_string() })?;
+
+        if export.ciphersuite != keep_core::frost::Ciphersuite::Secp256k1Tr {
+            return Err(KeepMobileError::InvalidShare {
+                msg: "Only secp256k1 (Bitcoin/Nostr) shares are supported on mobile".into(),
+            });
+        }
 
         let share = export
             .to_share(&passphrase, &name)
@@ -1795,7 +1804,7 @@ impl KeepMobile {
                 did_backup: share_meta.did_backup,
                 key_package: hex::encode(&stored.key_package_bytes),
                 pubkey_package: hex::encode(&stored.pubkey_package_bytes),
-                ciphersuite: keep_core::frost::Ciphersuite::Secp256k1Tr,
+                ciphersuite: stored.ciphersuite,
             });
         }
 
@@ -2049,6 +2058,7 @@ impl KeepMobile {
                 ),
                 pubkey_package_bytes,
                 plaintext_mnemonic: None,
+                ciphersuite: bs.ciphersuite,
             };
 
             let serialized = serde_json::to_vec(&stored)
@@ -2659,6 +2669,7 @@ impl KeepMobile {
                 }
             })?,
             plaintext_mnemonic,
+            ciphersuite: keep_core::frost::Ciphersuite::Secp256k1Tr,
         };
 
         Ok((metadata_info, stored))
@@ -2758,6 +2769,7 @@ impl KeepMobile {
                     msg: format!("Serialization failed: {e}"),
                 })?,
             plaintext_mnemonic: None,
+            ciphersuite: keep_core::frost::Ciphersuite::Secp256k1Tr,
         };
 
         let serialized = serde_json::to_vec(&stored)
@@ -3197,6 +3209,12 @@ impl KeepMobile {
             if display_name != metadata.name {
                 metadata.name = display_name;
             }
+        }
+
+        if stored.ciphersuite != keep_core::frost::Ciphersuite::Secp256k1Tr {
+            return Err(KeepMobileError::InvalidShare {
+                msg: "Only secp256k1 (Bitcoin/Nostr) shares are supported on mobile".into(),
+            });
         }
 
         let key_package = frost_secp256k1_tr::keys::KeyPackage::deserialize(

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1795,6 +1795,7 @@ impl KeepMobile {
                 did_backup: share_meta.did_backup,
                 key_package: hex::encode(&stored.key_package_bytes),
                 pubkey_package: hex::encode(&stored.pubkey_package_bytes),
+                ciphersuite: keep_core::frost::Ciphersuite::Secp256k1Tr,
             });
         }
 

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -2018,6 +2018,13 @@ impl KeepMobile {
         let mut prepared_health: Vec<KeyHealthStatusInfo> = Vec::new();
 
         for bs in &decrypted.shares {
+            if bs.ciphersuite != keep_core::frost::Ciphersuite::Secp256k1Tr {
+                tracing::warn!(
+                    name = %bs.name,
+                    "skipping non-secp256k1 share during restore: unsupported on mobile"
+                );
+                continue;
+            }
             let mut key_package_bytes = Zeroizing::new(decode_hex(&bs.key_package, "key_package")?);
             let pubkey_package_bytes = decode_hex(&bs.pubkey_package, "pubkey_package")?;
             let group_pubkey_bytes = decode_hex(&bs.group_pubkey, "group_pubkey")?;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Ed25519 FROST support with minisign-compatible detached signatures, plus file sign/verify CLI and public-key export.

* **Compatibility / Storage**
  * Share exports, backups and on-disk blobs are now ciphersuite-tagged and versioned; encryption binds ciphersuite metadata.

* **Mobile**
  * Mobile app enforces secp256k1-only shares and rejects non-secp256k1 imports.

* **Release / Verification**
  * Release signing and verification workflow added, with docs describing minisign-compatible verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->