### PR TITLE
ci: run macos build on main only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest", "macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies (Linux)


### PR DESCRIPTION
Gates the macOS leg of the `build` matrix to push events (main only), matching the existing `build-windows` pattern. PRs now run the build job on ubuntu only, while pushes to main still build/test on both ubuntu and macos.

Closes #475