### PR TITLE
Integrate nip55-frost-fix into automated WDC branch

### DIFF
--- a/keep-frost-net/src/ecdh.rs
+++ b/keep-frost-net/src/ecdh.rs
@@ -78,9 +78,9 @@ pub fn aggregate_ecdh_shares(
     partial_points: &[(u16, [u8; 33])],
     participants: &[u16],
 ) -> Result<[u8; 32]> {
-    if partial_points.len() < 2 {
+    if partial_points.is_empty() {
         return Err(FrostNetError::Crypto(
-            "Need at least 2 partial points".into(),
+            "Need at least 1 partial point".into(),
         ));
     }
 
@@ -218,7 +218,8 @@ impl EcdhSession {
             .iter()
             .map(|(id, p)| {
                 let id_bytes = id.serialize();
-                let share_index = u16::from_be_bytes([id_bytes[0], id_bytes[1]]);
+                let len = id_bytes.len();
+                let share_index = u16::from_be_bytes([id_bytes[len - 2], id_bytes[len - 1]]);
                 (share_index, *p)
             })
             .collect();
@@ -387,6 +388,30 @@ mod tests {
         let id1 = derive_ecdh_session_id(&recipient, &[1, 2, 3]);
         let id2 = derive_ecdh_session_id(&recipient, &[3, 1, 2]);
         assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_single_party_ecdh() {
+        let signing_share: [u8; 32] = [
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee,
+            0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc,
+            0xdd, 0xee, 0xff, 0x01,
+        ];
+        let recipient_pk: [u8; 33] = hex::decode(
+            "02bc52210b20d3fb89326463a3518674c7edde65794a7765c7f3a9119b20bfc6de",
+        )
+        .unwrap()
+        .try_into()
+        .unwrap();
+        let partial = compute_partial_ecdh(&signing_share, &recipient_pk).unwrap();
+        let result = aggregate_ecdh_shares(&[(1u16, partial)], &[1u16]);
+        assert!(result.is_ok(), "single-party aggregate failed: {:?}", result.err());
+
+        let session_id = [0u8; 32];
+        let mut session = EcdhSession::new(session_id, recipient_pk, 1, vec![1]);
+        session.add_partial(1, partial).unwrap();
+        let secret = session.try_complete().expect("try_complete should succeed");
+        assert!(secret.is_some(), "single-party session should produce secret");
     }
 
     #[test]

--- a/keep-frost-net/src/ecdh.rs
+++ b/keep-frost-net/src/ecdh.rs
@@ -397,21 +397,27 @@ mod tests {
             0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc,
             0xdd, 0xee, 0xff, 0x01,
         ];
-        let recipient_pk: [u8; 33] = hex::decode(
-            "02bc52210b20d3fb89326463a3518674c7edde65794a7765c7f3a9119b20bfc6de",
-        )
-        .unwrap()
-        .try_into()
-        .unwrap();
+        let recipient_pk: [u8; 33] =
+            hex::decode("02bc52210b20d3fb89326463a3518674c7edde65794a7765c7f3a9119b20bfc6de")
+                .unwrap()
+                .try_into()
+                .unwrap();
         let partial = compute_partial_ecdh(&signing_share, &recipient_pk).unwrap();
         let result = aggregate_ecdh_shares(&[(1u16, partial)], &[1u16]);
-        assert!(result.is_ok(), "single-party aggregate failed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "single-party aggregate failed: {:?}",
+            result.err()
+        );
 
         let session_id = [0u8; 32];
         let mut session = EcdhSession::new(session_id, recipient_pk, 1, vec![1]);
         session.add_partial(1, partial).unwrap();
         let secret = session.try_complete().expect("try_complete should succeed");
-        assert!(secret.is_some(), "single-party session should produce secret");
+        assert!(
+            secret.is_some(),
+            "single-party session should produce secret"
+        );
     }
 
     #[test]

--- a/keep-frost-net/src/node/ecdh.rs
+++ b/keep-frost-net/src/node/ecdh.rs
@@ -281,7 +281,15 @@ impl KfpNode {
         let single_party_secret = {
             let mut ecdh_sessions = self.ecdh_sessions.write();
             match ecdh_sessions.get_session_mut(&session_id) {
-                Some(s) if s.has_all_shares() => s.try_complete()?,
+                Some(s) if s.has_all_shares() => match s.try_complete() {
+                    Ok(secret) => secret,
+                    Err(e) => {
+                        // Drop the failed session instead of leaving it in
+                        // active_sessions until cleanup_expired reaps it.
+                        ecdh_sessions.complete_session(&session_id);
+                        return Err(e);
+                    }
+                },
                 _ => None,
             }
         };

--- a/keep-frost-net/src/node/ecdh.rs
+++ b/keep-frost-net/src/node/ecdh.rs
@@ -290,9 +290,7 @@ impl KfpNode {
                 session_id = %hex::encode(session_id),
                 "ECDH complete (single-party)!"
             );
-            self.ecdh_sessions
-                .write()
-                .complete_session(&session_id);
+            self.ecdh_sessions.write().complete_session(&session_id);
             if let Err(e) = self.event_tx.send(KfpNodeEvent::EcdhComplete {
                 session_id,
                 shared_secret: Zeroizing::new(*secret),

--- a/keep-frost-net/src/node/ecdh.rs
+++ b/keep-frost-net/src/node/ecdh.rs
@@ -293,10 +293,16 @@ impl KfpNode {
             self.ecdh_sessions
                 .write()
                 .complete_session(&session_id);
-            let _ = self.event_tx.send(KfpNodeEvent::EcdhComplete {
+            if let Err(e) = self.event_tx.send(KfpNodeEvent::EcdhComplete {
                 session_id,
                 shared_secret: Zeroizing::new(*secret),
-            });
+            }) {
+                warn!(
+                    session_id = %hex::encode(session_id),
+                    error = %e,
+                    "Failed to send EcdhComplete event (single-party)"
+                );
+            }
         }
 
         let timeout = Duration::from_secs(30);

--- a/keep-frost-net/src/node/ecdh.rs
+++ b/keep-frost-net/src/node/ecdh.rs
@@ -275,6 +275,30 @@ impl KfpNode {
         }
 
         let mut rx = self.event_tx.subscribe();
+
+        // For single-participant (threshold=1), our own partial is the only one needed.
+        // Subscribe first so we don't miss the EcdhComplete we send to ourselves.
+        let single_party_secret = {
+            let mut ecdh_sessions = self.ecdh_sessions.write();
+            match ecdh_sessions.get_session_mut(&session_id) {
+                Some(s) if s.has_all_shares() => s.try_complete()?,
+                _ => None,
+            }
+        };
+        if let Some(secret) = single_party_secret {
+            info!(
+                session_id = %hex::encode(session_id),
+                "ECDH complete (single-party)!"
+            );
+            self.ecdh_sessions
+                .write()
+                .complete_session(&session_id);
+            let _ = self.event_tx.send(KfpNodeEvent::EcdhComplete {
+                session_id,
+                shared_secret: Zeroizing::new(*secret),
+            });
+        }
+
         let timeout = Duration::from_secs(30);
 
         let result = tokio::time::timeout(timeout, async {

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -304,27 +304,21 @@ pub trait KeepStateCallback: Send + Sync + 'static {
 
 struct MobileSigningHooks {
     request_tx: mpsc::Sender<(SessionInfo, mpsc::Sender<bool>)>,
-    pre_approved_hash: Arc<std::sync::Mutex<Option<[u8; 32]>>>,
+    pre_approved_hashes: Arc<std::sync::Mutex<std::collections::HashSet<[u8; 32]>>>,
     /// Read on every round so the kill switch ("Signing Disabled") gates FROST
-    /// co-signing too — not just the NIP-55/NIP-46 paths.
+    /// co-signing too, not just the NIP-55/NIP-46 paths.
     storage: Arc<dyn SecureStorage>,
 }
 
 impl MobileSigningHooks {
     fn consume_pre_approval(&self, message: &[u8]) -> bool {
+        use sha2::{Digest, Sha256};
+        let msg_hash: [u8; 32] = Sha256::digest(message).into();
         let mut guard = self
-            .pre_approved_hash
+            .pre_approved_hashes
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        if let Some(hash) = guard.take() {
-            use sha2::{Digest, Sha256};
-            let msg_hash: [u8; 32] = Sha256::digest(message).into();
-            if hash == msg_hash {
-                return true;
-            }
-            *guard = Some(hash);
-        }
-        false
+        guard.remove(&msg_hash)
     }
 }
 
@@ -343,6 +337,16 @@ impl SigningHooks for MobileSigningHooks {
             return Ok(());
         }
 
+        // If we're already running inside a tokio runtime (i.e. the auto-sign /
+        // ContentProvider background path), we can't safely block here. The caller
+        // should have set a pre-approval via set_signing_pre_approved before invoking
+        // the signer. Fail loudly instead of panicking via block_on.
+        if tokio::runtime::Handle::try_current().is_ok() {
+            return Err(keep_frost_net::FrostNetError::Session(
+                "Sign request not pre-approved (background context)".into(),
+            ));
+        }
+
         let (response_tx, mut response_rx) = mpsc::channel(1);
         let request_tx = self.request_tx.clone();
         let session = session.clone();
@@ -351,9 +355,12 @@ impl SigningHooks for MobileSigningHooks {
         // handler, i.e. on a tokio worker thread. `blocking_send`/`Handle::block_on`
         // panic there ("cannot block the current thread from within a runtime"),
         // which silently killed the co-sign task (request received, no prompt, no
-        // response → initiator timeout). `block_in_place` hands the worker back to
-        // the scheduler so blocking here is safe (requires the multi-thread runtime
-        // this crate builds). Mirrors keep-desktop's hook.
+        // response, initiator timeout). `block_in_place` hands the worker back to
+        // the scheduler so blocking here is safe. INVARIANT: this requires a
+        // multi-thread tokio runtime; `block_in_place` panics on a current-thread
+        // runtime. The node task runs on the `new_multi_thread()` runtime built
+        // in `KeepMobile::new` (below), which satisfies this. Mirrors
+        // keep-desktop's hook.
         tokio::task::block_in_place(|| {
             let handle = tokio::runtime::Handle::try_current()
                 .map_err(|_| keep_frost_net::FrostNetError::Session("No tokio runtime".into()))?;
@@ -393,7 +400,7 @@ pub struct KeepMobile {
     pending_contributions: Arc<std::sync::Mutex<HashMap<[u8; 32], PendingContribution>>>,
     state_callback: Arc<RwLock<Option<Arc<dyn KeepStateCallback>>>>,
     state_rev: Arc<std::sync::atomic::AtomicU64>,
-    pre_approved_hash: Arc<std::sync::Mutex<Option<[u8; 32]>>>,
+    pre_approved_hashes: Arc<std::sync::Mutex<std::collections::HashSet<[u8; 32]>>>,
     session_store_path: Arc<std::sync::Mutex<Option<String>>>,
     descriptor_write_lock: Arc<std::sync::Mutex<()>>,
 }
@@ -532,7 +539,7 @@ impl KeepMobile {
             pending_contributions: Arc::new(std::sync::Mutex::new(HashMap::new())),
             state_callback: Arc::new(RwLock::new(None)),
             state_rev: Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            pre_approved_hash: Arc::new(std::sync::Mutex::new(None)),
+            pre_approved_hashes: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
             session_store_path: Arc::new(std::sync::Mutex::new(None)),
             descriptor_write_lock: Arc::new(std::sync::Mutex::new(())),
         })
@@ -668,10 +675,18 @@ impl KeepMobile {
     pub fn set_signing_pre_approved(&self, message: Vec<u8>) {
         use sha2::{Digest, Sha256};
         let hash: [u8; 32] = Sha256::digest(&message).into();
-        *self
-            .pre_approved_hash
+        self.pre_approved_hashes
             .lock()
-            .unwrap_or_else(|e| e.into_inner()) = Some(hash);
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(hash);
+    }
+
+    pub fn pre_approve_nostr_event(&self, event_json: String) -> Result<(), KeepMobileError> {
+        let event: serde_json::Value = serde_json::from_str(&event_json)
+            .map_err(|_| KeepMobileError::InvalidSession)?;
+        let event_hash = crate::nip55::compute_nostr_event_id(&event)?;
+        self.set_signing_pre_approved(event_hash.to_vec());
+        Ok(())
     }
 
     /// Pre-approve a specific Nostr event (by its computed event id) so the next
@@ -686,10 +701,10 @@ impl KeepMobile {
     }
 
     pub fn clear_signing_pre_approval(&self) {
-        *self
-            .pre_approved_hash
+        self.pre_approved_hashes
             .lock()
-            .unwrap_or_else(|e| e.into_inner()) = None;
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
     }
 
     pub fn get_pending_requests(&self) -> Vec<SignRequest> {
@@ -2394,7 +2409,7 @@ impl KeepMobile {
             let (request_tx, request_rx) = mpsc::channel(32);
             let hooks = Arc::new(MobileSigningHooks {
                 request_tx,
-                pre_approved_hash: self.pre_approved_hash.clone(),
+                pre_approved_hashes: self.pre_approved_hashes.clone(),
                 storage: self.storage.clone(),
             });
             node.set_hooks(hooks);

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -217,6 +217,8 @@ const MAX_PENDING_REQUESTS: usize = 100;
 const SIGNING_RESPONSE_TIMEOUT: Duration = Duration::from_secs(60);
 const MAX_IMPORT_DATA_SIZE: usize = 64 * 1024;
 const MAX_STORED_SHARES: usize = 100;
+const MAX_PRE_APPROVED_HASHES: usize = 100;
+const PRE_APPROVAL_TTL: Duration = Duration::from_secs(300);
 const MAX_SHARE_NAME_LENGTH: usize = 64;
 
 const POLICY_STORAGE_KEY: &str = "__keep_policy_v1";
@@ -304,7 +306,8 @@ pub trait KeepStateCallback: Send + Sync + 'static {
 
 struct MobileSigningHooks {
     request_tx: mpsc::Sender<(SessionInfo, mpsc::Sender<bool>)>,
-    pre_approved_hashes: Arc<std::sync::Mutex<std::collections::HashSet<[u8; 32]>>>,
+    pre_approved_hashes:
+        Arc<std::sync::Mutex<std::collections::HashMap<[u8; 32], std::time::Instant>>>,
     /// Read on every round so the kill switch ("Signing Disabled") gates FROST
     /// co-signing too, not just the NIP-55/NIP-46 paths.
     storage: Arc<dyn SecureStorage>,
@@ -314,11 +317,13 @@ impl MobileSigningHooks {
     fn consume_pre_approval(&self, message: &[u8]) -> bool {
         use sha2::{Digest, Sha256};
         let msg_hash: [u8; 32] = Sha256::digest(message).into();
+        let now = std::time::Instant::now();
         let mut guard = self
             .pre_approved_hashes
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        guard.remove(&msg_hash)
+        guard.retain(|_, &mut inserted| now.duration_since(inserted) < PRE_APPROVAL_TTL);
+        guard.remove(&msg_hash).is_some()
     }
 }
 
@@ -400,7 +405,7 @@ pub struct KeepMobile {
     pending_contributions: Arc<std::sync::Mutex<HashMap<[u8; 32], PendingContribution>>>,
     state_callback: Arc<RwLock<Option<Arc<dyn KeepStateCallback>>>>,
     state_rev: Arc<std::sync::atomic::AtomicU64>,
-    pre_approved_hashes: Arc<std::sync::Mutex<std::collections::HashSet<[u8; 32]>>>,
+    pre_approved_hashes: Arc<std::sync::Mutex<std::collections::HashMap<[u8; 32], std::time::Instant>>>,
     session_store_path: Arc<std::sync::Mutex<Option<String>>>,
     descriptor_write_lock: Arc<std::sync::Mutex<()>>,
 }
@@ -539,7 +544,7 @@ impl KeepMobile {
             pending_contributions: Arc::new(std::sync::Mutex::new(HashMap::new())),
             state_callback: Arc::new(RwLock::new(None)),
             state_rev: Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            pre_approved_hashes: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+            pre_approved_hashes: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             session_store_path: Arc::new(std::sync::Mutex::new(None)),
             descriptor_write_lock: Arc::new(std::sync::Mutex::new(())),
         })
@@ -675,15 +680,24 @@ impl KeepMobile {
     pub fn set_signing_pre_approved(&self, message: Vec<u8>) {
         use sha2::{Digest, Sha256};
         let hash: [u8; 32] = Sha256::digest(&message).into();
-        self.pre_approved_hashes
+        let now = std::time::Instant::now();
+        let mut guard = self
+            .pre_approved_hashes
             .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(hash);
+            .unwrap_or_else(|e| e.into_inner());
+        guard.retain(|_, &mut inserted| now.duration_since(inserted) < PRE_APPROVAL_TTL);
+        if guard.len() >= MAX_PRE_APPROVED_HASHES {
+            if let Some(&oldest) = guard.iter().min_by_key(|(_, &t)| t).map(|(k, _)| k) {
+                guard.remove(&oldest);
+            }
+        }
+        guard.insert(hash, now);
     }
 
     pub fn pre_approve_nostr_event(&self, event_json: String) -> Result<(), KeepMobileError> {
         let event: serde_json::Value = serde_json::from_str(&event_json)
             .map_err(|_| KeepMobileError::InvalidSession)?;
+        crate::nip55::validate_nostr_event(&event)?;
         let event_hash = crate::nip55::compute_nostr_event_id(&event)?;
         self.set_signing_pre_approved(event_hash.to_vec());
         Ok(())

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -221,6 +221,18 @@ const MAX_PRE_APPROVED_HASHES: usize = 100;
 const PRE_APPROVAL_TTL: Duration = Duration::from_secs(300);
 const MAX_SHARE_NAME_LENGTH: usize = 64;
 
+type PreApprovedHashes =
+    Arc<std::sync::Mutex<std::collections::HashMap<[u8; 32], std::time::Instant>>>;
+
+fn lock_pre_approved(
+    hashes: &PreApprovedHashes,
+) -> std::sync::MutexGuard<'_, std::collections::HashMap<[u8; 32], std::time::Instant>> {
+    let now = std::time::Instant::now();
+    let mut guard = hashes.lock().unwrap_or_else(|e| e.into_inner());
+    guard.retain(|_, &mut inserted| now.duration_since(inserted) < PRE_APPROVAL_TTL);
+    guard
+}
+
 const POLICY_STORAGE_KEY: &str = "__keep_policy_v1";
 const VELOCITY_STORAGE_KEY: &str = "__keep_velocity_v1";
 const TRUSTED_WARDENS_KEY: &str = "__keep_trusted_wardens_v1";
@@ -306,8 +318,7 @@ pub trait KeepStateCallback: Send + Sync + 'static {
 
 struct MobileSigningHooks {
     request_tx: mpsc::Sender<(SessionInfo, mpsc::Sender<bool>)>,
-    pre_approved_hashes:
-        Arc<std::sync::Mutex<std::collections::HashMap<[u8; 32], std::time::Instant>>>,
+    pre_approved_hashes: PreApprovedHashes,
     /// Read on every round so the kill switch ("Signing Disabled") gates FROST
     /// co-signing too, not just the NIP-55/NIP-46 paths.
     storage: Arc<dyn SecureStorage>,
@@ -317,13 +328,9 @@ impl MobileSigningHooks {
     fn consume_pre_approval(&self, message: &[u8]) -> bool {
         use sha2::{Digest, Sha256};
         let msg_hash: [u8; 32] = Sha256::digest(message).into();
-        let now = std::time::Instant::now();
-        let mut guard = self
-            .pre_approved_hashes
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        guard.retain(|_, &mut inserted| now.duration_since(inserted) < PRE_APPROVAL_TTL);
-        guard.remove(&msg_hash).is_some()
+        lock_pre_approved(&self.pre_approved_hashes)
+            .remove(&msg_hash)
+            .is_some()
     }
 }
 
@@ -417,8 +424,7 @@ pub struct KeepMobile {
     pending_contributions: Arc<std::sync::Mutex<HashMap<[u8; 32], PendingContribution>>>,
     state_callback: Arc<RwLock<Option<Arc<dyn KeepStateCallback>>>>,
     state_rev: Arc<std::sync::atomic::AtomicU64>,
-    pre_approved_hashes:
-        Arc<std::sync::Mutex<std::collections::HashMap<[u8; 32], std::time::Instant>>>,
+    pre_approved_hashes: PreApprovedHashes,
     session_store_path: Arc<std::sync::Mutex<Option<String>>>,
     descriptor_write_lock: Arc<std::sync::Mutex<()>>,
 }
@@ -694,11 +700,7 @@ impl KeepMobile {
         use sha2::{Digest, Sha256};
         let hash: [u8; 32] = Sha256::digest(&message).into();
         let now = std::time::Instant::now();
-        let mut guard = self
-            .pre_approved_hashes
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        guard.retain(|_, &mut inserted| now.duration_since(inserted) < PRE_APPROVAL_TTL);
+        let mut guard = lock_pre_approved(&self.pre_approved_hashes);
         if guard.len() >= MAX_PRE_APPROVED_HASHES {
             if let Some(&oldest) = guard.iter().min_by_key(|(_, &t)| t).map(|(k, _)| k) {
                 guard.remove(&oldest);
@@ -707,21 +709,13 @@ impl KeepMobile {
         guard.insert(hash, now);
     }
 
-    pub fn pre_approve_nostr_event(&self, event_json: String) -> Result<(), KeepMobileError> {
-        let event: serde_json::Value =
-            serde_json::from_str(&event_json).map_err(|_| KeepMobileError::InvalidSession)?;
-        crate::nip55::validate_nostr_event(&event)?;
-        let event_hash = crate::nip55::compute_nostr_event_id(&event)?;
-        self.set_signing_pre_approved(event_hash.to_vec());
-        Ok(())
-    }
-
     /// Pre-approve a specific Nostr event (by its computed event id) so the next
     /// matching sign request auto-approves without prompting. Convenience wrapper
     /// over [`set_signing_pre_approved`] for NIP-55 callers holding event JSON.
     pub fn pre_approve_nostr_event(&self, event_json: String) -> Result<(), KeepMobileError> {
         let event: serde_json::Value =
             serde_json::from_str(&event_json).map_err(|_| KeepMobileError::InvalidSession)?;
+        crate::nip55::validate_nostr_event(&event)?;
         let event_hash = crate::nip55::compute_nostr_event_id(&event)?;
         self.set_signing_pre_approved(event_hash.to_vec());
         Ok(())

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -342,49 +342,61 @@ impl SigningHooks for MobileSigningHooks {
             return Ok(());
         }
 
-        // If we're already running inside a tokio runtime (i.e. the auto-sign /
-        // ContentProvider background path), we can't safely block here. The caller
-        // should have set a pre-approval via set_signing_pre_approved before invoking
-        // the signer. Fail loudly instead of panicking via block_on.
-        if tokio::runtime::Handle::try_current().is_ok() {
-            return Err(keep_frost_net::FrostNetError::Session(
-                "Sign request not pre-approved (background context)".into(),
-            ));
-        }
-
         let (response_tx, mut response_rx) = mpsc::channel(1);
-        let request_tx = self.request_tx.clone();
-        let session = session.clone();
 
-        // `pre_sign` is a sync hook invoked from keep-frost-net's async signing
-        // handler, i.e. on a tokio worker thread. `blocking_send`/`Handle::block_on`
-        // panic there ("cannot block the current thread from within a runtime"),
-        // which silently killed the co-sign task (request received, no prompt, no
-        // response, initiator timeout). `block_in_place` hands the worker back to
-        // the scheduler so blocking here is safe. INVARIANT: this requires a
-        // multi-thread tokio runtime; `block_in_place` panics on a current-thread
-        // runtime. The node task runs on the `new_multi_thread()` runtime built
-        // in `KeepMobile::new` (below), which satisfies this. Mirrors
-        // keep-desktop's hook.
-        tokio::task::block_in_place(|| {
-            let handle = tokio::runtime::Handle::try_current()
-                .map_err(|_| keep_frost_net::FrostNetError::Session("No tokio runtime".into()))?;
-            handle.block_on(async {
-                request_tx
-                    .send((session, response_tx))
-                    .await
-                    .map_err(|_| keep_frost_net::FrostNetError::Session("Channel closed".into()))?;
-
-                match tokio::time::timeout(SIGNING_RESPONSE_TIMEOUT, response_rx.recv()).await {
-                    Ok(Some(true)) => Ok(()),
-                    Ok(Some(false)) => Err(keep_frost_net::FrostNetError::Session(
-                        "Request rejected".into(),
-                    )),
-                    Ok(None) => Err(keep_frost_net::FrostNetError::Session("No response".into())),
-                    Err(_) => Err(keep_frost_net::FrostNetError::Session("Timeout".into())),
+        // The interactive approval path runs inside the node's async message
+        // handler, so a current runtime is present. We must neither block a
+        // worker thread (blocking_send) nor start a nested runtime
+        // (Runtime::block_on panics inside a runtime). Use block_in_place to move
+        // off the worker, then drive the send + wait on the current handle.
+        // INVARIANT: block_in_place panics on a current-thread runtime; the node
+        // task runs on the `new_multi_thread()` runtime built in `KeepMobile::new`
+        // (below), which satisfies this. Outside a runtime (no current handle),
+        // fall back to a blocking send and an owned current-thread runtime.
+        let result = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                let request_tx = self.request_tx.clone();
+                let session = session.clone();
+                tokio::task::block_in_place(|| {
+                    handle.block_on(async {
+                        request_tx.send((session, response_tx)).await.map_err(|_| {
+                            keep_frost_net::FrostNetError::Session("Channel closed".into())
+                        })?;
+                        Ok::<_, keep_frost_net::FrostNetError>(
+                            tokio::time::timeout(SIGNING_RESPONSE_TIMEOUT, response_rx.recv())
+                                .await,
+                        )
+                    })
+                })?
+            }
+            Err(_) => {
+                if self
+                    .request_tx
+                    .blocking_send((session.clone(), response_tx))
+                    .is_err()
+                {
+                    return Err(keep_frost_net::FrostNetError::Session(
+                        "Channel closed".into(),
+                    ));
                 }
-            })
-        })
+                let owned_rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_time()
+                    .build()
+                    .map_err(|_| keep_frost_net::FrostNetError::Session("No runtime".into()))?;
+                owned_rt.block_on(async {
+                    tokio::time::timeout(SIGNING_RESPONSE_TIMEOUT, response_rx.recv()).await
+                })
+            }
+        };
+
+        match result {
+            Ok(Some(true)) => Ok(()),
+            Ok(Some(false)) => Err(keep_frost_net::FrostNetError::Session(
+                "Request rejected".into(),
+            )),
+            Ok(None) => Err(keep_frost_net::FrostNetError::Session("No response".into())),
+            Err(_) => Err(keep_frost_net::FrostNetError::Session("Timeout".into())),
+        }
     }
 
     fn post_sign(&self, _session: &SessionInfo, _signature: &[u8; 64]) {}
@@ -405,7 +417,8 @@ pub struct KeepMobile {
     pending_contributions: Arc<std::sync::Mutex<HashMap<[u8; 32], PendingContribution>>>,
     state_callback: Arc<RwLock<Option<Arc<dyn KeepStateCallback>>>>,
     state_rev: Arc<std::sync::atomic::AtomicU64>,
-    pre_approved_hashes: Arc<std::sync::Mutex<std::collections::HashMap<[u8; 32], std::time::Instant>>>,
+    pre_approved_hashes:
+        Arc<std::sync::Mutex<std::collections::HashMap<[u8; 32], std::time::Instant>>>,
     session_store_path: Arc<std::sync::Mutex<Option<String>>>,
     descriptor_write_lock: Arc<std::sync::Mutex<()>>,
 }
@@ -695,8 +708,8 @@ impl KeepMobile {
     }
 
     pub fn pre_approve_nostr_event(&self, event_json: String) -> Result<(), KeepMobileError> {
-        let event: serde_json::Value = serde_json::from_str(&event_json)
-            .map_err(|_| KeepMobileError::InvalidSession)?;
+        let event: serde_json::Value =
+            serde_json::from_str(&event_json).map_err(|_| KeepMobileError::InvalidSession)?;
         crate::nip55::validate_nostr_event(&event)?;
         let event_hash = crate::nip55::compute_nostr_event_id(&event)?;
         self.set_signing_pre_approved(event_hash.to_vec());

--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -20,7 +20,12 @@ const MAX_TAGS_COUNT: usize = 1000;
 const MAX_EVENT_SIZE: usize = 128 * 1024;
 const TIMESTAMP_DRIFT_SECS: i64 = 15 * 60;
 const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
-const MAX_REQUESTS_PER_WINDOW: u32 = 10;
+// Real Nostr clients (e.g. Amethyst sending NIP-17 DMs) easily fire 20-50 sign
+// requests in a short burst: kind 14 rumor + kind 13 seal + per-recipient
+// kind 1059 gift wraps + per-relay kind 22242 NIP-42 auth + reaction signing,
+// all chained. 10/min was a DoS guard that broke real-world flows; the Kotlin
+// IPC-level RateLimiter (30/sec) and per-app permissions already bound abuse.
+const MAX_REQUESTS_PER_WINDOW: u32 = 120;
 const MAX_BACKOFF: Duration = Duration::from_secs(300);
 const MAX_BATCH_SIZE: usize = 20;
 const MAX_RATE_LIMIT_ENTRIES: usize = 1000;
@@ -141,7 +146,12 @@ impl Nip55Handler {
         request: Nip55Request,
         caller_id: String,
     ) -> Result<Nip55Response, KeepMobileError> {
-        self.check_rate_limit(&caller_id)?;
+        if matches!(
+            request.request_type,
+            Nip55RequestType::SignEvent | Nip55RequestType::GetPublicKey
+        ) {
+            self.check_rate_limit(&caller_id)?;
+        }
 
         if let Some(ref current_user) = request.current_user {
             self.validate_current_user(current_user)?;
@@ -180,7 +190,12 @@ impl Nip55Handler {
             response.id = request_id;
         }
 
-        self.record_result(&caller_id, result.is_ok());
+        if matches!(
+            request.request_type,
+            Nip55RequestType::SignEvent | Nip55RequestType::GetPublicKey
+        ) {
+            self.record_result(&caller_id, result.is_ok());
+        }
         result
     }
 

--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -146,10 +146,7 @@ impl Nip55Handler {
         request: Nip55Request,
         caller_id: String,
     ) -> Result<Nip55Response, KeepMobileError> {
-        if matches!(
-            request.request_type,
-            Nip55RequestType::SignEvent | Nip55RequestType::GetPublicKey
-        ) {
+        if is_rate_limited_type(&request.request_type) {
             self.check_rate_limit(&caller_id)?;
         }
 
@@ -190,10 +187,7 @@ impl Nip55Handler {
             response.id = request_id;
         }
 
-        if matches!(
-            request.request_type,
-            Nip55RequestType::SignEvent | Nip55RequestType::GetPublicKey
-        ) {
+        if is_rate_limited_type(&request.request_type) {
             self.record_result(&caller_id, result.is_ok());
         }
         result
@@ -713,6 +707,19 @@ fn is_valid_package_name(name: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-')
 }
 
+fn is_rate_limited_type(t: &Nip55RequestType) -> bool {
+    matches!(
+        t,
+        Nip55RequestType::SignEvent
+            | Nip55RequestType::GetPublicKey
+            | Nip55RequestType::Nip04Encrypt
+            | Nip55RequestType::Nip04Decrypt
+            | Nip55RequestType::Nip44Encrypt
+            | Nip55RequestType::Nip44Decrypt
+            | Nip55RequestType::DecryptZapEvent
+    )
+}
+
 fn parse_request_type(value: &str) -> Result<Nip55RequestType, KeepMobileError> {
     match value {
         "get_public_key" => Ok(Nip55RequestType::GetPublicKey),
@@ -760,7 +767,7 @@ fn parse_pubkey_to_compressed(pubkey_hex: &str) -> Result<[u8; 33], KeepMobileEr
     }
 }
 
-fn validate_nostr_event(event: &serde_json::Value) -> Result<(), KeepMobileError> {
+pub(crate) fn validate_nostr_event(event: &serde_json::Value) -> Result<(), KeepMobileError> {
     if !event.is_object() {
         return Err(KeepMobileError::InvalidSession);
     }

--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -711,9 +711,10 @@ fn is_valid_package_name(name: &str) -> bool {
 }
 
 fn is_rate_limited_type(t: &Nip55RequestType) -> bool {
-    // GetPublicKey is a trivial local read of cached share info (no crypto/IPC),
-    // so it is exempt. Every other type triggers FROST/ECDH/IPC work and must be
-    // rate-limited. Exhaustive match so new variants force an explicit decision.
+    // GetPublicKey is a cheap cached-metadata read with no FROST/ECDH crypto and
+    // no signing round-trip, so it is exempt. Every other type triggers a signing
+    // or encryption operation and must be rate-limited. Exhaustive match so new
+    // variants force an explicit decision.
     match t {
         Nip55RequestType::GetPublicKey => false,
         Nip55RequestType::SignEvent

--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -23,9 +23,12 @@ const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
 // Real Nostr clients (e.g. Amethyst sending NIP-17 DMs) easily fire 20-50 sign
 // requests in a short burst: kind 14 rumor + kind 13 seal + per-recipient
 // kind 1059 gift wraps + per-relay kind 22242 NIP-42 auth + reaction signing,
-// all chained. 10/min was a DoS guard that broke real-world flows; the Kotlin
-// IPC-level RateLimiter (30/sec) and per-app permissions already bound abuse.
-const MAX_REQUESTS_PER_WINDOW: u32 = 120;
+// all chained. 10/min broke those real-world flows. This is a defense-in-depth
+// in-process cap covering legitimate bursts. The primary throttle is the
+// Kotlin IPC-level RateLimiter (30/sec) plus per-app permissions; that external
+// limiter is a REQUIRED invariant, not optional, since this in-process counter
+// alone is not a sufficient DoS guard.
+const MAX_REQUESTS_PER_WINDOW: u32 = 60;
 const MAX_BACKOFF: Duration = Duration::from_secs(300);
 const MAX_BATCH_SIZE: usize = 20;
 const MAX_RATE_LIMIT_ENTRIES: usize = 1000;
@@ -708,16 +711,18 @@ fn is_valid_package_name(name: &str) -> bool {
 }
 
 fn is_rate_limited_type(t: &Nip55RequestType) -> bool {
-    matches!(
-        t,
+    // GetPublicKey is a trivial local read of cached share info (no crypto/IPC),
+    // so it is exempt. Every other type triggers FROST/ECDH/IPC work and must be
+    // rate-limited. Exhaustive match so new variants force an explicit decision.
+    match t {
+        Nip55RequestType::GetPublicKey => false,
         Nip55RequestType::SignEvent
-            | Nip55RequestType::GetPublicKey
-            | Nip55RequestType::Nip04Encrypt
-            | Nip55RequestType::Nip04Decrypt
-            | Nip55RequestType::Nip44Encrypt
-            | Nip55RequestType::Nip44Decrypt
-            | Nip55RequestType::DecryptZapEvent
-    )
+        | Nip55RequestType::Nip04Encrypt
+        | Nip55RequestType::Nip04Decrypt
+        | Nip55RequestType::Nip44Encrypt
+        | Nip55RequestType::Nip44Decrypt
+        | Nip55RequestType::DecryptZapEvent => true,
+    }
 }
 
 fn parse_request_type(value: &str) -> Result<Nip55RequestType, KeepMobileError> {


### PR DESCRIPTION
Merges nip55-frost-fix (single-party FROST sign/ECDH + auto-sign pre-approval) into the automated WDC work so desktop and Android build from one keep and speak identical WDC protocol.

- single-party FROST sign/ECDH fix + `pre_approve_nostr_event`
- pre-approval set bounded (cap 100 + 300s TTL), validated before insert
- ECDH ops rate-limited

`cargo build --release -p keep-desktop` passes; keep-mobile tests pass.

Closes #396. Unblocks #395 and keep-android#272 (repin `keep.version`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Immediate local/single-party ECDH completion and a test verifying single-share flow.
  * Mobile: ability to pre-approve Nostr events (new helper).

* **Bug Fixes**
  * ECDH aggregation accepts a single partial share; improved completion/error handling and logging.
  * Mobile signing pre-approval uses a bounded TTL cache to avoid stale entries and uncontrolled growth.

* **Chores**
  * Raised and refined NIP-55 rate limits; validation helper visibility tightened.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->