### PR TITLE
Fix main CI: keep-web reproducible build + Windows compile

### DIFF
--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -27,6 +27,7 @@ COPY keep-frost-net ./keep-frost-net
 COPY keep-enclave ./keep-enclave
 COPY keep-mobile ./keep-mobile
 COPY keep-desktop ./keep-desktop
+COPY keep-web ./keep-web
 
 RUN cargo build --release --locked \
     && mkdir -p /out \

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -40,15 +40,21 @@ fn secret_from(key: &str) -> Result<Option<String>, Box<dyn std::error::Error>> 
 }
 
 fn read_secret_file(path: &str) -> Result<String, Box<dyn std::error::Error>> {
-    use std::os::unix::fs::PermissionsExt;
-    let meta = std::fs::metadata(path)?;
-    let mode = meta.permissions().mode() & 0o777;
-    if mode & 0o077 != 0 {
-        tracing::warn!(
-            path,
-            mode = format!("{mode:o}"),
-            "secret file is group/world accessible; tighten to 0600"
-        );
+    // The permission check is Unix-only (keep-web runs on Linux/StartOS); on
+    // other platforms the file is read without the mode warning so the
+    // workspace still builds (e.g. Windows CI).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let meta = std::fs::metadata(path)?;
+        let mode = meta.permissions().mode() & 0o777;
+        if mode & 0o077 != 0 {
+            tracing::warn!(
+                path,
+                mode = format!("{mode:o}"),
+                "secret file is group/world accessible; tighten to 0600"
+            );
+        }
     }
     Ok(std::fs::read_to_string(path)?.trim().to_string())
 }


### PR DESCRIPTION
Two CI jobs have been red on `main` since keep-web landed; both are because the workspace build now includes the `keep-web` crate and two places didn't account for it.

**`reproducible` job** — `Dockerfile.reproducible` copies each workspace member individually and was never updated for `keep-web`, so `cargo build --locked` fails ("workspace member keep-web not found") in seconds. Fixed by adding `COPY keep-web ./keep-web`.

**`build-windows` job** — `keep-web/src/main.rs` used `std::os::unix::fs::PermissionsExt` / `Permissions::mode()` for the secret-file permission warning, which doesn't exist on Windows. keep-web is a Linux/StartOS daemon, but the workspace build compiles it on every target. Gated the permission check behind `#[cfg(unix)]`; non-Unix reads the file without the mode warning.

Verified: `cargo build`, `cargo fmt -- --check`, `cargo clippy -- -D warnings` clean locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to improve reproducibility.

* **Refactor**
  * Enhanced cross-platform compatibility by implementing platform-specific conditional logic for file handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->