### PR TITLE
release: v0.4.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "keep-agent"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "chrono",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "keep-bitcoin"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "bitcoin",
  "getrandom 0.4.2",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "keep-cli"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4229,7 +4229,7 @@ dependencies = [
 
 [[package]]
 name = "keep-core"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "aes",
  "argon2",
@@ -4273,7 +4273,7 @@ dependencies = [
 
 [[package]]
 name = "keep-desktop"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4306,14 +4306,14 @@ dependencies = [
 
 [[package]]
 name = "keep-enclave"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "keep-enclave-host",
 ]
 
 [[package]]
 name = "keep-enclave-host"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -4344,7 +4344,7 @@ dependencies = [
 
 [[package]]
 name = "keep-frost-net"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "keep-mobile"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4412,7 +4412,7 @@ dependencies = [
 
 [[package]]
 name = "keep-nip46"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "bitflags 2.11.0",
  "chrono",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "keep-web"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "axum",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"


### PR DESCRIPTION
Bumps the workspace version `0.4.6 → 0.4.7` so the work merged after v0.4.6 ships as a tagged release.

## What lands in v0.4.7
- **#397** — nip55-frost-fix integration: bounded multi-event pre-approval cache (cap 100, TTL 300s), single-party FROST sign/ECDH refinements, validated `pre_approve_nostr_event`. Unblocks WDC manual testing (#395).
- **#391** — Automated fund sweep on descriptor migration.

After merge: tag v0.4.7 on the merged commit → keep-android re-pins `keep.version` → v0.4.7 (v1.0.4 release) so WDC testing has the bounded pre-approval cache.