### PR TITLE
keep-web multi-group (active-group + switcher); coracle default relay; desktop About section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4441,6 +4441,7 @@ name = "keep-web"
 version = "0.4.5"
 dependencies = [
  "axum",
+ "hex",
  "keep-core",
  "keep-frost-net",
  "keep-nip46",
@@ -4448,6 +4449,7 @@ dependencies = [
  "serde",
  "serde_json",
  "subtle",
+ "tempfile",
  "tokio",
  "tower",
  "tower-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "keep-agent"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "chrono",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "keep-bitcoin"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "bitcoin",
  "getrandom 0.4.2",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "keep-cli"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4229,7 +4229,7 @@ dependencies = [
 
 [[package]]
 name = "keep-core"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "aes",
  "argon2",
@@ -4273,7 +4273,7 @@ dependencies = [
 
 [[package]]
 name = "keep-desktop"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4306,14 +4306,14 @@ dependencies = [
 
 [[package]]
 name = "keep-enclave"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "keep-enclave-host",
 ]
 
 [[package]]
 name = "keep-enclave-host"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -4344,7 +4344,7 @@ dependencies = [
 
 [[package]]
 name = "keep-frost-net"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "keep-mobile"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4412,7 +4412,7 @@ dependencies = [
 
 [[package]]
 name = "keep-nip46"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "bitflags 2.11.0",
  "chrono",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "keep-web"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "axum",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"

--- a/keep-core/src/relay.rs
+++ b/keep-core/src/relay.rs
@@ -109,12 +109,11 @@ impl RelayConfig {
 
 /// Default FROST coordination relays.
 pub fn default_frost_relays() -> Vec<String> {
-    vec![
-        "wss://relay.primal.net/".into(),
-        "wss://relay.nsec.app/".into(),
-        "wss://relay.damus.io/".into(),
-        "wss://nos.lol/".into(),
-    ]
+    // coracle's relay reliably delivers the rapid ephemeral (kind 24242) events
+    // FROST coordination depends on; most public relays drop them, which causes
+    // missed or prematurely-rejected signing rounds. Operators can add more in
+    // settings for redundancy.
+    vec!["wss://bucket.coracle.social/".into()]
 }
 
 /// Normalize a relay URL: trim whitespace, lowercase scheme+host, ensure trailing slash.

--- a/keep-desktop/src/app/mod.rs
+++ b/keep-desktop/src/app/mod.rs
@@ -71,7 +71,7 @@ const IMPORT_COOLDOWN: Duration = Duration::from_secs(5);
 pub(crate) const MAX_BUNKER_LOG_ENTRIES: usize = 1000;
 pub(crate) const MAX_ACTIVE_COORDINATIONS: usize = 64;
 
-const DEFAULT_BUNKER_RELAYS: &[&str] = &["wss://relay.damus.io", "wss://relay.nsec.app"];
+const DEFAULT_BUNKER_RELAYS: &[&str] = &["wss://bucket.coracle.social"];
 
 #[derive(Clone)]
 pub enum ToastKind {

--- a/keep-desktop/src/screen/settings.rs
+++ b/keep-desktop/src/screen/settings.rs
@@ -467,7 +467,9 @@ impl SettingsScreen {
             .push(proxy_card)
             .push(cert_pins_card)
             .push(backup_card)
-            .push(info_card);
+            .push(info_card)
+            .push(theme::heading("About"))
+            .push(self.about_card());
 
         scrollable(content)
             .width(Length::Fill)
@@ -1011,9 +1013,18 @@ impl SettingsScreen {
 
     fn info_card(&self) -> Element<'_, Message> {
         container(
+            column![theme::label("Vault"), theme::muted(&self.vault_path)]
+                .spacing(theme::space::XS),
+        )
+        .style(theme::card_style)
+        .padding(theme::space::LG)
+        .width(Length::Fill)
+        .into()
+    }
+
+    fn about_card(&self) -> Element<'_, Message> {
+        container(
             column![
-                column![theme::label("Vault"), theme::muted(&self.vault_path),]
-                    .spacing(theme::space::XS),
                 column![
                     theme::label("Version"),
                     theme::muted(env!("CARGO_PKG_VERSION")),

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -305,6 +305,9 @@ pub trait KeepStateCallback: Send + Sync + 'static {
 struct MobileSigningHooks {
     request_tx: mpsc::Sender<(SessionInfo, mpsc::Sender<bool>)>,
     pre_approved_hash: Arc<std::sync::Mutex<Option<[u8; 32]>>>,
+    /// Read on every round so the kill switch ("Signing Disabled") gates FROST
+    /// co-signing too — not just the NIP-55/NIP-46 paths.
+    storage: Arc<dyn SecureStorage>,
 }
 
 impl MobileSigningHooks {
@@ -327,6 +330,14 @@ impl MobileSigningHooks {
 
 impl SigningHooks for MobileSigningHooks {
     fn pre_sign(&self, session: &SessionInfo) -> keep_frost_net::Result<()> {
+        // Kill switch: when co-signing is disabled, refuse to take part in any
+        // signing round — including pre-approved requests — without prompting.
+        // Fail-closed, mirroring keep-web's bunker.
+        if persistence::load_kill_switch(&self.storage, KILL_SWITCH_STORAGE_KEY).unwrap_or(false) {
+            return Err(keep_frost_net::FrostNetError::Session(
+                "co-signing is disabled".into(),
+            ));
+        }
         if self.consume_pre_approval(&session.message) {
             return Ok(());
         }
@@ -2383,6 +2394,7 @@ impl KeepMobile {
             let hooks = Arc::new(MobileSigningHooks {
                 request_tx,
                 pre_approved_hash: self.pre_approved_hash.clone(),
+                storage: self.storage.clone(),
             });
             node.set_hooks(hooks);
 

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -331,10 +331,11 @@ impl MobileSigningHooks {
 impl SigningHooks for MobileSigningHooks {
     fn pre_sign(&self, session: &SessionInfo) -> keep_frost_net::Result<()> {
         // Kill switch: when co-signing is disabled, refuse to take part in any
-        // signing round — including pre-approved requests — without prompting.
-        // Fail-closed, mirroring keep-web's bunker.
-        if persistence::load_kill_switch(&self.storage, KILL_SWITCH_STORAGE_KEY).unwrap_or(false) {
-            return Err(keep_frost_net::FrostNetError::Session(
+        // signing round, including pre-approved requests, without prompting.
+        // Fail-closed (an unreadable switch is treated as engaged), mirroring
+        // keep-web's bunker.
+        if persistence::load_kill_switch(&self.storage, KILL_SWITCH_STORAGE_KEY).unwrap_or(true) {
+            return Err(keep_frost_net::FrostNetError::PolicyViolation(
                 "co-signing is disabled".into(),
             ));
         }

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1552,7 +1552,14 @@ impl KeepMobile {
         }
         let key = relay_config_key(group_pubkey.as_deref());
         let stored = persistence::load_relay_config(&self.storage, &key)?;
-        let config = stored.unwrap_or_default();
+        // No saved config yet: pre-populate the reliable default relay so it
+        // shows in the UI and is used immediately, rather than an empty list the
+        // user has to fill in. An explicitly-saved empty list is left as-is.
+        let config = stored.unwrap_or_else(|| persistence::StoredRelayConfig {
+            frost_relays: keep_core::relay::default_frost_relays(),
+            bunker_relays: keep_core::relay::default_frost_relays(),
+            ..Default::default()
+        });
         Ok(RelayConfigInfo {
             frost_relays: config.frost_relays,
             profile_relays: config.profile_relays,

--- a/keep-web/Cargo.toml
+++ b/keep-web/Cargo.toml
@@ -21,6 +21,8 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 nostr-sdk = { workspace = true }
 subtle = { workspace = true }
+hex = { workspace = true }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
+tempfile = { workspace = true }

--- a/keep-web/src/api.rs
+++ b/keep-web/src/api.rs
@@ -157,7 +157,10 @@ pub async fn set_active_group(
         .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
         .is_err()
     {
-        return (StatusCode::CONFLICT, "an active-group switch is already in progress")
+        return (
+            StatusCode::CONFLICT,
+            "an active-group switch is already in progress",
+        )
             .into_response();
     }
     if let Err(e) = keep.set_active_share_key(Some(&hex_key)) {

--- a/keep-web/src/api.rs
+++ b/keep-web/src/api.rs
@@ -69,15 +69,19 @@ pub struct ShareDto {
     created_at: i64,
     last_used: Option<i64>,
     did_backup: bool,
+    /// True for the group the co-signer is currently serving (the active share).
+    active: bool,
 }
 
 pub async fn shares(State(state): State<AppState>) -> impl IntoResponse {
     let keep = state.keep.lock().await;
+    let active_hex = keep.get_active_share_key();
     match keep.frost_list_shares() {
         Ok(shares) => {
             let dto: Vec<ShareDto> = shares
                 .into_iter()
                 .map(|s| ShareDto {
+                    active: active_hex.as_deref() == Some(&hex::encode(s.metadata.group_pubkey)),
                     name: s.metadata.name,
                     group: keep_core::keys::bytes_to_npub(&s.metadata.group_pubkey),
                     identifier: s.metadata.identifier,
@@ -102,6 +106,56 @@ pub async fn shares(State(state): State<AppState>) -> impl IntoResponse {
 pub struct ShareRef {
     pub group: String,
     pub identifier: u16,
+}
+
+#[derive(Deserialize)]
+pub struct ActiveGroupRequest {
+    /// Group to co-sign for, as an npub.
+    pub group: String,
+}
+
+#[derive(Serialize)]
+pub struct ActiveGroupResponse {
+    pub restarting: bool,
+}
+
+/// Switches which FROST group the co-signer serves (the persisted active share,
+/// shared with keep-desktop/keep-android). The node rebinds by restarting: the
+/// StartOS supervisor relaunches keep-web on exit, and `resolve_group` picks up
+/// the new selection. Only groups this node holds a share for are accepted.
+pub async fn set_active_group(
+    State(state): State<AppState>,
+    Json(body): Json<ActiveGroupRequest>,
+) -> impl IntoResponse {
+    let group = match parse_group(&body.group) {
+        Ok(g) => g,
+        Err(e) => return e.into_response(),
+    };
+    let hex_key = hex::encode(group);
+    let keep = state.keep.lock().await;
+    match keep.frost_list_shares() {
+        Ok(shares) => {
+            if !shares.iter().any(|s| s.metadata.group_pubkey == group) {
+                return (StatusCode::NOT_FOUND, "no share for that group").into_response();
+            }
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "frost_list_shares failed");
+            return (err_status(&e), "failed to list shares").into_response();
+        }
+    }
+    if let Err(e) = keep.set_active_share_key(Some(&hex_key)) {
+        tracing::error!(error = %e, "set_active_share_key failed");
+        return (err_status(&e), "failed to set active group").into_response();
+    }
+    drop(keep);
+    tracing::info!(group = %hex_key, "active group switched; restarting co-signer");
+    // Exit after the response flushes; the supervisor relaunches and rebinds.
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        std::process::exit(0);
+    });
+    Json(ActiveGroupResponse { restarting: true }).into_response()
 }
 
 #[derive(Deserialize)]

--- a/keep-web/src/api.rs
+++ b/keep-web/src/api.rs
@@ -144,7 +144,24 @@ pub async fn set_active_group(
             return (err_status(&e), "failed to list shares").into_response();
         }
     }
+    // No-op when the requested group is already the active one: skip the
+    // pointless persist + co-signer bounce (and the restart-loop DoS vector).
+    if keep.get_active_share_key().as_deref() == Some(&hex_key) {
+        return Json(ActiveGroupResponse { restarting: false }).into_response();
+    }
+    // Single-flight: once a switch is claimed the node is on its way out, so
+    // reject a concurrent switch rather than letting two exit tasks race to
+    // persist different keys.
+    if state
+        .switching
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return (StatusCode::CONFLICT, "an active-group switch is already in progress")
+            .into_response();
+    }
     if let Err(e) = keep.set_active_share_key(Some(&hex_key)) {
+        state.switching.store(false, Ordering::SeqCst);
         tracing::error!(error = %e, "set_active_share_key failed");
         return (err_status(&e), "failed to set active group").into_response();
     }

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -68,12 +68,12 @@ fn parse_relays(value: &str) -> Vec<String> {
         .collect()
 }
 
-/// Resolve the FROST group to co-sign for: an explicit npub, else the single
-/// group present in the vault. Returns `None` (→ setup mode) when there is no
-/// share yet or the choice is ambiguous.
-// `Ok(None)` means genuine first-run (no shares → setup mode); `Err` means
-// misconfiguration (bad KEEP_FROST_GROUP, or multiple groups with no choice)
-// and is fatal so the operator sees the problem instead of a silent setup mode.
+/// Resolve the FROST group to co-sign for. Precedence: an explicit
+/// `KEEP_FROST_GROUP` npub, then the persisted active-share selection (the same
+/// key keep-desktop/keep-android use), then the first group present (which is
+/// persisted as the new default). The operator can switch the active group from
+/// the Web Admin. `Ok(None)` means genuine first-run (no shares → setup mode);
+/// `Err` only for a malformed `KEEP_FROST_GROUP` npub.
 fn resolve_group(
     keep: &Keep,
     explicit: Option<&str>,
@@ -93,14 +93,24 @@ fn resolve_group(
     let mut groups: Vec<[u8; 32]> = shares.iter().map(|s| s.metadata.group_pubkey).collect();
     groups.sort();
     groups.dedup();
-    match groups.as_slice() {
-        [g] => Ok(Some((*g, keep_core::keys::bytes_to_npub(g)))),
-        [] => Ok(None),
-        _ => Err(format!(
-            "multiple FROST groups present ({}); set KEEP_FROST_GROUP to choose one",
-            groups.len()
-        )),
+    if groups.is_empty() {
+        return Ok(None);
     }
+    // Honor the operator's persisted selection — the same active-share key that
+    // keep-desktop and keep-android use — if it still names a held group.
+    if let Some(active_hex) = keep.get_active_share_key() {
+        if let Some(g) = groups.iter().find(|g| hex::encode(g) == active_hex) {
+            return Ok(Some((*g, keep_core::keys::bytes_to_npub(g))));
+        }
+    }
+    // No valid selection: default to the first group and persist it, so the box
+    // co-signs immediately instead of erroring on ambiguity. The operator can
+    // switch which group is served from the Web Admin.
+    let g = groups[0];
+    if let Err(e) = keep.set_active_share_key(Some(&hex::encode(g))) {
+        tracing::warn!(error = %e, "failed to persist default active group");
+    }
+    Ok(Some((g, keep_core::keys::bytes_to_npub(&g))))
 }
 
 #[tokio::main]
@@ -256,6 +266,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/api/shares/export", post(api::export_share))
         .route("/api/shares/delete", post(api::delete_share))
         .route("/api/shares/rename", post(api::rename_share))
+        .route("/api/active-group", post(api::set_active_group))
         .route("/api/signing-log", get(api::signing_log))
         .route("/api/peers", get(api::peers))
         .route(
@@ -284,4 +295,68 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let listener = tokio::net::TcpListener::bind(listen).await?;
     axum::serve(listener, app).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use keep_core::Keep;
+    use tempfile::tempdir;
+
+    fn unlocked_keep(dir: &std::path::Path) -> Keep {
+        let mut keep = Keep::create(&dir.join("vault"), "password").unwrap();
+        keep.unlock("password").unwrap();
+        keep
+    }
+
+    #[test]
+    fn resolve_no_shares_is_setup() {
+        let dir = tempdir().unwrap();
+        let keep = unlocked_keep(dir.path());
+        assert!(resolve_group(&keep, None).unwrap().is_none());
+    }
+
+    #[test]
+    fn resolve_single_group() {
+        let dir = tempdir().unwrap();
+        let mut keep = unlocked_keep(dir.path());
+        let g = *keep.frost_generate(2, 3, "g").unwrap()[0].group_pubkey();
+        assert_eq!(resolve_group(&keep, None).unwrap().unwrap().0, g);
+    }
+
+    #[test]
+    fn resolve_multiple_defaults_and_persists() {
+        let dir = tempdir().unwrap();
+        let mut keep = unlocked_keep(dir.path());
+        keep.frost_generate(2, 3, "a").unwrap();
+        keep.frost_generate(2, 3, "b").unwrap();
+        // Must not error on ambiguity: pick a default and persist it.
+        let (bytes, _) = resolve_group(&keep, None).unwrap().unwrap();
+        assert_eq!(
+            keep.get_active_share_key().as_deref(),
+            Some(hex::encode(bytes).as_str())
+        );
+    }
+
+    #[test]
+    fn resolve_honors_active_selection() {
+        let dir = tempdir().unwrap();
+        let mut keep = unlocked_keep(dir.path());
+        let a = *keep.frost_generate(2, 3, "a").unwrap()[0].group_pubkey();
+        let b = *keep.frost_generate(2, 3, "b").unwrap()[0].group_pubkey();
+        let default = resolve_group(&keep, None).unwrap().unwrap().0;
+        let other = if default == a { b } else { a };
+        keep.set_active_share_key(Some(&hex::encode(other)))
+            .unwrap();
+        assert_eq!(resolve_group(&keep, None).unwrap().unwrap().0, other);
+    }
+
+    #[test]
+    fn resolve_explicit_override_wins() {
+        let dir = tempdir().unwrap();
+        let mut keep = unlocked_keep(dir.path());
+        let a = *keep.frost_generate(2, 3, "a").unwrap()[0].group_pubkey();
+        let npub = keep_core::keys::bytes_to_npub(&a);
+        assert_eq!(resolve_group(&keep, Some(&npub)).unwrap().unwrap().0, a);
+    }
 }

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -251,6 +251,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         signer_retired,
         signing_flag_path,
         node,
+        switching: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
 
     let serve_index = ServeFile::new(ui_dir.join("index.html"));

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -71,6 +71,10 @@ pub struct AppState {
     /// The running FROST node (network mode only), for reading the signing
     /// audit log and peer state.
     pub node: Option<Arc<KfpNode>>,
+    /// Single-flight latch for active-group switches. Once a switch is claimed,
+    /// the node is on its way to exiting/restarting, so a second concurrent
+    /// switch is rejected rather than racing to persist a different key.
+    pub switching: Arc<AtomicBool>,
 }
 
 #[derive(Clone, Serialize)]

--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -8,6 +8,7 @@
     exportShare,
     deleteShare,
     renameShare,
+    setActiveGroup,
     getSigningLog,
     getKillswitch,
     setKillswitch,
@@ -269,6 +270,28 @@
       m.set(s.group, list)
     }
     return [...m.entries()].map(([group, items]) => ({ group, items }))
+  })
+
+  // Switching the active group: the server persists the choice and restarts to
+  // rebind the co-signer, so we show a reconnecting state until it returns.
+  let switchingGroup = $state<string | null>(null)
+  async function switchGroup(group: string) {
+    if (switchingGroup) return
+    switchingGroup = group
+    try {
+      await setActiveGroup(group)
+    } catch (e) {
+      error = String(e)
+      switchingGroup = null
+    }
+  }
+
+  // Once the restarted co-signer reports the new active group, clear the
+  // reconnecting state so the operator can switch again.
+  $effect(() => {
+    if (switchingGroup && bunker?.group === switchingGroup) {
+      switchingGroup = null
+    }
   })
 
   function startRename(s: Share) {
@@ -822,6 +845,19 @@
         <span class="share-tag">{g.items[0].threshold}-of-{g.items[0].total_shares}</span>
         {#if bunker?.group === g.group}
           <span class="badge active-badge">active co-signer</span>
+        {:else if groupedShares.length > 1}
+          {#if switchingGroup === g.group}
+            <span class="badge">switching… reconnecting</span>
+          {:else}
+            <button
+              class="switch-group"
+              disabled={switchingGroup !== null}
+              title="Co-sign for this group instead. The co-signer restarts to switch."
+              onclick={() => switchGroup(g.group)}
+            >
+              Serve this group
+            </button>
+          {/if}
         {/if}
       </div>
       {#each g.items as s (s.identifier)}

--- a/keep-web/ui/src/app.css
+++ b/keep-web/ui/src/app.css
@@ -406,6 +406,16 @@ button:disabled {
   border: 1px solid var(--accent-soft);
 }
 
+.group-head .badge {
+  margin-left: auto;
+}
+
+.switch-group {
+  margin-left: auto;
+  font-size: 0.72rem;
+  padding: 0.3rem 0.6rem;
+}
+
 .export-value {
   align-items: flex-start;
   margin-top: 0.4rem;

--- a/keep-web/ui/src/lib/api.ts
+++ b/keep-web/ui/src/lib/api.ts
@@ -18,6 +18,7 @@ export interface Share {
   created_at: number
   last_used: number | null
   did_backup: boolean
+  active: boolean
 }
 
 export interface SigningEntry {
@@ -133,6 +134,18 @@ export async function deleteShare(group: string, identifier: number): Promise<vo
   if (!r.ok && r.status !== 204) {
     throw new Error((await r.text()) || `delete failed: ${r.status}`)
   }
+}
+
+export async function setActiveGroup(group: string): Promise<{ restarting: boolean }> {
+  const r = await api('/api/active-group', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ group }),
+  })
+  if (!r.ok) {
+    throw new Error((await r.text()) || `switch group failed: ${r.status}`)
+  }
+  return r.json()
 }
 
 export async function getSigningLog(): Promise<{


### PR DESCRIPTION
## Summary
- **keep-web: multi-group support via the active-group model.** No more crash when the vault holds more than one FROST group. `resolve_group` never errors now: explicit `KEEP_FROST_GROUP` > persisted active-share selection (the same key keep-desktop/keep-android use) > first group (auto-persisted as default). Adds a **Web Admin group switcher** (`/api/active-group`) and an `active` flag on `/api/shares`; switching persists the selection and restarts the co-signer to rebind.
- **Default relay → `wss://bucket.coracle.social`, pre-populated in the UI out of the box** (no manual relay entry):
  - `keep-core::relay::default_frost_relays()` → coracle (covers keep-cli + the `with_defaults` path desktop uses).
  - `keep-mobile::get_relay_config()` now returns coracle when nothing is saved, so the **Android relay list shows it by default** instead of being empty.
  - keep-desktop bunker default → coracle.
  - coracle reliably delivers the rapid ephemeral (kind 24242) events FROST coordination depends on; most public relays drop them, causing missed/early-rejected rounds. Matches keep-startos. Operators can still add/remove relays in settings; an explicitly-saved empty list is respected.
- **keep-desktop: version moved to its own "About" section** (out of the Settings info card).

## Consistency with mobile/desktop
keep-android and keep-desktop already use the shared keep-core active-share API (auto-default for a single group, UI switcher for multiple). keep-web was the only client that hard-errored on ambiguity; it now matches them and auto-defaults (right for a headless box). No mobile/desktop selection-logic changes needed. The Android relay default lives in Rust core (keep-mobile), per the RMP architecture — Android picks it up when `keep.version` bumps to a release containing this PR.

## Tests
New `resolve_group` precedence tests (override > active > default; multi-group no longer errors; default persisted). `cargo test` green (keep-core 208, keep-web 14), clippy + fmt clean across keep-core/keep-web/keep-desktop/keep-mobile.

## Notes
- A node still serves one group at a time; simultaneous multi-group co-signing on the box is tracked in privkeyio/keep-startos#1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to switch the active FROST co-signer group with visual indicators showing which group is currently serving.
  * Enhanced Settings screen with vault information display and new About section.

* **Chores**
  * Version updated to 0.4.6.
  * Updated default relay endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->