### PR TITLE
keep-web UI polish: status pills, tooltips, click-to-copy, signing-log export

### DIFF
--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -50,18 +50,6 @@
   let importMsg = $state<string | null>(null)
   let importOk = $state(false)
 
-  // What the Connection panel shows once a share is imported and the
-  // co-signer is running.
-  const fieldLegend: [string, string][] = [
-    ['mode', 'network FROST co-signer once running (vs. setup)'],
-    ['group', 'the FROST group npub this node co-signs for'],
-    ['threshold', 'signatures needed, e.g. 2-of-3'],
-    ['npub', "this signer's own public key"],
-    ['bunker', 'NIP-46 connection string to paste into a Nostr client'],
-    ['bunker relay', 'relay where clients reach the bunker'],
-    ['frost relays', 'relays used to coordinate signing rounds with your devices'],
-  ]
-
   // undefined = status not yet loaded (interaction disabled until known).
   let signingEnabled = $state<boolean | undefined>(undefined)
   let signingLoadError = $state<string | null>(null)
@@ -141,6 +129,20 @@
         signingVerified = r.verified
       })
       .catch(() => {})
+  }
+
+  function exportSigningLog() {
+    const data = JSON.stringify(
+      { verified: signingVerified, exported_at: new Date().toISOString(), entries: signingLog },
+      null,
+      2,
+    )
+    const url = URL.createObjectURL(new Blob([data], { type: 'application/json' }))
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `keep-signing-log-${Date.now()}.json`
+    a.click()
+    URL.revokeObjectURL(url)
   }
 
   async function toggleKillswitch() {
@@ -273,12 +275,30 @@
   }
 </script>
 
-{#snippet copyField(label: string, value: string)}
+{#snippet tip(text: string)}
+  <span class="tip" data-tip={text}>
+    <svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true">
+      <circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" stroke-width="1.3" />
+      <circle cx="8" cy="4.7" r="0.95" fill="currentColor" />
+      <rect x="7.1" y="6.7" width="1.8" height="5" rx="0.9" fill="currentColor" />
+    </svg>
+  </span>
+{/snippet}
+
+{#snippet copyField(label: string, value: string, hint: string)}
   <div class="field">
-    <span class="field-label">{label}</span>
-    <span class="field-value" title={value}>{value}</span>
-    <button class="copy-btn" onclick={() => copy(value, label + value)}>
-      {copied === label + value ? '✓ Copied' : 'Copy'}
+    <span class="field-label">
+      {label}{@render tip(hint)}
+    </span>
+    <button
+      class="field-value copyable"
+      title="Click to copy"
+      onclick={() => copy(value, 'f' + value)}
+    >
+      <span class="cv-text">{value}</span>
+      <span class="cv-icon" class:done={copied === 'f' + value}>
+        {copied === 'f' + value ? '✓ copied' : 'copy'}
+      </span>
     </button>
   </div>
 {/snippet}
@@ -309,7 +329,7 @@
     <div class="panel setup">
       <strong>🔒 Authentication required.</strong>
       <p>
-        Enter the auth token. It is set via <code>KEEP_WEB_AUTH_TOKEN</code>, or, if
+        Enter the auth token. It is set via <span class="token">KEEP_WEB_AUTH_TOKEN</span>, or, if
         unset, generated once at startup and printed to the service logs.
       </p>
       <form onsubmit={(e) => (e.preventDefault(), submitToken())}>
@@ -343,50 +363,95 @@
     </div>
   {/if}
 
+  {#if bunker && bunker.mode !== 'setup' && signingEnabled === false}
+    <div class="panel disabled-banner">
+      <div>
+        <strong>⏸ Co-signing is disabled.</strong>
+        This node is online but will <strong>not sign</strong> until you enable it.
+      </div>
+      <button class="ok" onclick={toggleKillswitch}>Enable signing</button>
+    </div>
+  {/if}
+
   <h2>Connection</h2>
   <div class="panel">
     {#if bunker}
-      <div class="kv">
-        <span>mode</span>
-        {#if bunker.mode === 'network-frost'}
-          <code>network FROST co-signer</code>
-        {:else if bunker.mode === 'setup'}
-          <code class="warn">setup (not signing yet)</code>
+      <div class="conn-status">
+        {#if bunker.mode === 'setup'}
+          <span class="dot warn"></span>
+          <span>Not signing yet. Import a share and restart to begin.</span>
+        {:else if signingEnabled === false}
+          <span class="dot warn"></span>
+          <span>Online, but <strong>co-signing is off</strong>. It won't sign until you enable it.</span>
+        {:else if bunker.mode === 'single-key'}
+          <span class="dot warn"></span>
+          <span>Single-key mode (no threshold security).</span>
         {:else}
-          <code class="warn">single-key (no threshold security)</code>
+          <span class="dot ok"></span>
+          <span>Co-signer online and coordinating with your devices.</span>
         {/if}
       </div>
       {#if bunker.mode === 'setup'}
-        <p class="muted legend-intro">
-          Once a share is imported and the service is restarted, this panel will
-          show:
+        <p class="muted setup-hint">
+          Once your share is imported and the service is restarted, this card
+          shows the bunker connection string, the group it co-signs for, and the
+          relays it uses.
         </p>
-        <dl class="legend">
-          {#each fieldLegend as [field, desc]}
-            <dt>{field}</dt>
-            <dd>{desc}</dd>
-          {/each}
-        </dl>
       {/if}
       {#if bunker.threshold}
-        <div class="kv"><span>threshold</span><strong>{bunker.threshold}</strong></div>
+        <div class="kv">
+          <span>
+            threshold{@render tip(
+              'Signatures required to sign, out of the total shares (e.g. 2-of-3).',
+            )}
+          </span>
+          <strong>{bunker.threshold}</strong>
+        </div>
       {/if}
-      {#if bunker.group}{@render copyField('group', bunker.group)}{/if}
-      {#if bunker.npub}{@render copyField('npub', bunker.npub)}{/if}
-      {#if bunker.url}{@render copyField('bunker', bunker.url)}{/if}
-      {#if bunker.relay}{@render copyField('bunker relay', bunker.relay)}{/if}
+      {#if bunker.group}
+        {@render copyField(
+          'group',
+          bunker.group,
+          'The FROST group this node co-signs for (its public key / npub).',
+        )}
+      {/if}
+      {#if bunker.npub}
+        {@render copyField('npub', bunker.npub, "This signer node's own public key.")}
+      {/if}
+      {#if bunker.url}
+        {@render copyField(
+          'bunker',
+          bunker.url,
+          'NIP-46 connection string. Paste this into a Nostr client to sign through this node.',
+        )}
+      {/if}
+      {#if bunker.relay}
+        {@render copyField(
+          'bunker relay',
+          bunker.relay,
+          'Relay where Nostr clients reach the bunker.',
+        )}
+      {/if}
       {#each bunker.frost_relays as r (r)}
-        {@render copyField('frost relay', r)}
+        {@render copyField(
+          'frost relay',
+          r,
+          'Relay used to coordinate signing rounds with your other devices. Must match the relay they use.',
+        )}
       {/each}
       {#if bunker.mode !== 'setup'}
         <div class="kv killswitch">
-          <span>co-signing</span>
+          <span>
+            co-signing{@render tip(
+              'When off, this node refuses to join signing rounds (a kill switch). New installs start off until you enable it.',
+            )}
+          </span>
           {#if signingEnabled === undefined}
-            <code class="warn">unknown{signingLoadError ? ` (${signingLoadError})` : ''}</code>
+            <span class="status-pill warn">unknown</span>
           {:else}
-            <code class={signingEnabled ? '' : 'warn'}>
-              {signingEnabled ? 'enabled' : 'DISABLED (kill switch)'}
-            </code>
+            <span class="status-pill {signingEnabled ? 'on' : 'off'}">
+              {signingEnabled ? 'Enabled' : 'Disabled'}
+            </span>
             <button class={signingEnabled ? 'no' : 'ok'} onclick={toggleKillswitch}>
               {signingEnabled ? 'Disable signing' : 'Enable signing'}
             </button>
@@ -403,14 +468,17 @@
     <div class="panel group-panel">
       <div class="group-head">
         <span class="group-label">Group</span>
-        <code class="group-npub" title={g.group}>{shortNpub(g.group)}</code>
+        <button
+          class="group-npub copyable"
+          title="Click to copy the full group npub"
+          onclick={() => copy(g.group, 'g' + g.group)}
+        >
+          {copied === 'g' + g.group ? '✓ copied' : shortNpub(g.group)}
+        </button>
         <span class="share-tag">{g.items[0].threshold}-of-{g.items[0].total_shares}</span>
         {#if bunker?.group === g.group}
           <span class="badge active-badge">active co-signer</span>
         {/if}
-        <button class="copy-btn group-copy" onclick={() => copy(g.group, 'g' + g.group)}>
-          {copied === 'g' + g.group ? '✓ Copied' : 'Copy npub'}
-        </button>
       </div>
       {#each g.items as s (s.identifier)}
         <div class="share">
@@ -427,7 +495,11 @@
               <div class="share-head">
                 <span class="share-name">{s.name}</span>
                 <span class="share-idx">#{s.identifier}</span>
-                {#if !s.did_backup}<span class="badge warn-badge">not backed up</span>{/if}
+                {#if !s.did_backup}<span
+                    class="badge warn-badge"
+                    title="This share hasn't been exported anywhere. Export it (below) to back it up; the badge clears once you do."
+                    >not backed up</span
+                  >{/if}
               </div>
             {/if}
             <dl class="meta-grid">
@@ -450,13 +522,17 @@
         {#if exportFor === s.group + ':' + s.identifier}
           <div class="export-box">
             {#if exportResult}
-              <div class="export-head">
-                <span class="muted">Encrypted export (back this up):</span>
-                <button class="copy-btn" onclick={() => copy(exportResult, 'export')}>
-                  {copied === 'export' ? '✓ Copied' : 'Copy'}
-                </button>
-              </div>
-              <textarea readonly rows="3">{exportResult}</textarea>
+              <span class="muted">Encrypted export (back this up):</span>
+              <button
+                class="field-value copyable export-value"
+                title="Click to copy"
+                onclick={() => copy(exportResult, 'export')}
+              >
+                <span class="cv-text">{exportResult}</span>
+                <span class="cv-icon" class:done={copied === 'export'}>
+                  {copied === 'export' ? '✓ copied' : 'copy'}
+                </span>
+              </button>
             {:else}
               <div class="row">
                 <input
@@ -552,12 +628,13 @@
       <span class="verify {signingVerified ? 'ok' : 'fail'}">
         {signingVerified ? '✓ chain verified' : '✗ chain INVALID'}
       </span>
+      <button class="link-btn" onclick={exportSigningLog}>Export</button>
     {/if}
   </h2>
   <div class="panel">
     {#each signingLog as e (e.timestamp_ms + ':' + e.session + ':' + e.operation)}
       <div class="event">
-        <code>{e.session}</code>
+        <span class="token">{e.session}</span>
         <span>{e.operation}</span>
         <span class="muted">
           · participants {e.participants.join(',')} · {new Date(

--- a/keep-web/ui/src/app.css
+++ b/keep-web/ui/src/app.css
@@ -170,7 +170,7 @@ code {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.55rem 0;
+  padding: 0.4rem 0;
   border-top: 1px solid var(--border-soft);
 }
 
@@ -178,41 +178,65 @@ code {
   border-top: none;
 }
 
+/* Fixed width so every value box lines up regardless of label length. */
 .field-label {
+  flex: none;
+  width: 7.5rem;
+  display: flex;
+  align-items: center;
   color: var(--faint);
-  min-width: 6rem;
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
 
-.field-value {
+/* Click-to-copy value (no separate Copy button). */
+.field-value.copyable {
   flex: 1;
   min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-align: left;
   font-family: 'SF Mono', ui-monospace, monospace;
   font-size: 0.8rem;
-  letter-spacing: 0.01em;
   color: var(--text);
   background: var(--bg);
   border: 1px solid var(--border-soft);
   border-radius: var(--radius-sm);
   padding: 0.45rem 0.65rem;
+  cursor: pointer;
+}
+
+.field-value.copyable:hover {
+  border-color: var(--accent);
+}
+
+.cv-text {
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.copy-btn {
+.cv-icon {
   flex: none;
-  min-width: 5.2rem;
-  background: var(--panel-2);
-  color: var(--muted);
-  border: 1px solid var(--border);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--faint);
+  opacity: 0;
+  transition: opacity 0.12s ease;
 }
 
-.copy-btn:hover {
-  color: var(--text);
-  border-color: var(--accent);
+.field-value.copyable:hover .cv-icon,
+.cv-icon.done {
+  opacity: 1;
+}
+
+.cv-icon.done {
+  color: var(--ok);
 }
 
 /* ---- Buttons ---- */
@@ -269,9 +293,10 @@ button:disabled {
   border-top: 1px solid var(--border-soft);
 }
 
-.share:first-of-type {
+/* First share sits right under the group-head divider; don't double the line. */
+.group-head + .share {
   border-top: none;
-  padding-top: 0.25rem;
+  padding-top: 0.5rem;
 }
 
 .share-main {
@@ -307,27 +332,38 @@ button:disabled {
   color: var(--faint);
 }
 
-.group-npub {
+.group-npub.copyable {
   color: var(--text);
   font-size: 0.8rem;
+  font-family: 'SF Mono', ui-monospace, monospace;
+  background: var(--bg);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.55rem;
+  cursor: pointer;
 }
 
-.group-copy {
-  margin-left: auto;
+.group-npub.copyable:hover {
+  border-color: var(--accent);
 }
 
 .active-badge {
+  margin-left: auto;
   color: var(--ok);
   background: rgba(47, 143, 91, 0.12);
   border: 1px solid var(--accent-soft);
 }
 
-.export-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  margin-bottom: 0.4rem;
+.export-value {
+  align-items: flex-start;
+  margin-top: 0.4rem;
+  max-height: 5.5rem;
+  overflow: auto;
+}
+
+.export-value .cv-text {
+  white-space: normal;
+  word-break: break-all;
 }
 
 .share-head {
@@ -466,28 +502,158 @@ textarea:focus {
   padding: 0.55rem 0.75rem;
 }
 
-.legend-intro {
-  margin: 0.4rem 0 0.5rem;
-  font-size: 0.85rem;
+.conn-status {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-size: 0.95rem;
+  padding: 0.1rem 0 0.3rem;
 }
 
-dl.legend {
-  margin: 0;
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.35rem 0.85rem;
-  font-size: 0.85rem;
+.dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex: none;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.04);
 }
 
-dl.legend dt {
+.dot.ok {
+  background: var(--ok);
+  box-shadow: 0 0 8px 1px rgba(63, 185, 80, 0.5);
+}
+
+.dot.warn {
+  background: var(--warn);
+  box-shadow: 0 0 8px 1px rgba(227, 179, 65, 0.4);
+}
+
+.setup-hint {
+  margin: 0.5rem 0 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.disabled-banner {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  border-color: #3a3320;
+  background: linear-gradient(180deg, #211d10 0%, #1a1810 100%);
+  margin-bottom: 0.5rem;
+}
+
+.disabled-banner > div {
+  flex: 1;
+  font-size: 0.9rem;
+}
+
+.disabled-banner strong {
+  color: var(--warn);
+}
+
+.disabled-banner button {
+  flex: none;
+}
+
+/* Inline SVG info marker with a styled hover tooltip. */
+.tip {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.35rem;
+  color: var(--faint);
+  vertical-align: middle;
+  cursor: help;
+  position: relative;
+}
+
+.tip svg {
+  display: block;
+}
+
+.tip:hover {
   color: var(--accent);
-  font-family: ui-monospace, monospace;
-  white-space: nowrap;
 }
 
-dl.legend dd {
-  margin: 0;
+/* Status pill (co-signing on/off/unknown) — not code-styled. */
+.status-pill {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
   color: var(--muted);
+}
+
+.status-pill.on {
+  color: var(--ok);
+  background: rgba(47, 143, 91, 0.12);
+  border-color: var(--accent-soft);
+}
+
+.status-pill.off,
+.status-pill.warn {
+  color: var(--warn);
+  background: rgba(227, 179, 65, 0.1);
+  border-color: #3a3320;
+}
+
+/* Inline technical token (env var, session id) — subtle, not a code block. */
+.token {
+  font-family: 'SF Mono', ui-monospace, monospace;
+  font-size: 0.82em;
+  color: var(--muted);
+  letter-spacing: 0.01em;
+}
+
+/* Text-style action button (e.g. signing-log Export). */
+.link-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: 0;
+  cursor: pointer;
+}
+
+.link-btn:hover {
+  background: none;
+  text-decoration: underline;
+}
+
+.tip::after {
+  content: attr(data-tip);
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: max-content;
+  max-width: 230px;
+  padding: 0.55rem 0.7rem;
+  background: #0b0e13;
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1.45;
+  text-transform: none;
+  letter-spacing: 0;
+  white-space: normal;
+  text-align: left;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+  z-index: 20;
+}
+
+.tip:hover::after {
+  opacity: 1;
 }
 
 ol.tasks {


### PR DESCRIPTION
UI/UX refinements to the keep-web admin (no behavior change to the daemon/API).

- **Setup panel** no longer reads like code: a friendly status line with a colored dot ("Not signing yet…"), no monospace field legend.
- **Won't-sign indicator**: when co-signing is off the status reflects it ("Online, but co-signing is off…") plus a prominent banner with an Enable button. The connection status now tracks the kill switch, not just the mode.
- **Status as pills, not `<code>`**: co-signing shows a green `Enabled` / amber `Disabled` pill; session id and the env-var reference are subtle `.token` text instead of code blocks.
- **Click-to-copy** everywhere (npub, bunker, relays, group npub, export) — removed the separate Copy buttons; values reveal a copy hint on hover and flip to "✓ copied". Saves the button column.
- **Field alignment**: fixed-width labels so every value box lines up regardless of label length.
- **SVG info tooltips**: crisp vector `ⓘ` (centered, small) with a styled hover bubble; replaces the native-title `i`. Reused via one snippet.
- **Signing-log Export**: downloads the tamper-evident audit (verified flag + entries) as JSON.
- Removed em dashes from UI copy; fixed a double divider under group headers.

svelte-check + vite build clean.