### PR TITLE
fix: frost split deletes original key; serve surfaces signing identity

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -331,6 +331,11 @@ pub(crate) enum FrostCommands {
         threshold: u16,
         #[arg(short, long, default_value = "3")]
         shares: u16,
+        #[arg(
+            long,
+            help = "Retain the original single-key Nostr key after splitting (default: delete it so threshold security is actually in effect)"
+        )]
+        keep_original: bool,
     },
     List,
     Export {

--- a/keep-cli/src/commands/frost.rs
+++ b/keep-cli/src/commands/frost.rs
@@ -95,10 +95,11 @@ pub fn cmd_frost_split(
     key_name: &str,
     threshold: u16,
     total_shares: u16,
+    keep_original: bool,
 ) -> Result<()> {
     debug!(
         key_name,
-        threshold, total_shares, "splitting key into FROST shares"
+        threshold, total_shares, keep_original, "splitting key into FROST shares"
     );
 
     let mut keep = Keep::open(path)?;
@@ -118,8 +119,14 @@ pub fn cmd_frost_split(
         ));
     }
 
-    let group_pubkey = shares[0].group_pubkey();
-    let npub = bytes_to_npub(group_pubkey);
+    let group_pubkey = *shares[0].group_pubkey();
+    let npub = bytes_to_npub(&group_pubkey);
+
+    if !keep_original {
+        let spinner = out.spinner("Deleting original single-key Nostr key...");
+        keep.delete_key(&group_pubkey)?;
+        spinner.finish();
+    }
 
     out.newline();
     out.success("Split key into FROST shares!");
@@ -135,6 +142,13 @@ pub fn cmd_frost_split(
     }
 
     out.newline();
+    if keep_original {
+        out.warn(
+            "Original single-key Nostr key was RETAINED (--keep-original): threshold security is NOT in effect until you delete it manually.",
+        );
+    } else {
+        out.info("Original single-key Nostr key deleted; threshold security is now in effect.");
+    }
     out.warn("BACKUP: Export shares to different locations for recovery!");
 
     Ok(())

--- a/keep-cli/src/commands/serve.rs
+++ b/keep-cli/src/commands/serve.rs
@@ -14,6 +14,7 @@ use zeroize::Zeroize;
 
 use keep_core::error::{KeepError, Result};
 use keep_core::keyring::Keyring;
+use keep_core::keys::bytes_to_npub;
 use keep_core::Keep;
 use keep_nip46::types::{ApprovalRequest, LogEvent, ServerCallbacks};
 use keep_nip46::{FrostSigner, NetworkFrostSigner, Server, ServerConfig};
@@ -147,6 +148,22 @@ pub fn cmd_serve(
     }
 
     let shares = keep.frost_list_shares()?;
+    let distinct_groups: std::collections::BTreeSet<[u8; 32]> =
+        shares.iter().map(|s| s.metadata.group_pubkey).collect();
+
+    if distinct_groups.len() > 1 {
+        let mut listing = String::new();
+        for g in &distinct_groups {
+            listing.push_str("\n  ");
+            listing.push_str(&bytes_to_npub(g));
+        }
+        return Err(KeepError::InvalidInput(format!(
+            "vault holds shares for {} distinct FROST groups; pass --frost-group <npub> to choose one:{}",
+            distinct_groups.len(),
+            listing
+        )));
+    }
+
     let frost_signer = if !shares.is_empty() {
         let first_group = &shares[0].metadata.group_pubkey;
         let group_shares: Vec<_> = shares
@@ -161,7 +178,8 @@ pub fn cmd_serve(
             let group_pubkey = *first_group;
             match FrostSigner::new(group_pubkey, group_shares, data_key) {
                 Ok(signer) => {
-                    out.info(&format!("Using FROST signing ({threshold}-of-{total})"));
+                    out.field("Signing mode", &format!("FROST {threshold}-of-{total}"));
+                    out.field("Signing identity", &bytes_to_npub(&group_pubkey));
                     Some(signer)
                 }
                 Err(_) => None,
@@ -170,6 +188,13 @@ pub fn cmd_serve(
             None
         }
     } else {
+        let primary_npub = keep
+            .keyring()
+            .get_primary()
+            .map(|slot| bytes_to_npub(&slot.pubkey))
+            .unwrap_or_else(|| "(no keys)".to_string());
+        out.field("Signing mode", "Single-key");
+        out.field("Signing identity", &primary_npub);
         None
     };
 

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -197,7 +197,8 @@ fn dispatch_frost(
             key,
             threshold,
             shares,
-        } => commands::frost::cmd_frost_split(out, path, &key, threshold, shares),
+            keep_original,
+        } => commands::frost::cmd_frost_split(out, path, &key, threshold, shares, keep_original),
         FrostCommands::List => commands::frost::cmd_frost_list(out, path),
         FrostCommands::Export {
             share,


### PR DESCRIPTION
Two surgical fixes from the #434 sweep.

## #456 `frost split` leaves original key in vault
**Default before:** `keep frost split -k mykey` produced 3 FROST shares AND kept the original single-key Nostr key in the vault. An attacker who unlocked the vault had both the raw key and all shares; threshold security was decorative.

**Default after:** the original is deleted after the split. Opt-out with `--keep-original` if the user explicitly wants to retain it (loud warning printed).

- `keep-cli/src/cli.rs`: new `--keep-original` flag.
- `keep-cli/src/main.rs`: dispatch wires it.
- `keep-cli/src/commands/frost.rs`: `cmd_frost_split` calls `keep.delete_key(&group_pubkey)?` after success; output explains which mode it ran in.

Closes #456.

## #465 headless bunker silently picks FROST mode + undocumented identity
**Before:** with shares in the vault, `keep serve --headless` silently picked the first FROST group. No CLI output told operators which key the bunker would sign as. Multiple FROST groups: the first one wins by hash order, silently.

**After:**
- Multiple distinct FROST groups: refuse with a clear error listing the npubs, suggesting `--frost-group <npub>`.
- Single FROST group: print `Signing mode: FROST t-of-n` and `Signing identity: <group npub>`.
- Single-key vault: print `Signing mode: Single-key` and `Signing identity: <primary npub>`.

- `keep-cli/src/commands/serve.rs`: build the distinct-groups set, refuse ambiguous case, print identity fields in all single-group paths.

Closes #465.

## What's NOT in this PR
- **#447 (audit log not preserved by backup):** prototype showed that shipping raw `audit.log` bytes doesn't work: the restored vault has a different data key and can't decrypt the historical entries. The correct fix decrypts entries during backup and re-encrypts them with the new data key during restore (and accepts a hash-chain restart at the restore boundary). That's a larger lift than fits here; I'll file the design in a follow-up under #447.

## Test plan
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test -p keep-cli -p keep-core -p keep-nip46 --lib` — 312 passed, 0 failed.
- [x] Manual: `keep frost split -k orig` deletes the original; `keep list` shows no Nostr key, `frost list` shows 3 shares.
- [x] Manual: `keep frost split -k kept --keep-original` retains the original and warns; `keep list` shows the original.
- [x] Manual: single-key bunker startup prints `Signing identity: npub1...` matching the primary key.
- [x] Manual: bunker startup on a vault with 2 distinct FROST groups refuses with `vault holds shares for 2 distinct FROST groups; pass --frost-group <npub> to choose one:` followed by both npubs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--keep-original` flag to FROST split command to optionally retain the original single-key Nostr key after splitting, instead of automatic deletion
  * Signing identity now displays as NIP-19 npub format for improved readability and consistency
  * Improved handling for vaults with multiple FROST groups, including enhanced selection prompts and clear display of each group's identity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->