### PR TITLE
cli: default general relay to coracle (matches FROST default)

### DIFF
--- a/keep-cli/contrib/config.toml.example
+++ b/keep-cli/contrib/config.toml.example
@@ -15,7 +15,7 @@
 # log_level = "info"
 
 # Default Nostr relays for FROST operations
-# relays = ["wss://bucket.coracle.social/"]
+# relays = ["wss://bucket.coracle.social"]
 
 # Network operation timeout in seconds
 # timeout = 30

--- a/keep-cli/contrib/config.toml.example
+++ b/keep-cli/contrib/config.toml.example
@@ -15,7 +15,7 @@
 # log_level = "info"
 
 # Default Nostr relays for FROST operations
-# relays = ["wss://nos.lol"]
+# relays = ["wss://bucket.coracle.social/"]
 
 # Network operation timeout in seconds
 # timeout = 30

--- a/keep-cli/contrib/config.toml.example
+++ b/keep-cli/contrib/config.toml.example
@@ -14,7 +14,7 @@
 # Options: error, warn, info, debug, trace
 # log_level = "info"
 
-# Default Nostr relays for FROST operations
+# Default Nostr relay(s) for general use and FROST operations
 # relays = ["wss://bucket.coracle.social"]
 
 # Network operation timeout in seconds

--- a/keep-cli/src/config.rs
+++ b/keep-cli/src/config.rs
@@ -160,7 +160,7 @@ impl Config {
         self.relays
             .first()
             .map(|s| s.as_str())
-            .unwrap_or("wss://bucket.coracle.social/")
+            .unwrap_or("wss://bucket.coracle.social")
     }
 
     pub fn timeout_secs(&self) -> u64 {

--- a/keep-cli/src/config.rs
+++ b/keep-cli/src/config.rs
@@ -160,7 +160,7 @@ impl Config {
         self.relays
             .first()
             .map(|s| s.as_str())
-            .unwrap_or("wss://nos.lol")
+            .unwrap_or("wss://bucket.coracle.social/")
     }
 
     pub fn timeout_secs(&self) -> u64 {

--- a/keep-cli/src/config.rs
+++ b/keep-cli/src/config.rs
@@ -173,6 +173,17 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_default_relay_fallback_matches_frost_default() {
+        let config = Config::parse("").unwrap();
+        assert!(config.relays.is_empty());
+        assert_eq!(config.default_relay(), "wss://bucket.coracle.social");
+        assert_eq!(
+            config.default_relay(),
+            keep_core::relay::default_frost_relays()[0]
+        );
+    }
+
+    #[test]
     fn test_parse_full_config() {
         let content = r#"
 vault_path = "~/.keep"

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -601,7 +601,7 @@ fn dispatch_config(out: &Output, cfg: &Config, command: ConfigCommands) -> Resul
             out.field("argon2_profile", &cfg.argon2_profile.to_string());
             out.field("log_level", &cfg.log_level.to_string());
             let relays = if cfg.relays.is_empty() {
-                "(default: wss://nos.lol)".to_string()
+                "(default: wss://bucket.coracle.social/)".to_string()
             } else {
                 cfg.relays.join(", ")
             };

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -601,7 +601,7 @@ fn dispatch_config(out: &Output, cfg: &Config, command: ConfigCommands) -> Resul
             out.field("argon2_profile", &cfg.argon2_profile.to_string());
             out.field("log_level", &cfg.log_level.to_string());
             let relays = if cfg.relays.is_empty() {
-                "(default: wss://bucket.coracle.social/)".to_string()
+                "(default: wss://bucket.coracle.social)".to_string()
             } else {
                 cfg.relays.join(", ")
             };

--- a/keep-core/src/relay.rs
+++ b/keep-core/src/relay.rs
@@ -113,7 +113,7 @@ pub fn default_frost_relays() -> Vec<String> {
     // FROST coordination depends on; most public relays drop them, which causes
     // missed or prematurely-rejected signing rounds. Operators can add more in
     // settings for redundancy.
-    vec!["wss://bucket.coracle.social/".into()]
+    vec!["wss://bucket.coracle.social".into()]
 }
 
 /// Normalize a relay URL: trim whitespace, lowercase scheme+host, ensure trailing slash.


### PR DESCRIPTION
## Summary
- Updates the CLI general-purpose default relay from `wss://nos.lol` to `wss://bucket.coracle.social/`, matching `keep_core::default_frost_relays()`.
- Removes the dual-default that confused operators debugging FROST traffic; `config show` and `config init` now advertise the same relay that `frost network serve` already uses.

Closes #453, #458.

## Files
- `keep-cli/src/config.rs` (`Config::default_relay()`)
- `keep-cli/src/main.rs` (`config show` display text)
- `keep-cli/contrib/config.toml.example` (config init template)

## Verify
```
keep config show           # relays: (default: wss://bucket.coracle.social/)
keep config init           # template uses coracle
```

## Test plan
- [ ] `keep config show` reflects the new default.
- [ ] `keep config init` writes the new default in the template.
- [ ] `keep frost network peers` / `health-check` discover peers without needing an explicit `--relay`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default Nostr relay endpoint from `wss://nos.lol` to `wss://bucket.coracle.social/` across configuration defaults and example settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->