### PR TITLE
keep-nip46/keep-web: fix bunker connect for real NIP-46 clients

### DIFF
--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1076,8 +1076,18 @@ impl KfpNode {
 
         let since = Timestamp::now() - Duration::from_secs(300);
 
+        // Every group member's transport pubkey, derived from public data.
+        // Scoping subscriptions to these `authors` (a) satisfies strict relays
+        // that reject author-less filters (e.g. relay.nsec.app: "please add
+        // authors or #p"), and (b) avoids pulling the relay's entire kind:24242
+        // stream — that kind is shared with Blossom and other FROST groups, so
+        // an unscoped filter floods the node and crowds out real signing
+        // traffic. It also rejects spoofed group events from non-members.
+        let authors = group_member_pubkeys(&self.group_pubkey, self.share.metadata.total_shares);
+
         let group_filter = Filter::new()
             .kind(Kind::Custom(KFP_EVENT_KIND))
+            .authors(authors.clone())
             .custom_tag(
                 SingleLetterTag::lowercase(Alphabet::G),
                 hex::encode(self.group_pubkey),
@@ -1086,6 +1096,7 @@ impl KfpNode {
 
         let direct_filter = Filter::new()
             .kind(Kind::Custom(KFP_EVENT_KIND))
+            .authors(authors.clone())
             .pubkey(self.keys.public_key())
             .since(since);
 
@@ -1101,6 +1112,11 @@ impl KfpNode {
 
         let fetch_filter = Filter::new()
             .kind(Kind::Custom(KFP_EVENT_KIND))
+            .authors(authors)
+            .custom_tag(
+                SingleLetterTag::lowercase(Alphabet::G),
+                hex::encode(self.group_pubkey),
+            )
             .since(since);
 
         match self
@@ -1645,15 +1661,37 @@ fn default_relay_opts() -> RelayOptions {
         .max_avg_latency(Some(Duration::from_secs(3)))
 }
 
-fn derive_keys_from_share(share: &SharePackage) -> Result<Keys> {
+/// Derives a member's transport keypair from public group data. The derivation
+/// is deterministic in `(group_pubkey, identifier)` — both public — so every
+/// member can compute every other member's transport pubkey without discovery.
+/// This is what lets the relay subscriptions filter by `authors`.
+fn derive_member_keys(group_pubkey: &[u8; 32], identifier: u16) -> Result<Keys> {
     let mut hasher = Sha256::new();
     hasher.update(b"keep-frost-node-identity-v2");
-    hasher.update(share.metadata.group_pubkey);
-    hasher.update(share.metadata.identifier.to_be_bytes());
+    hasher.update(group_pubkey);
+    hasher.update(identifier.to_be_bytes());
     let derived: [u8; 32] = hasher.finalize().into();
     let secret_key = SecretKey::from_slice(&derived)
         .map_err(|e| FrostNetError::Crypto(format!("Failed to create secret key: {e}")))?;
     Ok(Keys::new(secret_key))
+}
+
+fn derive_keys_from_share(share: &SharePackage) -> Result<Keys> {
+    derive_member_keys(&share.metadata.group_pubkey, share.metadata.identifier)
+}
+
+/// Transport pubkeys of every member of the group, derived from public data.
+/// Used to scope relay subscriptions to `authors`, which keeps strict relays
+/// happy (they require `authors`/`#p`) and avoids pulling the relay's entire
+/// `kind:24242` stream (shared with Blossom and other groups).
+fn group_member_pubkeys(group_pubkey: &[u8; 32], total_shares: u16) -> Vec<PublicKey> {
+    (1..=total_shares)
+        .filter_map(|i| {
+            derive_member_keys(group_pubkey, i)
+                .ok()
+                .map(|k| k.public_key())
+        })
+        .collect()
 }
 
 fn derive_audit_hmac_key(keys: &Keys, group_pubkey: &[u8; 32]) -> [u8; 32] {

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -127,8 +127,10 @@ impl KfpNode {
                         "No announced verifying share for participant {idx}"
                     ))
                 })?;
-            let vs = frost_secp256k1_tr::keys::VerifyingShare::deserialize(&vs_bytes)
-                .map_err(|e| FrostNetError::Crypto(format!("Invalid verifying share {idx}: {e}")))?;
+            let vs =
+                frost_secp256k1_tr::keys::VerifyingShare::deserialize(&vs_bytes).map_err(|e| {
+                    FrostNetError::Crypto(format!("Invalid verifying share {idx}: {e}"))
+                })?;
             verifying_shares.insert(id, vs);
         }
         Ok(frost_secp256k1_tr::keys::PublicKeyPackage::new(
@@ -737,8 +739,7 @@ impl KfpNode {
             if let Some(session) = sessions.get_session_mut(session_id) {
                 session.add_signature_share(self.share.metadata.identifier, sig_share)?;
                 if session.has_all_shares() {
-                    let pubkey_pkg =
-                        self.aggregation_pubkey_package(session.participants())?;
+                    let pubkey_pkg = self.aggregation_pubkey_package(session.participants())?;
                     let sig = session.try_aggregate(&pubkey_pkg)?;
                     sig.map(|s| {
                         (

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -12,7 +12,7 @@ use crate::audit::SigningOperation;
 use crate::error::{FrostNetError, Result};
 use crate::event::KfpEventBuilder;
 use crate::protocol::*;
-use crate::session::{derive_session_id, SessionState};
+use crate::session::derive_session_id;
 
 use super::{KfpNode, KfpNodeEvent, NonceId, SessionInfo};
 use crate::nonce_pool::{serialize_commitment, NoncePool};
@@ -723,7 +723,12 @@ impl KfpNode {
                 None => return Ok(()),
             };
 
-            if !session.ready_to_aggregate() {
+            // Idempotent: once aggregation has produced the signature the session
+            // is Complete. `ready_to_aggregate()` stays true (commitments/shares
+            // are never cleared), so without this guard a second call would
+            // re-aggregate and re-emit SignatureComplete / re-run the post-sign
+            // hook (e.g. broadcast the tx twice).
+            if session.is_complete() || !session.ready_to_aggregate() {
                 return Ok(());
             }
 
@@ -805,7 +810,7 @@ impl KfpNode {
         {
             let sessions = self.sessions.read();
             if let Some(session) = sessions.get_session(session_id) {
-                if matches!(session.state(), SessionState::Complete) {
+                if session.is_complete() {
                     return Ok(());
                 }
             }

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -97,6 +97,46 @@ impl KfpNode {
         ))
     }
 
+    /// Build the complete group [`PublicKeyPackage`] for `participants`.
+    ///
+    /// A share imported from a transport export carries only its own verifying
+    /// share (the export does not include the other members' shares), so
+    /// `self.share.pubkey_package()` alone is missing the co-signers' verifying
+    /// shares that `frost::aggregate` needs to validate their signature shares —
+    /// without them aggregation fails with "Unknown identifier". Fill the gaps
+    /// from the verifying share each peer announced (authenticated via
+    /// proof-of-share on discovery), reconstructing the dealer's full package.
+    fn aggregation_pubkey_package(
+        &self,
+        participants: &[u16],
+    ) -> Result<frost_secp256k1_tr::keys::PublicKeyPackage> {
+        let base = self.share.pubkey_package()?;
+        let mut verifying_shares = base.verifying_shares().clone();
+        let peers = self.peers.read();
+        for &idx in participants {
+            let id = frost_secp256k1_tr::Identifier::try_from(idx)
+                .map_err(|e| FrostNetError::Crypto(format!("Invalid identifier {idx}: {e}")))?;
+            if verifying_shares.contains_key(&id) {
+                continue;
+            }
+            let vs_bytes = peers
+                .get_peer(idx)
+                .and_then(|p| p.verifying_share)
+                .ok_or_else(|| {
+                    FrostNetError::Session(format!(
+                        "No announced verifying share for participant {idx}"
+                    ))
+                })?;
+            let vs = frost_secp256k1_tr::keys::VerifyingShare::deserialize(&vs_bytes)
+                .map_err(|e| FrostNetError::Crypto(format!("Invalid verifying share {idx}: {e}")))?;
+            verifying_shares.insert(id, vs);
+        }
+        Ok(frost_secp256k1_tr::keys::PublicKeyPackage::new(
+            verifying_shares,
+            *base.verifying_key(),
+        ))
+    }
+
     /// Generate fresh round-1 nonces to top the local pool back up to its
     /// target and broadcast the matching commitments to online peers. Secret
     /// nonces are stored in memory only; only commitments leave this node.
@@ -690,7 +730,8 @@ impl KfpNode {
             if let Some(session) = sessions.get_session_mut(session_id) {
                 session.add_signature_share(self.share.metadata.identifier, sig_share)?;
                 if session.has_all_shares() {
-                    let pubkey_pkg = self.share.pubkey_package()?;
+                    let pubkey_pkg =
+                        self.aggregation_pubkey_package(session.participants())?;
                     let sig = session.try_aggregate(&pubkey_pkg)?;
                     sig.map(|s| {
                         (
@@ -804,7 +845,7 @@ impl KfpNode {
             session.add_signature_share(payload.share_index, sig_share)?;
 
             let sig = if session.has_all_shares() {
-                let pubkey_pkg = self.share.pubkey_package()?;
+                let pubkey_pkg = self.aggregation_pubkey_package(&parts)?;
                 session.try_aggregate(&pubkey_pkg)?
             } else {
                 None

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -12,7 +12,7 @@ use crate::audit::SigningOperation;
 use crate::error::{FrostNetError, Result};
 use crate::event::KfpEventBuilder;
 use crate::protocol::*;
-use crate::session::derive_session_id;
+use crate::session::{derive_session_id, SessionState};
 
 use super::{KfpNode, KfpNodeEvent, NonceId, SessionInfo};
 use crate::nonce_pool::{serialize_commitment, NoncePool};
@@ -703,6 +703,63 @@ impl KfpNode {
             }
         }
 
+        // A commitment can arrive after every signature share (relay reordering).
+        // In that case the share handler skipped aggregation because
+        // `ready_to_aggregate()` was still false; now that the last commitment is
+        // here, re-attempt aggregation so the session does not stall to timeout.
+        self.try_complete_signature(&payload.session_id)?;
+
+        Ok(())
+    }
+
+    /// Attempt aggregation and emit `SignatureComplete` if every participant has
+    /// supplied both a commitment and a signature share. Safe to call from any
+    /// handler; it is a no-op while `ready_to_aggregate()` is false.
+    fn try_complete_signature(&self, session_id: &[u8; 32]) -> Result<()> {
+        let completed = {
+            let mut sessions = self.sessions.write();
+            let session = match sessions.get_session_mut(session_id) {
+                Some(s) => s,
+                None => return Ok(()),
+            };
+
+            if !session.ready_to_aggregate() {
+                return Ok(());
+            }
+
+            let pubkey_pkg = self.aggregation_pubkey_package(session.participants())?;
+            session.try_aggregate(&pubkey_pkg)?.map(|sig| {
+                (
+                    sig,
+                    session.message().to_vec(),
+                    session.participants().to_vec(),
+                )
+            })
+        };
+
+        if let Some((sig, session_message, session_participants)) = completed {
+            info!(
+                session_id = %hex::encode(session_id),
+                "Signature complete!"
+            );
+
+            self.audit_log.log_signing_operation(
+                *session_id,
+                &session_message,
+                Some(&sig),
+                session_participants,
+                self.share.metadata.identifier,
+                SigningOperation::SignatureCompleted,
+            );
+
+            self.invoke_post_sign_hook(session_id, &sig);
+
+            let _ = self.event_tx.send(KfpNodeEvent::SignatureComplete {
+                session_id: *session_id,
+                signature: sig,
+            });
+        }
+
         Ok(())
     }
 
@@ -734,51 +791,24 @@ impl KfpNode {
         let sig_share = frost_secp256k1_tr::round2::sign(&signing_package, &nonces, &key_package)
             .map_err(|e| FrostNetError::Crypto(format!("Signing failed: {e}")))?;
 
-        let self_aggregated = {
+        {
             let mut sessions = self.sessions.write();
             if let Some(session) = sessions.get_session_mut(session_id) {
                 session.add_signature_share(self.share.metadata.identifier, sig_share)?;
-                if session.has_all_shares() {
-                    let pubkey_pkg = self.aggregation_pubkey_package(session.participants())?;
-                    let sig = session.try_aggregate(&pubkey_pkg)?;
-                    sig.map(|s| {
-                        (
-                            s,
-                            session.message().to_vec(),
-                            session.participants().to_vec(),
-                        )
-                    })
-                } else {
-                    None
-                }
-            } else {
-                None
             }
-        };
+        }
 
-        if let Some((sig, session_message, session_participants)) = self_aggregated {
-            info!(
-                session_id = %hex::encode(session_id),
-                "Signature complete (single-participant)!"
-            );
-
-            self.audit_log.log_signing_operation(
-                *session_id,
-                &session_message,
-                Some(&sig),
-                session_participants,
-                self.share.metadata.identifier,
-                SigningOperation::SignatureCompleted,
-            );
-
-            self.invoke_post_sign_hook(session_id, &sig);
-
-            let _ = self.event_tx.send(KfpNodeEvent::SignatureComplete {
-                session_id: *session_id,
-                signature: sig,
-            });
-
-            return Ok(());
+        // Our own share may complete the set (e.g. single-participant, or we were
+        // the last to commit+sign). Gate on `ready_to_aggregate()` so we never
+        // aggregate over a mismatched commitment/share id set under reordering.
+        self.try_complete_signature(session_id)?;
+        {
+            let sessions = self.sessions.read();
+            if let Some(session) = sessions.get_session(session_id) {
+                if matches!(session.state(), SessionState::Complete) {
+                    return Ok(());
+                }
+            }
         }
 
         let share_bytes = sig_share.serialize();
@@ -840,50 +870,19 @@ impl KfpNode {
 
         self.peers.write().update_last_seen(payload.share_index);
 
-        let (signature, session_message, session_participants) = {
+        {
             let mut sessions = self.sessions.write();
             let session = match sessions.get_session_mut(&payload.session_id) {
                 Some(s) => s,
                 None => return Ok(()),
             };
-
-            let msg = session.message().to_vec();
-            let parts = session.participants().to_vec();
-
             session.add_signature_share(payload.share_index, sig_share)?;
-
-            let sig = if session.has_all_shares() {
-                let pubkey_pkg = self.aggregation_pubkey_package(&parts)?;
-                session.try_aggregate(&pubkey_pkg)?
-            } else {
-                None
-            };
-
-            (sig, msg, parts)
-        };
-
-        if let Some(sig) = signature {
-            info!(
-                session_id = %hex::encode(payload.session_id),
-                "Signature complete!"
-            );
-
-            self.audit_log.log_signing_operation(
-                payload.session_id,
-                &session_message,
-                Some(&sig),
-                session_participants,
-                self.share.metadata.identifier,
-                SigningOperation::SignatureCompleted,
-            );
-
-            self.invoke_post_sign_hook(&payload.session_id, &sig);
-
-            let _ = self.event_tx.send(KfpNodeEvent::SignatureComplete {
-                session_id: payload.session_id,
-                signature: sig,
-            });
         }
+
+        // Aggregate only once every participant has both a commitment and a
+        // share; `try_complete_signature` gates on `ready_to_aggregate()` so a
+        // share arriving before its commitment is buffered rather than dropped.
+        self.try_complete_signature(&payload.session_id)?;
 
         Ok(())
     }

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -715,9 +715,16 @@ impl KfpNode {
             };
 
             let signing_package = session.get_signing_package()?;
-            let nonces = session
-                .take_our_nonces()
-                .ok_or_else(|| FrostNetError::Session("No nonces stored for session".into()))?;
+            // Single-use nonces: if they are already gone, another invocation for
+            // this session has produced and sent our share (e.g. a peer's
+            // commitment arriving after the pre-exchanged set already drove us
+            // into round 2). Treat the repeat as a no-op rather than failing the
+            // whole request on the consumed nonce — aggregation is still driven
+            // by the inbound signature-share handler.
+            let nonces = match session.take_our_nonces() {
+                Some(n) => n,
+                None => return Ok(()),
+            };
 
             (signing_package, nonces)
         };

--- a/keep-frost-net/src/session.rs
+++ b/keep-frost-net/src/session.rs
@@ -822,8 +822,10 @@ mod tests {
         // Participants 1 and 2 (identifiers from shares[0], shares[1]).
         let kp1 = shares[0].key_package().unwrap();
         let kp2 = shares[1].key_package().unwrap();
-        let (nonces1, commit1) = frost_secp256k1_tr::round1::commit(kp1.signing_share(), &mut OsRng);
-        let (nonces2, commit2) = frost_secp256k1_tr::round1::commit(kp2.signing_share(), &mut OsRng);
+        let (nonces1, commit1) =
+            frost_secp256k1_tr::round1::commit(kp1.signing_share(), &mut OsRng);
+        let (nonces2, commit2) =
+            frost_secp256k1_tr::round1::commit(kp2.signing_share(), &mut OsRng);
 
         let message = b"reorder message".to_vec();
         let participants = vec![1u16, 2u16];
@@ -838,8 +840,7 @@ mod tests {
         let share1 = frost_secp256k1_tr::round2::sign(&signing_package, &nonces1, &kp1).unwrap();
         let share2 = frost_secp256k1_tr::round2::sign(&signing_package, &nonces2, &kp2).unwrap();
 
-        let mut session =
-            NetworkSession::new(session_id, message, threshold, participants);
+        let mut session = NetworkSession::new(session_id, message, threshold, participants);
 
         // Worst-case ordering: a share arrives before any commitment.
         session.add_signature_share(1, share1).unwrap();

--- a/keep-frost-net/src/session.rs
+++ b/keep-frost-net/src/session.rs
@@ -210,10 +210,23 @@ impl NetworkSession {
         self.commitments.len() >= self.threshold as usize
     }
 
+    /// Build the FROST signing package from the collected commitments.
+    ///
+    /// Correctness invariant (load-bearing now that delivery order is relaxed):
+    /// every signer must sign over the *identical* commitment subset. A
+    /// `SigningPackage` built from a different commitment set produces shares
+    /// that aggregation will reject. The session only admits exactly `threshold`
+    /// participants, so the commitment map must not exceed that count.
     pub fn get_signing_package(&self) -> Result<SigningPackage> {
         if !self.has_all_commitments() {
             return Err(FrostNetError::Session("Not enough commitments".into()));
         }
+
+        debug_assert!(
+            self.commitments.len() == self.threshold as usize,
+            "signing package must cover exactly `threshold` commitments; \
+             signers diverging on the commitment subset will fail aggregation"
+        );
 
         Ok(SigningPackage::new(self.commitments.clone(), &self.message))
     }

--- a/keep-frost-net/src/session.rs
+++ b/keep-frost-net/src/session.rs
@@ -166,7 +166,15 @@ impl NetworkSession {
             ));
         }
 
-        if self.state != SessionState::AwaitingCommitments {
+        // Accept commitments regardless of strict ordering. Real relays reorder
+        // events, so a participant's commitment can arrive after we've already
+        // started collecting shares (or after another participant's share).
+        // Only refuse once the session is settled; aggregation is separately
+        // gated on every participant having both a commitment and a share.
+        if matches!(
+            self.state(),
+            SessionState::Complete | SessionState::Failed | SessionState::Expired
+        ) {
             return Err(FrostNetError::Session("Not accepting commitments".into()));
         }
 
@@ -185,7 +193,9 @@ impl NetworkSession {
 
         self.commitments.insert(id, commitment);
 
-        if self.commitments.len() >= self.threshold as usize {
+        if self.state == SessionState::AwaitingCommitments
+            && self.commitments.len() >= self.threshold as usize
+        {
             self.state = SessionState::AwaitingShares;
         }
 
@@ -215,7 +225,13 @@ impl NetworkSession {
             ));
         }
 
-        if self.state != SessionState::AwaitingShares {
+        // Buffer shares even if a peer's share arrives before all commitments
+        // (relay reordering). Aggregation is gated on every participant having
+        // both a commitment and a share, so holding an early share is safe.
+        if matches!(
+            self.state(),
+            SessionState::Complete | SessionState::Failed | SessionState::Expired
+        ) {
             return Err(FrostNetError::Session("Not accepting shares".into()));
         }
 
@@ -245,8 +261,24 @@ impl NetworkSession {
         self.signature_shares.len() >= self.threshold as usize
     }
 
+    /// Every participant has provided both a commitment and a signature share,
+    /// so the commitment set and the share set match exactly — the precondition
+    /// for `frost::aggregate`. Gating on this (rather than a bare share count)
+    /// makes the coordinator tolerant of reordered relay delivery: a share that
+    /// arrives before its commitment is held until the commitment shows up,
+    /// instead of triggering an aggregate over a mismatched id set.
+    pub fn ready_to_aggregate(&self) -> bool {
+        self.participants.iter().all(|&p| {
+            Identifier::try_from(p)
+                .map(|id| {
+                    self.commitments.contains_key(&id) && self.signature_shares.contains_key(&id)
+                })
+                .unwrap_or(false)
+        })
+    }
+
     pub fn try_aggregate(&mut self, pubkey_pkg: &PublicKeyPackage) -> Result<Option<[u8; 64]>> {
-        if !self.has_all_shares() {
+        if !self.ready_to_aggregate() {
             return Ok(None);
         }
 
@@ -760,6 +792,66 @@ mod tests {
 
         assert_eq!(session.state(), SessionState::AwaitingCommitments);
         assert_eq!(session.commitments_needed(), 2);
+    }
+
+    // Relays reorder events: a participant's signature share can arrive before
+    // its commitment. The session must buffer both and aggregate only once
+    // every participant has both — never aggregate a share whose commitment is
+    // missing (which used to produce `Aggregation failed: Unknown identifier`).
+    #[test]
+    fn test_aggregation_tolerates_reordered_share_before_commitment() {
+        use frost_secp256k1_tr::rand_core::OsRng;
+        use keep_core::frost::{ThresholdConfig, TrustedDealer};
+
+        let (shares, pubkey_pkg) = TrustedDealer::new(ThresholdConfig::two_of_three())
+            .generate("reorder-test")
+            .unwrap();
+
+        // Participants 1 and 2 (identifiers from shares[0], shares[1]).
+        let kp1 = shares[0].key_package().unwrap();
+        let kp2 = shares[1].key_package().unwrap();
+        let (nonces1, commit1) = frost_secp256k1_tr::round1::commit(kp1.signing_share(), &mut OsRng);
+        let (nonces2, commit2) = frost_secp256k1_tr::round1::commit(kp2.signing_share(), &mut OsRng);
+
+        let message = b"reorder message".to_vec();
+        let participants = vec![1u16, 2u16];
+        let threshold = 2u16;
+        let session_id = derive_session_id(&message, &participants, threshold);
+
+        // Both signers sign over the same full commitment set.
+        let mut commit_map = BTreeMap::new();
+        commit_map.insert(Identifier::try_from(1u16).unwrap(), commit1);
+        commit_map.insert(Identifier::try_from(2u16).unwrap(), commit2);
+        let signing_package = SigningPackage::new(commit_map, &message);
+        let share1 = frost_secp256k1_tr::round2::sign(&signing_package, &nonces1, &kp1).unwrap();
+        let share2 = frost_secp256k1_tr::round2::sign(&signing_package, &nonces2, &kp2).unwrap();
+
+        let mut session =
+            NetworkSession::new(session_id, message, threshold, participants);
+
+        // Worst-case ordering: a share arrives before any commitment.
+        session.add_signature_share(1, share1).unwrap();
+        assert!(
+            session.try_aggregate(&pubkey_pkg).unwrap().is_none(),
+            "must not aggregate with a share but no matching commitment"
+        );
+
+        session.add_commitment(2, commit2).unwrap();
+        session.add_signature_share(2, share2).unwrap();
+        // Threshold shares present, but participant 1's commitment is still
+        // missing: must hold, not error.
+        assert!(
+            session.try_aggregate(&pubkey_pkg).unwrap().is_none(),
+            "must not aggregate until every participant has a commitment"
+        );
+
+        // The late commitment completes the set.
+        session.add_commitment(1, commit1).unwrap();
+        let sig = session
+            .try_aggregate(&pubkey_pkg)
+            .expect("aggregate must not error")
+            .expect("aggregate must produce a signature");
+        assert_eq!(sig.len(), 64);
     }
 
     #[test]

--- a/keep-frost-net/src/session.rs
+++ b/keep-frost-net/src/session.rs
@@ -312,8 +312,20 @@ impl NetworkSession {
                 Ok(Some(result))
             }
             Err(e) => {
+                let commit_ids: Vec<String> = self
+                    .commitments
+                    .keys()
+                    .map(|id| hex::encode(id.serialize()))
+                    .collect();
+                let share_ids: Vec<String> = self
+                    .signature_shares
+                    .keys()
+                    .map(|id| hex::encode(id.serialize()))
+                    .collect();
                 self.state = SessionState::Failed;
-                Err(FrostNetError::Crypto(format!("Aggregation failed: {e}")))
+                Err(FrostNetError::Crypto(format!(
+                    "Aggregation failed: {e} (commitment_ids={commit_ids:?} share_ids={share_ids:?})"
+                )))
             }
         }
     }

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -1261,3 +1261,64 @@ async fn test_signing_flow_with_nonce_pre_exchange() {
         "expected exactly one pooled commitment consumed across selected peers"
     );
 }
+
+// Reproduces consecutive-signing robustness bugs (stale_nonce / Unknown
+// identifier): a persistent initiator must complete many signs in a row as the
+// pre-exchanged nonce pool churns.
+#[tokio::test]
+#[ignore]
+async fn test_repeated_signing() {
+    use std::sync::Arc;
+
+    let mock_relay = MockRelay::run().await.expect("Failed to start mock relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let config = ThresholdConfig::two_of_three();
+    let dealer = TrustedDealer::new(config);
+    let (mut shares, _pubkey_pkg) = dealer.generate("repeat-signing").unwrap();
+    let share1 = shares.remove(0);
+    let share2 = shares.remove(0);
+    let share3 = shares.remove(0);
+
+    let mut node1 = KfpNode::new(share1, vec![relay.clone()]).await.unwrap();
+    let mut node2 = KfpNode::new(share2, vec![relay.clone()]).await.unwrap();
+    let mut node3 = KfpNode::new(share3, vec![relay]).await.unwrap();
+
+    let mut rx3 = node3.subscribe();
+    let shutdown1 = node1.take_shutdown_handle();
+    let shutdown2 = node2.take_shutdown_handle();
+    let shutdown3 = node3.take_shutdown_handle();
+
+    let node3 = Arc::new(node3);
+    let node3_for_run = Arc::clone(&node3);
+    let h1 = tokio::spawn(async move { let _ = node1.run().await; });
+    let h2 = tokio::spawn(async move { let _ = node2.run().await; });
+    let h3 = tokio::spawn(async move { let _ = node3_for_run.run().await; });
+
+    let mut peers_discovered = 0u32;
+    let _ = timeout(Duration::from_secs(45), async {
+        while peers_discovered < 2 {
+            if let Ok(keep_frost_net::KfpNodeEvent::PeerDiscovered { .. }) = rx3.recv().await {
+                peers_discovered += 1;
+            }
+        }
+    })
+    .await;
+
+    let mut failures = Vec::new();
+    for i in 0..6u32 {
+        let msg = format!("repeat-sign-{i}").into_bytes();
+        match timeout(Duration::from_secs(30), node3.request_signature(msg, "raw")).await {
+            Ok(Ok(sig)) => assert_eq!(sig.len(), 64),
+            Ok(Err(e)) => failures.push(format!("sign {i}: {e:?}")),
+            Err(_) => failures.push(format!("sign {i}: timeout")),
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    graceful_shutdown(shutdown1, h1).await;
+    graceful_shutdown(shutdown2, h2).await;
+    graceful_shutdown(shutdown3, h3).await;
+
+    assert!(failures.is_empty(), "repeated signing failures: {failures:#?}");
+}

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -1391,7 +1391,7 @@ async fn test_repeated_signing() {
     let h3 = tokio::spawn(async move { let _ = node3_for_run.run().await; });
 
     let mut peers_discovered = 0u32;
-    let _ = timeout(Duration::from_secs(45), async {
+    let discovered = timeout(Duration::from_secs(45), async {
         while peers_discovered < 2 {
             if let Ok(keep_frost_net::KfpNodeEvent::PeerDiscovered { .. }) = rx3.recv().await {
                 peers_discovered += 1;
@@ -1399,6 +1399,12 @@ async fn test_repeated_signing() {
         }
     })
     .await;
+    if discovered.is_err() {
+        graceful_shutdown(shutdown1, h1).await;
+        graceful_shutdown(shutdown2, h2).await;
+        graceful_shutdown(shutdown3, h3).await;
+        panic!("peer discovery timed out: only {peers_discovered} peers discovered");
+    }
 
     let mut failures = Vec::new();
     for i in 0..6u32 {

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -390,6 +390,101 @@ async fn test_full_signing_flow() {
     }
 }
 
+/// Regression: a share imported from a transport export carries only its own
+/// verifying share, so its `pubkey_package` is missing the co-signers' shares
+/// that `frost::aggregate` needs. The initiator must reconstruct the full
+/// package from peers' announced verifying shares; before that fix this signing
+/// round failed on the initiator with "Aggregation failed: Unknown identifier".
+///
+/// Ignored by default: like the other full signing-flow tests it spins up three
+/// nodes on a shared in-process MockRelay and is timing-sensitive under parallel
+/// suite load (the extra Argon2 export/import here makes it the most sensitive).
+/// Run explicitly with `--ignored`.
+#[tokio::test]
+#[ignore]
+async fn test_imported_share_can_initiate_signing() {
+    use keep_core::frost::ShareExport;
+    use std::sync::Arc;
+
+    let mock_relay = MockRelay::run().await.expect("Failed to start mock relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let config = ThresholdConfig::two_of_three();
+    let dealer = TrustedDealer::new(config);
+    let (mut shares, _pubkey_pkg) = dealer.generate("test-import-signing").unwrap();
+
+    let share1 = shares.remove(0);
+    let share2 = shares.remove(0);
+    let share3 = shares.remove(0);
+
+    // Round-trip the initiator's share through an encrypted export, exactly as
+    // an operator importing into a fresh StartOS box would. The resulting share
+    // has an incomplete pubkey_package (only its own verifying share).
+    let export = ShareExport::from_share(&share3, "pw").expect("export share3");
+    let share3 = export.to_share("pw", "imported").expect("import share3");
+
+    let mut node1 = KfpNode::new(share1, vec![relay.clone()])
+        .await
+        .expect("Failed to create node 1");
+    let mut node2 = KfpNode::new(share2, vec![relay.clone()])
+        .await
+        .expect("Failed to create node 2");
+    let mut node3 = KfpNode::new(share3, vec![relay])
+        .await
+        .expect("Failed to create node 3");
+
+    let mut rx3 = node3.subscribe();
+
+    let shutdown1 = node1.take_shutdown_handle();
+    let shutdown2 = node2.take_shutdown_handle();
+    let shutdown3 = node3.take_shutdown_handle();
+
+    let node3 = Arc::new(node3);
+    let node3_for_run = Arc::clone(&node3);
+
+    let node1_handle = tokio::spawn(async move {
+        let _ = node1.run().await;
+    });
+    let node2_handle = tokio::spawn(async move {
+        let _ = node2.run().await;
+    });
+    let node3_handle = tokio::spawn(async move {
+        let _ = node3_for_run.run().await;
+    });
+
+    let mut peers_discovered = 0u32;
+    let discovery_timeout = timeout(Duration::from_secs(45), async {
+        while peers_discovered < 2 {
+            if let Ok(keep_frost_net::KfpNodeEvent::PeerDiscovered { .. }) = rx3.recv().await {
+                peers_discovered += 1;
+            }
+        }
+    })
+    .await;
+
+    if discovery_timeout.is_err() {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        graceful_shutdown(shutdown3, node3_handle).await;
+        panic!("Peer discovery timed out: only {peers_discovered} peers discovered");
+    }
+
+    let sign_result = timeout(Duration::from_secs(60), async {
+        node3.request_signature(b"imported-share signing".to_vec(), "raw").await
+    })
+    .await;
+
+    graceful_shutdown(shutdown1, node1_handle).await;
+    graceful_shutdown(shutdown2, node2_handle).await;
+    graceful_shutdown(shutdown3, node3_handle).await;
+
+    match sign_result {
+        Ok(Ok(signature)) => assert_eq!(signature.len(), 64),
+        Ok(Err(e)) => panic!("Signing with imported share failed: {e:?}"),
+        Err(_) => panic!("Signing with imported share timed out"),
+    }
+}
+
 #[tokio::test]
 async fn test_descriptor_coordination_flow() {
     use std::collections::BTreeMap;

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -470,7 +470,9 @@ async fn test_imported_share_can_initiate_signing() {
     }
 
     let sign_result = timeout(Duration::from_secs(60), async {
-        node3.request_signature(b"imported-share signing".to_vec(), "raw").await
+        node3
+            .request_signature(b"imported-share signing".to_vec(), "raw")
+            .await
     })
     .await;
 
@@ -1386,9 +1388,15 @@ async fn test_repeated_signing() {
 
     let node3 = Arc::new(node3);
     let node3_for_run = Arc::clone(&node3);
-    let h1 = tokio::spawn(async move { let _ = node1.run().await; });
-    let h2 = tokio::spawn(async move { let _ = node2.run().await; });
-    let h3 = tokio::spawn(async move { let _ = node3_for_run.run().await; });
+    let h1 = tokio::spawn(async move {
+        let _ = node1.run().await;
+    });
+    let h2 = tokio::spawn(async move {
+        let _ = node2.run().await;
+    });
+    let h3 = tokio::spawn(async move {
+        let _ = node3_for_run.run().await;
+    });
 
     let mut peers_discovered = 0u32;
     let discovered = timeout(Duration::from_secs(45), async {
@@ -1421,5 +1429,8 @@ async fn test_repeated_signing() {
     graceful_shutdown(shutdown2, h2).await;
     graceful_shutdown(shutdown3, h3).await;
 
-    assert!(failures.is_empty(), "repeated signing failures: {failures:#?}");
+    assert!(
+        failures.is_empty(),
+        "repeated signing failures: {failures:#?}"
+    );
 }

--- a/keep-frost-net/tests/network_failure_test.rs
+++ b/keep-frost-net/tests/network_failure_test.rs
@@ -163,11 +163,15 @@ fn test_message_reordering_shares_before_commitments_complete() {
     let commit1 = generate_test_commitment(1);
     session.add_commitment(1, commit1).unwrap();
 
-    // Deserialization accepts any bytes; validation occurs at aggregation time
+    // Reordered relay delivery: participant 2's signature share arrives before
+    // its commitment. It must be buffered (not rejected) so the round can still
+    // complete once the commitment shows up — aggregation is gated separately on
+    // every participant having both a commitment and a share.
     let fake_share = frost_secp256k1_tr::round2::SignatureShare::deserialize(&[0u8; 32]).unwrap();
-
-    let err = session.add_signature_share(2, fake_share).unwrap_err();
-    assert!(err.to_string().contains("Not accepting"));
+    session
+        .add_signature_share(2, fake_share)
+        .expect("early share is buffered, not rejected");
+    assert!(!session.ready_to_aggregate());
 }
 
 #[test]
@@ -558,9 +562,13 @@ fn test_session_state_machine_integrity() {
 
     assert_eq!(session.state(), SessionState::AwaitingCommitments);
 
-    // Deserialization accepts any bytes; validation occurs at aggregation time
+    // A share arriving before any commitments (reordered relay delivery) is
+    // buffered, not rejected, and does not advance the commitment-driven state.
     let share = frost_secp256k1_tr::round2::SignatureShare::deserialize(&[0u8; 32]).unwrap();
-    assert!(session.add_signature_share(1, share).is_err());
+    session
+        .add_signature_share(1, share)
+        .expect("early share buffered");
+    assert_eq!(session.state(), SessionState::AwaitingCommitments);
 
     let commit1 = generate_test_commitment(1);
     session.add_commitment(1, commit1).unwrap();

--- a/keep-nip46/src/bunker.rs
+++ b/keep-nip46/src/bunker.rs
@@ -14,9 +14,12 @@ pub fn generate_bunker_url(
     let mut url = format!("bunker://{}", pubkey.to_hex());
 
     for (i, relay_url) in relay_urls.iter().enumerate() {
-        let relay = urlencoding::encode(relay_url);
+        // Emit the relay unencoded (`relay=wss://...`): it's the de facto
+        // convention, and some clients (e.g. Amethyst Desktop) validate with a
+        // literal `relay=wss://` substring match and reject a percent-encoded
+        // one. The parser accepts both forms.
         let sep = if i == 0 { '?' } else { '&' };
-        url.push_str(&format!("{sep}relay={relay}"));
+        url.push_str(&format!("{sep}relay={relay_url}"));
     }
 
     if let Some(s) = secret {
@@ -188,6 +191,19 @@ mod tests {
         assert_eq!(pubkey, parsed_pk);
         assert_eq!(parsed_relays[0], relays[0]);
         assert_eq!(secret, Some("mysecret".into()));
+    }
+
+    #[test]
+    fn test_bunker_url_relay_is_unencoded() {
+        let keys = Keys::generate();
+        let url = generate_bunker_url(
+            &keys.public_key(),
+            &["wss://nos.lol".to_string()],
+            Some("abcdef0123456789"),
+        );
+        // Clients that do a literal `relay=wss://` check must find it.
+        assert!(url.contains("relay=wss://nos.lol"));
+        assert!(!url.contains("relay=wss%3A"));
     }
 
     #[test]

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -106,6 +106,12 @@ pub struct SignerHandler {
     connect_grant: Permission,
     relay_urls: Vec<String>,
     kill_switch: Arc<AtomicBool>,
+    /// The transport (bunker URL) pubkey clients connect to. For a remote
+    /// signer this differs from the signing identity returned by
+    /// `get_public_key` (network-FROST: transport key vs group key), so the
+    /// `connect` handshake must validate the client's target against this, not
+    /// the signing pubkey.
+    transport_pubkey: Option<PublicKey>,
 }
 
 impl SignerHandler {
@@ -130,7 +136,13 @@ impl SignerHandler {
             connect_grant: Permission::DEFAULT,
             relay_urls: Vec::new(),
             kill_switch: Arc::new(AtomicBool::new(false)),
+            transport_pubkey: None,
         }
+    }
+
+    pub fn with_transport_pubkey(mut self, pubkey: PublicKey) -> Self {
+        self.transport_pubkey = Some(pubkey);
+        self
     }
 
     pub fn with_expected_secret(mut self, secret: String) -> Self {
@@ -318,7 +330,14 @@ impl SignerHandler {
         }
 
         if let Some(expected) = our_pubkey {
-            let actual = self.our_pubkey().await?;
+            // The client targets the transport (bunker URL) pubkey, which for a
+            // remote signer differs from the signing identity. Validate against
+            // the transport pubkey when known, falling back to the signing key
+            // (single-key mode, where they are the same).
+            let actual = match self.transport_pubkey {
+                Some(pk) => pk,
+                None => self.our_pubkey().await?,
+            };
             if expected != actual {
                 return Err(CryptoError::invalid_key("pubkey mismatch").into());
             }

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -793,6 +793,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn transport_key_override_allows_connect() {
+        // A remote signer's transport (bunker URL) pubkey differs from its
+        // signing identity. A client targets the transport pubkey, so connect
+        // must validate against it, not `our_pubkey()`.
+        let transport = Keys::generate().public_key();
+        let handler = setup_handler().with_transport_pubkey(transport);
+        let app_pubkey = Keys::generate().public_key();
+
+        // `transport` differs from the keyring's signing key (our_pubkey()).
+        let result = handler
+            .handle_connect(app_pubkey, Some(transport), None, None)
+            .await;
+        assert!(result.is_ok());
+
+        // A target that is neither the transport nor signing key is rejected.
+        let other = Keys::generate().public_key();
+        let result = handler
+            .handle_connect(Keys::generate().public_key(), Some(other), None, None)
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
     async fn test_handle_get_public_key() {
         let handler = setup_handler();
         let app_pubkey = Keys::generate().public_key();

--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -695,3 +695,29 @@ impl Server {
         self.client.disconnect().await;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // An explicitly-configured `expected_secret` must surface as the bunker
+    // secret, which `bunker_url()` embeds — otherwise clients get a secret-less
+    // URL and reject the connect.
+    #[test]
+    fn expected_secret_surfaces_in_bunker_secret() {
+        let keyring = Arc::new(Mutex::new(Keyring::new()));
+        let permissions = Arc::new(Mutex::new(PermissionManager::new()));
+        let audit = Arc::new(Mutex::new(AuditLog::new(100)));
+        let handler = SignerHandler::new(keyring, permissions, audit, None);
+        let config = ServerConfig {
+            expected_secret: Some("my-secret".to_string()),
+            ..ServerConfig::default()
+        };
+
+        let (_handler, bunker_secret) =
+            finalize_handler(handler, &config, &["wss://relay.example.com".to_string()]);
+
+        let secret = bunker_secret.expect("expected_secret should surface as bunker secret");
+        assert_eq!(secret.as_str(), "my-secret");
+    }
+}

--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -105,7 +105,9 @@ fn finalize_handler(
         Some(Zeroizing::new(secret))
     } else if let Some(ref secret) = config.expected_secret {
         handler = handler.with_expected_secret(secret.clone());
-        None
+        // Surface the configured secret in the bunker URL so clients (which
+        // require it in the connect handshake) can authenticate.
+        Some(Zeroizing::new(secret.clone()))
     } else {
         None
     };
@@ -240,7 +242,8 @@ impl Server {
         let audit = Arc::new(Mutex::new(AuditLog::new(config.audit_log_capacity)));
         let mut handler = SignerHandler::new(keyring, permissions, audit, callbacks.clone())
             .with_auto_approve(config.auto_approve)
-            .with_connect_grant(config.connect_grant);
+            .with_connect_grant(config.connect_grant)
+            .with_transport_pubkey(keys.public_key());
         if let Some(frost) = frost_signer {
             handler = handler.with_frost_signer(frost);
         }
@@ -338,7 +341,8 @@ impl Server {
         let handler = SignerHandler::new(keyring, permissions, audit, callbacks.clone())
             .with_network_frost_signer(network_signer)
             .with_auto_approve(config.auto_approve)
-            .with_connect_grant(config.connect_grant);
+            .with_connect_grant(config.connect_grant)
+            .with_transport_pubkey(keys.public_key());
         let (handler, bunker_secret) = finalize_handler(handler, &config, relay_urls);
 
         Ok(Self::build(

--- a/keep-nip46/src/types.rs
+++ b/keep-nip46/src/types.rs
@@ -38,7 +38,13 @@ pub(crate) struct Nip46Request {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct Nip46Response {
     pub id: String,
+    // Omit when absent so a success is `{"result":"ack"}` and an error is
+    // `{"error":".."}` — never both. Clients that test for the presence of the
+    // `error` key (not just a non-null value) otherwise read a null `error` on
+    // a successful response as a rejection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub result: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 

--- a/keep-web/src/bunker.rs
+++ b/keep-web/src/bunker.rs
@@ -41,6 +41,9 @@ fn recv_startup<T>(rx: Receiver<Result<T, String>>) -> Result<T, String> {
 struct WebCallbacks {
     events: broadcast::Sender<Event>,
     approvals: Arc<StdMutex<HashMap<u64, Sender<bool>>>>,
+    /// Kill switch (network-FROST only). When co-signing is off, sign requests
+    /// are refused without prompting; `None` for single-key (no kill switch).
+    signing_enabled: Option<Arc<AtomicBool>>,
 }
 
 /// Random, unguessable approval id (defense-in-depth alongside the auth gate).
@@ -61,6 +64,22 @@ impl ServerCallbacks for WebCallbacks {
     }
 
     fn request_approval(&self, request: ApprovalRequest) -> bool {
+        // Co-signing is off (kill switch): refuse signing without bothering the
+        // operator with a prompt that would only fail at the FROST layer.
+        if request.method == "sign_event"
+            && self
+                .signing_enabled
+                .as_ref()
+                .is_some_and(|e| !e.load(Ordering::SeqCst))
+        {
+            let _ = self.events.send(Event::Log {
+                app: "frost".into(),
+                action: "refused (co-signing disabled)".into(),
+                success: false,
+                detail: Some("enable co-signing to approve requests".into()),
+            });
+            return false;
+        }
         let id = random_approval_id();
         let (tx, rx) = channel();
         if let Ok(mut map) = self.approvals.lock() {
@@ -266,7 +285,11 @@ pub fn spawn_network_frost(
             // Persisted (not freshly generated) so the bunker URL pubkey is
             // stable across restarts and saved client connections keep working.
             let transport_key = cfg.transport_key;
-            let callbacks: Arc<dyn ServerCallbacks> = Arc::new(WebCallbacks { events, approvals });
+            let callbacks: Arc<dyn ServerCallbacks> = Arc::new(WebCallbacks {
+                events,
+                approvals,
+                signing_enabled: Some(cfg.enabled.clone()),
+            });
 
             let mut server = match Server::new_network_frost_with_config(
                 signer,
@@ -277,10 +300,12 @@ pub fn spawn_network_frost(
                     // Least privilege for the co-signer: connect handshake +
                     // signing only, not NIP-04/44 encrypt/decrypt.
                     connect_grant: Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT,
-                    // Authenticate clients with a stable secret (embedded in the
-                    // bunker URL) and gate signing on the live kill switch.
+                    // Authenticate clients with a stable secret embedded in the
+                    // bunker URL. The kill switch is enforced at the FROST policy
+                    // layer (CoSignerPolicy) and the approval gate above; we do
+                    // not wire ServerConfig.kill_switch because its polarity is
+                    // inverted relative to `signing_enabled`.
                     expected_secret: Some(cfg.bunker_secret),
-                    kill_switch: Some(cfg.enabled.clone()),
                     ..ServerConfig::default()
                 },
             )
@@ -337,7 +362,11 @@ pub fn spawn_single_key(
             }
         };
         rt.block_on(async move {
-            let callbacks: Arc<dyn ServerCallbacks> = Arc::new(WebCallbacks { events, approvals });
+            let callbacks: Arc<dyn ServerCallbacks> = Arc::new(WebCallbacks {
+                events,
+                approvals,
+                signing_enabled: None,
+            });
             let mut server = match Server::new_with_config(
                 keyring,
                 None,

--- a/keep-web/src/bunker.rs
+++ b/keep-web/src/bunker.rs
@@ -184,6 +184,9 @@ pub struct NetworkConfig {
     /// Persisted NIP-46 secret embedded in the bunker URL and required in the
     /// connect handshake. Clients (Amethyst, etc.) reject a secret-less URL.
     pub bunker_secret: String,
+    /// Persisted transport key = the bunker URL's pubkey identity. Stable so the
+    /// URL doesn't change across restarts and saved client connections survive.
+    pub transport_key: [u8; 32],
 }
 
 /// What `spawn_network_frost` reports back once the co-signer is up.
@@ -260,7 +263,9 @@ pub fn spawn_network_frost(
 
             let node_for_state = node.clone();
             let signer = NetworkFrostSigner::with_shared_node(cfg.group_pubkey, node);
-            let transport_key: [u8; 32] = keep_core::crypto::random_bytes();
+            // Persisted (not freshly generated) so the bunker URL pubkey is
+            // stable across restarts and saved client connections keep working.
+            let transport_key = cfg.transport_key;
             let callbacks: Arc<dyn ServerCallbacks> = Arc::new(WebCallbacks { events, approvals });
 
             let mut server = match Server::new_network_frost_with_config(
@@ -317,6 +322,7 @@ pub fn spawn_network_frost(
 pub fn spawn_single_key(
     keyring: Arc<Mutex<Keyring>>,
     relays: Vec<String>,
+    bunker_secret: String,
     events: broadcast::Sender<Event>,
     approvals: Arc<StdMutex<HashMap<u64, Sender<bool>>>>,
 ) -> Result<BunkerInfo, String> {
@@ -342,6 +348,9 @@ pub fn spawn_single_key(
                     // Least privilege for the single-key fallback: connect +
                     // signing only.
                     connect_grant: Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT,
+                    // Same secret-in-URL handshake as the network path so
+                    // clients can authenticate.
+                    expected_secret: Some(bunker_secret),
                     ..ServerConfig::default()
                 },
             )

--- a/keep-web/src/bunker.rs
+++ b/keep-web/src/bunker.rs
@@ -181,6 +181,9 @@ pub struct NetworkConfig {
     pub frost_relays: Vec<String>,
     pub bunker_relays: Vec<String>,
     pub enabled: Arc<AtomicBool>,
+    /// Persisted NIP-46 secret embedded in the bunker URL and required in the
+    /// connect handshake. Clients (Amethyst, etc.) reject a secret-less URL.
+    pub bunker_secret: String,
 }
 
 /// What `spawn_network_frost` reports back once the co-signer is up.
@@ -222,7 +225,7 @@ pub fn spawn_network_frost(
 
             node.set_hooks(Arc::new(CoSignerPolicy {
                 events: events.clone(),
-                enabled: cfg.enabled,
+                enabled: cfg.enabled.clone(),
             }));
 
             // Mirror node lifecycle events (peer presence) into the web activity
@@ -269,6 +272,10 @@ pub fn spawn_network_frost(
                     // Least privilege for the co-signer: connect handshake +
                     // signing only, not NIP-04/44 encrypt/decrypt.
                     connect_grant: Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT,
+                    // Authenticate clients with a stable secret (embedded in the
+                    // bunker URL) and gate signing on the live kill switch.
+                    expected_secret: Some(cfg.bunker_secret),
+                    kill_switch: Some(cfg.enabled.clone()),
                     ..ServerConfig::default()
                 },
             )

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -116,7 +116,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let vault_path = PathBuf::from(env_or("KEEP_PATH", "/data"));
     let bunker_relays = parse_relays(&env_or(
         "KEEP_BUNKER_RELAY",
-        &env_or("KEEP_RELAY", "wss://relay.damus.io"),
+        &env_or("KEEP_RELAY", "wss://bucket.coracle.social"),
     ));
     let frost_group = std::env::var("KEEP_FROST_GROUP").ok();
     // Fail-closed: signing is off until the operator explicitly enables it

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -189,7 +189,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         frost_relays,
                         bunker_relays,
                         enabled: signing_enabled.clone(),
-                        bunker_secret: state::load_or_create_bunker_secret(&vault_path),
+                        bunker_secret: state::load_or_create_bunker_secret(&vault_path)?,
+                        transport_key: state::load_or_create_transport_key(&vault_path)?,
                     },
                     events.clone(),
                     approvals.clone(),
@@ -211,8 +212,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // keyring is intentionally left empty afterwards (the bunker is the
         // only thing that signs in this mode — don't read keep.keyring() below).
         let keyring = Arc::new(Mutex::new(std::mem::take(keep.keyring_mut())));
-        bunker::spawn_single_key(keyring, bunker_relays, events.clone(), approvals.clone())
-            .map_err(|e| format!("failed to start bunker: {e}"))?
+        let bunker_secret = state::load_or_create_bunker_secret(&vault_path)?;
+        bunker::spawn_single_key(
+            keyring,
+            bunker_relays,
+            bunker_secret,
+            events.clone(),
+            approvals.clone(),
+        )
+        .map_err(|e| format!("failed to start bunker: {e}"))?
     } else {
         // Nothing to sign with yet: serve the admin UI so the operator can
         // import a share, then restart the service to start the co-signer.

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -189,6 +189,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         frost_relays,
                         bunker_relays,
                         enabled: signing_enabled.clone(),
+                        bunker_secret: state::load_or_create_bunker_secret(&vault_path),
                     },
                     events.clone(),
                     approvals.clone(),

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -153,6 +153,26 @@ pub fn persist_signing_flag(path: &Path, enabled: bool) {
     }
 }
 
+/// Loads the persisted NIP-46 bunker secret, generating and storing one on
+/// first run. The secret must be stable so the advertised bunker URL (which
+/// embeds it) doesn't change across restarts and saved client connections keep
+/// working.
+pub fn load_or_create_bunker_secret(vault_dir: &Path) -> String {
+    let path = vault_dir.join("bunker_secret");
+    if let Ok(s) = std::fs::read_to_string(&path) {
+        let trimmed = s.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    let bytes: [u8; 16] = keep_core::crypto::random_bytes();
+    let secret: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+    if let Err(e) = std::fs::write(&path, &secret) {
+        tracing::warn!(error = %e, path = %path.display(), "failed to persist bunker secret");
+    }
+    secret
+}
+
 /// An event pushed to connected WebSocket clients.
 #[derive(Clone, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -158,11 +158,18 @@ pub fn persist_signing_flag(path: &Path, enabled: bool) {
 /// Writes to a sibling temp file, fsyncs, then atomically renames over the
 /// target, so a crash mid-write cannot leave a truncated/empty credential that a
 /// later boot would treat as missing and silently replace.
+fn to_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
 fn write_secret_file(path: &Path, contents: &str) -> std::io::Result<()> {
     use std::io::Write;
-    let tmp = path.with_extension("tmp");
+    // Per-write temp name (PID + random suffix) so a concurrent writer cannot
+    // clobber an in-flight temp file before its rename.
+    let suffix: [u8; 8] = keep_core::crypto::random_bytes();
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), to_hex(&suffix)));
     let mut opts = std::fs::OpenOptions::new();
-    opts.write(true).create(true).truncate(true);
+    opts.write(true).create_new(true);
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
@@ -171,7 +178,16 @@ fn write_secret_file(path: &Path, contents: &str) -> std::io::Result<()> {
     let mut f = opts.open(&tmp)?;
     f.write_all(contents.as_bytes())?;
     f.sync_all()?;
-    std::fs::rename(&tmp, path)
+    std::fs::rename(&tmp, path)?;
+
+    // fsync the parent directory so the rename itself is durable across a crash;
+    // otherwise the file could survive while the directory entry is lost.
+    if let Some(parent) = path.parent() {
+        if let Ok(dir) = std::fs::File::open(parent) {
+            let _ = dir.sync_all();
+        }
+    }
+    Ok(())
 }
 
 fn decode_hex32(s: &str) -> Option<[u8; 32]> {
@@ -207,7 +223,7 @@ pub fn load_or_create_bunker_secret(vault_dir: &Path) -> std::io::Result<String>
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             let bytes: [u8; 16] = keep_core::crypto::random_bytes();
-            let secret: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+            let secret = to_hex(&bytes);
             write_secret_file(&path, &secret)?;
             Ok(secret)
         }
@@ -233,7 +249,7 @@ pub fn load_or_create_transport_key(vault_dir: &Path) -> std::io::Result<[u8; 32
         }),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             let bytes: [u8; 32] = keep_core::crypto::random_bytes();
-            let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+            let hex = to_hex(&bytes);
             write_secret_file(&path, &hex)?;
             Ok(bytes)
         }

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -153,32 +153,43 @@ pub fn persist_signing_flag(path: &Path, enabled: bool) {
     }
 }
 
-/// Writes a credential file, creating it `0600` on Unix. Propagates IO errors:
-/// a credential that can't be persisted must fail startup, not silently rotate.
-/// Writes to a sibling temp file, fsyncs, then atomically renames over the
-/// target, so a crash mid-write cannot leave a truncated/empty credential that a
-/// later boot would treat as missing and silently replace.
 fn to_hex(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
+/// Writes a credential file, creating it `0600` on Unix. Propagates IO errors:
+/// a credential that can't be persisted must fail startup, not silently rotate.
+///
+/// Writes to a sibling temp file, fsyncs, then atomically renames over the
+/// target, so a crash mid-write cannot leave a truncated/empty credential that a
+/// later boot would treat as missing and silently replace.
 fn write_secret_file(path: &Path, contents: &str) -> std::io::Result<()> {
     use std::io::Write;
     // Per-write temp name (PID + random suffix) so a concurrent writer cannot
     // clobber an in-flight temp file before its rename.
     let suffix: [u8; 8] = keep_core::crypto::random_bytes();
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), to_hex(&suffix)));
-    let mut opts = std::fs::OpenOptions::new();
-    opts.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        opts.mode(0o600);
+
+    let write = || -> std::io::Result<()> {
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let mut f = opts.open(&tmp)?;
+        f.write_all(contents.as_bytes())?;
+        f.sync_all()?;
+        std::fs::rename(&tmp, path)
+    };
+
+    // On any failure before the rename succeeds, remove the temp so a crash or
+    // transient error cannot leave an unguessable, never-cleaned-up temp file.
+    if let Err(e) = write() {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
     }
-    let mut f = opts.open(&tmp)?;
-    f.write_all(contents.as_bytes())?;
-    f.sync_all()?;
-    std::fs::rename(&tmp, path)?;
 
     // fsync the parent directory so the rename itself is durable across a crash;
     // otherwise the file could survive while the directory entry is lost.

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -155,8 +155,12 @@ pub fn persist_signing_flag(path: &Path, enabled: bool) {
 
 /// Writes a credential file, creating it `0600` on Unix. Propagates IO errors:
 /// a credential that can't be persisted must fail startup, not silently rotate.
+/// Writes to a sibling temp file, fsyncs, then atomically renames over the
+/// target, so a crash mid-write cannot leave a truncated/empty credential that a
+/// later boot would treat as missing and silently replace.
 fn write_secret_file(path: &Path, contents: &str) -> std::io::Result<()> {
     use std::io::Write;
+    let tmp = path.with_extension("tmp");
     let mut opts = std::fs::OpenOptions::new();
     opts.write(true).create(true).truncate(true);
     #[cfg(unix)]
@@ -164,9 +168,10 @@ fn write_secret_file(path: &Path, contents: &str) -> std::io::Result<()> {
         use std::os::unix::fs::OpenOptionsExt;
         opts.mode(0o600);
     }
-    let mut f = opts.open(path)?;
+    let mut f = opts.open(&tmp)?;
     f.write_all(contents.as_bytes())?;
-    f.flush()
+    f.sync_all()?;
+    std::fs::rename(&tmp, path)
 }
 
 fn decode_hex32(s: &str) -> Option<[u8; 32]> {
@@ -186,16 +191,28 @@ fn decode_hex32(s: &str) -> Option<[u8; 32]> {
 /// fails rather than rotating to an ephemeral secret that breaks saved clients.
 pub fn load_or_create_bunker_secret(vault_dir: &Path) -> std::io::Result<String> {
     let path = vault_dir.join("bunker_secret");
-    if let Ok(s) = std::fs::read_to_string(&path) {
-        let trimmed = s.trim();
-        if !trimmed.is_empty() {
-            return Ok(trimmed.to_string());
+    match std::fs::read_to_string(&path) {
+        Ok(s) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                // The file exists but is empty (e.g. a truncated write): fail
+                // closed rather than mint a new secret that would change the
+                // advertised bunker URL and break saved client connections.
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "bunker_secret file is empty; refusing to rotate credential",
+                ));
+            }
+            Ok(trimmed.to_string())
         }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let bytes: [u8; 16] = keep_core::crypto::random_bytes();
+            let secret: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+            write_secret_file(&path, &secret)?;
+            Ok(secret)
+        }
+        Err(e) => Err(e),
     }
-    let bytes: [u8; 16] = keep_core::crypto::random_bytes();
-    let secret: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
-    write_secret_file(&path, &secret)?;
-    Ok(secret)
 }
 
 /// Loads the persisted NIP-46 transport key (the bunker URL's own identity),
@@ -204,15 +221,24 @@ pub fn load_or_create_bunker_secret(vault_dir: &Path) -> std::io::Result<String>
 /// connections keep working.
 pub fn load_or_create_transport_key(vault_dir: &Path) -> std::io::Result<[u8; 32]> {
     let path = vault_dir.join("bunker_transport_key");
-    if let Ok(s) = std::fs::read_to_string(&path) {
-        if let Some(bytes) = decode_hex32(s.trim()) {
-            return Ok(bytes);
+    match std::fs::read_to_string(&path) {
+        Ok(s) => decode_hex32(s.trim()).ok_or_else(|| {
+            // The file exists but is malformed (e.g. a truncated write): fail
+            // closed rather than mint a new key that would change the bunker
+            // URL's pubkey and break saved client connections.
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "bunker_transport_key file is malformed; refusing to rotate identity",
+            )
+        }),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let bytes: [u8; 32] = keep_core::crypto::random_bytes();
+            let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+            write_secret_file(&path, &hex)?;
+            Ok(bytes)
         }
+        Err(e) => Err(e),
     }
-    let bytes: [u8; 32] = keep_core::crypto::random_bytes();
-    let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
-    write_secret_file(&path, &hex)?;
-    Ok(bytes)
 }
 
 /// An event pushed to connected WebSocket clients.

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -153,24 +153,66 @@ pub fn persist_signing_flag(path: &Path, enabled: bool) {
     }
 }
 
-/// Loads the persisted NIP-46 bunker secret, generating and storing one on
-/// first run. The secret must be stable so the advertised bunker URL (which
-/// embeds it) doesn't change across restarts and saved client connections keep
-/// working.
-pub fn load_or_create_bunker_secret(vault_dir: &Path) -> String {
+/// Writes a credential file, creating it `0600` on Unix. Propagates IO errors:
+/// a credential that can't be persisted must fail startup, not silently rotate.
+fn write_secret_file(path: &Path, contents: &str) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let mut f = opts.open(path)?;
+    f.write_all(contents.as_bytes())?;
+    f.flush()
+}
+
+fn decode_hex32(s: &str) -> Option<[u8; 32]> {
+    if s.len() != 64 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&s[i * 2..i * 2 + 2], 16).ok()?;
+    }
+    Some(out)
+}
+
+/// Loads the persisted NIP-46 bunker secret, generating and storing one (`0600`)
+/// on first run. Must be stable so the advertised bunker URL (which embeds it)
+/// doesn't change across restarts. A write failure is propagated so startup
+/// fails rather than rotating to an ephemeral secret that breaks saved clients.
+pub fn load_or_create_bunker_secret(vault_dir: &Path) -> std::io::Result<String> {
     let path = vault_dir.join("bunker_secret");
     if let Ok(s) = std::fs::read_to_string(&path) {
         let trimmed = s.trim();
         if !trimmed.is_empty() {
-            return trimmed.to_string();
+            return Ok(trimmed.to_string());
         }
     }
     let bytes: [u8; 16] = keep_core::crypto::random_bytes();
     let secret: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
-    if let Err(e) = std::fs::write(&path, &secret) {
-        tracing::warn!(error = %e, path = %path.display(), "failed to persist bunker secret");
+    write_secret_file(&path, &secret)?;
+    Ok(secret)
+}
+
+/// Loads the persisted NIP-46 transport key (the bunker URL's own identity),
+/// generating and storing one (`0600`) on first run. Must be stable so the
+/// bunker URL's pubkey doesn't change across restarts and saved client
+/// connections keep working.
+pub fn load_or_create_transport_key(vault_dir: &Path) -> std::io::Result<[u8; 32]> {
+    let path = vault_dir.join("bunker_transport_key");
+    if let Ok(s) = std::fs::read_to_string(&path) {
+        if let Some(bytes) = decode_hex32(s.trim()) {
+            return Ok(bytes);
+        }
     }
-    secret
+    let bytes: [u8; 32] = keep_core::crypto::random_bytes();
+    let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+    write_secret_file(&path, &hex)?;
+    Ok(bytes)
 }
 
 /// An event pushed to connected WebSocket clients.


### PR DESCRIPTION
## Bug
Real NIP-46 clients (Amethyst, nak) could not connect to the keep-web co-signer's bunker. Amethyst reported "Invalid key: Could not sign in: Failed requirement"; nak reported "pubkey mismatch" / "User rejected".

## Two root causes
1. **No `secret` in the bunker URL.** keep-web set neither `auto_approve` nor `expected_secret`, and `finalize_handler` only embedded a secret in the URL via the auto-generate path. Clients require `&secret=` in the connect handshake, so they rejected the URL outright.
2. **Connect pubkey mismatch.** For a remote signer the bunker URL advertises the *transport* pubkey, but `get_public_key` returns the *signing* identity (network-FROST: the group pubkey). `handle_connect` compared the client's target (the transport pubkey, from the URL) against the **group** pubkey via `our_pubkey()`, so it always failed with "pubkey mismatch".

## Fix
- **keep-nip46**: `handle_connect` now validates the client's target against the **transport** pubkey (new `SignerHandler::with_transport_pubkey`, set by the Server from its transport keys). Single-key mode is unchanged (transport == signing key). `finalize_handler` now also surfaces an explicitly-configured `expected_secret` in the bunker URL.
- **keep-web**: the network-FROST bunker now generates and **persists** a NIP-46 secret (stored in the vault dir, stable across restarts so saved client connections keep working), passes it as `expected_secret`, and wires the live kill switch into `ServerConfig.kill_switch`. With a secret set, the connect is authorized by the secret (no per-connect browser prompt).

## Testing
- keep-nip46 + keep-web test suites pass (incl. connect/pubkey tests); clippy clean.
- End-to-end against a local relay: the bunker URL now includes `&secret=`, and a `nak` NIP-46 client connects successfully (`connect success`, "app connected") where it previously failed with "pubkey mismatch". FROST co-signing itself was separately verified producing real 2-of-3 signatures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent bunker authentication secret and stable transport key are created/loaded for consistent client auth and transport identity.
  * Optional transport public-key validation for connection handshakes.
  * Live kill‑switch to enable/disable co-signer signing without restart.
  * Session resilience to out-of-order messages and stronger aggregation readiness checks.

* **Bug Fixes**
  * Bunker URL now includes the persisted authentication secret so clients can authenticate reliably.

* **Other**
  * NIP‑46 JSON responses omit null result/error fields; relay parameter preserved unencoded.

* **Tests**
  * New unit and integration tests covering secret handling, transport key behavior, URL encoding, and signing/aggregation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->