### PR TITLE
keep-web ui: declutter activity feed + prominent approval bar

### DIFF
--- a/keep-web/src/api.rs
+++ b/keep-web/src/api.rs
@@ -251,6 +251,44 @@ pub async fn signing_log(State(state): State<AppState>) -> impl IntoResponse {
 }
 
 #[derive(Serialize)]
+pub struct PeerDto {
+    share_index: u16,
+    name: Option<String>,
+    online: bool,
+}
+
+#[derive(Serialize)]
+pub struct PeersResponse {
+    peers: Vec<PeerDto>,
+    /// Co-signer peers currently online (this node is not counted).
+    online: usize,
+}
+
+/// Live co-signer presence, so the UI can show readiness as a status instead of
+/// reconstructing it from the activity stream. Empty in setup/single-key mode.
+pub async fn peers(State(state): State<AppState>) -> impl IntoResponse {
+    let Some(node) = state.node.as_ref() else {
+        return Json(PeersResponse {
+            peers: Vec::new(),
+            online: 0,
+        })
+        .into_response();
+    };
+    let mut peers: Vec<PeerDto> = node
+        .peer_status()
+        .into_iter()
+        .map(|(share_index, status, name, _pubkey)| PeerDto {
+            share_index,
+            name,
+            online: status == keep_frost_net::PeerStatus::Online,
+        })
+        .collect();
+    peers.sort_by_key(|p| p.share_index);
+    let online = peers.iter().filter(|p| p.online).count();
+    Json(PeersResponse { peers, online }).into_response()
+}
+
+#[derive(Serialize)]
 pub struct KillswitchStatus {
     enabled: bool,
     /// True once the active share was deleted at runtime: signing is locked off

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -257,6 +257,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/api/shares/delete", post(api::delete_share))
         .route("/api/shares/rename", post(api::rename_share))
         .route("/api/signing-log", get(api::signing_log))
+        .route("/api/peers", get(api::peers))
         .route(
             "/api/killswitch",
             get(api::killswitch_status).post(api::set_killswitch),

--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -43,7 +43,13 @@
 
   type PendingApproval = ApprovalEvent & { resolved?: 'approved' | 'denied' }
   let approvals = $state<PendingApproval[]>([])
-  let logs = $state<LogEvent[]>([])
+  // Still-unresolved requests, surfaced in a prominent banner so they aren't
+  // missed in the activity stream.
+  const pendingApprovals = $derived(approvals.filter((a) => !a.resolved))
+  // Repeated identical events (e.g. periodic "peer online" announcements) are
+  // coalesced into one line with a count so real signal isn't buried.
+  type CountedLog = LogEvent & { count: number; ts: number }
+  let logs = $state<CountedLog[]>([])
 
   let importData = $state('')
   let importPass = $state('')
@@ -60,6 +66,30 @@
   let signingLog = $state<SigningEntry[]>([])
   let signingVerified = $state(true)
   let wsConnected = $state(false)
+
+  // One row per signing session (the raw log has 3+ operations each). Status is
+  // "signed" once a SignatureCompleted entry exists, otherwise "in progress".
+  type SigningSession = {
+    session: string
+    participants: number[]
+    completed: boolean
+    latest: number
+  }
+  const signingSessions = $derived.by<SigningSession[]>(() => {
+    const byId = new Map<string, SigningSession>()
+    for (const e of signingLog) {
+      const g = byId.get(e.session) ?? {
+        session: e.session,
+        participants: e.participants,
+        completed: false,
+        latest: e.timestamp_ms,
+      }
+      if (e.operation === 'SignatureCompleted') g.completed = true
+      g.latest = Math.max(g.latest, e.timestamp_ms)
+      byId.set(e.session, g)
+    }
+    return [...byId.values()].sort((a, b) => b.latest - a.latest)
+  })
 
   // Per-share export UI state.
   let exportFor = $state<string | null>(null) // "group:id"
@@ -280,7 +310,18 @@
           const resolved = next.filter((x) => x.resolved)
           approvals = [...pending, ...resolved].slice(0, 100)
         } else {
-          logs = [e, ...logs].slice(0, 100)
+          const head = logs[0]
+          if (
+            head &&
+            head.app === e.app &&
+            head.action === e.action &&
+            head.detail === e.detail &&
+            head.success === e.success
+          ) {
+            logs[0] = { ...head, count: head.count + 1, ts: Date.now() }
+          } else {
+            logs = [{ ...e, count: 1, ts: Date.now() }, ...logs].slice(0, 100)
+          }
           // A co-sign just happened: refresh the persistent audit log.
           if (e.app === 'frost') refreshSigningLog()
         }
@@ -393,6 +434,24 @@
 <main>
   {#if error}
     <p class="fail banner">{error}</p>
+  {/if}
+
+  {#if authed && pendingApprovals.length}
+    <div class="approval-bar">
+      {#each pendingApprovals as a (a.id)}
+        <div class="approval-bar-row">
+          <span class="approval-bar-text">
+            <strong>{a.app}</strong> requests <strong>{a.method}</strong>{#if a.kind !== null}
+              · kind {a.kind}{/if}
+            {#if a.preview}<span class="muted"> · {a.preview}</span>{/if}
+          </span>
+          <span class="approval-bar-actions">
+            <button class="ok" onclick={() => decide(a, true)}>Approve</button>
+            <button class="no" onclick={() => decide(a, false)}>Deny</button>
+          </span>
+        </div>
+      {/each}
+    </div>
   {/if}
 
   {#if !authed}
@@ -716,25 +775,21 @@
     </span>
   </h2>
   <div class="panel">
-    {#each approvals as a (a.id)}
+    {#each approvals.filter((a) => a.resolved) as a (a.id)}
       <div class="event approval">
-        <span><strong>{a.app}</strong> requests {a.method}</span>
-        {#if a.resolved}
-          <span class="muted">→ {a.resolved}</span>
-        {:else}
-          <button class="ok" onclick={() => decide(a, true)}>Approve</button>
-          <button class="no" onclick={() => decide(a, false)}>Deny</button>
-        {/if}
+        <span><strong>{a.app}</strong> requested {a.method}</span>
+        <span class="muted">→ {a.resolved}</span>
       </div>
     {/each}
     {#each logs as l, i (i)}
       <div class="event">
         <strong>{l.app}</strong>: {l.action}
         <span class:fail={!l.success}>{l.success ? '✓' : '✗'}</span>
+        {#if l.count > 1}<span class="count-badge">×{l.count}</span>{/if}
         {#if l.detail}<span class="muted"> · {l.detail}</span>{/if}
       </div>
     {/each}
-    {#if approvals.length === 0 && logs.length === 0}
+    {#if approvals.every((a) => !a.resolved) && logs.length === 0}
       <p class="muted">Waiting for signing activity…</p>
     {/if}
   </div>
@@ -749,14 +804,14 @@
     {/if}
   </h2>
   <div class="panel">
-    {#each signingLog as e (e.timestamp_ms + ':' + e.session + ':' + e.operation)}
+    {#each signingSessions as s (s.session)}
       <div class="event">
-        <span class="token">{e.session}</span>
-        <span>{e.operation}</span>
+        <span class="token">{s.session}</span>
+        <span class="verify {s.completed ? 'ok' : 'warn'}">
+          {s.completed ? '✓ signed' : '… in progress'}
+        </span>
         <span class="muted">
-          · participants {e.participants.join(',')} · {new Date(
-            e.timestamp_ms,
-          ).toLocaleString()}
+          · participants {s.participants.join(',')} · {new Date(s.latest).toLocaleString()}
         </span>
       </div>
     {:else}

--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -50,9 +50,9 @@
   const pendingApprovals = $derived(approvals.filter((a) => !a.resolved))
   // Repeated identical events (e.g. periodic "peer online" announcements) are
   // coalesced into one line with a count so real signal isn't buried.
-  // `ts` is first-seen (drives relative time); `lastTs` tracks the latest repeat.
+  // `ts` is first-seen (drives relative time).
   // `cid` is a stable client-side id for keyed list rendering.
-  type CountedLog = LogEvent & { count: number; ts: number; lastTs: number; cid: number }
+  type CountedLog = LogEvent & { count: number; ts: number; cid: number }
   let logs = $state<CountedLog[]>([])
   let logCid = 0
 
@@ -117,6 +117,7 @@
     participants: number[]
     completed: boolean
     latest: number
+    ops: SigningEntry[]
   }
   const signingSessions = $derived.by<SigningSession[]>(() => {
     const byId = new Map<string, SigningSession>()
@@ -126,9 +127,11 @@
         participants: e.participants,
         completed: false,
         latest: e.timestamp_ms,
+        ops: [],
       }
       if (e.operation === 'SignatureCompleted') g.completed = true
       g.latest = Math.max(g.latest, e.timestamp_ms)
+      g.ops.push(e)
       byId.set(e.session, g)
     }
     return [...byId.values()].sort((a, b) => b.latest - a.latest)
@@ -160,6 +163,10 @@
   function fmtDate(secs: number | null): string {
     if (!secs) return 'never'
     return new Date(secs * 1000).toLocaleString()
+  }
+
+  function fmtTime(ms: number): string {
+    return new Date(ms).toLocaleString()
   }
 
   function shortNpub(npub: string): string {
@@ -456,10 +463,9 @@
             head.detail === e.detail &&
             head.success === e.success
           ) {
-            logs[0] = { ...head, count: head.count + 1, lastTs: Date.now() }
+            logs[0] = { ...head, count: head.count + 1 }
           } else {
-            const now = Date.now()
-            logs = [{ ...e, count: 1, ts: now, lastTs: now, cid: logCid++ }, ...logs].slice(0, 100)
+            logs = [{ ...e, count: 1, ts: Date.now(), cid: logCid++ }, ...logs].slice(0, 100)
           }
           // A co-sign just happened: refresh the persistent audit log.
           if (e.app === 'frost') {
@@ -966,7 +972,7 @@
         <span class:fail={!l.success}>{l.success ? '✓' : '✗'}</span>
         {#if l.count > 1}<span class="count-badge">×{l.count}</span>{/if}
         {#if l.detail}<span class="muted"> · {l.detail}</span>{/if}
-        <span class="muted row-time" title={new Date(l.ts).toLocaleString()}>
+        <span class="muted row-time" title={fmtTime(l.ts)}>
           · {relTime(l.ts)}
         </span>
       </div>
@@ -1002,16 +1008,16 @@
         <span class="verify {s.completed ? 'ok' : 'warn'}">
           {s.completed ? '✓ signed' : '… in progress'}
         </span>
-        <span class="muted" title={new Date(s.latest).toLocaleString()}>
+        <span class="muted" title={fmtTime(s.latest)}>
           · participants {s.participants.join(',')} · {relTime(s.latest)}
         </span>
       </div>
       {#if expandedSessions[s.session]}
         <div class="session-detail">
-          {#each signingLog.filter((e) => e.session === s.session) as op (op.timestamp_ms + ':' + op.operation)}
+          {#each s.ops as op (op.timestamp_ms + ':' + op.operation)}
             <div class="op-row">
               <span>{op.operation}</span>
-              <span class="muted">· {new Date(op.timestamp_ms).toLocaleString()}</span>
+              <span class="muted">· {fmtTime(op.timestamp_ms)}</span>
             </div>
           {/each}
         </div>

--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -50,8 +50,11 @@
   const pendingApprovals = $derived(approvals.filter((a) => !a.resolved))
   // Repeated identical events (e.g. periodic "peer online" announcements) are
   // coalesced into one line with a count so real signal isn't buried.
-  type CountedLog = LogEvent & { count: number; ts: number }
+  // `ts` is first-seen (drives relative time); `lastTs` tracks the latest repeat.
+  // `cid` is a stable client-side id for keyed list rendering.
+  type CountedLog = LogEvent & { count: number; ts: number; lastTs: number; cid: number }
   let logs = $state<CountedLog[]>([])
+  let logCid = 0
 
   let importData = $state('')
   let importPass = $state('')
@@ -163,10 +166,14 @@
     return npub.length > 24 ? `${npub.slice(0, 12)}…${npub.slice(-6)}` : npub
   }
 
+  // How often relative timestamps re-render, and how often presence is polled.
+  const REL_TIME_TICK_MS = 30000
+  const PEERS_POLL_MS = 10000
+
   // Ticks so relative timestamps stay current without a new event.
   let nowTick = $state(Date.now())
   $effect(() => {
-    const t = setInterval(() => (nowTick = Date.now()), 30000)
+    const t = setInterval(() => (nowTick = Date.now()), REL_TIME_TICK_MS)
     return () => clearInterval(t)
   })
 
@@ -198,6 +205,24 @@
   let notifyEnabled = $state(canNotify && Notification.permission === 'granted')
   const notifiedApprovals = new Set<number>()
 
+  // Remote NIP-46 clients self-report app/method names; strip control chars and
+  // truncate before placing them in an OS notification to avoid spoofing.
+  function sanitizeForNotification(s: string): string {
+    return (s ?? '')
+      .normalize('NFC')
+      .split('')
+      .filter((ch) => {
+        const c = ch.charCodeAt(0)
+        if (c < 0x20 || (c >= 0x7f && c <= 0x9f)) return false // C0/C1 controls
+        if (c === 0x200b || c === 0x200c || c === 0x200d || c === 0xfeff) return false // zero-width
+        if (c >= 0x202a && c <= 0x202e) return false // bidi embedding/override
+        if (c >= 0x2066 && c <= 0x2069) return false // bidi isolates
+        return true
+      })
+      .join('')
+      .slice(0, 64)
+  }
+
   async function toggleNotify() {
     if (!canNotify) return
     if (Notification.permission === 'granted') {
@@ -208,13 +233,21 @@
   }
 
   $effect(() => {
+    // Drop ids that have aged out of the (capped) approvals list so the set
+    // can't grow unbounded on a long-running appliance tab.
+    const live = new Set(approvals.map((a) => a.id))
+    for (const id of notifiedApprovals) {
+      if (!live.has(id)) notifiedApprovals.delete(id)
+    }
     if (!notifyEnabled || !canNotify || Notification.permission !== 'granted') return
     for (const a of pendingApprovals) {
       if (notifiedApprovals.has(a.id)) continue
       notifiedApprovals.add(a.id)
       // Only nag when the page isn't visible; otherwise the banner suffices.
       if (document.hidden) {
-        new Notification('Keep: approval needed', { body: `${a.app} requests ${a.method}` })
+        new Notification('Keep: approval needed', {
+          body: `${sanitizeForNotification(a.app)} requests ${sanitizeForNotification(a.method)}`,
+        })
       }
     }
   })
@@ -397,7 +430,7 @@
   // without a triggering event.
   $effect(() => {
     if (!authed) return
-    const t = setInterval(refreshPeers, 10000)
+    const t = setInterval(refreshPeers, PEERS_POLL_MS)
     return () => clearInterval(t)
   })
 
@@ -423,9 +456,10 @@
             head.detail === e.detail &&
             head.success === e.success
           ) {
-            logs[0] = { ...head, count: head.count + 1, ts: Date.now() }
+            logs[0] = { ...head, count: head.count + 1, lastTs: Date.now() }
           } else {
-            logs = [{ ...e, count: 1, ts: Date.now() }, ...logs].slice(0, 100)
+            const now = Date.now()
+            logs = [{ ...e, count: 1, ts: now, lastTs: now, cid: logCid++ }, ...logs].slice(0, 100)
           }
           // A co-sign just happened: refresh the persistent audit log.
           if (e.app === 'frost') {
@@ -926,7 +960,7 @@
         <span class="muted">→ {a.resolved}</span>
       </div>
     {/each}
-    {#each logs as l, i (i)}
+    {#each logs as l (l.cid)}
       <div class="event">
         <strong>{l.app}</strong>: {l.action}
         <span class:fail={!l.success}>{l.success ? '✓' : '✗'}</span>

--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -123,6 +123,35 @@
     return npub.length > 24 ? `${npub.slice(0, 12)}…${npub.slice(-6)}` : npub
   }
 
+  // Ticks so relative timestamps stay current without a new event.
+  let nowTick = $state(Date.now())
+  $effect(() => {
+    const t = setInterval(() => (nowTick = Date.now()), 30000)
+    return () => clearInterval(t)
+  })
+
+  // Relative time for activity/log rows; full timestamp shown on hover.
+  function relTime(ms: number): string {
+    const s = Math.max(0, Math.round((nowTick - ms) / 1000))
+    if (s < 5) return 'just now'
+    if (s < 60) return `${s}s ago`
+    const m = Math.round(s / 60)
+    if (m < 60) return `${m}m ago`
+    const h = Math.round(m / 60)
+    if (h < 24) return `${h}h ago`
+    return new Date(ms).toLocaleDateString()
+  }
+
+  // Surface pending approvals in the tab title so a backgrounded tab still
+  // shows that a co-sign decision is waiting.
+  $effect(() => {
+    if (typeof document !== 'undefined') {
+      document.title = pendingApprovals.length
+        ? `(${pendingApprovals.length}) Approval needed — Keep`
+        : 'Keep'
+    }
+  })
+
   // Shares grouped by their FROST group, so a vault holding more than one
   // group renders as separate sections instead of one flat pile.
   let groupedShares = $derived.by(() => {
@@ -437,7 +466,7 @@
   {/if}
 
   {#if authed && pendingApprovals.length}
-    <div class="approval-bar">
+    <div class="approval-bar" role="alert" aria-live="assertive">
       {#each pendingApprovals as a (a.id)}
         <div class="approval-bar-row">
           <span class="approval-bar-text">
@@ -787,6 +816,9 @@
         <span class:fail={!l.success}>{l.success ? '✓' : '✗'}</span>
         {#if l.count > 1}<span class="count-badge">×{l.count}</span>{/if}
         {#if l.detail}<span class="muted"> · {l.detail}</span>{/if}
+        <span class="muted row-time" title={new Date(l.ts).toLocaleString()}>
+          · {relTime(l.ts)}
+        </span>
       </div>
     {/each}
     {#if approvals.every((a) => !a.resolved) && logs.length === 0}
@@ -810,8 +842,8 @@
         <span class="verify {s.completed ? 'ok' : 'warn'}">
           {s.completed ? '✓ signed' : '… in progress'}
         </span>
-        <span class="muted">
-          · participants {s.participants.join(',')} · {new Date(s.latest).toLocaleString()}
+        <span class="muted" title={new Date(s.latest).toLocaleString()}>
+          · participants {s.participants.join(',')} · {relTime(s.latest)}
         </span>
       </div>
     {:else}

--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -11,6 +11,7 @@
     getSigningLog,
     getKillswitch,
     setKillswitch,
+    getPeers,
     resolveApproval,
     connectEvents,
     hasAuthToken,
@@ -20,6 +21,7 @@
     type SigningEntry,
     type LogEvent,
     type ApprovalEvent,
+    type PeerInfo,
   } from './lib/api'
 
   let bunker = $state<BunkerInfo | null>(null)
@@ -66,6 +68,44 @@
   let signingLog = $state<SigningEntry[]>([])
   let signingVerified = $state(true)
   let wsConnected = $state(false)
+
+  // Live co-signer presence, polled so readiness is a glanceable status rather
+  // than something to reconstruct from the activity stream.
+  let peers = $state<PeerInfo[]>([])
+  let peersOnline = $state(0)
+
+  // Signing-log rows expand to show their underlying operations on demand.
+  let expandedSessions = $state<Record<string, boolean>>({})
+  function toggleSession(id: string) {
+    expandedSessions = { ...expandedSessions, [id]: !expandedSessions[id] }
+  }
+
+  function refreshPeers() {
+    getPeers()
+      .then((p) => {
+        peers = p.peers
+        peersOnline = p.online
+      })
+      .catch(() => {})
+  }
+
+  // Co-signers that must be online besides this node, parsed from "t-of-n".
+  const coSignersNeeded = $derived.by(() => {
+    const t = bunker?.threshold ? parseInt(bunker.threshold.split('-')[0], 10) : NaN
+    return Number.isFinite(t) ? Math.max(0, t - 1) : 0
+  })
+
+  type Readiness = { label: string; cls: 'ok' | 'warn' | 'fail' }
+  const readiness = $derived.by<Readiness>(() => {
+    if (signerRetired) return { label: 'Signer retired — restart required', cls: 'fail' }
+    if (signingEnabled === undefined) return { label: 'Checking…', cls: 'warn' }
+    if (signingEnabled === false) return { label: 'Co-signing off', cls: 'warn' }
+    if (peersOnline >= coSignersNeeded) return { label: 'Ready to sign', cls: 'ok' }
+    return {
+      label: `Waiting for co-signers (${peersOnline}/${coSignersNeeded})`,
+      cls: 'warn',
+    }
+  })
 
   // One row per signing session (the raw log has 3+ operations each). Status is
   // "signed" once a SignatureCompleted entry exists, otherwise "in progress".
@@ -149,6 +189,33 @@
       document.title = pendingApprovals.length
         ? `(${pendingApprovals.length}) Approval needed — Keep`
         : 'Keep'
+    }
+  })
+
+  // Optional OS-level notification when a request arrives while the tab is in
+  // the background — useful for an appliance you only glance at occasionally.
+  const canNotify = typeof Notification !== 'undefined'
+  let notifyEnabled = $state(canNotify && Notification.permission === 'granted')
+  const notifiedApprovals = new Set<number>()
+
+  async function toggleNotify() {
+    if (!canNotify) return
+    if (Notification.permission === 'granted') {
+      notifyEnabled = !notifyEnabled
+      return
+    }
+    notifyEnabled = (await Notification.requestPermission()) === 'granted'
+  }
+
+  $effect(() => {
+    if (!notifyEnabled || !canNotify || Notification.permission !== 'granted') return
+    for (const a of pendingApprovals) {
+      if (notifiedApprovals.has(a.id)) continue
+      notifiedApprovals.add(a.id)
+      // Only nag when the page isn't visible; otherwise the banner suffices.
+      if (document.hidden) {
+        new Notification('Keep: approval needed', { body: `${a.app} requests ${a.method}` })
+      }
     }
   })
 
@@ -323,7 +390,16 @@
         signingLoadError = String(err)
       })
     refreshSigningLog()
+    refreshPeers()
   }
+
+  // Poll presence while authed so an offline/online transition shows up even
+  // without a triggering event.
+  $effect(() => {
+    if (!authed) return
+    const t = setInterval(refreshPeers, 10000)
+    return () => clearInterval(t)
+  })
 
   function load() {
     refreshState()
@@ -352,7 +428,10 @@
             logs = [{ ...e, count: 1, ts: Date.now() }, ...logs].slice(0, 100)
           }
           // A co-sign just happened: refresh the persistent audit log.
-          if (e.app === 'frost') refreshSigningLog()
+          if (e.app === 'frost') {
+            refreshSigningLog()
+            refreshPeers()
+          }
         }
       },
       (connected) => {
@@ -600,6 +679,34 @@
           <strong>{bunker.threshold}</strong>
         </div>
       {/if}
+      {#if bunker.mode === 'network-frost'}
+        <div class="kv">
+          <span>
+            readiness{@render tip(
+              'Whether this node can sign right now: co-signing enabled and enough co-signers online.',
+            )}
+          </span>
+          <span class="status-pill {readiness.cls}">{readiness.label}</span>
+        </div>
+        <div class="cosigners">
+          <span class="cosigners-label">
+            co-signers{@render tip('Your other share-holders, and whether each is reachable now.')}
+          </span>
+          {#if peers.length === 0}
+            <span class="muted">none discovered yet</span>
+          {:else}
+            <ul class="cosigner-list">
+              {#each peers as p (p.share_index)}
+                <li>
+                  <span class="dot {p.online ? 'ok' : 'warn'}"></span>
+                  <span>share {p.share_index}{#if p.name} · {p.name}{/if}</span>
+                  <span class="muted">{p.online ? 'online' : 'offline'}</span>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </div>
+      {/if}
       {#if bunker.group}
         {@render copyField(
           'group',
@@ -802,6 +909,15 @@
     <span class="verify {wsConnected ? 'ok' : 'fail'}">
       {wsConnected ? '● live' : '○ reconnecting…'}
     </span>
+    {#if canNotify}
+      <button
+        class="link-btn"
+        onclick={toggleNotify}
+        title="Get a desktop notification when an approval is waiting and this tab is in the background."
+      >
+        {notifyEnabled ? '🔔 notifications on' : '🔕 notify me'}
+      </button>
+    {/if}
   </h2>
   <div class="panel">
     {#each approvals.filter((a) => a.resolved) as a (a.id)}
@@ -837,7 +953,17 @@
   </h2>
   <div class="panel">
     {#each signingSessions as s (s.session)}
-      <div class="event">
+      <div
+        class="event session-row"
+        role="button"
+        tabindex="0"
+        aria-expanded={!!expandedSessions[s.session]}
+        onclick={() => toggleSession(s.session)}
+        onkeydown={(e) =>
+          (e.key === 'Enter' || e.key === ' ') &&
+          (e.preventDefault(), toggleSession(s.session))}
+      >
+        <span class="caret">{expandedSessions[s.session] ? '▾' : '▸'}</span>
         <span class="token">{s.session}</span>
         <span class="verify {s.completed ? 'ok' : 'warn'}">
           {s.completed ? '✓ signed' : '… in progress'}
@@ -846,6 +972,16 @@
           · participants {s.participants.join(',')} · {relTime(s.latest)}
         </span>
       </div>
+      {#if expandedSessions[s.session]}
+        <div class="session-detail">
+          {#each signingLog.filter((e) => e.session === s.session) as op (op.timestamp_ms + ':' + op.operation)}
+            <div class="op-row">
+              <span>{op.operation}</span>
+              <span class="muted">· {new Date(op.timestamp_ms).toLocaleString()}</span>
+            </div>
+          {/each}
+        </div>
+      {/if}
     {:else}
       <p class="muted">No signatures recorded yet.</p>
     {/each}

--- a/keep-web/ui/src/app.css
+++ b/keep-web/ui/src/app.css
@@ -780,6 +780,57 @@ ol.tasks li {
   color: var(--no);
 }
 
+.verify.warn {
+  color: var(--warn);
+}
+
+/* ---- Pending-approval bar (prominent, can't be missed) ---- */
+.approval-bar {
+  position: sticky;
+  top: 0.5rem;
+  z-index: 10;
+  margin-bottom: 1rem;
+  border: 1px solid var(--accent);
+  border-left: 3px solid var(--accent);
+  border-radius: 8px;
+  background: var(--accent-soft);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 0.35);
+}
+
+.approval-bar-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.7rem 0.9rem;
+}
+
+.approval-bar-row + .approval-bar-row {
+  border-top: 1px solid var(--accent);
+}
+
+.approval-bar-text {
+  font-size: 0.9rem;
+}
+
+.approval-bar-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* Count of coalesced repeated activity lines (e.g. periodic announcements). */
+.count-badge {
+  font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+  background: var(--panel-2);
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  padding: 0 0.4rem;
+  margin-left: 0.25rem;
+}
+
 .muted {
   color: var(--muted);
 }

--- a/keep-web/ui/src/app.css
+++ b/keep-web/ui/src/app.css
@@ -819,6 +819,95 @@ ol.tasks li {
   gap: 0.5rem;
 }
 
+/* Readiness pill + co-signer presence list. */
+.status-pill {
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.1rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+}
+
+.status-pill.ok {
+  color: var(--ok);
+  border-color: var(--accent-soft);
+  background: var(--accent-soft);
+}
+
+.status-pill.warn {
+  color: var(--warn);
+  border-color: rgba(227, 179, 65, 0.3);
+  background: rgba(227, 179, 65, 0.1);
+}
+
+.status-pill.fail {
+  color: var(--no);
+  border-color: rgba(229, 83, 75, 0.3);
+  background: rgba(229, 83, 75, 0.1);
+}
+
+.cosigners {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  padding: 0.3rem 0;
+}
+
+.cosigners-label {
+  color: var(--faint);
+  min-width: 6rem;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.cosigner-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.cosigner-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.85rem;
+}
+
+/* Expandable signing-log session rows. */
+.session-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+}
+
+.session-row:hover {
+  background: var(--panel-2);
+}
+
+.caret {
+  color: var(--muted);
+  font-size: 0.7rem;
+  width: 0.8rem;
+}
+
+.session-detail {
+  padding: 0.25rem 0 0.5rem 1.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.op-row {
+  font-size: 0.8rem;
+  display: flex;
+  gap: 0.4rem;
+}
+
 /* Count of coalesced repeated activity lines (e.g. periodic announcements). */
 .count-badge {
   font-size: 0.72rem;

--- a/keep-web/ui/src/lib/api.ts
+++ b/keep-web/ui/src/lib/api.ts
@@ -144,6 +144,23 @@ export async function getSigningLog(): Promise<{
   return r.json()
 }
 
+export interface PeerInfo {
+  share_index: number
+  name: string | null
+  online: boolean
+}
+
+export interface PeersResponse {
+  peers: PeerInfo[]
+  online: number
+}
+
+export async function getPeers(): Promise<PeersResponse> {
+  const r = await api('/api/peers')
+  if (!r.ok) throw new Error(`peers: ${r.status}`)
+  return r.json()
+}
+
 export interface KillswitchStatus {
   enabled: boolean
   retired: boolean


### PR DESCRIPTION
Makes the Web Admin signal-dense: co-sign approvals are impossible to miss, the activity feed no longer floods, and signing state is glanceable.

**Approvals**
- Sticky **pending-approval bar** pinned at the top (`aria-live` for screen readers) with Approve/Deny. Resolved requests drop into the activity feed as compact history.
- Pending count in the **browser tab title** (`(1) Approval needed — Keep`).
- Opt-in **desktop notification** (`🔔 notify me`) when a request arrives while the tab is backgrounded.

**Live co-signer presence + readiness** (new `/api/peers`)
- A **readiness pill**: *Ready to sign* / *Waiting for co-signers (n/m)* / *Co-signing off* / *Signer retired*.
- Per-peer presence list: each co-signer `● online / ○ offline` with its share index and name. Polled every 10s and on signing events — so presence is a status, not something to reconstruct from the log.

**Activity feed**
- Repeated identical events (e.g. periodic "peer online" announcements) **coalesce into one line with a `×N` count**.
- **Relative timestamps** ("2m ago", full time on hover), kept live by a 30s ticker.

**Signing log**
- **Grouped by session**: one row per signature (`✓ signed` / `… in progress`) instead of three. Click a row to **expand** its underlying operations + timestamps. Chain-verify badge + Export unchanged.

Backend: read-only `/api/peers` from the node's existing peer tracking. svelte-check + clippy clean; `/api/peers` verified live (reports the co-signer peer online → readiness "Ready to sign").
