### PR TITLE
keep-web: always-on network-FROST co-signer daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "keep-agent"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "chrono",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "keep-bitcoin"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitcoin",
  "getrandom 0.4.2",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "keep-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4229,7 +4229,7 @@ dependencies = [
 
 [[package]]
 name = "keep-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aes",
  "argon2",
@@ -4273,7 +4273,7 @@ dependencies = [
 
 [[package]]
 name = "keep-desktop"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4306,14 +4306,14 @@ dependencies = [
 
 [[package]]
 name = "keep-enclave"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "keep-enclave-host",
 ]
 
 [[package]]
 name = "keep-enclave-host"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -4344,7 +4344,7 @@ dependencies = [
 
 [[package]]
 name = "keep-frost-net"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "keep-mobile"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4412,7 +4412,7 @@ dependencies = [
 
 [[package]]
 name = "keep-nip46"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitflags 2.11.0",
  "chrono",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "keep-web"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "axum",
  "keep-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-socks",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.2",
  "url",
  "wasm-bindgen",
  "web-sys",
@@ -633,6 +633,61 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "base64 0.22.1",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite 0.29.0",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3378,10 +3433,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
@@ -3405,6 +3472,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -4369,6 +4437,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "keep-web"
+version = "0.3.0"
+dependencies = [
+ "axum",
+ "keep-core",
+ "keep-frost-net",
+ "keep-nip46",
+ "nostr-sdk",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4741,6 +4826,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4867,6 +4958,22 @@ dependencies = [
  "log",
  "objc",
  "paste",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -7496,6 +7603,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8385,8 +8503,33 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.26.2",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -8507,6 +8650,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -8517,14 +8661,24 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
  "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -8681,6 +8835,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8717,6 +8887,12 @@ checksum = "4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e"
 dependencies = [
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "keep-nip46",
     "keep-mobile",
     "keep-desktop",
+    "keep-web",
 ]
 exclude = [
     "keep-enclave/enclave",

--- a/keep-bitcoin/Cargo.toml
+++ b/keep-bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keep-bitcoin"
-version = "0.3.0"
+version.workspace = true
 edition = "2021"
 rust-version = "1.89"
 description = "Bitcoin PSBT and Taproot support for Keep"

--- a/keep-cli/Cargo.toml
+++ b/keep-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keep-cli"
-version = "0.3.0"
+version.workspace = true
 edition = "2021"
 description = "CLI for Keep - sovereign key management for Nostr and Bitcoin"
 license = "MIT"

--- a/keep-core/Cargo.toml
+++ b/keep-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keep-core"
-version = "0.3.0"
+version.workspace = true
 edition = "2021"
 rust-version = "1.89"
 description = "Core library for Keep - sovereign key management for Nostr and Bitcoin"

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -623,6 +623,9 @@ impl Keep {
         identifier: u16,
         name: &str,
     ) -> Result<()> {
+        if !self.is_unlocked() {
+            return Err(KeepError::Locked);
+        }
         let name = name.trim();
         if name.is_empty() {
             return Err(KeepError::InvalidInput(

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -616,6 +616,30 @@ impl Keep {
         Ok(())
     }
 
+    /// Rename a stored FROST share (updates its display name only).
+    pub fn frost_rename_share(
+        &mut self,
+        group_pubkey: &[u8; 32],
+        identifier: u16,
+        name: &str,
+    ) -> Result<()> {
+        let name = name.trim();
+        if name.is_empty() {
+            return Err(KeepError::InvalidInput(
+                "share name must not be empty".into(),
+            ));
+        }
+        if name.chars().count() > 64 {
+            return Err(KeepError::InvalidInput(
+                "share name must not exceed 64 characters".into(),
+            ));
+        }
+        let mut stored = self.find_stored_share(group_pubkey, identifier)?;
+        stored.metadata.name = name.to_string();
+        self.storage.store_share(&stored)?;
+        Ok(())
+    }
+
     /// Get the hex-encoded group pubkey of the active share, if set.
     pub fn get_active_share_key(&self) -> Option<String> {
         std::fs::read_to_string(self.active_share_path())

--- a/keep-enclave/Cargo.toml
+++ b/keep-enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keep-enclave"
-version = "0.3.0"
+version.workspace = true
 edition = "2021"
 rust-version = "1.89"
 description = "AWS Nitro Enclave signer for Keep"

--- a/keep-enclave/enclave/Cargo.toml
+++ b/keep-enclave/enclave/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "keep-enclave-bin"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.89"
 description = "AWS Nitro Enclave binary for Keep"

--- a/keep-enclave/host/Cargo.toml
+++ b/keep-enclave/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keep-enclave-host"
-version = "0.3.0"
+version.workspace = true
 edition = "2021"
 rust-version = "1.89"
 description = "Host-side enclave client for Keep"

--- a/keep-frost-net/Cargo.toml
+++ b/keep-frost-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keep-frost-net"
-version = "0.3.0"
+version.workspace = true
 edition = "2021"
 rust-version = "1.89"
 description = "FROST coordination protocol over nostr for Keep"

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1130,7 +1130,11 @@ impl KfpNode {
 
         self.announce().await?;
 
-        let mut announce_interval = tokio::time::interval(Duration::from_secs(60));
+        // Re-announce often enough that an initiator with a short discovery
+        // window reliably catches a periodic announce even if the immediate
+        // reciprocal announce (see handle_announce) is missed. Must stay well
+        // under PEER_OFFLINE_THRESHOLD so peers don't flap offline.
+        let mut announce_interval = tokio::time::interval(Duration::from_secs(20));
         announce_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         let mut cleanup_interval = tokio::time::interval(Duration::from_secs(120));
@@ -1458,12 +1462,25 @@ impl KfpNode {
             name: name_clone,
         });
 
-        // A newly discovered peer may have come online after we last replenished
-        // (whose broadcast only carries freshly generated commitments). Send it
-        // our currently available pool so it can instant-sign with us right away.
-        if is_new_peer && self.can_send_to(&pubkey) {
-            if let Err(e) = self.send_nonce_pool_to(&pubkey).await {
-                warn!(peer = %pubkey, error = %e, "Failed to send nonce pool to new peer");
+        if is_new_peer {
+            // Reciprocate our own announcement so the new peer discovers us
+            // right away, instead of waiting for our next periodic re-announce.
+            // Without this, an initiator's short discovery window can miss an
+            // already-online co-signer. Gated on `is_new_peer` so the exchange
+            // terminates: once a peer knows us, our announce no longer looks
+            // new to it and it won't reciprocate again.
+            if let Err(e) = self.announce().await {
+                warn!(peer = %pubkey, error = %e, "Failed to reciprocate announce to new peer");
+            }
+
+            // A newly discovered peer may have come online after we last
+            // replenished (whose broadcast only carries freshly generated
+            // commitments). Send it our current pool so it can instant-sign
+            // with us right away.
+            if self.can_send_to(&pubkey) {
+                if let Err(e) = self.send_nonce_pool_to(&pubkey).await {
+                    warn!(peer = %pubkey, error = %e, "Failed to send nonce pool to new peer");
+                }
             }
         }
 

--- a/keep-mobile/Cargo.toml
+++ b/keep-mobile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keep-mobile"
-version = "0.3.0"
+version.workspace = true
 edition = "2021"
 rust-version = "1.89"
 description = "UniFFI bindings for Keep mobile platforms"

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -99,6 +99,11 @@ pub struct SignerHandler {
     new_conn_timestamps: Mutex<VecDeque<Instant>>,
     expected_secret: Option<Zeroizing<String>>,
     auto_approve: bool,
+    /// Permissions granted to a client that connects without requesting any
+    /// (many clients, e.g. nostr-tools, send no `connect` permissions). The
+    /// act of approving the connection is the grant. Defaults to the
+    /// least-privilege `Permission::DEFAULT`.
+    connect_grant: Permission,
     relay_urls: Vec<String>,
     kill_switch: Arc<AtomicBool>,
 }
@@ -122,6 +127,7 @@ impl SignerHandler {
             new_conn_timestamps: Mutex::new(VecDeque::new()),
             expected_secret: None,
             auto_approve: false,
+            connect_grant: Permission::DEFAULT,
             relay_urls: Vec::new(),
             kill_switch: Arc::new(AtomicBool::new(false)),
         }
@@ -129,6 +135,11 @@ impl SignerHandler {
 
     pub fn with_expected_secret(mut self, secret: String) -> Self {
         self.expected_secret = Some(Zeroizing::new(secret));
+        self
+    }
+
+    pub fn with_connect_grant(mut self, grant: Permission) -> Self {
+        self.connect_grant = grant;
         self
     }
 
@@ -316,7 +327,7 @@ impl SignerHandler {
         let (requested_perms, auto_kinds) = permissions
             .as_deref()
             .map(parse_permission_string)
-            .unwrap_or((Permission::DEFAULT, HashSet::new()));
+            .unwrap_or((self.connect_grant, HashSet::new()));
 
         let mut pm = self.permissions.lock().await;
         if !pm.connect_with_permissions(app_pubkey, name.clone(), requested_perms, auto_kinds) {
@@ -594,7 +605,7 @@ impl SignerHandler {
 
         let (requested_perms, auto_kinds) = permissions_str
             .map(parse_permission_string)
-            .unwrap_or((Permission::DEFAULT, HashSet::new()));
+            .unwrap_or((self.connect_grant, HashSet::new()));
 
         let mut pm = self.permissions.lock().await;
         if !pm.connect_with_permissions(app_pubkey, name.clone(), requested_perms, auto_kinds) {

--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -17,7 +17,7 @@ use crate::bunker::generate_bunker_url;
 use crate::error::Result;
 use crate::frost_signer::{FrostSigner, NetworkFrostSigner};
 use crate::handler::SignerHandler;
-use crate::permissions::PermissionManager;
+use crate::permissions::{Permission, PermissionManager};
 use crate::rate_limit::RateLimitConfig;
 use crate::types::{LogEvent, Nip46Request, Nip46Response, PartialEvent, ServerCallbacks};
 use keep_core::relay::TIMESTAMP_TWEAK_RANGE;
@@ -29,6 +29,11 @@ pub struct ServerConfig {
     pub auto_approve: bool,
     pub expected_secret: Option<String>,
     pub kill_switch: Option<Arc<AtomicBool>>,
+    /// Permissions granted when a client connects without requesting any.
+    /// Defaults to least-privilege `Permission::DEFAULT`; an always-on bunker
+    /// (keep-web) sets this to `Permission::ALL` so approving a connection lets
+    /// the client sign.
+    pub connect_grant: Permission,
 }
 
 impl Default for ServerConfig {
@@ -40,6 +45,7 @@ impl Default for ServerConfig {
             auto_approve: false,
             expected_secret: None,
             kill_switch: None,
+            connect_grant: Permission::DEFAULT,
         }
     }
 }
@@ -233,7 +239,8 @@ impl Server {
         let permissions = Arc::new(Mutex::new(PermissionManager::new()));
         let audit = Arc::new(Mutex::new(AuditLog::new(config.audit_log_capacity)));
         let mut handler = SignerHandler::new(keyring, permissions, audit, callbacks.clone())
-            .with_auto_approve(config.auto_approve);
+            .with_auto_approve(config.auto_approve)
+            .with_connect_grant(config.connect_grant);
         if let Some(frost) = frost_signer {
             handler = handler.with_frost_signer(frost);
         }
@@ -330,7 +337,8 @@ impl Server {
         let audit = Arc::new(Mutex::new(AuditLog::new(config.audit_log_capacity)));
         let handler = SignerHandler::new(keyring, permissions, audit, callbacks.clone())
             .with_network_frost_signer(network_signer)
-            .with_auto_approve(config.auto_approve);
+            .with_auto_approve(config.auto_approve)
+            .with_connect_grant(config.connect_grant);
         let (handler, bunker_secret) = finalize_handler(handler, &config, relay_urls);
 
         Ok(Self::build(

--- a/keep-web/Cargo.toml
+++ b/keep-web/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "keep-web"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Web admin + NIP-46 bunker daemon for Keep (StartOS deployment)"
+
+[dependencies]
+keep-core = { path = "../keep-core" }
+keep-nip46 = { path = "../keep-nip46" }
+keep-frost-net = { path = "../keep-frost-net" }
+
+axum = { version = "0.8", features = ["ws"] }
+tower-http = { version = "0.6", features = ["fs", "trace"] }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+nostr-sdk = { workspace = true }

--- a/keep-web/src/api.rs
+++ b/keep-web/src/api.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::Ordering;
+
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -7,6 +9,13 @@ use serde::{Deserialize, Serialize};
 use keep_core::frost::ShareExport;
 
 use crate::state::AppState;
+
+fn hex8(bytes: &[u8]) -> String {
+    bytes[..4.min(bytes.len())]
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
 
 pub async fn health() -> &'static str {
     "ok"
@@ -19,6 +28,7 @@ pub async fn bunker(State(state): State<AppState>) -> impl IntoResponse {
 #[derive(Serialize)]
 pub struct ShareDto {
     name: String,
+    group: String,
     identifier: u16,
     threshold: u16,
     total_shares: u16,
@@ -33,6 +43,7 @@ pub async fn shares(State(state): State<AppState>) -> impl IntoResponse {
                 .into_iter()
                 .map(|s| ShareDto {
                     name: s.metadata.name,
+                    group: keep_core::keys::bytes_to_npub(&s.metadata.group_pubkey),
                     identifier: s.metadata.identifier,
                     threshold: s.metadata.threshold,
                     total_shares: s.metadata.total_shares,
@@ -43,6 +54,130 @@ pub async fn shares(State(state): State<AppState>) -> impl IntoResponse {
         }
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
+}
+
+#[derive(Deserialize)]
+pub struct ShareRef {
+    pub group: String,
+    pub identifier: u16,
+}
+
+/// Exports a stored share, re-encrypted under `passphrase`, as a bech32
+/// `kshare1…` string for backup or migration.
+pub async fn export_share(
+    State(state): State<AppState>,
+    Json(body): Json<ExportRequest>,
+) -> impl IntoResponse {
+    let group = match keep_core::keys::npub_to_bytes(&body.group) {
+        Ok(g) => g,
+        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+    };
+    let mut keep = state.keep.lock().await;
+    match keep.frost_export_share(&group, body.identifier, &body.passphrase) {
+        Ok(export) => match export.to_bech32() {
+            Ok(s) => Json(ExportResponse { export: s }).into_response(),
+            Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        },
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ExportRequest {
+    pub group: String,
+    pub identifier: u16,
+    pub passphrase: String,
+}
+
+#[derive(Serialize)]
+pub struct ExportResponse {
+    pub export: String,
+}
+
+/// Permanently deletes a stored share.
+pub async fn delete_share(
+    State(state): State<AppState>,
+    Json(body): Json<ShareRef>,
+) -> impl IntoResponse {
+    let group = match keep_core::keys::npub_to_bytes(&body.group) {
+        Ok(g) => g,
+        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+    };
+    let mut keep = state.keep.lock().await;
+    match keep.frost_delete_share(&group, body.identifier) {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+#[derive(Serialize)]
+pub struct SigningEntryDto {
+    timestamp_ms: u64,
+    session: String,
+    operation: String,
+    participants: Vec<u16>,
+    our_index: u16,
+}
+
+#[derive(Serialize)]
+pub struct SigningLogResponse {
+    verified: bool,
+    entries: Vec<SigningEntryDto>,
+}
+
+/// Returns the FROST node's tamper-evident signing audit log (network mode).
+pub async fn signing_log(State(state): State<AppState>) -> impl IntoResponse {
+    let Some(node) = state.node.as_ref() else {
+        return Json(SigningLogResponse {
+            verified: true,
+            entries: Vec::new(),
+        })
+        .into_response();
+    };
+    let log = node.audit_log();
+    let verified = log.verify_all();
+    let mut entries: Vec<SigningEntryDto> = log
+        .entries()
+        .into_iter()
+        .map(|e| SigningEntryDto {
+            timestamp_ms: e.timestamp_ms,
+            session: hex8(&e.session_id),
+            operation: format!("{:?}", e.operation),
+            participants: e.participant_indices,
+            our_index: e.our_index,
+        })
+        .collect();
+    entries.reverse();
+    Json(SigningLogResponse { verified, entries }).into_response()
+}
+
+#[derive(Serialize)]
+pub struct KillswitchStatus {
+    enabled: bool,
+}
+
+pub async fn killswitch_status(State(state): State<AppState>) -> impl IntoResponse {
+    Json(KillswitchStatus {
+        enabled: state.signing_enabled.load(Ordering::Relaxed),
+    })
+}
+
+#[derive(Deserialize)]
+pub struct KillswitchRequest {
+    pub enabled: bool,
+}
+
+/// Toggles co-signing live, with no restart — the policy hook reads this on
+/// every round.
+pub async fn set_killswitch(
+    State(state): State<AppState>,
+    Json(body): Json<KillswitchRequest>,
+) -> impl IntoResponse {
+    state.signing_enabled.store(body.enabled, Ordering::Relaxed);
+    tracing::warn!(enabled = body.enabled, "co-signing toggled via kill switch");
+    Json(KillswitchStatus {
+        enabled: body.enabled,
+    })
 }
 
 #[derive(Deserialize)]

--- a/keep-web/src/api.rs
+++ b/keep-web/src/api.rs
@@ -1,0 +1,64 @@
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::state::AppState;
+
+pub async fn health() -> &'static str {
+    "ok"
+}
+
+pub async fn bunker(State(state): State<AppState>) -> impl IntoResponse {
+    Json(state.bunker.clone())
+}
+
+#[derive(Serialize)]
+pub struct ShareDto {
+    name: String,
+    identifier: u16,
+    threshold: u16,
+    total_shares: u16,
+    sign_count: u64,
+}
+
+pub async fn shares(State(state): State<AppState>) -> impl IntoResponse {
+    let keep = state.keep.lock().await;
+    match keep.frost_list_shares() {
+        Ok(shares) => {
+            let dto: Vec<ShareDto> = shares
+                .into_iter()
+                .map(|s| ShareDto {
+                    name: s.metadata.name,
+                    identifier: s.metadata.identifier,
+                    threshold: s.metadata.threshold,
+                    total_shares: s.metadata.total_shares,
+                    sign_count: s.metadata.sign_count,
+                })
+                .collect();
+            Json(dto).into_response()
+        }
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ApprovalDecision {
+    pub approve: bool,
+}
+
+pub async fn resolve_approval(
+    State(state): State<AppState>,
+    Path(id): Path<u64>,
+    Json(body): Json<ApprovalDecision>,
+) -> impl IntoResponse {
+    let sender = state.approvals.lock().ok().and_then(|mut m| m.remove(&id));
+    match sender {
+        Some(tx) => match tx.send(body.approve) {
+            Ok(()) => StatusCode::NO_CONTENT,
+            Err(_) => StatusCode::GONE,
+        },
+        None => StatusCode::NOT_FOUND,
+    }
+}

--- a/keep-web/src/api.rs
+++ b/keep-web/src/api.rs
@@ -4,6 +4,8 @@ use axum::response::IntoResponse;
 use axum::Json;
 use serde::{Deserialize, Serialize};
 
+use keep_core::frost::ShareExport;
+
 use crate::state::AppState;
 
 pub async fn health() -> &'static str {
@@ -39,6 +41,34 @@ pub async fn shares(State(state): State<AppState>) -> impl IntoResponse {
                 .collect();
             Json(dto).into_response()
         }
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ImportRequest {
+    pub data: String,
+    pub passphrase: String,
+    pub name: Option<String>,
+}
+
+/// Imports a FROST share export (bech32 `kshare1…` or JSON) into the vault.
+///
+/// The share is persisted immediately and appears in `GET /api/shares`. The
+/// running bunker only loads shares at startup, so signing with a newly
+/// imported share requires a service restart.
+pub async fn import_share(
+    State(state): State<AppState>,
+    Json(body): Json<ImportRequest>,
+) -> impl IntoResponse {
+    let export = match ShareExport::parse(body.data.trim()) {
+        Ok(e) => e,
+        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+    };
+    let name = body.name.unwrap_or_else(|| "imported".to_string());
+    let mut keep = state.keep.lock().await;
+    match keep.frost_import_share(&export, &body.passphrase, &name) {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }

--- a/keep-web/src/api.rs
+++ b/keep-web/src/api.rs
@@ -33,6 +33,9 @@ pub struct ShareDto {
     threshold: u16,
     total_shares: u16,
     sign_count: u64,
+    created_at: i64,
+    last_used: Option<i64>,
+    did_backup: bool,
 }
 
 pub async fn shares(State(state): State<AppState>) -> impl IntoResponse {
@@ -48,6 +51,9 @@ pub async fn shares(State(state): State<AppState>) -> impl IntoResponse {
                     threshold: s.metadata.threshold,
                     total_shares: s.metadata.total_shares,
                     sign_count: s.metadata.sign_count,
+                    created_at: s.metadata.created_at,
+                    last_used: s.metadata.last_used,
+                    did_backup: s.metadata.did_backup,
                 })
                 .collect();
             Json(dto).into_response()
@@ -60,6 +66,29 @@ pub async fn shares(State(state): State<AppState>) -> impl IntoResponse {
 pub struct ShareRef {
     pub group: String,
     pub identifier: u16,
+}
+
+#[derive(Deserialize)]
+pub struct RenameRequest {
+    pub group: String,
+    pub identifier: u16,
+    pub name: String,
+}
+
+/// Renames a stored share.
+pub async fn rename_share(
+    State(state): State<AppState>,
+    Json(body): Json<RenameRequest>,
+) -> impl IntoResponse {
+    let group = match keep_core::keys::npub_to_bytes(&body.group) {
+        Ok(g) => g,
+        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+    };
+    let mut keep = state.keep.lock().await;
+    match keep.frost_rename_share(&group, body.identifier, &body.name) {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+    }
 }
 
 /// Exports a stored share, re-encrypted under `passphrase`, as a bech32

--- a/keep-web/src/api.rs
+++ b/keep-web/src/api.rs
@@ -6,9 +6,20 @@ use axum::response::IntoResponse;
 use axum::Json;
 use serde::{Deserialize, Serialize};
 
+use keep_core::error::KeepError;
 use keep_core::frost::ShareExport;
 
 use crate::state::AppState;
+
+/// Map a keep-core error to an HTTP status: client errors (bad input, missing
+/// share) vs. server-side failures (storage/IO/crypto).
+fn err_status(e: &KeepError) -> StatusCode {
+    match e {
+        KeepError::InvalidInput(_) => StatusCode::BAD_REQUEST,
+        KeepError::KeyNotFound(_) | KeepError::NotFound(_) => StatusCode::NOT_FOUND,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
 
 fn hex8(bytes: &[u8]) -> String {
     bytes[..4.min(bytes.len())]
@@ -87,7 +98,7 @@ pub async fn rename_share(
     let mut keep = state.keep.lock().await;
     match keep.frost_rename_share(&group, body.identifier, &body.name) {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
-        Err(e) => (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+        Err(e) => (err_status(&e), e.to_string()).into_response(),
     }
 }
 
@@ -128,6 +139,16 @@ pub async fn delete_share(
     State(state): State<AppState>,
     Json(body): Json<ShareRef>,
 ) -> impl IntoResponse {
+    // Refuse to delete the share the running co-signer is using: the node holds
+    // it in memory and would keep signing with a share that's gone from disk,
+    // leaving an inconsistent state. The operator must reconfigure/stop first.
+    if state.bunker.group.as_deref() == Some(body.group.as_str()) {
+        return (
+            StatusCode::CONFLICT,
+            "cannot delete the active co-signer's share; reconfigure or stop the service first",
+        )
+            .into_response();
+    }
     let group = match keep_core::keys::npub_to_bytes(&body.group) {
         Ok(g) => g,
         Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
@@ -135,7 +156,7 @@ pub async fn delete_share(
     let mut keep = state.keep.lock().await;
     match keep.frost_delete_share(&group, body.identifier) {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        Err(e) => (err_status(&e), e.to_string()).into_response(),
     }
 }
 
@@ -247,7 +268,11 @@ pub async fn resolve_approval(
     Path(id): Path<u64>,
     Json(body): Json<ApprovalDecision>,
 ) -> impl IntoResponse {
-    let sender = state.approvals.lock().ok().and_then(|mut m| m.remove(&id));
+    let sender = match state.approvals.lock() {
+        Ok(mut m) => m.remove(&id),
+        // A poisoned mutex is a server-side failure, not a missing approval.
+        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR,
+    };
     match sender {
         Some(tx) => match tx.send(body.approve) {
             Ok(()) => StatusCode::NO_CONTENT,

--- a/keep-web/src/bunker.rs
+++ b/keep-web/src/bunker.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::mpsc::{channel, Sender};
+use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
@@ -16,6 +16,22 @@ use keep_nip46::{NetworkFrostSigner, Permission, Server, ServerConfig};
 use crate::state::{BunkerInfo, Event};
 
 const APPROVAL_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// How long the main thread waits for the bunker thread to report startup
+/// before giving up (relay connect + announce + server bind). Bounded so a
+/// hung startup surfaces a clear error instead of blocking the daemon forever.
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(45);
+
+fn recv_startup<T>(rx: Receiver<Result<T, String>>) -> Result<T, String> {
+    match rx.recv_timeout(STARTUP_TIMEOUT) {
+        Ok(res) => res,
+        Err(RecvTimeoutError::Timeout) => Err(format!(
+            "bunker did not start within {}s",
+            STARTUP_TIMEOUT.as_secs()
+        )),
+        Err(RecvTimeoutError::Disconnected) => Err("bunker thread terminated before start".into()),
+    }
+}
 
 /// Bridges the bunker's NIP-46 client callbacks onto the web event stream.
 ///
@@ -229,9 +245,7 @@ pub fn spawn_network_frost(
         });
     });
 
-    info_rx
-        .recv()
-        .map_err(|_| "frost co-signer thread terminated before start".to_string())?
+    recv_startup(info_rx)
 }
 
 /// Spawns the single-key fallback bunker (no FROST group configured). The vault
@@ -295,7 +309,5 @@ pub fn spawn_single_key(
         });
     });
 
-    info_rx
-        .recv()
-        .map_err(|_| "bunker thread terminated before start".to_string())?
+    recv_startup(info_rx)
 }

--- a/keep-web/src/bunker.rs
+++ b/keep-web/src/bunker.rs
@@ -1,0 +1,112 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{channel, Sender};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+
+use nostr_sdk::prelude::ToBech32;
+use tokio::sync::{broadcast, Mutex};
+
+use keep_core::keyring::Keyring;
+use keep_nip46::types::{ApprovalRequest, LogEvent, ServerCallbacks};
+use keep_nip46::Server;
+
+use crate::state::{BunkerInfo, Event};
+
+const APPROVAL_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Bridges the bunker's signing callbacks onto the web event stream.
+///
+/// `on_log` fans out to every connected browser; `request_approval` parks the
+/// signing thread on a channel until a `POST /api/approvals/:id` resolves it
+/// (or it times out), mirroring the desktop approval flow.
+struct WebCallbacks {
+    events: broadcast::Sender<Event>,
+    approvals: Arc<StdMutex<HashMap<u64, Sender<bool>>>>,
+    next_id: AtomicU64,
+}
+
+impl ServerCallbacks for WebCallbacks {
+    fn on_log(&self, event: LogEvent) {
+        let _ = self.events.send(Event::Log {
+            app: event.app,
+            action: event.action,
+            success: event.success,
+            detail: event.detail,
+        });
+    }
+
+    fn request_approval(&self, request: ApprovalRequest) -> bool {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = channel();
+        if let Ok(mut map) = self.approvals.lock() {
+            map.insert(id, tx);
+        }
+
+        let _ = self.events.send(Event::Approval {
+            id,
+            app: request.app_name,
+            method: request.method,
+            kind: request.event_kind.map(|k| k.as_u16()),
+            preview: request.event_content,
+        });
+
+        let decision =
+            tokio::task::block_in_place(|| rx.recv_timeout(APPROVAL_TIMEOUT).unwrap_or(false));
+        if let Ok(mut map) = self.approvals.lock() {
+            map.remove(&id);
+        }
+        decision
+    }
+}
+
+/// Spawns the NIP-46 bunker on a dedicated thread+runtime (mirroring the CLI
+/// `serve` path, where the server is not `Send`) and returns its connection
+/// details once it has started.
+pub fn spawn(
+    keyring: Arc<Mutex<Keyring>>,
+    relay: String,
+    events: broadcast::Sender<Event>,
+    approvals: Arc<StdMutex<HashMap<u64, Sender<bool>>>>,
+) -> Result<BunkerInfo, String> {
+    let (info_tx, info_rx) = channel::<Result<BunkerInfo, String>>();
+
+    std::thread::spawn(move || {
+        let rt = match tokio::runtime::Runtime::new() {
+            Ok(rt) => rt,
+            Err(e) => {
+                let _ = info_tx.send(Err(format!("tokio runtime: {e}")));
+                return;
+            }
+        };
+        rt.block_on(async move {
+            let callbacks: Arc<dyn ServerCallbacks> = Arc::new(WebCallbacks {
+                events,
+                approvals,
+                next_id: AtomicU64::new(1),
+            });
+            let mut server =
+                match Server::new(keyring, std::slice::from_ref(&relay), Some(callbacks)).await {
+                    Ok(s) => s,
+                    Err(e) => {
+                        let _ = info_tx.send(Err(format!("bunker start: {e}")));
+                        return;
+                    }
+                };
+            let info = BunkerInfo {
+                url: server.bunker_url(),
+                npub: server.pubkey().to_bech32().unwrap_or_default(),
+                relay,
+            };
+            let _ = info_tx.send(Ok(info));
+
+            if let Err(e) = server.run().await {
+                tracing::error!(error = %e, "bunker exited");
+            }
+        });
+    });
+
+    info_rx
+        .recv()
+        .map_err(|_| "bunker thread terminated before start".to_string())?
+}

--- a/keep-web/src/bunker.rs
+++ b/keep-web/src/bunker.rs
@@ -11,7 +11,7 @@ use keep_core::frost::SharePackage;
 use keep_core::keyring::Keyring;
 use keep_frost_net::{KfpNode, SessionInfo, SigningHooks};
 use keep_nip46::types::{ApprovalRequest, LogEvent, ServerCallbacks};
-use keep_nip46::{NetworkFrostSigner, Server, ServerConfig};
+use keep_nip46::{NetworkFrostSigner, Permission, Server, ServerConfig};
 
 use crate::state::{BunkerInfo, Event};
 
@@ -195,7 +195,10 @@ pub fn spawn_network_frost(
                 transport_key,
                 &cfg.bunker_relays,
                 Some(callbacks),
-                ServerConfig::default(),
+                ServerConfig {
+                    connect_grant: Permission::ALL,
+                    ..ServerConfig::default()
+                },
             )
             .await
             {
@@ -256,14 +259,25 @@ pub fn spawn_single_key(
                 approvals,
                 next_id: AtomicU64::new(1),
             });
-            let mut server =
-                match Server::new(keyring, std::slice::from_ref(&relay), Some(callbacks)).await {
-                    Ok(s) => s,
-                    Err(e) => {
-                        let _ = info_tx.send(Err(format!("bunker start: {e}")));
-                        return;
-                    }
-                };
+            let mut server = match Server::new_with_config(
+                keyring,
+                None,
+                None,
+                std::slice::from_ref(&relay),
+                Some(callbacks),
+                ServerConfig {
+                    connect_grant: Permission::ALL,
+                    ..ServerConfig::default()
+                },
+            )
+            .await
+            {
+                Ok(s) => s,
+                Err(e) => {
+                    let _ = info_tx.send(Err(format!("bunker start: {e}")));
+                    return;
+                }
+            };
             let info = BunkerInfo {
                 mode: "single-key".into(),
                 url: server.bunker_url(),

--- a/keep-web/src/bunker.rs
+++ b/keep-web/src/bunker.rs
@@ -7,19 +7,21 @@ use std::time::Duration;
 use nostr_sdk::prelude::ToBech32;
 use tokio::sync::{broadcast, Mutex};
 
+use keep_core::frost::SharePackage;
 use keep_core::keyring::Keyring;
+use keep_frost_net::{KfpNode, SessionInfo, SigningHooks};
 use keep_nip46::types::{ApprovalRequest, LogEvent, ServerCallbacks};
-use keep_nip46::Server;
+use keep_nip46::{NetworkFrostSigner, Server, ServerConfig};
 
 use crate::state::{BunkerInfo, Event};
 
 const APPROVAL_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Bridges the bunker's signing callbacks onto the web event stream.
+/// Bridges the bunker's NIP-46 client callbacks onto the web event stream.
 ///
 /// `on_log` fans out to every connected browser; `request_approval` parks the
-/// signing thread on a channel until a `POST /api/approvals/:id` resolves it
-/// (or it times out), mirroring the desktop approval flow.
+/// signing thread until a `POST /api/approvals/:id` resolves it (or it times
+/// out). This gates requests from NIP-46 *clients* that connect to this box.
 struct WebCallbacks {
     events: broadcast::Sender<Event>,
     approvals: Arc<StdMutex<HashMap<u64, Sender<bool>>>>,
@@ -60,10 +62,169 @@ impl ServerCallbacks for WebCallbacks {
     }
 }
 
-/// Spawns the NIP-46 bunker on a dedicated thread+runtime (mirroring the CLI
-/// `serve` path, where the server is not `Send`) and returns its connection
-/// details once it has started.
-pub fn spawn(
+fn short_id(id: &[u8; 32]) -> String {
+    id[..4].iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Policy gate for this node's participation in peer-initiated FROST rounds.
+///
+/// The always-on co-signer auto-participates within policy rather than
+/// prompting a human (the human approval happens on the *initiating* device).
+/// `auto_approve = false` acts as a kill switch: the node refuses to co-sign.
+/// Every decision is streamed to the web UI for observability.
+struct CoSignerPolicy {
+    events: broadcast::Sender<Event>,
+    auto_approve: bool,
+}
+
+impl SigningHooks for CoSignerPolicy {
+    fn pre_sign(&self, session: &SessionInfo) -> keep_frost_net::Result<()> {
+        let detail = format!(
+            "session {} · {}-of-{} · {} participants",
+            short_id(&session.session_id),
+            session.threshold,
+            session.participants.len(),
+            session.participants.len(),
+        );
+        if self.auto_approve {
+            let _ = self.events.send(Event::Log {
+                app: "frost".into(),
+                action: "co-signing".into(),
+                success: true,
+                detail: Some(detail),
+            });
+            Ok(())
+        } else {
+            let _ = self.events.send(Event::Log {
+                app: "frost".into(),
+                action: "refused (co-signing disabled)".into(),
+                success: false,
+                detail: Some(detail),
+            });
+            Err(keep_frost_net::FrostNetError::PolicyViolation(
+                "co-signing disabled".into(),
+            ))
+        }
+    }
+
+    fn post_sign(&self, session: &SessionInfo, _signature: &[u8; 64]) {
+        let _ = self.events.send(Event::Log {
+            app: "frost".into(),
+            action: "co-signed".into(),
+            success: true,
+            detail: Some(format!("session {}", short_id(&session.session_id))),
+        });
+    }
+}
+
+/// Parameters for the always-on network-FROST co-signer.
+pub struct NetworkConfig {
+    pub share: SharePackage,
+    pub group_pubkey: [u8; 32],
+    pub group_npub: String,
+    pub frost_relays: Vec<String>,
+    pub bunker_relays: Vec<String>,
+    pub auto_approve: bool,
+}
+
+/// Spawns the always-on network-FROST co-signer: a long-lived `KfpNode` that
+/// holds one share and coordinates with peers over the FROST relays, fronted by
+/// a NIP-46 bunker on the bunker relays. Runs on a dedicated thread+runtime
+/// (the server/node are driven by a non-`Send` event loop, mirroring the CLI).
+pub fn spawn_network_frost(
+    cfg: NetworkConfig,
+    events: broadcast::Sender<Event>,
+    approvals: Arc<StdMutex<HashMap<u64, Sender<bool>>>>,
+) -> Result<BunkerInfo, String> {
+    let (info_tx, info_rx) = channel::<Result<BunkerInfo, String>>();
+
+    std::thread::spawn(move || {
+        let rt = match tokio::runtime::Runtime::new() {
+            Ok(rt) => rt,
+            Err(e) => {
+                let _ = info_tx.send(Err(format!("tokio runtime: {e}")));
+                return;
+            }
+        };
+        rt.block_on(async move {
+            let threshold = cfg.share.metadata.threshold;
+            let total = cfg.share.metadata.total_shares;
+
+            let node = match KfpNode::new(cfg.share, cfg.frost_relays.clone()).await {
+                Ok(n) => Arc::new(n),
+                Err(e) => {
+                    let _ = info_tx.send(Err(format!("frost node: {e}")));
+                    return;
+                }
+            };
+
+            node.set_hooks(Arc::new(CoSignerPolicy {
+                events: events.clone(),
+                auto_approve: cfg.auto_approve,
+            }));
+
+            if let Err(e) = node.announce().await {
+                let _ = info_tx.send(Err(format!("announce: {e}")));
+                return;
+            }
+
+            let node_for_run = node.clone();
+            tokio::spawn(async move {
+                if let Err(e) = node_for_run.run().await {
+                    tracing::error!(error = %e, "frost node exited");
+                }
+            });
+
+            let signer = NetworkFrostSigner::with_shared_node(cfg.group_pubkey, node);
+            let transport_key: [u8; 32] = keep_core::crypto::random_bytes();
+            let callbacks: Arc<dyn ServerCallbacks> = Arc::new(WebCallbacks {
+                events,
+                approvals,
+                next_id: AtomicU64::new(1),
+            });
+
+            let mut server = match Server::new_network_frost_with_config(
+                signer,
+                transport_key,
+                &cfg.bunker_relays,
+                Some(callbacks),
+                ServerConfig::default(),
+            )
+            .await
+            {
+                Ok(s) => s,
+                Err(e) => {
+                    let _ = info_tx.send(Err(format!("bunker start: {e}")));
+                    return;
+                }
+            };
+
+            let info = BunkerInfo {
+                mode: "network-frost".into(),
+                url: server.bunker_url(),
+                npub: server.pubkey().to_bech32().unwrap_or_default(),
+                relay: cfg.bunker_relays.first().cloned().unwrap_or_default(),
+                frost_relays: cfg.frost_relays,
+                group: Some(cfg.group_npub),
+                threshold: Some(format!("{threshold}-of-{total}")),
+            };
+            let _ = info_tx.send(Ok(info));
+
+            if let Err(e) = server.run().await {
+                tracing::error!(error = %e, "bunker exited");
+            }
+        });
+    });
+
+    info_rx
+        .recv()
+        .map_err(|_| "frost co-signer thread terminated before start".to_string())?
+}
+
+/// Spawns the single-key fallback bunker (no FROST group configured). The vault
+/// signs with its primary key directly — convenient, but the full key lives on
+/// this one box, so it does not provide threshold security.
+pub fn spawn_single_key(
     keyring: Arc<Mutex<Keyring>>,
     relay: String,
     events: broadcast::Sender<Event>,
@@ -94,9 +255,13 @@ pub fn spawn(
                     }
                 };
             let info = BunkerInfo {
+                mode: "single-key".into(),
                 url: server.bunker_url(),
                 npub: server.pubkey().to_bech32().unwrap_or_default(),
                 relay,
+                frost_relays: Vec::new(),
+                group: None,
+                threshold: None,
             };
             let _ = info_tx.send(Ok(info));
 

--- a/keep-web/src/bunker.rs
+++ b/keep-web/src/bunker.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{channel, Sender};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
@@ -70,11 +70,12 @@ fn short_id(id: &[u8; 32]) -> String {
 ///
 /// The always-on co-signer auto-participates within policy rather than
 /// prompting a human (the human approval happens on the *initiating* device).
-/// `auto_approve = false` acts as a kill switch: the node refuses to co-sign.
-/// Every decision is streamed to the web UI for observability.
+/// `enabled = false` is the kill switch: the node refuses to co-sign. The flag
+/// is shared with the API so it can be toggled live (no restart). Every
+/// decision is streamed to the web UI for observability.
 struct CoSignerPolicy {
     events: broadcast::Sender<Event>,
-    auto_approve: bool,
+    enabled: Arc<AtomicBool>,
 }
 
 impl SigningHooks for CoSignerPolicy {
@@ -85,7 +86,7 @@ impl SigningHooks for CoSignerPolicy {
             session.threshold,
             session.participants.len(),
         );
-        if self.auto_approve {
+        if self.enabled.load(Ordering::Relaxed) {
             let _ = self.events.send(Event::Log {
                 app: "frost".into(),
                 action: "co-signing".into(),
@@ -123,7 +124,13 @@ pub struct NetworkConfig {
     pub group_npub: String,
     pub frost_relays: Vec<String>,
     pub bunker_relays: Vec<String>,
-    pub auto_approve: bool,
+    pub enabled: Arc<AtomicBool>,
+}
+
+/// What `spawn_network_frost` reports back once the co-signer is up.
+pub struct NetworkHandle {
+    pub info: BunkerInfo,
+    pub node: Arc<KfpNode>,
 }
 
 /// Spawns the always-on network-FROST co-signer: a long-lived `KfpNode` that
@@ -134,8 +141,8 @@ pub fn spawn_network_frost(
     cfg: NetworkConfig,
     events: broadcast::Sender<Event>,
     approvals: Arc<StdMutex<HashMap<u64, Sender<bool>>>>,
-) -> Result<BunkerInfo, String> {
-    let (info_tx, info_rx) = channel::<Result<BunkerInfo, String>>();
+) -> Result<NetworkHandle, String> {
+    let (info_tx, info_rx) = channel::<Result<NetworkHandle, String>>();
 
     std::thread::spawn(move || {
         let rt = match tokio::runtime::Runtime::new() {
@@ -159,7 +166,7 @@ pub fn spawn_network_frost(
 
             node.set_hooks(Arc::new(CoSignerPolicy {
                 events: events.clone(),
-                auto_approve: cfg.auto_approve,
+                enabled: cfg.enabled,
             }));
 
             if let Err(e) = node.announce().await {
@@ -174,6 +181,7 @@ pub fn spawn_network_frost(
                 }
             });
 
+            let node_for_state = node.clone();
             let signer = NetworkFrostSigner::with_shared_node(cfg.group_pubkey, node);
             let transport_key: [u8; 32] = keep_core::crypto::random_bytes();
             let callbacks: Arc<dyn ServerCallbacks> = Arc::new(WebCallbacks {
@@ -207,7 +215,10 @@ pub fn spawn_network_frost(
                 group: Some(cfg.group_npub),
                 threshold: Some(format!("{threshold}-of-{total}")),
             };
-            let _ = info_tx.send(Ok(info));
+            let _ = info_tx.send(Ok(NetworkHandle {
+                info,
+                node: node_for_state,
+            }));
 
             if let Err(e) = server.run().await {
                 tracing::error!(error = %e, "bunker exited");

--- a/keep-web/src/bunker.rs
+++ b/keep-web/src/bunker.rs
@@ -80,10 +80,9 @@ struct CoSignerPolicy {
 impl SigningHooks for CoSignerPolicy {
     fn pre_sign(&self, session: &SessionInfo) -> keep_frost_net::Result<()> {
         let detail = format!(
-            "session {} · {}-of-{} · {} participants",
+            "session {} · threshold {} · {} participants",
             short_id(&session.session_id),
             session.threshold,
-            session.participants.len(),
             session.participants.len(),
         );
         if self.auto_approve {

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -175,6 +175,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/api/shares/import", post(api::import_share))
         .route("/api/shares/export", post(api::export_share))
         .route("/api/shares/delete", post(api::delete_share))
+        .route("/api/shares/rename", post(api::rename_share))
         .route("/api/signing-log", get(api::signing_log))
         .route(
             "/api/killswitch",

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -68,6 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/api/health", get(api::health))
         .route("/api/bunker", get(api::bunker))
         .route("/api/shares", get(api::shares))
+        .route("/api/shares/import", post(api::import_share))
         .route("/api/approvals/{id}", post(api::resolve_approval))
         .route("/api/events", get(ws::events))
         .fallback_service(static_files)

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -33,30 +33,35 @@ fn parse_relays(value: &str) -> Vec<String> {
 /// Resolve the FROST group to co-sign for: an explicit npub, else the single
 /// group present in the vault. Returns `None` (→ setup mode) when there is no
 /// share yet or the choice is ambiguous.
-fn resolve_group(keep: &Keep, explicit: Option<&str>) -> Option<([u8; 32], String)> {
+// `Ok(None)` means genuine first-run (no shares → setup mode); `Err` means
+// misconfiguration (bad KEEP_FROST_GROUP, or multiple groups with no choice)
+// and is fatal so the operator sees the problem instead of a silent setup mode.
+fn resolve_group(
+    keep: &Keep,
+    explicit: Option<&str>,
+) -> Result<Option<([u8; 32], String)>, String> {
     if let Some(npub) = explicit {
-        return match keep_core::keys::npub_to_bytes(npub) {
-            Ok(bytes) => Some((bytes, npub.to_string())),
-            Err(e) => {
-                tracing::warn!(error = %e, "invalid KEEP_FROST_GROUP npub");
-                None
-            }
-        };
+        let bytes = keep_core::keys::npub_to_bytes(npub)
+            .map_err(|e| format!("invalid KEEP_FROST_GROUP npub: {e}"))?;
+        return Ok(Some((bytes, npub.to_string())));
     }
-    let shares = keep.frost_list_shares().unwrap_or_default();
+    let shares = match keep.frost_list_shares() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(error = %e, "frost_list_shares failed; treating as no shares");
+            Vec::new()
+        }
+    };
     let mut groups: Vec<[u8; 32]> = shares.iter().map(|s| s.metadata.group_pubkey).collect();
     groups.sort();
     groups.dedup();
     match groups.as_slice() {
-        [g] => Some((*g, keep_core::keys::bytes_to_npub(g))),
-        [] => None,
-        _ => {
-            tracing::warn!(
-                count = groups.len(),
-                "multiple groups present; set KEEP_FROST_GROUP to choose one"
-            );
-            None
-        }
+        [g] => Ok(Some((*g, keep_core::keys::bytes_to_npub(g)))),
+        [] => Ok(None),
+        _ => Err(format!(
+            "multiple FROST groups present ({}); set KEEP_FROST_GROUP to choose one",
+            groups.len()
+        )),
     }
 }
 
@@ -104,7 +109,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // KEEP_FROST_GROUP, otherwise the single group present in the vault.
     // Auto-resolution avoids the chicken-and-egg of needing the group npub
     // before the share has been imported.
-    let resolved_group = resolve_group(&keep, frost_group.as_deref());
+    let resolved_group = resolve_group(&keep, frost_group.as_deref())?;
 
     let allow_single_key = env_or("KEEP_ALLOW_SINGLE_KEY", "false") == "true";
 
@@ -143,6 +148,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Explicit opt-in: sign with the vault's primary key alone (no
         // threshold security — the full key lives on this box).
         tracing::warn!("KEEP_ALLOW_SINGLE_KEY set; single-key bunker (no threshold security)");
+        // Transfer ownership of the keyring into the bunker thread; `keep`'s
+        // keyring is intentionally left empty afterwards (the bunker is the
+        // only thing that signs in this mode — don't read keep.keyring() below).
         let keyring = Arc::new(Mutex::new(std::mem::take(keep.keyring_mut())));
         let relay = bunker_relays.first().cloned().unwrap_or_default();
         bunker::spawn_single_key(keyring, relay, events.clone(), approvals.clone())

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let vault_path = PathBuf::from(env_or("KEEP_PATH", "/data"));
     let relay = env_or("KEEP_RELAY", "wss://relay.damus.io");
-    let ui_dir = PathBuf::from(env_or("KEEP_WEB_UI_DIR", "ui"));
+    let ui_dir = PathBuf::from(env_or("KEEP_WEB_UI_DIR", "ui/dist"));
     let listen: SocketAddr = env_or("KEEP_WEB_LISTEN", "0.0.0.0:8080").parse()?;
     let password = std::env::var("KEEP_PASSWORD")
         .map_err(|_| "KEEP_PASSWORD must be set for headless unlock")?;

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -97,6 +97,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let (events, _) = broadcast::channel(256);
     let approvals = Arc::new(StdMutex::new(HashMap::new()));
+    // Kill switch shared with the co-signer policy; starts from the env default.
+    let signing_enabled = Arc::new(std::sync::atomic::AtomicBool::new(auto_approve));
 
     // Resolve which FROST group this node co-signs for: an explicit
     // KEEP_FROST_GROUP, otherwise the single group present in the vault.
@@ -106,6 +108,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let allow_single_key = env_or("KEEP_ALLOW_SINGLE_KEY", "false") == "true";
 
+    let mut node = None;
     let bunker_info = if let Some((group_pubkey, group_npub)) = resolved_group {
         match keep.frost_get_share(&group_pubkey) {
             Ok(share) => {
@@ -115,19 +118,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 } else {
                     frost_relays
                 };
-                bunker::spawn_network_frost(
+                let handle = bunker::spawn_network_frost(
                     bunker::NetworkConfig {
                         share,
                         group_pubkey,
                         group_npub,
                         frost_relays,
                         bunker_relays,
-                        auto_approve,
+                        enabled: signing_enabled.clone(),
                     },
                     events.clone(),
                     approvals.clone(),
                 )
-                .map_err(|e| format!("failed to start co-signer: {e}"))?
+                .map_err(|e| format!("failed to start co-signer: {e}"))?;
+                node = Some(handle.node);
+                handle.info
             }
             Err(_) => {
                 tracing::warn!(group = %group_npub, "group configured but no share present; setup mode");
@@ -156,6 +161,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         bunker: bunker_info,
         events,
         approvals,
+        signing_enabled,
+        node,
     };
 
     let serve_index = ServeFile::new(ui_dir.join("index.html"));
@@ -166,6 +173,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/api/bunker", get(api::bunker))
         .route("/api/shares", get(api::shares))
         .route("/api/shares/import", post(api::import_share))
+        .route("/api/shares/export", post(api::export_share))
+        .route("/api/shares/delete", post(api::delete_share))
+        .route("/api/signing-log", get(api::signing_log))
+        .route(
+            "/api/killswitch",
+            get(api::killswitch_status).post(api::set_killswitch),
+        )
         .route("/api/approvals/{id}", post(api::resolve_approval))
         .route("/api/events", get(ws::events))
         .fallback_service(static_files)

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -15,7 +15,7 @@ use tower_http::services::{ServeDir, ServeFile};
 
 use keep_core::Keep;
 
-use crate::state::AppState;
+use crate::state::{AppState, BunkerInfo};
 
 fn env_or(key: &str, default: &str) -> String {
     std::env::var(key).unwrap_or_else(|_| default.to_string())
@@ -28,6 +28,36 @@ fn parse_relays(value: &str) -> Vec<String> {
         .filter(|s| !s.is_empty())
         .map(str::to_string)
         .collect()
+}
+
+/// Resolve the FROST group to co-sign for: an explicit npub, else the single
+/// group present in the vault. Returns `None` (→ setup mode) when there is no
+/// share yet or the choice is ambiguous.
+fn resolve_group(keep: &Keep, explicit: Option<&str>) -> Option<([u8; 32], String)> {
+    if let Some(npub) = explicit {
+        return match keep_core::keys::npub_to_bytes(npub) {
+            Ok(bytes) => Some((bytes, npub.to_string())),
+            Err(e) => {
+                tracing::warn!(error = %e, "invalid KEEP_FROST_GROUP npub");
+                None
+            }
+        };
+    }
+    let shares = keep.frost_list_shares().unwrap_or_default();
+    let mut groups: Vec<[u8; 32]> = shares.iter().map(|s| s.metadata.group_pubkey).collect();
+    groups.sort();
+    groups.dedup();
+    match groups.as_slice() {
+        [g] => Some((*g, keep_core::keys::bytes_to_npub(g))),
+        [] => None,
+        _ => {
+            tracing::warn!(
+                count = groups.len(),
+                "multiple groups present; set KEEP_FROST_GROUP to choose one"
+            );
+            None
+        }
+    }
 }
 
 #[tokio::main]
@@ -52,53 +82,74 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let password = std::env::var("KEEP_PASSWORD")
         .map_err(|_| "KEEP_PASSWORD must be set for headless unlock")?;
 
-    let mut keep = Keep::open(&vault_path)?;
+    // First-run provisioning: create the vault if this is a fresh install
+    // (e.g. first StartOS boot) rather than crashing.
+    let mut keep = match Keep::open(&vault_path) {
+        Ok(k) => k,
+        Err(keep_core::error::KeepError::NotFound(_)) => {
+            tracing::info!(path = %vault_path.display(), "no vault found; creating");
+            Keep::create(&vault_path, &password)?
+        }
+        Err(e) => return Err(e.into()),
+    };
     keep.unlock(&password)?;
     tracing::info!(path = %vault_path.display(), "vault unlocked");
 
     let (events, _) = broadcast::channel(256);
     let approvals = Arc::new(StdMutex::new(HashMap::new()));
 
-    let bunker_info = if let Some(group_npub) = frost_group {
-        // Always-on network-FROST co-signer: hold one share, coordinate to
-        // threshold with peers over the FROST relays.
-        let group_pubkey = keep_core::keys::npub_to_bytes(&group_npub)?;
-        let share = keep.frost_get_share(&group_pubkey)?;
-        let frost_relays = parse_relays(&env_or("KEEP_FROST_RELAY", ""));
-        let frost_relays = if frost_relays.is_empty() {
-            bunker_relays.clone()
-        } else {
-            frost_relays
-        };
-        bunker::spawn_network_frost(
-            bunker::NetworkConfig {
-                share,
-                group_pubkey,
-                group_npub,
-                frost_relays,
-                bunker_relays,
-                auto_approve,
-            },
-            events.clone(),
-            approvals.clone(),
-        )
-        .map_err(|e| format!("failed to start co-signer: {e}"))?
-    } else {
-        // No FROST group configured: single-key fallback (no threshold
-        // security — the full key lives on this box).
-        tracing::warn!(
-            "no KEEP_FROST_GROUP set; running single-key bunker (no threshold security)"
-        );
+    // Resolve which FROST group this node co-signs for: an explicit
+    // KEEP_FROST_GROUP, otherwise the single group present in the vault.
+    // Auto-resolution avoids the chicken-and-egg of needing the group npub
+    // before the share has been imported.
+    let resolved_group = resolve_group(&keep, frost_group.as_deref());
+
+    let allow_single_key = env_or("KEEP_ALLOW_SINGLE_KEY", "false") == "true";
+
+    let bunker_info = if let Some((group_pubkey, group_npub)) = resolved_group {
+        match keep.frost_get_share(&group_pubkey) {
+            Ok(share) => {
+                let frost_relays = parse_relays(&env_or("KEEP_FROST_RELAY", ""));
+                let frost_relays = if frost_relays.is_empty() {
+                    bunker_relays.clone()
+                } else {
+                    frost_relays
+                };
+                bunker::spawn_network_frost(
+                    bunker::NetworkConfig {
+                        share,
+                        group_pubkey,
+                        group_npub,
+                        frost_relays,
+                        bunker_relays,
+                        auto_approve,
+                    },
+                    events.clone(),
+                    approvals.clone(),
+                )
+                .map_err(|e| format!("failed to start co-signer: {e}"))?
+            }
+            Err(_) => {
+                tracing::warn!(group = %group_npub, "group configured but no share present; setup mode");
+                BunkerInfo::setup()
+            }
+        }
+    } else if allow_single_key && keep.keyring().get_primary().is_some() {
+        // Explicit opt-in: sign with the vault's primary key alone (no
+        // threshold security — the full key lives on this box).
+        tracing::warn!("KEEP_ALLOW_SINGLE_KEY set; single-key bunker (no threshold security)");
         let keyring = Arc::new(Mutex::new(std::mem::take(keep.keyring_mut())));
         let relay = bunker_relays.first().cloned().unwrap_or_default();
         bunker::spawn_single_key(keyring, relay, events.clone(), approvals.clone())
             .map_err(|e| format!("failed to start bunker: {e}"))?
+    } else {
+        // Nothing to sign with yet: serve the admin UI so the operator can
+        // import a share, then restart the service to start the co-signer.
+        tracing::info!("no FROST share available; serving in setup mode");
+        BunkerInfo::setup()
     };
     let keep = Arc::new(Mutex::new(keep));
-    tracing::info!(
-        mode = %bunker_info.mode, url = %bunker_info.url, npub = %bunker_info.npub,
-        "bunker online"
-    );
+    tracing::info!(mode = %bunker_info.mode, "started");
 
     let state = AppState {
         keep,

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -21,6 +21,15 @@ fn env_or(key: &str, default: &str) -> String {
     std::env::var(key).unwrap_or_else(|_| default.to_string())
 }
 
+fn parse_relays(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
@@ -32,7 +41,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     keep_frost_net::install_default_crypto_provider();
 
     let vault_path = PathBuf::from(env_or("KEEP_PATH", "/data"));
-    let relay = env_or("KEEP_RELAY", "wss://relay.damus.io");
+    let bunker_relays = parse_relays(&env_or(
+        "KEEP_BUNKER_RELAY",
+        &env_or("KEEP_RELAY", "wss://relay.damus.io"),
+    ));
+    let frost_group = std::env::var("KEEP_FROST_GROUP").ok();
+    let auto_approve = env_or("KEEP_FROST_AUTO_APPROVE", "true") != "false";
     let ui_dir = PathBuf::from(env_or("KEEP_WEB_UI_DIR", "ui/dist"));
     let listen: SocketAddr = env_or("KEEP_WEB_LISTEN", "0.0.0.0:8080").parse()?;
     let password = std::env::var("KEEP_PASSWORD")
@@ -42,17 +56,49 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     keep.unlock(&password)?;
     tracing::info!(path = %vault_path.display(), "vault unlocked");
 
-    // Hand the keyring to the bunker; keep the (now keyring-less) vault for
-    // read-only storage queries, exactly as the CLI `serve` path does.
-    let keyring = Arc::new(Mutex::new(std::mem::take(keep.keyring_mut())));
-    let keep = Arc::new(Mutex::new(keep));
-
     let (events, _) = broadcast::channel(256);
     let approvals = Arc::new(StdMutex::new(HashMap::new()));
 
-    let bunker_info = bunker::spawn(keyring, relay, events.clone(), approvals.clone())
-        .map_err(|e| format!("failed to start bunker: {e}"))?;
-    tracing::info!(url = %bunker_info.url, npub = %bunker_info.npub, "bunker online");
+    let bunker_info = if let Some(group_npub) = frost_group {
+        // Always-on network-FROST co-signer: hold one share, coordinate to
+        // threshold with peers over the FROST relays.
+        let group_pubkey = keep_core::keys::npub_to_bytes(&group_npub)?;
+        let share = keep.frost_get_share(&group_pubkey)?;
+        let frost_relays = parse_relays(&env_or("KEEP_FROST_RELAY", ""));
+        let frost_relays = if frost_relays.is_empty() {
+            bunker_relays.clone()
+        } else {
+            frost_relays
+        };
+        bunker::spawn_network_frost(
+            bunker::NetworkConfig {
+                share,
+                group_pubkey,
+                group_npub,
+                frost_relays,
+                bunker_relays,
+                auto_approve,
+            },
+            events.clone(),
+            approvals.clone(),
+        )
+        .map_err(|e| format!("failed to start co-signer: {e}"))?
+    } else {
+        // No FROST group configured: single-key fallback (no threshold
+        // security — the full key lives on this box).
+        tracing::warn!(
+            "no KEEP_FROST_GROUP set; running single-key bunker (no threshold security)"
+        );
+        let keyring = Arc::new(Mutex::new(std::mem::take(keep.keyring_mut())));
+        let relay = bunker_relays.first().cloned().unwrap_or_default();
+        bunker::spawn_single_key(keyring, relay, events.clone(), approvals.clone())
+            .map_err(|e| format!("failed to start bunker: {e}"))?
+    };
+    let keep = Arc::new(Mutex::new(keep));
+    tracing::info!(
+        mode = %bunker_info.mode, url = %bunker_info.url, npub = %bunker_info.npub,
+        "bunker online"
+    );
 
     let state = AppState {
         keep,

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -1,0 +1,80 @@
+mod api;
+mod bunker;
+mod state;
+mod ws;
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex as StdMutex};
+
+use axum::routing::{get, post};
+use axum::Router;
+use tokio::sync::{broadcast, Mutex};
+use tower_http::services::{ServeDir, ServeFile};
+
+use keep_core::Keep;
+
+use crate::state::AppState;
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    keep_frost_net::install_default_crypto_provider();
+
+    let vault_path = PathBuf::from(env_or("KEEP_PATH", "/data"));
+    let relay = env_or("KEEP_RELAY", "wss://relay.damus.io");
+    let ui_dir = PathBuf::from(env_or("KEEP_WEB_UI_DIR", "ui"));
+    let listen: SocketAddr = env_or("KEEP_WEB_LISTEN", "0.0.0.0:8080").parse()?;
+    let password = std::env::var("KEEP_PASSWORD")
+        .map_err(|_| "KEEP_PASSWORD must be set for headless unlock")?;
+
+    let mut keep = Keep::open(&vault_path)?;
+    keep.unlock(&password)?;
+    tracing::info!(path = %vault_path.display(), "vault unlocked");
+
+    // Hand the keyring to the bunker; keep the (now keyring-less) vault for
+    // read-only storage queries, exactly as the CLI `serve` path does.
+    let keyring = Arc::new(Mutex::new(std::mem::take(keep.keyring_mut())));
+    let keep = Arc::new(Mutex::new(keep));
+
+    let (events, _) = broadcast::channel(256);
+    let approvals = Arc::new(StdMutex::new(HashMap::new()));
+
+    let bunker_info = bunker::spawn(keyring, relay, events.clone(), approvals.clone())
+        .map_err(|e| format!("failed to start bunker: {e}"))?;
+    tracing::info!(url = %bunker_info.url, npub = %bunker_info.npub, "bunker online");
+
+    let state = AppState {
+        keep,
+        bunker: bunker_info,
+        events,
+        approvals,
+    };
+
+    let serve_index = ServeFile::new(ui_dir.join("index.html"));
+    let static_files = ServeDir::new(&ui_dir).fallback(serve_index);
+
+    let app = Router::new()
+        .route("/api/health", get(api::health))
+        .route("/api/bunker", get(api::bunker))
+        .route("/api/shares", get(api::shares))
+        .route("/api/approvals/{id}", post(api::resolve_approval))
+        .route("/api/events", get(ws::events))
+        .fallback_service(static_files)
+        .with_state(state);
+
+    tracing::info!(%listen, "serving web admin");
+    let listener = tokio::net::TcpListener::bind(listen).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -1,23 +1,31 @@
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::Sender;
-use std::sync::Mutex as StdMutex;
+use std::sync::{Arc, Mutex as StdMutex};
 
 use serde::Serialize;
 use tokio::sync::{broadcast, Mutex};
 
 use keep_core::Keep;
+use keep_frost_net::KfpNode;
 
 /// Shared application state handed to every axum handler.
 #[derive(Clone)]
 pub struct AppState {
     /// Unlocked vault, used for read-only queries (share listing, etc.).
-    pub keep: std::sync::Arc<Mutex<Keep>>,
+    pub keep: Arc<Mutex<Keep>>,
     /// Bunker connection details, populated once the server is up.
     pub bunker: BunkerInfo,
     /// Live event stream (logs + approval requests) for WebSocket clients.
     pub events: broadcast::Sender<Event>,
     /// Pending approval requests awaiting a browser decision, keyed by id.
-    pub approvals: std::sync::Arc<StdMutex<HashMap<u64, Sender<bool>>>>,
+    pub approvals: Arc<StdMutex<HashMap<u64, Sender<bool>>>>,
+    /// Kill switch: when false, the co-signer refuses to participate. Toggled
+    /// live (no restart); the policy hook reads it on every round.
+    pub signing_enabled: Arc<AtomicBool>,
+    /// The running FROST node (network mode only), for reading the signing
+    /// audit log and peer state.
+    pub node: Option<Arc<KfpNode>>,
 }
 
 #[derive(Clone, Serialize)]

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -36,6 +36,22 @@ pub struct BunkerInfo {
     pub threshold: Option<String>,
 }
 
+impl BunkerInfo {
+    /// Not yet provisioned: the admin UI is served, but no bunker/co-signer is
+    /// running. The operator imports a share, then restarts the service.
+    pub fn setup() -> Self {
+        Self {
+            mode: "setup".into(),
+            url: String::new(),
+            npub: String::new(),
+            relay: String::new(),
+            frost_relays: Vec::new(),
+            group: None,
+            threshold: None,
+        }
+    }
+}
+
 /// An event pushed to connected WebSocket clients.
 #[derive(Clone, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -22,9 +22,18 @@ pub struct AppState {
 
 #[derive(Clone, Serialize)]
 pub struct BunkerInfo {
+    /// "network-frost" (always-on co-signer) or "single-key" (fallback).
+    pub mode: String,
     pub url: String,
     pub npub: String,
+    /// NIP-46 bunker transport relay.
     pub relay: String,
+    /// FROST peer-coordination relays (network mode only).
+    pub frost_relays: Vec<String>,
+    /// Group npub this node co-signs for (network mode only).
+    pub group: Option<String>,
+    /// Threshold as "t-of-n" (network mode only).
+    pub threshold: Option<String>,
 }
 
 /// An event pushed to connected WebSocket clients.

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -1,0 +1,47 @@
+use std::collections::HashMap;
+use std::sync::mpsc::Sender;
+use std::sync::Mutex as StdMutex;
+
+use serde::Serialize;
+use tokio::sync::{broadcast, Mutex};
+
+use keep_core::Keep;
+
+/// Shared application state handed to every axum handler.
+#[derive(Clone)]
+pub struct AppState {
+    /// Unlocked vault, used for read-only queries (share listing, etc.).
+    pub keep: std::sync::Arc<Mutex<Keep>>,
+    /// Bunker connection details, populated once the server is up.
+    pub bunker: BunkerInfo,
+    /// Live event stream (logs + approval requests) for WebSocket clients.
+    pub events: broadcast::Sender<Event>,
+    /// Pending approval requests awaiting a browser decision, keyed by id.
+    pub approvals: std::sync::Arc<StdMutex<HashMap<u64, Sender<bool>>>>,
+}
+
+#[derive(Clone, Serialize)]
+pub struct BunkerInfo {
+    pub url: String,
+    pub npub: String,
+    pub relay: String,
+}
+
+/// An event pushed to connected WebSocket clients.
+#[derive(Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Event {
+    Log {
+        app: String,
+        action: String,
+        success: bool,
+        detail: Option<String>,
+    },
+    Approval {
+        id: u64,
+        app: String,
+        method: String,
+        kind: Option<u16>,
+        preview: Option<String>,
+    },
+}

--- a/keep-web/src/ws.rs
+++ b/keep-web/src/ws.rs
@@ -14,8 +14,12 @@ async fn handle(mut socket: WebSocket, state: AppState) {
     loop {
         match rx.recv().await {
             Ok(event) => {
-                let Ok(json) = serde_json::to_string(&event) else {
-                    continue;
+                let json = match serde_json::to_string(&event) {
+                    Ok(j) => j,
+                    Err(e) => {
+                        tracing::debug!(error = %e, "failed to serialize event for WS");
+                        continue;
+                    }
                 };
                 if socket.send(Message::Text(json.into())).await.is_err() {
                     break;

--- a/keep-web/src/ws.rs
+++ b/keep-web/src/ws.rs
@@ -1,0 +1,28 @@
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::State;
+use axum::response::IntoResponse;
+use tokio::sync::broadcast::error::RecvError;
+
+use crate::state::AppState;
+
+pub async fn events(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle(socket, state))
+}
+
+async fn handle(mut socket: WebSocket, state: AppState) {
+    let mut rx = state.events.subscribe();
+    loop {
+        match rx.recv().await {
+            Ok(event) => {
+                let Ok(json) = serde_json::to_string(&event) else {
+                    continue;
+                };
+                if socket.send(Message::Text(json.into())).await.is_err() {
+                    break;
+                }
+            }
+            Err(RecvError::Lagged(_)) => continue,
+            Err(RecvError::Closed) => break,
+        }
+    }
+}

--- a/keep-web/ui/.gitignore
+++ b/keep-web/ui/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/keep-web/ui/index.html
+++ b/keep-web/ui/index.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Keep</title>
+    <style>
+      body { font-family: system-ui, sans-serif; max-width: 40rem; margin: 2rem auto; padding: 0 1rem; }
+      code { background: #f0f0f0; padding: 0.1rem 0.3rem; border-radius: 3px; }
+      .ev { font-size: 0.85rem; border-bottom: 1px solid #eee; padding: 0.25rem 0; }
+      button { margin-right: 0.5rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Keep — FROST Bunker</h1>
+    <p>Bunker: <code id="url">…</code></p>
+    <p>npub: <code id="npub">…</code></p>
+    <h2>Shares</h2>
+    <ul id="shares"></ul>
+    <h2>Activity</h2>
+    <div id="log"></div>
+    <script>
+      const $ = (id) => document.getElementById(id);
+      fetch('/api/bunker').then(r => r.json()).then(b => {
+        $('url').textContent = b.url;
+        $('npub').textContent = b.npub;
+      });
+      fetch('/api/shares').then(r => r.json()).then(rows => {
+        $('shares').innerHTML = rows.map(s =>
+          `<li>${s.name} — ${s.threshold}-of-${s.total_shares} (signed ${s.sign_count})</li>`
+        ).join('') || '<li>No shares imported yet.</li>';
+      });
+      const ws = new WebSocket(`ws://${location.host}/api/events`);
+      ws.onmessage = (m) => {
+        const e = JSON.parse(m.data);
+        const div = document.createElement('div');
+        div.className = 'ev';
+        if (e.type === 'approval') {
+          div.innerHTML = `<b>${e.app}</b> requests ${e.method}. ` +
+            `<button data-ok>Approve</button><button data-no>Deny</button>`;
+          const send = (approve) => fetch(`/api/approvals/${e.id}`, {
+            method: 'POST', headers: {'content-type': 'application/json'},
+            body: JSON.stringify({ approve })
+          }).then(() => div.append(' → ' + (approve ? 'approved' : 'denied')));
+          div.querySelector('[data-ok]').onclick = () => send(true);
+          div.querySelector('[data-no]').onclick = () => send(false);
+        } else {
+          div.textContent = `${e.app}: ${e.action} ${e.success ? '✓' : '✗'}` +
+            (e.detail ? ` (${e.detail})` : '');
+        }
+        $('log').prepend(div);
+      };
+    </script>
+  </body>
+</html>

--- a/keep-web/ui/index.html
+++ b/keep-web/ui/index.html
@@ -4,52 +4,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Keep</title>
-    <style>
-      body { font-family: system-ui, sans-serif; max-width: 40rem; margin: 2rem auto; padding: 0 1rem; }
-      code { background: #f0f0f0; padding: 0.1rem 0.3rem; border-radius: 3px; }
-      .ev { font-size: 0.85rem; border-bottom: 1px solid #eee; padding: 0.25rem 0; }
-      button { margin-right: 0.5rem; }
-    </style>
   </head>
   <body>
-    <h1>Keep — FROST Bunker</h1>
-    <p>Bunker: <code id="url">…</code></p>
-    <p>npub: <code id="npub">…</code></p>
-    <h2>Shares</h2>
-    <ul id="shares"></ul>
-    <h2>Activity</h2>
-    <div id="log"></div>
-    <script>
-      const $ = (id) => document.getElementById(id);
-      fetch('/api/bunker').then(r => r.json()).then(b => {
-        $('url').textContent = b.url;
-        $('npub').textContent = b.npub;
-      });
-      fetch('/api/shares').then(r => r.json()).then(rows => {
-        $('shares').innerHTML = rows.map(s =>
-          `<li>${s.name} — ${s.threshold}-of-${s.total_shares} (signed ${s.sign_count})</li>`
-        ).join('') || '<li>No shares imported yet.</li>';
-      });
-      const ws = new WebSocket(`ws://${location.host}/api/events`);
-      ws.onmessage = (m) => {
-        const e = JSON.parse(m.data);
-        const div = document.createElement('div');
-        div.className = 'ev';
-        if (e.type === 'approval') {
-          div.innerHTML = `<b>${e.app}</b> requests ${e.method}. ` +
-            `<button data-ok>Approve</button><button data-no>Deny</button>`;
-          const send = (approve) => fetch(`/api/approvals/${e.id}`, {
-            method: 'POST', headers: {'content-type': 'application/json'},
-            body: JSON.stringify({ approve })
-          }).then(() => div.append(' → ' + (approve ? 'approved' : 'denied')));
-          div.querySelector('[data-ok]').onclick = () => send(true);
-          div.querySelector('[data-no]').onclick = () => send(false);
-        } else {
-          div.textContent = `${e.app}: ${e.action} ${e.success ? '✓' : '✗'}` +
-            (e.detail ? ` (${e.detail})` : '');
-        }
-        $('log').prepend(div);
-      };
-    </script>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/keep-web/ui/package-lock.json
+++ b/keep-web/ui/package-lock.json
@@ -1,0 +1,1562 @@
+{
+  "name": "keep-web-ui",
+  "version": "0.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "keep-web-ui",
+      "version": "0.3.0",
+      "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^5.0.3",
+        "@tsconfig/svelte": "^5.0.4",
+        "svelte": "^5.19.0",
+        "svelte-check": "^4.1.4",
+        "typescript": "^5.7.3",
+        "vite": "^6.0.7"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.1.1.tgz",
+      "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
+        "debug": "^4.4.1",
+        "deepmerge": "^4.3.1",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.17",
+        "vitefu": "^1.0.6"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-4.0.1.tgz",
+      "integrity": "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.7"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^5.0.0",
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@tsconfig/svelte": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.8.tgz",
+      "integrity": "sha512-UkNnw1/oFEfecR8ypyHIQuWYdkPvHiwcQ78sh+ymIiYoF+uc5H1UBetbjyqT+vgGJ3qQN6nhucJviX6HesWtKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esrap": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
+      "integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.55.9",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.9.tgz",
+      "integrity": "sha512-fTjjT8cHLDwigcu2j3pv7Jq04LklXevPB8uBgyHNiTXv+RMNvVnrjS4UEYrLMkhuq1vpCodHjiW+z/95SDs/fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.9",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/svelte-check": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.8.tgz",
+      "integrity": "sha512-67adfgBox5eNSNIvIIwgFizKGdcRrGpiMoNO2obHcYuLz7iTa8Xgm/NGU3ntMFnNm8K1grFOIG6HhMLX/vcN8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "chokidar": "^4.0.1",
+        "fdir": "^6.2.0",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/keep-web/ui/package.json
+++ b/keep-web/ui/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "keep-web-ui",
+  "private": true,
+  "version": "0.3.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "svelte-check --tsconfig ./tsconfig.json && vite build",
+    "preview": "vite preview",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^5.0.3",
+    "@tsconfig/svelte": "^5.0.4",
+    "svelte": "^5.19.0",
+    "svelte-check": "^4.1.4",
+    "typescript": "^5.7.3",
+    "vite": "^6.0.7"
+  }
+}

--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -3,6 +3,7 @@
   import {
     getBunker,
     getShares,
+    importShare,
     resolveApproval,
     connectEvents,
     type BunkerInfo,
@@ -19,13 +20,41 @@
   let approvals = $state<PendingApproval[]>([])
   let logs = $state<LogEvent[]>([])
 
+  let importData = $state('')
+  let importPass = $state('')
+  let importName = $state('')
+  let importing = $state(false)
+  let importMsg = $state<string | null>(null)
+
+  function refreshShares() {
+    getShares()
+      .then((s) => (shares = s))
+      .catch((e) => (error = String(e)))
+  }
+
+  async function submitImport(e: Event) {
+    e.preventDefault()
+    importing = true
+    importMsg = null
+    try {
+      await importShare(importData, importPass, importName)
+      importMsg = 'Share imported. Restart the service for the bunker to sign with it.'
+      importData = ''
+      importPass = ''
+      importName = ''
+      refreshShares()
+    } catch (err) {
+      importMsg = String(err)
+    } finally {
+      importing = false
+    }
+  }
+
   onMount(() => {
     getBunker()
       .then((b) => (bunker = b))
       .catch((e) => (error = String(e)))
-    getShares()
-      .then((s) => (shares = s))
-      .catch((e) => (error = String(e)))
+    refreshShares()
 
     const ws = connectEvents((e) => {
       if (e.type === 'approval') {
@@ -75,6 +104,30 @@
     {:else}
       <p class="muted">No shares imported yet.</p>
     {/each}
+  </div>
+
+  <h2>Import Share</h2>
+  <div class="panel">
+    <form onsubmit={submitImport}>
+      <textarea
+        bind:value={importData}
+        placeholder="Paste share export (kshare1… or JSON)"
+        rows="3"
+      ></textarea>
+      <div class="row">
+        <input
+          type="password"
+          bind:value={importPass}
+          placeholder="Passphrase"
+          autocomplete="off"
+        />
+        <input type="text" bind:value={importName} placeholder="Name (optional)" />
+        <button class="ok" type="submit" disabled={importing || !importData || !importPass}>
+          {importing ? 'Importing…' : 'Import'}
+        </button>
+      </div>
+      {#if importMsg}<p class="muted">{importMsg}</p>{/if}
+    </form>
   </div>
 
   <h2>Activity</h2>

--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -142,6 +142,11 @@
 
   <h2>Import Share</h2>
   <div class="panel">
+    <p class="note">
+      The FROST relay must match the one your other share-holders use, or you
+      won't find each other for signing rounds. Set it with the Configure
+      action; the current relays are shown above.
+    </p>
     <form onsubmit={submitImport}>
       <textarea
         bind:value={importData}

--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -4,10 +4,16 @@
     getBunker,
     getShares,
     importShare,
+    exportShare,
+    deleteShare,
+    getSigningLog,
+    getKillswitch,
+    setKillswitch,
     resolveApproval,
     connectEvents,
     type BunkerInfo,
     type Share,
+    type SigningEntry,
     type LogEvent,
     type ApprovalEvent,
   } from './lib/api'
@@ -39,10 +45,64 @@
     ['frost relays', 'relays used to coordinate signing rounds with your devices'],
   ]
 
+  let signingEnabled = $state(true)
+  let signingLog = $state<SigningEntry[]>([])
+  let signingVerified = $state(true)
+
+  // Per-share export UI state.
+  let exportFor = $state<string | null>(null) // "group:id"
+  let exportPass = $state('')
+  let exportResult = $state('')
+  let exportErr = $state<string | null>(null)
+
   function refreshShares() {
     getShares()
       .then((s) => (shares = s))
       .catch((e) => (error = String(e)))
+  }
+
+  function refreshSigningLog() {
+    getSigningLog()
+      .then((r) => {
+        signingLog = r.entries
+        signingVerified = r.verified
+      })
+      .catch(() => {})
+  }
+
+  async function toggleKillswitch() {
+    try {
+      signingEnabled = await setKillswitch(!signingEnabled)
+    } catch (e) {
+      error = String(e)
+    }
+  }
+
+  async function confirmDelete(s: Share) {
+    if (!confirm(`Delete share "${s.name}" (${s.identifier})? This cannot be undone.`))
+      return
+    try {
+      await deleteShare(s.group, s.identifier)
+      refreshShares()
+    } catch (e) {
+      error = String(e)
+    }
+  }
+
+  function startExport(s: Share) {
+    exportFor = `${s.group}:${s.identifier}`
+    exportPass = ''
+    exportResult = ''
+    exportErr = null
+  }
+
+  async function doExport(s: Share) {
+    exportErr = null
+    try {
+      exportResult = await exportShare(s.group, s.identifier, exportPass)
+    } catch (e) {
+      exportErr = String(e)
+    }
   }
 
   async function submitImport(e: Event) {
@@ -70,12 +130,18 @@
       .then((b) => (bunker = b))
       .catch((e) => (error = String(e)))
     refreshShares()
+    getKillswitch()
+      .then((e) => (signingEnabled = e))
+      .catch(() => {})
+    refreshSigningLog()
 
     const ws = connectEvents((e) => {
       if (e.type === 'approval') {
         approvals = [{ ...e }, ...approvals]
       } else {
         logs = [e, ...logs].slice(0, 100)
+        // A co-sign just happened — refresh the persistent audit log.
+        if (e.app === 'frost') refreshSigningLog()
       }
     })
     return () => ws.close()
@@ -161,6 +227,17 @@
           <span>frost relays</span><code>{bunker.frost_relays.join(', ')}</code>
         </div>
       {/if}
+      {#if bunker.mode !== 'setup'}
+        <div class="kv killswitch">
+          <span>co-signing</span>
+          <code class={signingEnabled ? '' : 'warn'}>
+            {signingEnabled ? 'enabled' : 'DISABLED (kill switch)'}
+          </code>
+          <button class={signingEnabled ? 'no' : 'ok'} onclick={toggleKillswitch}>
+            {signingEnabled ? 'Disable signing' : 'Enable signing'}
+          </button>
+        </div>
+      {/if}
     {:else}
       <p class="muted">Connecting…</p>
     {/if}
@@ -168,13 +245,39 @@
 
   <h2>Shares</h2>
   <div class="panel">
-    {#each shares as s (s.name)}
+    {#each shares as s (s.group + ':' + s.identifier)}
       <div class="share">
         <span>{s.name}</span>
         <span class="muted">
-          {s.threshold}-of-{s.total_shares} · signed {s.sign_count}
+          #{s.identifier} · {s.threshold}-of-{s.total_shares} · signed {s.sign_count}
+        </span>
+        <span class="share-actions">
+          <button onclick={() => startExport(s)}>Export</button>
+          <button class="no" onclick={() => confirmDelete(s)}>Delete</button>
         </span>
       </div>
+      {#if exportFor === s.group + ':' + s.identifier}
+        <div class="export-box">
+          {#if exportResult}
+            <p class="muted">Encrypted export (back this up):</p>
+            <textarea readonly rows="3">{exportResult}</textarea>
+          {:else}
+            <div class="row">
+              <input
+                type="password"
+                bind:value={exportPass}
+                placeholder="Export passphrase"
+                autocomplete="off"
+              />
+              <button class="ok" onclick={() => doExport(s)} disabled={!exportPass}>
+                Export
+              </button>
+              <button onclick={() => (exportFor = null)}>Cancel</button>
+            </div>
+          {/if}
+          {#if exportErr}<p class="fail">{exportErr}</p>{/if}
+        </div>
+      {/if}
     {:else}
       <p class="muted">No shares imported yet.</p>
     {/each}
@@ -239,5 +342,29 @@
     {#if approvals.length === 0 && logs.length === 0}
       <p class="muted">Waiting for signing activity…</p>
     {/if}
+  </div>
+
+  <h2>
+    Signing Log
+    {#if signingLog.length}
+      <span class="verify {signingVerified ? 'ok' : 'fail'}">
+        {signingVerified ? '✓ chain verified' : '✗ chain INVALID'}
+      </span>
+    {/if}
+  </h2>
+  <div class="panel">
+    {#each signingLog as e (e.timestamp_ms + ':' + e.session + ':' + e.operation)}
+      <div class="event">
+        <code>{e.session}</code>
+        <span>{e.operation}</span>
+        <span class="muted">
+          · participants {e.participants.join(',')} · {new Date(
+            e.timestamp_ms,
+          ).toLocaleString()}
+        </span>
+      </div>
+    {:else}
+      <p class="muted">No signatures recorded yet.</p>
+    {/each}
   </div>
 </main>

--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -84,9 +84,28 @@
   <h2>Connection</h2>
   <div class="panel">
     {#if bunker}
+      <div class="kv">
+        <span>mode</span>
+        {#if bunker.mode === 'network-frost'}
+          <code>network FROST co-signer</code>
+        {:else}
+          <code class="warn">single-key (no threshold security)</code>
+        {/if}
+      </div>
+      {#if bunker.group}
+        <div class="kv"><span>group</span><code>{bunker.group}</code></div>
+      {/if}
+      {#if bunker.threshold}
+        <div class="kv"><span>threshold</span><code>{bunker.threshold}</code></div>
+      {/if}
       <div class="kv"><span>npub</span><code>{bunker.npub}</code></div>
       <div class="kv"><span>bunker</span><code>{bunker.url}</code></div>
-      <div class="kv"><span>relay</span><code>{bunker.relay}</code></div>
+      <div class="kv"><span>bunker relay</span><code>{bunker.relay}</code></div>
+      {#if bunker.frost_relays.length}
+        <div class="kv">
+          <span>frost relays</span><code>{bunker.frost_relays.join(', ')}</code>
+        </div>
+      {/if}
     {:else}
       <p class="muted">Connecting…</p>
     {/if}

--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -6,6 +6,7 @@
     importShare,
     exportShare,
     deleteShare,
+    renameShare,
     getSigningLog,
     getKillswitch,
     setKillswitch,
@@ -54,6 +55,43 @@
   let exportPass = $state('')
   let exportResult = $state('')
   let exportErr = $state<string | null>(null)
+
+  // Per-share rename UI state.
+  let renameFor = $state<string | null>(null)
+  let renameVal = $state('')
+
+  // Copy-to-clipboard feedback (which value was just copied).
+  let copied = $state<string | null>(null)
+
+  async function copy(value: string, label: string) {
+    try {
+      await navigator.clipboard.writeText(value)
+      copied = label
+      setTimeout(() => (copied === label ? (copied = null) : null), 1500)
+    } catch {
+      /* clipboard blocked (non-https); ignore */
+    }
+  }
+
+  function fmtDate(secs: number | null): string {
+    if (!secs) return 'never'
+    return new Date(secs * 1000).toLocaleString()
+  }
+
+  function startRename(s: Share) {
+    renameFor = `${s.group}:${s.identifier}`
+    renameVal = s.name
+  }
+
+  async function doRename(s: Share) {
+    try {
+      await renameShare(s.group, s.identifier, renameVal.trim())
+      renameFor = null
+      refreshShares()
+    } catch (e) {
+      error = String(e)
+    }
+  }
 
   function refreshShares() {
     getShares()
@@ -155,6 +193,16 @@
   }
 </script>
 
+{#snippet copyField(label: string, value: string)}
+  <div class="field">
+    <span class="field-label">{label}</span>
+    <span class="field-value" title={value}>{value}</span>
+    <button class="copy-btn" onclick={() => copy(value, label + value)}>
+      {copied === label + value ? '✓ Copied' : 'Copy'}
+    </button>
+  </div>
+{/snippet}
+
 <main>
   <h1>Keep — FROST Bunker</h1>
 
@@ -207,26 +255,16 @@
           {/each}
         </dl>
       {/if}
-      {#if bunker.group}
-        <div class="kv"><span>group</span><code>{bunker.group}</code></div>
-      {/if}
       {#if bunker.threshold}
-        <div class="kv"><span>threshold</span><code>{bunker.threshold}</code></div>
+        <div class="kv"><span>threshold</span><strong>{bunker.threshold}</strong></div>
       {/if}
-      {#if bunker.npub}
-        <div class="kv"><span>npub</span><code>{bunker.npub}</code></div>
-      {/if}
-      {#if bunker.url}
-        <div class="kv"><span>bunker</span><code>{bunker.url}</code></div>
-      {/if}
-      {#if bunker.relay}
-        <div class="kv"><span>bunker relay</span><code>{bunker.relay}</code></div>
-      {/if}
-      {#if bunker.frost_relays.length}
-        <div class="kv">
-          <span>frost relays</span><code>{bunker.frost_relays.join(', ')}</code>
-        </div>
-      {/if}
+      {#if bunker.group}{@render copyField('group', bunker.group)}{/if}
+      {#if bunker.npub}{@render copyField('npub', bunker.npub)}{/if}
+      {#if bunker.url}{@render copyField('bunker', bunker.url)}{/if}
+      {#if bunker.relay}{@render copyField('bunker relay', bunker.relay)}{/if}
+      {#each bunker.frost_relays as r (r)}
+        {@render copyField('frost relay', r)}
+      {/each}
       {#if bunker.mode !== 'setup'}
         <div class="kv killswitch">
           <span>co-signing</span>
@@ -247,11 +285,28 @@
   <div class="panel">
     {#each shares as s (s.group + ':' + s.identifier)}
       <div class="share">
-        <span>{s.name}</span>
-        <span class="muted">
-          #{s.identifier} · {s.threshold}-of-{s.total_shares} · signed {s.sign_count}
-        </span>
+        <div class="share-main">
+          {#if renameFor === s.group + ':' + s.identifier}
+            <div class="row">
+              <input type="text" bind:value={renameVal} maxlength="64" />
+              <button class="ok" onclick={() => doRename(s)} disabled={!renameVal.trim()}>
+                Save
+              </button>
+              <button onclick={() => (renameFor = null)}>Cancel</button>
+            </div>
+          {:else}
+            <span class="share-name">{s.name}</span>
+          {/if}
+          <span class="muted share-meta">
+            #{s.identifier} · {s.threshold}-of-{s.total_shares} · signed {s.sign_count}
+            {#if !s.did_backup}· <span class="warn-text">not backed up</span>{/if}
+          </span>
+          <span class="muted share-meta">
+            created {fmtDate(s.created_at)} · last used {fmtDate(s.last_used)}
+          </span>
+        </div>
         <span class="share-actions">
+          <button onclick={() => startRename(s)}>Rename</button>
           <button onclick={() => startExport(s)}>Export</button>
           <button class="no" onclick={() => confirmDelete(s)}>Delete</button>
         </span>

--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -25,6 +25,19 @@
   let importName = $state('')
   let importing = $state(false)
   let importMsg = $state<string | null>(null)
+  let importOk = $state(false)
+
+  // What the Connection panel shows once a share is imported and the
+  // co-signer is running.
+  const fieldLegend: [string, string][] = [
+    ['mode', 'network FROST co-signer once running (vs. setup)'],
+    ['group', 'the FROST group npub this node co-signs for'],
+    ['threshold', 'signatures needed, e.g. 2-of-3'],
+    ['npub', "this signer's own public key"],
+    ['bunker', 'NIP-46 connection string to paste into a Nostr client'],
+    ['bunker relay', 'relay where clients reach the bunker'],
+    ['frost relays', 'relays used to coordinate signing rounds with your devices'],
+  ]
 
   function refreshShares() {
     getShares()
@@ -38,12 +51,14 @@
     importMsg = null
     try {
       await importShare(importData, importPass, importName)
-      importMsg = 'Share imported. Restart the service for the bunker to sign with it.'
+      importOk = true
+      importMsg = null
       importData = ''
       importPass = ''
       importName = ''
       refreshShares()
     } catch (err) {
+      importOk = false
       importMsg = String(err)
     } finally {
       importing = false
@@ -83,8 +98,21 @@
 
   {#if bunker && bunker.mode === 'setup'}
     <div class="panel setup">
-      <strong>⚙ Setup required.</strong> No FROST share is loaded yet. Import your
-      share below, then restart the service to start the co-signer.
+      <strong>⚙ Setup required.</strong> No FROST share is loaded yet — this node
+      isn't signing.
+      <h3>Tasks to finish setup</h3>
+      <ol class="tasks">
+        <li>Import your FROST share below (export it from the device that holds it).</li>
+        <li>
+          Open the <strong>Configure</strong> action and set <strong>FROST Relays</strong>
+          to match the relays your other share-holders use.
+        </li>
+        <li><strong>Restart the service</strong> to start the co-signer.</li>
+        <li>
+          Copy the bunker connection string (shown here after restart) into your
+          Nostr client.
+        </li>
+      </ol>
     </div>
   {/if}
 
@@ -101,6 +129,18 @@
           <code class="warn">single-key (no threshold security)</code>
         {/if}
       </div>
+      {#if bunker.mode === 'setup'}
+        <p class="muted legend-intro">
+          Once a share is imported and the service is restarted, this panel will
+          show:
+        </p>
+        <dl class="legend">
+          {#each fieldLegend as [field, desc]}
+            <dt>{field}</dt>
+            <dd>{desc}</dd>
+          {/each}
+        </dl>
+      {/if}
       {#if bunker.group}
         <div class="kv"><span>group</span><code>{bunker.group}</code></div>
       {/if}
@@ -165,7 +205,14 @@
           {importing ? 'Importing…' : 'Import'}
         </button>
       </div>
-      {#if importMsg}<p class="muted">{importMsg}</p>{/if}
+      {#if importOk}
+        <div class="import-ok">
+          <strong>✓ Share imported.</strong>
+          <span>Now <strong>restart the service</strong> to start the co-signer.</span>
+        </div>
+      {:else if importMsg}
+        <p class="fail">{importMsg}</p>
+      {/if}
     </form>
   </div>
 

--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -46,9 +46,12 @@
     ['frost relays', 'relays used to coordinate signing rounds with your devices'],
   ]
 
-  let signingEnabled = $state(true)
+  // undefined = status not yet loaded (interaction disabled until known).
+  let signingEnabled = $state<boolean | undefined>(undefined)
+  let signingLoadError = $state<string | null>(null)
   let signingLog = $state<SigningEntry[]>([])
   let signingVerified = $state(true)
+  let wsConnected = $state(false)
 
   // Per-share export UI state.
   let exportFor = $state<string | null>(null) // "group:id"
@@ -140,6 +143,9 @@
       exportResult = await exportShare(s.group, s.identifier, exportPass)
     } catch (e) {
       exportErr = String(e)
+    } finally {
+      // Don't leave the passphrase sitting in client memory.
+      exportPass = ''
     }
   }
 
@@ -147,6 +153,7 @@
     e.preventDefault()
     importing = true
     importMsg = null
+    importOk = false
     try {
       await importShare(importData, importPass, importName)
       importOk = true
@@ -169,27 +176,41 @@
       .catch((e) => (error = String(e)))
     refreshShares()
     getKillswitch()
-      .then((e) => (signingEnabled = e))
-      .catch(() => {})
+      .then((e) => {
+        signingEnabled = e
+        signingLoadError = null
+      })
+      .catch((err) => {
+        signingEnabled = undefined
+        signingLoadError = String(err)
+      })
     refreshSigningLog()
 
-    const ws = connectEvents((e) => {
-      if (e.type === 'approval') {
-        approvals = [{ ...e }, ...approvals]
-      } else {
-        logs = [e, ...logs].slice(0, 100)
-        // A co-sign just happened — refresh the persistent audit log.
-        if (e.app === 'frost') refreshSigningLog()
-      }
-    })
-    return () => ws.close()
+    const stream = connectEvents(
+      (e) => {
+        if (e.type === 'approval') {
+          approvals = [{ ...e }, ...approvals]
+        } else {
+          logs = [e, ...logs].slice(0, 100)
+          // A co-sign just happened — refresh the persistent audit log.
+          if (e.app === 'frost') refreshSigningLog()
+        }
+      },
+      (connected) => (wsConnected = connected),
+    )
+    return () => stream.close()
   })
 
   async function decide(a: PendingApproval, approve: boolean) {
-    await resolveApproval(a.id, approve)
-    approvals = approvals.map((x) =>
-      x.id === a.id ? { ...x, resolved: approve ? 'approved' : 'denied' } : x,
-    )
+    try {
+      await resolveApproval(a.id, approve)
+      approvals = approvals.map((x) =>
+        x.id === a.id ? { ...x, resolved: approve ? 'approved' : 'denied' } : x,
+      )
+    } catch (e) {
+      // The request may have already timed out / been resolved on the signer.
+      error = `Could not ${approve ? 'approve' : 'deny'} request: ${e}`
+    }
   }
 </script>
 
@@ -268,12 +289,16 @@
       {#if bunker.mode !== 'setup'}
         <div class="kv killswitch">
           <span>co-signing</span>
-          <code class={signingEnabled ? '' : 'warn'}>
-            {signingEnabled ? 'enabled' : 'DISABLED (kill switch)'}
-          </code>
-          <button class={signingEnabled ? 'no' : 'ok'} onclick={toggleKillswitch}>
-            {signingEnabled ? 'Disable signing' : 'Enable signing'}
-          </button>
+          {#if signingEnabled === undefined}
+            <code class="warn">unknown{signingLoadError ? ` (${signingLoadError})` : ''}</code>
+          {:else}
+            <code class={signingEnabled ? '' : 'warn'}>
+              {signingEnabled ? 'enabled' : 'DISABLED (kill switch)'}
+            </code>
+            <button class={signingEnabled ? 'no' : 'ok'} onclick={toggleKillswitch}>
+              {signingEnabled ? 'Disable signing' : 'Enable signing'}
+            </button>
+          {/if}
         </div>
       {/if}
     {:else}
@@ -374,7 +399,12 @@
     </form>
   </div>
 
-  <h2>Activity</h2>
+  <h2>
+    Activity
+    <span class="verify {wsConnected ? 'ok' : 'fail'}">
+      {wsConnected ? '● live' : '○ reconnecting…'}
+    </span>
+  </h2>
   <div class="panel">
     {#each approvals as a (a.id)}
       <div class="event approval">

--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -81,6 +81,13 @@
     <p class="fail">{error}</p>
   {/if}
 
+  {#if bunker && bunker.mode === 'setup'}
+    <div class="panel setup">
+      <strong>⚙ Setup required.</strong> No FROST share is loaded yet. Import your
+      share below, then restart the service to start the co-signer.
+    </div>
+  {/if}
+
   <h2>Connection</h2>
   <div class="panel">
     {#if bunker}
@@ -88,6 +95,8 @@
         <span>mode</span>
         {#if bunker.mode === 'network-frost'}
           <code>network FROST co-signer</code>
+        {:else if bunker.mode === 'setup'}
+          <code class="warn">setup — not signing yet</code>
         {:else}
           <code class="warn">single-key (no threshold security)</code>
         {/if}
@@ -98,9 +107,15 @@
       {#if bunker.threshold}
         <div class="kv"><span>threshold</span><code>{bunker.threshold}</code></div>
       {/if}
-      <div class="kv"><span>npub</span><code>{bunker.npub}</code></div>
-      <div class="kv"><span>bunker</span><code>{bunker.url}</code></div>
-      <div class="kv"><span>bunker relay</span><code>{bunker.relay}</code></div>
+      {#if bunker.npub}
+        <div class="kv"><span>npub</span><code>{bunker.npub}</code></div>
+      {/if}
+      {#if bunker.url}
+        <div class="kv"><span>bunker</span><code>{bunker.url}</code></div>
+      {/if}
+      {#if bunker.relay}
+        <div class="kv"><span>bunker relay</span><code>{bunker.relay}</code></div>
+      {/if}
       {#if bunker.frost_relays.length}
         <div class="kv">
           <span>frost relays</span><code>{bunker.frost_relays.join(', ')}</code>

--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import {
+    getBunker,
+    getShares,
+    resolveApproval,
+    connectEvents,
+    type BunkerInfo,
+    type Share,
+    type LogEvent,
+    type ApprovalEvent,
+  } from './lib/api'
+
+  let bunker = $state<BunkerInfo | null>(null)
+  let shares = $state<Share[]>([])
+  let error = $state<string | null>(null)
+
+  type PendingApproval = ApprovalEvent & { resolved?: 'approved' | 'denied' }
+  let approvals = $state<PendingApproval[]>([])
+  let logs = $state<LogEvent[]>([])
+
+  onMount(() => {
+    getBunker()
+      .then((b) => (bunker = b))
+      .catch((e) => (error = String(e)))
+    getShares()
+      .then((s) => (shares = s))
+      .catch((e) => (error = String(e)))
+
+    const ws = connectEvents((e) => {
+      if (e.type === 'approval') {
+        approvals = [{ ...e }, ...approvals]
+      } else {
+        logs = [e, ...logs].slice(0, 100)
+      }
+    })
+    return () => ws.close()
+  })
+
+  async function decide(a: PendingApproval, approve: boolean) {
+    await resolveApproval(a.id, approve)
+    approvals = approvals.map((x) =>
+      x.id === a.id ? { ...x, resolved: approve ? 'approved' : 'denied' } : x,
+    )
+  }
+</script>
+
+<main>
+  <h1>Keep — FROST Bunker</h1>
+
+  {#if error}
+    <p class="fail">{error}</p>
+  {/if}
+
+  <h2>Connection</h2>
+  <div class="panel">
+    {#if bunker}
+      <div class="kv"><span>npub</span><code>{bunker.npub}</code></div>
+      <div class="kv"><span>bunker</span><code>{bunker.url}</code></div>
+      <div class="kv"><span>relay</span><code>{bunker.relay}</code></div>
+    {:else}
+      <p class="muted">Connecting…</p>
+    {/if}
+  </div>
+
+  <h2>Shares</h2>
+  <div class="panel">
+    {#each shares as s (s.name)}
+      <div class="share">
+        <span>{s.name}</span>
+        <span class="muted">
+          {s.threshold}-of-{s.total_shares} · signed {s.sign_count}
+        </span>
+      </div>
+    {:else}
+      <p class="muted">No shares imported yet.</p>
+    {/each}
+  </div>
+
+  <h2>Activity</h2>
+  <div class="panel">
+    {#each approvals as a (a.id)}
+      <div class="event approval">
+        <span><strong>{a.app}</strong> requests {a.method}</span>
+        {#if a.resolved}
+          <span class="muted">→ {a.resolved}</span>
+        {:else}
+          <button class="ok" onclick={() => decide(a, true)}>Approve</button>
+          <button class="no" onclick={() => decide(a, false)}>Deny</button>
+        {/if}
+      </div>
+    {/each}
+    {#each logs as l, i (i)}
+      <div class="event">
+        <strong>{l.app}</strong>: {l.action}
+        <span class:fail={!l.success}>{l.success ? '✓' : '✗'}</span>
+        {#if l.detail}<span class="muted"> · {l.detail}</span>{/if}
+      </div>
+    {/each}
+    {#if approvals.length === 0 && logs.length === 0}
+      <p class="muted">Waiting for signing activity…</p>
+    {/if}
+  </div>
+</main>

--- a/keep-web/ui/src/app.css
+++ b/keep-web/ui/src/app.css
@@ -143,6 +143,64 @@ code.warn {
   padding-left: 0.6rem;
 }
 
+.setup h3 {
+  font-size: 0.9rem;
+  margin: 1rem 0 0.5rem;
+  color: var(--text);
+}
+
+ol.tasks {
+  margin: 0;
+  padding-left: 1.2rem;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+ol.tasks li {
+  margin: 0.2rem 0;
+}
+
+.legend-intro {
+  margin: 0.5rem 0 0.4rem;
+  font-size: 0.85rem;
+}
+
+dl.legend {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.2rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+dl.legend dt {
+  color: var(--accent);
+  font-family: ui-monospace, monospace;
+  white-space: nowrap;
+}
+
+dl.legend dd {
+  margin: 0;
+  color: var(--muted);
+}
+
+.import-ok {
+  margin-top: 0.6rem;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--ok);
+  border-radius: 6px;
+  background: #11240f;
+  font-size: 0.88rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.import-ok strong {
+  color: var(--ok);
+}
+
 textarea,
 input {
   width: 100%;

--- a/keep-web/ui/src/app.css
+++ b/keep-web/ui/src/app.css
@@ -1,0 +1,126 @@
+:root {
+  color-scheme: dark;
+  --bg: #14181f;
+  --panel: #1c222c;
+  --border: #2a313d;
+  --text: #e6e9ef;
+  --muted: #8b93a1;
+  --accent: #0877d2;
+  --ok: #3fb950;
+  --no: #e5534b;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+main {
+  max-width: 48rem;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 4rem;
+}
+
+h1 {
+  font-size: 1.4rem;
+}
+
+h2 {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  margin: 2rem 0 0.75rem;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.kv {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.35rem 0;
+  font-size: 0.9rem;
+}
+
+.kv span {
+  color: var(--muted);
+  min-width: 5rem;
+}
+
+code {
+  font-family: ui-monospace, monospace;
+  word-break: break-all;
+  background: #0f131a;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.82rem;
+}
+
+.share {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.share:last-child {
+  border-bottom: none;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.event {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.88rem;
+}
+
+.event:last-child {
+  border-bottom: none;
+}
+
+.event.approval {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+button {
+  border: none;
+  border-radius: 6px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  color: #fff;
+}
+
+button.ok {
+  background: var(--ok);
+}
+
+button.no {
+  background: var(--no);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.fail {
+  color: var(--no);
+}

--- a/keep-web/ui/src/app.css
+++ b/keep-web/ui/src/app.css
@@ -135,6 +135,14 @@ code.warn {
   margin-bottom: 0.5rem;
 }
 
+.note {
+  margin: 0 0 0.75rem;
+  font-size: 0.82rem;
+  color: #e3b341;
+  border-left: 2px solid #e3b341;
+  padding-left: 0.6rem;
+}
+
 textarea,
 input {
   width: 100%;

--- a/keep-web/ui/src/app.css
+++ b/keep-web/ui/src/app.css
@@ -124,3 +124,31 @@ button:disabled {
 .fail {
   color: var(--no);
 }
+
+textarea,
+input {
+  width: 100%;
+  background: #0f131a;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  padding: 0.5rem;
+  font-size: 0.88rem;
+  font-family: inherit;
+}
+
+textarea {
+  resize: vertical;
+  font-family: ui-monospace, monospace;
+}
+
+.row {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  align-items: center;
+}
+
+.row button {
+  white-space: nowrap;
+}

--- a/keep-web/ui/src/app.css
+++ b/keep-web/ui/src/app.css
@@ -248,6 +248,68 @@ dl.legend dd {
   color: var(--no);
 }
 
+/* Copyable connection fields */
+.field {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.field:last-child {
+  border-bottom: none;
+}
+
+.field-label {
+  color: var(--muted);
+  min-width: 6rem;
+  font-size: 0.85rem;
+}
+
+.field-value {
+  flex: 1;
+  font-family: ui-monospace, monospace;
+  font-size: 0.82rem;
+  background: #0f131a;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.35rem 0.55rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.copy-btn {
+  background: var(--border);
+  color: var(--text);
+  white-space: nowrap;
+  min-width: 5rem;
+}
+
+.share-main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.share-name {
+  font-weight: 600;
+}
+
+.share-meta {
+  font-size: 0.8rem;
+}
+
+.warn-text {
+  color: #e3b341;
+}
+
+.share-actions button {
+  padding: 0.25rem 0.6rem;
+}
+
 textarea,
 input {
   width: 100%;

--- a/keep-web/ui/src/app.css
+++ b/keep-web/ui/src/app.css
@@ -129,6 +129,12 @@ code.warn {
   color: #e3b341;
 }
 
+.panel.setup {
+  border-color: #e3b341;
+  background: #2a2410;
+  margin-bottom: 0.5rem;
+}
+
 textarea,
 input {
   width: 100%;

--- a/keep-web/ui/src/app.css
+++ b/keep-web/ui/src/app.css
@@ -125,6 +125,10 @@ button:disabled {
   color: var(--no);
 }
 
+code.warn {
+  color: #e3b341;
+}
+
 textarea,
 input {
   width: 100%;

--- a/keep-web/ui/src/app.css
+++ b/keep-web/ui/src/app.css
@@ -8,6 +8,7 @@
   --accent: #0877d2;
   --ok: #3fb950;
   --no: #e5534b;
+
   font-family: system-ui, -apple-system, sans-serif;
 }
 

--- a/keep-web/ui/src/app.css
+++ b/keep-web/ui/src/app.css
@@ -201,6 +201,53 @@ dl.legend dd {
   color: var(--ok);
 }
 
+.killswitch {
+  align-items: center;
+  margin-top: 0.6rem;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--border);
+}
+
+.killswitch button {
+  margin-left: auto;
+}
+
+.share-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 0.4rem;
+}
+
+.share-actions button {
+  padding: 0.25rem 0.6rem;
+  background: var(--border);
+}
+
+.share-actions button.no {
+  background: var(--no);
+}
+
+.export-box {
+  padding: 0.5rem 0 0.75rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.verify {
+  font-size: 0.75rem;
+  font-weight: normal;
+  margin-left: 0.5rem;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.verify.ok {
+  color: var(--ok);
+}
+
+.verify.fail {
+  color: var(--no);
+}
+
 textarea,
 input {
   width: 100%;

--- a/keep-web/ui/src/lib/api.ts
+++ b/keep-web/ui/src/lib/api.ts
@@ -10,10 +10,19 @@ export interface BunkerInfo {
 
 export interface Share {
   name: string
+  group: string
   identifier: number
   threshold: number
   total_shares: number
   sign_count: number
+}
+
+export interface SigningEntry {
+  timestamp_ms: number
+  session: string
+  operation: string
+  participants: number[]
+  our_index: number
 }
 
 export interface LogEvent {
@@ -60,6 +69,56 @@ export async function importShare(
   if (!r.ok && r.status !== 204) {
     throw new Error((await r.text()) || `import failed: ${r.status}`)
   }
+}
+
+export async function exportShare(
+  group: string,
+  identifier: number,
+  passphrase: string,
+): Promise<string> {
+  const r = await fetch('/api/shares/export', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ group, identifier, passphrase }),
+  })
+  if (!r.ok) throw new Error((await r.text()) || `export failed: ${r.status}`)
+  return (await r.json()).export
+}
+
+export async function deleteShare(group: string, identifier: number): Promise<void> {
+  const r = await fetch('/api/shares/delete', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ group, identifier }),
+  })
+  if (!r.ok && r.status !== 204) {
+    throw new Error((await r.text()) || `delete failed: ${r.status}`)
+  }
+}
+
+export async function getSigningLog(): Promise<{
+  verified: boolean
+  entries: SigningEntry[]
+}> {
+  const r = await fetch('/api/signing-log')
+  if (!r.ok) throw new Error(`signing log: ${r.status}`)
+  return r.json()
+}
+
+export async function getKillswitch(): Promise<boolean> {
+  const r = await fetch('/api/killswitch')
+  if (!r.ok) throw new Error(`killswitch: ${r.status}`)
+  return (await r.json()).enabled
+}
+
+export async function setKillswitch(enabled: boolean): Promise<boolean> {
+  const r = await fetch('/api/killswitch', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ enabled }),
+  })
+  if (!r.ok) throw new Error(`killswitch: ${r.status}`)
+  return (await r.json()).enabled
 }
 
 export async function resolveApproval(id: number, approve: boolean): Promise<void> {

--- a/keep-web/ui/src/lib/api.ts
+++ b/keep-web/ui/src/lib/api.ts
@@ -1,0 +1,66 @@
+export interface BunkerInfo {
+  url: string
+  npub: string
+  relay: string
+}
+
+export interface Share {
+  name: string
+  identifier: number
+  threshold: number
+  total_shares: number
+  sign_count: number
+}
+
+export interface LogEvent {
+  type: 'log'
+  app: string
+  action: string
+  success: boolean
+  detail: string | null
+}
+
+export interface ApprovalEvent {
+  type: 'approval'
+  id: number
+  app: string
+  method: string
+  kind: number | null
+  preview: string | null
+}
+
+export type ServerEvent = LogEvent | ApprovalEvent
+
+export async function getBunker(): Promise<BunkerInfo> {
+  const r = await fetch('/api/bunker')
+  if (!r.ok) throw new Error(`bunker: ${r.status}`)
+  return r.json()
+}
+
+export async function getShares(): Promise<Share[]> {
+  const r = await fetch('/api/shares')
+  if (!r.ok) throw new Error(`shares: ${r.status}`)
+  return r.json()
+}
+
+export async function resolveApproval(id: number, approve: boolean): Promise<void> {
+  const r = await fetch(`/api/approvals/${id}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ approve }),
+  })
+  if (!r.ok && r.status !== 204) throw new Error(`approval: ${r.status}`)
+}
+
+export function connectEvents(onEvent: (e: ServerEvent) => void): WebSocket {
+  const proto = location.protocol === 'https:' ? 'wss' : 'ws'
+  const ws = new WebSocket(`${proto}://${location.host}/api/events`)
+  ws.onmessage = (m) => {
+    try {
+      onEvent(JSON.parse(m.data))
+    } catch {
+      /* ignore malformed frames */
+    }
+  }
+  return ws
+}

--- a/keep-web/ui/src/lib/api.ts
+++ b/keep-web/ui/src/lib/api.ts
@@ -43,6 +43,21 @@ export async function getShares(): Promise<Share[]> {
   return r.json()
 }
 
+export async function importShare(
+  data: string,
+  passphrase: string,
+  name: string,
+): Promise<void> {
+  const r = await fetch('/api/shares/import', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ data, passphrase, name: name || null }),
+  })
+  if (!r.ok && r.status !== 204) {
+    throw new Error((await r.text()) || `import failed: ${r.status}`)
+  }
+}
+
 export async function resolveApproval(id: number, approve: boolean): Promise<void> {
   const r = await fetch(`/api/approvals/${id}`, {
     method: 'POST',

--- a/keep-web/ui/src/lib/api.ts
+++ b/keep-web/ui/src/lib/api.ts
@@ -1,7 +1,11 @@
 export interface BunkerInfo {
+  mode: string
   url: string
   npub: string
   relay: string
+  frost_relays: string[]
+  group: string | null
+  threshold: string | null
 }
 
 export interface Share {

--- a/keep-web/ui/src/lib/api.ts
+++ b/keep-web/ui/src/lib/api.ts
@@ -15,6 +15,9 @@ export interface Share {
   threshold: number
   total_shares: number
   sign_count: number
+  created_at: number
+  last_used: number | null
+  did_backup: boolean
 }
 
 export interface SigningEntry {
@@ -83,6 +86,21 @@ export async function exportShare(
   })
   if (!r.ok) throw new Error((await r.text()) || `export failed: ${r.status}`)
   return (await r.json()).export
+}
+
+export async function renameShare(
+  group: string,
+  identifier: number,
+  name: string,
+): Promise<void> {
+  const r = await fetch('/api/shares/rename', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ group, identifier, name }),
+  })
+  if (!r.ok && r.status !== 204) {
+    throw new Error((await r.text()) || `rename failed: ${r.status}`)
+  }
 }
 
 export async function deleteShare(group: string, identifier: number): Promise<void> {

--- a/keep-web/ui/src/lib/api.ts
+++ b/keep-web/ui/src/lib/api.ts
@@ -148,15 +148,55 @@ export async function resolveApproval(id: number, approve: boolean): Promise<voi
   if (!r.ok && r.status !== 204) throw new Error(`approval: ${r.status}`)
 }
 
-export function connectEvents(onEvent: (e: ServerEvent) => void): WebSocket {
+export interface EventStream {
+  close(): void
+}
+
+/**
+ * Subscribe to the live event stream, auto-reconnecting with exponential
+ * backoff (1s→30s, reset on connect). `onStatus(connected)` lets the UI show
+ * connection state. Returns a handle whose `close()` stops reconnection.
+ */
+export function connectEvents(
+  onEvent: (e: ServerEvent) => void,
+  onStatus?: (connected: boolean) => void,
+): EventStream {
   const proto = location.protocol === 'https:' ? 'wss' : 'ws'
-  const ws = new WebSocket(`${proto}://${location.host}/api/events`)
-  ws.onmessage = (m) => {
-    try {
-      onEvent(JSON.parse(m.data))
-    } catch {
-      /* ignore malformed frames */
+  const url = `${proto}://${location.host}/api/events`
+  let ws: WebSocket | null = null
+  let stopped = false
+  let backoff = 1000
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  const connect = () => {
+    if (stopped) return
+    ws = new WebSocket(url)
+    ws.onopen = () => {
+      backoff = 1000
+      onStatus?.(true)
+    }
+    ws.onmessage = (m) => {
+      try {
+        onEvent(JSON.parse(m.data))
+      } catch {
+        /* ignore malformed frames */
+      }
+    }
+    // onclose fires after onerror too, so schedule the reconnect there only.
+    ws.onclose = () => {
+      onStatus?.(false)
+      if (stopped) return
+      timer = setTimeout(connect, backoff)
+      backoff = Math.min(backoff * 2, 30000)
     }
   }
-  return ws
+  connect()
+
+  return {
+    close() {
+      stopped = true
+      if (timer) clearTimeout(timer)
+      ws?.close()
+    },
+  }
 }

--- a/keep-web/ui/src/main.ts
+++ b/keep-web/ui/src/main.ts
@@ -1,0 +1,7 @@
+import { mount } from 'svelte'
+import './app.css'
+import App from './App.svelte'
+
+const app = mount(App, { target: document.getElementById('app')! })
+
+export default app

--- a/keep-web/ui/svelte.config.js
+++ b/keep-web/ui/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
+
+export default {
+  preprocess: vitePreprocess(),
+}

--- a/keep-web/ui/tsconfig.json
+++ b/keep-web/ui/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "checkJs": true,
+    "isolatedModules": true,
+    "moduleResolution": "bundler"
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte", "vite.config.ts"]
+}

--- a/keep-web/ui/vite.config.ts
+++ b/keep-web/ui/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
+
+// Relative base so assets resolve behind the StartOS reverse proxy.
+export default defineConfig({
+  plugins: [svelte()],
+  base: './',
+  build: { outDir: 'dist' },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:8080',
+        ws: true,
+      },
+    },
+  },
+})


### PR DESCRIPTION
New `keep-web` crate: a headless, always-on FROST threshold co-signer that holds one share and coordinates to threshold with peer devices over Nostr relays. Built to be packaged for StartOS (see the companion `keep-startos` repo), but usable standalone.

## What it is
- **axum HTTP API + WebSocket**, embedding the NIP-46 bunker / `KfpNode` in-process, serving a Vite + Svelte 5 admin SPA (`keep-web/ui/`, ~17 KB gz).
- **Network-FROST co-signer** (mirrors keep-android): builds a `KfpNode` from one share, announces, and auto-participates in signing rounds via a policy-gated `SigningHooks` (`KEEP_FROST_AUTO_APPROVE=false` is a kill switch). Single-key bunker is an opt-in fallback.
- **NIP-46 client requests** are gated through the browser via a WebSocket approve/deny bridge.
- **First-run provisioning**: creates the vault if absent, serves a setup mode until a share is imported, and auto-resolves the group from the imported share (no chicken-and-egg with the group npub).

## Config (env)
`KEEP_PATH`, `KEEP_PASSWORD` (headless unlock), `KEEP_BUNKER_RELAY`, `KEEP_FROST_RELAY`, `KEEP_FROST_GROUP` (optional, else auto-resolved), `KEEP_FROST_AUTO_APPROVE`, `KEEP_WEB_LISTEN`, `KEEP_WEB_UI_DIR`.

## Testing
- Full 2-of-3 threshold signature with keep-web as the responder co-signer (interactive round, verified signature).
- Kill switch refusal + live WebSocket observability event.
- Import-share flow (204 / wrong-passphrase 500 / garbage 400).
- First-run lifecycle: fresh path -> vault created -> setup mode -> import -> restart -> auto-resolved network-FROST.
- `cargo clippy`, `cargo fmt`, `svelte-check` clean.

The endpoint not yet exercised end-to-end is an external NIP-46 client requesting `sign_event` permission through the bunker (no on-hand CLI client requests perms); the underlying handler is covered by keep-nip46's integration tests, and the approval bridge is proven via the connect flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full web admin UI for bunker setup/status, shares, approvals, signing log, and health.
  * Import, export (bech32 JSON), rename, and delete shares with passphrase support.
  * Real-time event stream (WebSocket) with approval review (approve/deny) and persistent signing audit log.
  * Killswitch: view and toggle co-signing enable/disable; single-key or network co-signer modes.

* **Chores**
  * Added web crate and frontend scaffold to the workspace.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->