### PR TITLE
wallet/serve: always emit signing identity; refuse single-chain descriptor by default

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -176,6 +176,11 @@ pub(crate) enum WalletCommands {
         group: String,
         #[arg(long, default_value = "testnet")]
         network: String,
+        #[arg(
+            long,
+            help = "Allow a single-chain descriptor where external (receive) and internal (change) collapse to the same address. Required because simple FROST-key descriptors have no BIP-32 derivation; addresses will be reused. Prefer `wallet propose` with a recovery tier for proper external/internal split."
+        )]
+        allow_address_reuse: bool,
     },
     /// Delete a stored wallet descriptor
     Delete {

--- a/keep-cli/src/commands/serve.rs
+++ b/keep-cli/src/commands/serve.rs
@@ -164,7 +164,7 @@ pub fn cmd_serve(
         )));
     }
 
-    let frost_signer = if !shares.is_empty() {
+    let (frost_signer, signing_mode, signing_identity) = if !shares.is_empty() {
         let first_group = &shares[0].metadata.group_pubkey;
         let group_shares: Vec<_> = shares
             .iter()
@@ -173,30 +173,26 @@ pub fn cmd_serve(
             .collect();
         let threshold = group_shares[0].metadata.threshold as usize;
         let total = group_shares.len();
-        if total >= threshold {
+        let group_pubkey = *first_group;
+        let group_npub = bytes_to_npub(&group_pubkey);
+        let mode = format!("FROST {threshold}-of-{total}");
+        let signer = if total >= threshold {
             let data_key = keep.data_key()?;
-            let group_pubkey = *first_group;
-            match FrostSigner::new(group_pubkey, group_shares, data_key) {
-                Ok(signer) => {
-                    out.field("Signing mode", &format!("FROST {threshold}-of-{total}"));
-                    out.field("Signing identity", &bytes_to_npub(&group_pubkey));
-                    Some(signer)
-                }
-                Err(_) => None,
-            }
+            FrostSigner::new(group_pubkey, group_shares, data_key).ok()
         } else {
             None
-        }
+        };
+        (signer, mode, group_npub)
     } else {
         let primary_npub = keep
             .keyring()
             .get_primary()
             .map(|slot| bytes_to_npub(&slot.pubkey))
             .unwrap_or_else(|| "(no keys)".to_string());
-        out.field("Signing mode", "Single-key");
-        out.field("Signing identity", &primary_npub);
-        None
+        (None, "Single-key".to_string(), primary_npub)
     };
+    out.field("Signing mode", &signing_mode);
+    out.field("Signing identity", &signing_identity);
 
     let keyring = Arc::new(Mutex::new(std::mem::take(keep.keyring_mut())));
     let rt =

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -169,6 +169,7 @@ pub fn cmd_wallet_descriptor(
     path: &Path,
     group_hex: &str,
     network: &str,
+    allow_address_reuse: bool,
 ) -> Result<()> {
     let group_pubkey = parse_group_hex(group_hex)?;
     let net = crate::commands::bitcoin::parse_network(network)?;
@@ -179,6 +180,12 @@ pub fn cmd_wallet_descriptor(
     let internal = export
         .internal_descriptor()
         .map_err(|e| KeepError::Runtime(e.to_string()))?;
+
+    if internal == export.descriptor && !allow_address_reuse {
+        return Err(KeepError::InvalidInput(
+            "simple FROST-key descriptor has identical external (receive) and internal (change) outputs; the wallet would reuse the same address for every receive and every change output. Pass --allow-address-reuse to accept this for single-address use cases, or use `keep wallet propose` with a recovery tier for a wallet with proper external/internal split.".into(),
+        ));
+    }
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -218,6 +225,12 @@ pub fn cmd_wallet_descriptor(
     out.field("External (receive)", &export.descriptor);
     out.newline();
     out.field("Internal (change)", &internal);
+    if internal == export.descriptor {
+        out.newline();
+        out.warn(
+            "Single-chain descriptor: every receive and every change output lands on the same address. Address reuse weakens on-chain privacy.",
+        );
+    }
 
     Ok(())
 }

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -445,9 +445,17 @@ fn dispatch_wallet(
         WalletCommands::Export { group, format } => {
             commands::wallet::cmd_wallet_export(out, path, &group, &format)
         }
-        WalletCommands::Descriptor { group, network } => {
-            commands::wallet::cmd_wallet_descriptor(out, path, &group, &network)
-        }
+        WalletCommands::Descriptor {
+            group,
+            network,
+            allow_address_reuse,
+        } => commands::wallet::cmd_wallet_descriptor(
+            out,
+            path,
+            &group,
+            &network,
+            allow_address_reuse,
+        ),
         WalletCommands::Delete { group } => commands::wallet::cmd_wallet_delete(out, path, &group),
         WalletCommands::AnnounceKeys {
             group,


### PR DESCRIPTION
Two fixes rolled together: a follow-up to a #484 review comment, and #471.

## serve: always emit Signing mode / Signing identity (#484 review fix)
Review on PR #484 noted that the identity lines were only printed when `FrostSigner::new` succeeded (or `shares.is_empty()` for single-key). When `total < threshold` or `FrostSigner::new` returned `Err(..)`, both branches fell through to `None` without printing anything, leaving the operator with no idea what key the bunker would attempt to sign with.

Fix: compute `(frost_signer, signing_mode, signing_identity)` in one expression, then emit both fields unconditionally. The signer is `None` in the sub-threshold / construction-failed cases; the identity strings still reflect what would be used.

- `keep-cli/src/commands/serve.rs`: refactor so `out.field("Signing mode", ...)` and `out.field("Signing identity", ...)` run after the match, on every path.

## #471: `wallet descriptor` produces identical external/internal descriptors
`keep wallet descriptor` (the simple-descriptor command, no recovery tiers) produced external (receive) and internal (change) descriptors that were byte-identical:
```
External (receive): tr(<group>)#85jf8qd0
Internal (change):  tr(<group>)#85jf8qd0
```
because a bare FROST-key descriptor has no `/0/*` tail for `rewrite_trailing_zero_to_one` to rewrite. Every receive output and every change output landed on the same address. Address reuse weakens on-chain privacy and is a common UX foot-gun.

Proper external/internal split would require giving the FROST group an xpub-equivalent with a chaincode and supporting BIP-32 derivation, which is a larger cryptographic decision (out of scope here, tracked separately on #471).

Surgical fix: refuse to store a single-chain descriptor unless the user explicitly opts in with `--allow-address-reuse`. With the flag, the descriptor is stored and a loud warning is printed.

- `keep-cli/src/cli.rs`: add `--allow-address-reuse` flag on `wallet descriptor`.
- `keep-cli/src/main.rs`: wire it through.
- `keep-cli/src/commands/wallet.rs`: `cmd_wallet_descriptor` rejects with a clear error when `internal == external && !allow_address_reuse`; with the flag, stores and warns.

Closes #471.

## Test plan
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test -p keep-cli -p keep-core -p keep-nip46 --lib` — 312 passed.
- [x] Manual: `keep serve --headless` on a FROST vault prints `Signing mode: FROST 2-of-3` + `Signing identity: npub1...` (verified end-to-end with `nak serve` relay).
- [x] Manual: `keep wallet descriptor --group <hex> --network mainnet` refuses with the clear error including the suggestion to use `wallet propose`.
- [x] Manual: `keep wallet descriptor --group <hex> --network mainnet --allow-address-reuse` stores the descriptor and prints the single-chain warning.