### PR TITLE
fix: four P1 headless bugs surfaced by #434 sweep

### DIFF
--- a/keep-cli/src/commands/mod.rs
+++ b/keep-cli/src/commands/mod.rs
@@ -76,6 +76,22 @@ pub fn get_password_with_confirm(prompt: &str, confirm: &str) -> Result<SecretSt
     Ok(SecretString::from(pw))
 }
 
+pub fn get_new_password_with_confirm(prompt: &str, confirm: &str) -> Result<SecretString> {
+    if let Some(pw) = password_from_env("KEEP_NEW_PASSWORD") {
+        return Ok(pw);
+    }
+    let pw = Password::with_theme(&ColorfulTheme::default())
+        .with_prompt(prompt)
+        .with_confirmation(confirm, "Passwords don't match")
+        .interact()
+        .map_err(|e| {
+            KeepError::StorageErr(keep_core::error::StorageError::io(format!(
+                "read password: {e}"
+            )))
+        })?;
+    Ok(SecretString::from(pw))
+}
+
 pub fn get_confirm(prompt: &str) -> Result<bool> {
     if std::env::var("KEEP_YES").is_ok() {
         return Ok(true);

--- a/keep-cli/src/commands/vault.rs
+++ b/keep-cli/src/commands/vault.rs
@@ -611,8 +611,7 @@ pub fn cmd_rotate_password(out: &Output, path: &Path) -> Result<()> {
 
     let mut keep = Keep::open(path)?;
     let old_password = get_password("Enter current password")?;
-    let new_password =
-        get_new_password_with_confirm("Enter new password", "Confirm new password")?;
+    let new_password = get_new_password_with_confirm("Enter new password", "Confirm new password")?;
 
     if new_password.expose_secret().len() < 8 {
         return Err(KeepError::InvalidInput(

--- a/keep-cli/src/commands/vault.rs
+++ b/keep-cli/src/commands/vault.rs
@@ -16,8 +16,8 @@ use keep_core::Keep;
 use crate::output::Output;
 
 use super::{
-    get_confirm, get_hidden_password, get_nsec, get_password, get_password_with_confirm,
-    is_hidden_vault,
+    get_confirm, get_hidden_password, get_new_password_with_confirm, get_nsec, get_password,
+    get_password_with_confirm, is_hidden_vault,
 };
 
 #[tracing::instrument(skip(out), fields(path = %path.display()))]
@@ -611,11 +611,18 @@ pub fn cmd_rotate_password(out: &Output, path: &Path) -> Result<()> {
 
     let mut keep = Keep::open(path)?;
     let old_password = get_password("Enter current password")?;
-    let new_password = get_password_with_confirm("Enter new password", "Confirm new password")?;
+    let new_password =
+        get_new_password_with_confirm("Enter new password", "Confirm new password")?;
 
     if new_password.expose_secret().len() < 8 {
         return Err(KeepError::InvalidInput(
             "password must be at least 8 characters".into(),
+        ));
+    }
+
+    if old_password.expose_secret() == new_password.expose_secret() {
+        return Err(KeepError::InvalidInput(
+            "new password is identical to current password; set KEEP_NEW_PASSWORD to a different value or run interactively".into(),
         ));
     }
 
@@ -647,6 +654,10 @@ pub fn cmd_rotate_data_key(out: &Output, path: &Path) -> Result<()> {
 
     let mut keep = Keep::open(path)?;
     let password = get_password("Enter password")?;
+
+    let spinner = out.spinner("Unlocking vault...");
+    keep.unlock(password.expose_secret())?;
+    spinner.finish();
 
     if !get_confirm("Rotate data encryption key? This will re-encrypt all stored keys and shares.")?
     {
@@ -779,6 +790,12 @@ fn cmd_delete_hidden(out: &Output, path: &Path, name: &str) -> Result<()> {
 #[tracing::instrument(skip(out), fields(path = %path.display()))]
 pub fn cmd_backup(out: &Output, path: &Path, output: Option<&Path>) -> Result<()> {
     debug!("creating backup");
+
+    if is_hidden_vault(path) {
+        return Err(KeepError::NotImplemented(
+            "backup of vaults initialized with --hidden is not yet supported".into(),
+        ));
+    }
 
     let mut keep = Keep::open(path)?;
     let password = get_password("Enter password")?;

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -343,10 +343,14 @@ impl SignerHandler {
             }
         }
 
-        let (requested_perms, auto_kinds) = permissions
+        let (mut requested_perms, auto_kinds) = permissions
             .as_deref()
             .map(parse_permission_string)
             .unwrap_or((self.connect_grant, HashSet::new()));
+
+        if self.auto_approve {
+            requested_perms = Permission::ALL;
+        }
 
         let mut pm = self.permissions.lock().await;
         if !pm.connect_with_permissions(app_pubkey, name.clone(), requested_perms, auto_kinds) {
@@ -781,6 +785,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_auto_approve_grants_all_permissions_on_connect() {
+        // Headless bunker mode (`auto_approve=true`) must grant Permission::ALL
+        // on connect so that sign_event / nip04 / nip44 succeed without an
+        // interactive approval callback. This is the fix for the regression
+        // where headless bunkers rejected every sign_event with "Permission
+        // denied: operation not permitted".
+        let handler = setup_handler();
+        let app_pubkey = Keys::generate().public_key();
+
+        handler
+            .handle_connect(app_pubkey, None, None, None)
+            .await
+            .unwrap();
+
+        let pm = handler.permissions.lock().await;
+        for perm in [
+            Permission::GET_PUBLIC_KEY,
+            Permission::SIGN_EVENT,
+            Permission::NIP04_ENCRYPT,
+            Permission::NIP04_DECRYPT,
+            Permission::NIP44_ENCRYPT,
+            Permission::NIP44_DECRYPT,
+        ] {
+            assert!(
+                pm.has_permission(&app_pubkey, perm),
+                "auto_approve must grant {perm:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn test_handle_connect_with_pubkey_mismatch() {
         let handler = setup_handler();
         let app_pubkey = Keys::generate().public_key();
@@ -978,12 +1013,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_client_permissions() {
-        let handler = setup_handler();
+        let handler = setup_handler().with_auto_approve(false);
         let app_pubkey = Keys::generate().public_key();
-        handler
-            .handle_connect(app_pubkey, None, None, None)
-            .await
-            .unwrap();
+        let permissions = handler.permissions.clone();
+        let mut pm = permissions.lock().await;
+        pm.connect_with_permissions(
+            app_pubkey,
+            "test".into(),
+            Permission::DEFAULT,
+            HashSet::new(),
+        );
+        drop(pm);
 
         assert!(!handler
             .permissions


### PR DESCRIPTION
Fixes four P1 bugs surfaced by the #434 broader CLI testing sweep. Each is a small, surgical change with verification.

## #444 NIP-46 headless bunker rejects every sign_event
Headless bunkers always denied sign_event with "Permission denied: operation not permitted", because `Permission::DEFAULT = GET_PUBLIC_KEY` and `require_permission` was gating sign_event before the `auto_approve` short-circuit. Fix: when `auto_approve` is true, grant `Permission::ALL` on connect. Revocation semantics preserved (revoke_client drops permissions; require_permission stays strict).

- `keep-nip46/src/handler.rs`: in `handle_connect`, if `self.auto_approve`, override `requested_perms` to `Permission::ALL`.
- New test `test_auto_approve_grants_all_permissions_on_connect` confirms the fix.

## #449 rotate-password silent no-op in headless
`get_password_with_confirm` only read `KEEP_PASSWORD`, so headless `rotate-password` used the SAME value for old and new, then printed "Password rotated successfully" without changing anything.

- `keep-cli/src/commands/mod.rs`: add `get_new_password_with_confirm` reading `KEEP_NEW_PASSWORD`.
- `keep-cli/src/commands/vault.rs`: `cmd_rotate_password` uses it; refuses with clear error if old and new are identical.

## #476 rotate-data-key always failed "Keep is locked"
The command opened the vault but never unlocked it before calling rotate_data_key, which requires the data key in memory.

- `keep-cli/src/commands/vault.rs`: add `keep.unlock(password.expose_secret())?;` between open and rotate.

## #473 backup silently failed on hidden vaults
`cmd_backup` called `Keep::open` unconditionally, which reads `keep.hdr` that does not exist on hidden-init vaults. Error surfaced as raw `os error 2` with no path or category.

- `keep-cli/src/commands/vault.rs`: detect `is_hidden_vault(path)` and return a clear `NotImplemented` error pending the proper hidden-aware backup path.

Closes #444. Closes #449. Closes #473. Closes #476.

## Test plan
- [x] `cargo test -p keep-nip46 --lib` — 104 passed.
- [x] `cargo test -p keep-cli` — 13 passed.
- [x] Manual: `KEEP_PASSWORD=... KEEP_YES=1 keep rotate-data-key` now succeeds.
- [x] Manual: `KEEP_PASSWORD=old KEEP_NEW_PASSWORD=new KEEP_YES=1 keep rotate-password` rotates; new pw unlocks, old pw fails.
- [x] Manual: `KEEP_PASSWORD=old KEEP_YES=1 keep rotate-password` (no `KEEP_NEW_PASSWORD`) refuses with clear error instead of silent no-op.
- [x] Manual: `keep backup` on a hidden vault returns "backup of vaults initialized with --hidden is not yet supported" instead of "No such file or directory".
- [x] Manual: NIP-46 headless bunker now grants all permissions on connect (auto-approve unit test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Auto-approval mode now grants full permissions for headless connections.
  * Backup operations explicitly block hidden vaults.

* **Improvements**
  * Password rotation now validates minimum length (8 characters) and prevents reusing the current password.
  * Data key rotation flow improved with immediate vault unlock after password verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/482?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->