### PR TITLE
fix: remove -p short alias from bitcoin sign --psbt

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -553,7 +553,7 @@ pub(crate) enum BitcoinCommands {
     Sign {
         #[arg(short, long)]
         key: String,
-        #[arg(short, long)]
+        #[arg(long)]
         psbt: String,
         #[arg(short, long)]
         output: Option<String>,
@@ -566,6 +566,53 @@ pub(crate) enum BitcoinCommands {
         #[arg(long, default_value = "testnet")]
         network: String,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn bitcoin_sign_short_p_is_global_path_not_psbt() {
+        let cli = Cli::try_parse_from([
+            "keep",
+            "-p",
+            "/tmp/vault",
+            "bitcoin",
+            "sign",
+            "--key",
+            "main",
+            "--psbt",
+            "/tmp/unsigned.psbt",
+        ])
+        .expect("parse bitcoin sign args");
+
+        assert_eq!(cli.path, Some(PathBuf::from("/tmp/vault")));
+
+        let Commands::Bitcoin { command } = cli.command else {
+            panic!("expected bitcoin command");
+        };
+        let BitcoinCommands::Sign { psbt, .. } = command else {
+            panic!("expected bitcoin sign command");
+        };
+        assert_eq!(psbt, "/tmp/unsigned.psbt");
+    }
+
+    #[test]
+    fn bitcoin_sign_help_does_not_show_short_psbt_flag() {
+        let mut command = Cli::command();
+        let help = command
+            .find_subcommand_mut("bitcoin")
+            .expect("bitcoin subcommand")
+            .find_subcommand_mut("sign")
+            .expect("sign subcommand")
+            .render_help()
+            .to_string();
+
+        assert!(help.contains("--psbt <PSBT>"));
+        assert!(!help.contains("-p, --psbt"));
+    }
 }
 
 #[derive(Subcommand)]


### PR DESCRIPTION
`keep bitcoin sign` gave both the global `--path` and the subcommand `--psbt` the same `-p` short flag. Because `--path` is `global = true`, clap resolves `-p` to `--psbt` inside the subcommand, so `keep --path vault bitcoin sign -k key -p file` silently binds `-p` to the PSBT argument instead of the vault path the user almost certainly intended.

This drops the `short` from `--psbt` (one of the two fixes suggested in #451), leaving `-p` to unambiguously mean the global `--path`. `--psbt` is still available as a long flag, so the only break is the undocumented, collision-prone `-p` alias.

`keep bitcoin sign --help` after the change:

```
Options:
  -k, --key <KEY>
  -p, --path <PATH>
      --hidden
      --psbt <PSBT>
  -o, --output <OUTPUT>
      --network <NETWORK>  [default: testnet]
  -h, --help
```

Added two regression tests in `keep-cli/src/cli.rs`: one asserting `-p` parses as the global path on `bitcoin sign`, and one asserting the subcommand help no longer advertises `-p, --psbt`.

Verified with `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test -p keep-cli --bin keep` (all pass).

Closes #451


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `psbt` argument in `bitcoin sign` command now uses only the long-form `--psbt` flag; the short `-p` alias has been removed.

* **Tests**
  * Added unit tests to verify flag parsing behavior and help text display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->