### PR TITLE
keep-web: surface peer online/offline in the activity feed

### DIFF
--- a/keep-web/src/bunker.rs
+++ b/keep-web/src/bunker.rs
@@ -9,7 +9,7 @@ use tokio::sync::{broadcast, Mutex};
 
 use keep_core::frost::SharePackage;
 use keep_core::keyring::Keyring;
-use keep_frost_net::{KfpNode, SessionInfo, SigningHooks};
+use keep_frost_net::{KfpNode, KfpNodeEvent, SessionInfo, SigningHooks};
 use keep_nip46::types::{ApprovalRequest, LogEvent, ServerCallbacks};
 use keep_nip46::{NetworkFrostSigner, Permission, Server, ServerConfig};
 
@@ -149,6 +149,30 @@ impl SigningHooks for CoSignerPolicy {
     }
 }
 
+/// Maps a node lifecycle event to a web activity entry, or `None` for events
+/// the co-signer UI doesn't surface here (signing rounds are already reported
+/// through the signing hooks above).
+fn node_event_to_log(ev: &KfpNodeEvent) -> Option<Event> {
+    match ev {
+        KfpNodeEvent::PeerDiscovered { share_index, name } => Some(Event::Log {
+            app: "frost".into(),
+            action: "peer online".into(),
+            success: true,
+            detail: Some(match name {
+                Some(n) => format!("share {share_index} ({n})"),
+                None => format!("share {share_index}"),
+            }),
+        }),
+        KfpNodeEvent::PeerOffline { share_index } => Some(Event::Log {
+            app: "frost".into(),
+            action: "peer offline".into(),
+            success: false,
+            detail: Some(format!("share {share_index}")),
+        }),
+        _ => None,
+    }
+}
+
 /// Parameters for the always-on network-FROST co-signer.
 pub struct NetworkConfig {
     pub share: SharePackage,
@@ -200,6 +224,24 @@ pub fn spawn_network_frost(
                 events: events.clone(),
                 enabled: cfg.enabled,
             }));
+
+            // Mirror node lifecycle events (peer presence) into the web activity
+            // feed so the UI reflects who is online, not just signing rounds.
+            let mut node_events = node.subscribe();
+            let events_for_feed = events.clone();
+            tokio::spawn(async move {
+                loop {
+                    match node_events.recv().await {
+                        Ok(ev) => {
+                            if let Some(log) = node_event_to_log(&ev) {
+                                let _ = events_for_feed.send(log);
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+            });
 
             if let Err(e) = node.announce().await {
                 let _ = info_tx.send(Err(format!("announce: {e}")));


### PR DESCRIPTION
## Bug
On the StartOS co-signer, when a peer (e.g. a mobile share-holder) comes online, keep-frost-net discovers it and logs `Peer discovered with valid proof-of-share`, and the peer's own UI shows the co-signer online. But the co-signer's web Activity feed never updated, so peer presence was invisible there despite the WebSocket being live.

## Cause
keep-frost-net already broadcasts `KfpNodeEvent::PeerDiscovered`/`PeerOffline` over `node.subscribe()`, but keep-web only wired the `pre_sign`/`post_sign` signing hooks and never subscribed to the node's event stream, so peer lifecycle events had no path to the UI.

## Fix
In `spawn_network_frost`, subscribe to the node's event stream and forward peer presence into keep-web's activity broadcast as log entries ("peer online" / "peer offline", with share index and name). Signing rounds are still reported via the existing hooks, so there is no duplication. The subscription is set up before the run loop starts, so startup discoveries are captured.

## Testing
Verified end-to-end against a local relay with a fresh 2-of-3 group:
- Peer comes online -> `{"action":"peer online","detail":"share 1 (disctest)"}` appears live in the Activity stream.
- A real 2-of-3 FROST signature completes (keep-web co-signs with the initiator); `co-signing` shows in the feed and the signing log records it (`verified:true`).

`cargo clippy` clean, keep-web tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network-FROST node lifecycle events (peer online/offline status) are now available in the web event feed and visible in the web interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->