### PR TITLE
release: v0.4.4 — restore pre_approve_nostr_event binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "keep-agent"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "chrono",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "keep-bitcoin"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bitcoin",
  "getrandom 0.4.2",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "keep-cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4229,7 +4229,7 @@ dependencies = [
 
 [[package]]
 name = "keep-core"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "aes",
  "argon2",
@@ -4273,7 +4273,7 @@ dependencies = [
 
 [[package]]
 name = "keep-desktop"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4306,14 +4306,14 @@ dependencies = [
 
 [[package]]
 name = "keep-enclave"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "keep-enclave-host",
 ]
 
 [[package]]
 name = "keep-enclave-host"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -4344,7 +4344,7 @@ dependencies = [
 
 [[package]]
 name = "keep-frost-net"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "keep-mobile"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4412,7 +4412,7 @@ dependencies = [
 
 [[package]]
 name = "keep-nip46"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bitflags 2.11.0",
  "chrono",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "keep-web"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "axum",
  "keep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -667,6 +667,17 @@ impl KeepMobile {
             .unwrap_or_else(|e| e.into_inner()) = Some(hash);
     }
 
+    /// Pre-approve a specific Nostr event (by its computed event id) so the next
+    /// matching sign request auto-approves without prompting. Convenience wrapper
+    /// over [`set_signing_pre_approved`] for NIP-55 callers holding event JSON.
+    pub fn pre_approve_nostr_event(&self, event_json: String) -> Result<(), KeepMobileError> {
+        let event: serde_json::Value =
+            serde_json::from_str(&event_json).map_err(|_| KeepMobileError::InvalidSession)?;
+        let event_hash = crate::nip55::compute_nostr_event_id(&event)?;
+        self.set_signing_pre_approved(event_hash.to_vec());
+        Ok(())
+    }
+
     pub fn clear_signing_pre_approval(&self) {
         *self
             .pre_approved_hash

--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -782,7 +782,9 @@ fn validate_nostr_event(event: &serde_json::Value) -> Result<(), KeepMobileError
     Ok(())
 }
 
-fn compute_nostr_event_id(event: &serde_json::Value) -> Result<[u8; 32], KeepMobileError> {
+pub(crate) fn compute_nostr_event_id(
+    event: &serde_json::Value,
+) -> Result<[u8; 32], KeepMobileError> {
     let serialized = serde_json::json!([
         0,
         event["pubkey"],


### PR DESCRIPTION
Restores the `pre_approve_nostr_event(event_json)` keep-mobile UniFFI binding that #349's NIP-55 rework dropped (it kept only the lower-level `set_signing_pre_approved(bytes)`). keep-android's auto-sign pre-approval (its PR #270) calls this binding, so without it the Android build fails with `Unresolved reference 'preApproveNostrEvent'`.

The wrapper is a thin convenience over existing helpers (`compute_nostr_event_id` + `set_signing_pre_approved`); `compute_nostr_event_id` is made `pub(crate)` so lib.rs can reuse it. Workspace bumped to 0.4.4.