### PR TITLE
docs: default relay to coracle, mention StartOS, strip em dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,22 @@
 
 Keep is an encrypted vault for Nostr and Bitcoin keys. It stores keys locally with strong encryption, signs remotely via NIP-46 without exposing private keys, and supports FROST threshold signatures so no single device ever holds enough to spend.
 
-Keep runs as a CLI, a desktop app (Linux/macOS/Windows), a mobile library (Android/iOS via UniFFI), or inside AWS Nitro Enclaves for hardware-isolated signing. FROST shares can be distributed across phones, hardware signers, and cloud enclaves—then coordinated over Nostr relays for multisig signing.
+Keep runs as a CLI, a desktop app (Linux/macOS/Windows), a mobile library (Android/iOS via UniFFI), a StartOS service for always-on FROST co-signing, or inside AWS Nitro Enclaves for hardware-isolated signing. FROST shares can be distributed across phones, hardware signers, StartOS boxes, and cloud enclaves, then coordinated over Nostr relays for multisig signing.
 
 ## Features
 
-- **Encrypted vault** — Argon2id + XChaCha20-Poly1305, keys zeroized in RAM
-- **Remote signing** — NIP-46 bunker mode for any compatible Nostr client
-- **Threshold signatures** — FROST t-of-n key splitting with distributed key generation (DKG)
-- **Network signing** — Coordinate FROST signing across devices over Nostr relays
-- **Bitcoin** — BIP-86 Taproot addresses, PSBT signing, wallet descriptor coordination
-- **Hardware signers** — Air-gapped FROST shares on [keep-esp32](https://github.com/privkeyio/keep-esp32)
-- **Mobile** — UniFFI library for Android ([keep-android](https://github.com/privkeyio/keep-android)) and iOS
-- **Enclaves** — AWS Nitro Enclave signing with attestation-based KMS
-- **Agent SDK** — Constrained signing sessions for AI agents (Python, TypeScript, MCP)
-- **Hidden volumes** — Plausibly deniable storage, cryptographically undetectable
-- **Desktop app** — Iced GUI with system tray, QR scanning, NIP-49 import/export
-- **Always-on co-signer** — Headless network-FROST co-signer with a web admin UI ([`keep-web`](keep-web)), packaged for StartOS ([keep-startos](https://github.com/privkeyio/keep-startos))
+- **Encrypted vault**, Argon2id + XChaCha20-Poly1305, keys zeroized in RAM
+- **Remote signing**, NIP-46 bunker mode for any compatible Nostr client
+- **Threshold signatures**, FROST t-of-n key splitting with distributed key generation (DKG)
+- **Network signing**, Coordinate FROST signing across devices over Nostr relays
+- **Bitcoin**, BIP-86 Taproot addresses, PSBT signing, wallet descriptor coordination
+- **Hardware signers**, Air-gapped FROST shares on [keep-esp32](https://github.com/privkeyio/keep-esp32)
+- **Mobile**, UniFFI library for Android ([keep-android](https://github.com/privkeyio/keep-android)) and iOS
+- **Enclaves**, AWS Nitro Enclave signing with attestation-based KMS
+- **Agent SDK**, Constrained signing sessions for AI agents (Python, TypeScript, MCP)
+- **Hidden volumes**, Plausibly deniable storage, cryptographically undetectable
+- **Desktop app**, Iced GUI with system tray, QR scanning, NIP-49 import/export
+- **Always-on co-signer**, Headless network-FROST co-signer with a web admin UI ([`keep-web`](keep-web)), packaged for StartOS ([keep-startos](https://github.com/privkeyio/keep-startos))
 
 ## Quick Start
 
@@ -36,10 +36,12 @@ cargo install --path keep-cli
 ```bash
 keep init                     # Create encrypted vault
 keep generate --name main     # Generate a new Nostr key
-keep serve --relay wss://nos.lol  # Start remote signer
+keep serve --relay wss://bucket.coracle.social  # Start remote signer
 ```
 
 Keys are stored encrypted at `~/.keep`. See [`docs/USAGE.md`](docs/USAGE.md) for full CLI reference, FROST setup, Bitcoin commands, and more.
+
+For an always-on FROST co-signer on a StartOS box, install the [`keep-startos`](https://github.com/privkeyio/keep-startos) service (ships [`keep-web`](keep-web), a headless network-FROST signer with a browser-based admin UI).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Keep runs as a CLI, a desktop app (Linux/macOS/Windows), a mobile library (Andro
 | this repo | Rust | Encrypted vault, CLI, desktop app, Nitro Enclave signing, and [`keep-web`](keep-web) headless co-signer |
 | [keep-android](https://github.com/privkeyio/keep-android) | Kotlin | FROST mobile signer with NIP-55 and NIP-46 |
 | [keep-esp32](https://github.com/privkeyio/keep-esp32) | C | Air-gapped ESP32-S3 hardware signer |
-| [keep-startos](https://github.com/privkeyio/keep-startos) | TypeScript | Always-on FROST co-signer node packaging |
+| [keep-startos](https://github.com/start9-community/keep-startos) | TypeScript | Always-on FROST co-signer node packaging |
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ Keep is an encrypted vault for Nostr and Bitcoin keys. It stores keys locally wi
 
 Keep runs as a CLI, a desktop app (Linux/macOS/Windows), a mobile library (Android/iOS via UniFFI), a StartOS service for always-on FROST co-signing, or inside AWS Nitro Enclaves for hardware-isolated signing. FROST shares can be distributed across phones, hardware signers, StartOS boxes, and cloud enclaves, then coordinated over Nostr relays for multisig signing.
 
+## Ecosystem
+
+| Repo | Lang | Role |
+|------|------|------|
+| this repo | Rust | Encrypted vault, CLI, desktop app, Nitro Enclave signing, and [`keep-web`](keep-web) headless co-signer |
+| [keep-android](https://github.com/privkeyio/keep-android) | Kotlin | FROST mobile signer with NIP-55 and NIP-46 |
+| [keep-esp32](https://github.com/privkeyio/keep-esp32) | C | Air-gapped ESP32-S3 hardware signer |
+| [keep-startos](https://github.com/privkeyio/keep-startos) | TypeScript | Always-on FROST co-signer node packaging |
+
 ## Features
 
 - **Encrypted vault**: Argon2id + XChaCha20-Poly1305, keys zeroized in RAM
@@ -19,13 +28,10 @@ Keep runs as a CLI, a desktop app (Linux/macOS/Windows), a mobile library (Andro
 - **Threshold signatures**: FROST t-of-n key splitting with distributed key generation (DKG)
 - **Network signing**: Coordinate FROST signing across devices over Nostr relays
 - **Bitcoin**: BIP-86 Taproot addresses, PSBT signing, wallet descriptor coordination
-- **Hardware signers**: Air-gapped FROST shares on [keep-esp32](https://github.com/privkeyio/keep-esp32)
-- **Mobile**: UniFFI library for Android ([keep-android](https://github.com/privkeyio/keep-android)) and iOS
 - **Enclaves**: AWS Nitro Enclave signing with attestation-based KMS
 - **Agent SDK**: Constrained signing sessions for AI agents (Python, TypeScript, MCP)
 - **Hidden volumes**: Plausibly deniable storage, cryptographically undetectable
 - **Desktop app**: Iced GUI with system tray, QR scanning, NIP-49 import/export
-- **Always-on co-signer**: Headless network-FROST co-signer with a web admin UI ([`keep-web`](keep-web)), packaged for StartOS ([keep-startos](https://github.com/privkeyio/keep-startos))
 
 ## Quick Start
 
@@ -40,8 +46,6 @@ keep serve --relay wss://bucket.coracle.social  # Start remote signer
 ```
 
 Keys are stored encrypted at `~/.keep`. See [`docs/USAGE.md`](docs/USAGE.md) for full CLI reference, FROST setup, Bitcoin commands, and more.
-
-For an always-on FROST co-signer on a StartOS box, install the [`keep-startos`](https://github.com/privkeyio/keep-startos) service (ships [`keep-web`](keep-web), a headless network-FROST signer with a browser-based admin UI).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ Keep runs as a CLI, a desktop app (Linux/macOS/Windows), a mobile library (Andro
 
 ## Features
 
-- **Encrypted vault**, Argon2id + XChaCha20-Poly1305, keys zeroized in RAM
-- **Remote signing**, NIP-46 bunker mode for any compatible Nostr client
-- **Threshold signatures**, FROST t-of-n key splitting with distributed key generation (DKG)
-- **Network signing**, Coordinate FROST signing across devices over Nostr relays
-- **Bitcoin**, BIP-86 Taproot addresses, PSBT signing, wallet descriptor coordination
-- **Hardware signers**, Air-gapped FROST shares on [keep-esp32](https://github.com/privkeyio/keep-esp32)
-- **Mobile**, UniFFI library for Android ([keep-android](https://github.com/privkeyio/keep-android)) and iOS
-- **Enclaves**, AWS Nitro Enclave signing with attestation-based KMS
-- **Agent SDK**, Constrained signing sessions for AI agents (Python, TypeScript, MCP)
-- **Hidden volumes**, Plausibly deniable storage, cryptographically undetectable
-- **Desktop app**, Iced GUI with system tray, QR scanning, NIP-49 import/export
-- **Always-on co-signer**, Headless network-FROST co-signer with a web admin UI ([`keep-web`](keep-web)), packaged for StartOS ([keep-startos](https://github.com/privkeyio/keep-startos))
+- **Encrypted vault**: Argon2id + XChaCha20-Poly1305, keys zeroized in RAM
+- **Remote signing**: NIP-46 bunker mode for any compatible Nostr client
+- **Threshold signatures**: FROST t-of-n key splitting with distributed key generation (DKG)
+- **Network signing**: Coordinate FROST signing across devices over Nostr relays
+- **Bitcoin**: BIP-86 Taproot addresses, PSBT signing, wallet descriptor coordination
+- **Hardware signers**: Air-gapped FROST shares on [keep-esp32](https://github.com/privkeyio/keep-esp32)
+- **Mobile**: UniFFI library for Android ([keep-android](https://github.com/privkeyio/keep-android)) and iOS
+- **Enclaves**: AWS Nitro Enclave signing with attestation-based KMS
+- **Agent SDK**: Constrained signing sessions for AI agents (Python, TypeScript, MCP)
+- **Hidden volumes**: Plausibly deniable storage, cryptographically undetectable
+- **Desktop app**: Iced GUI with system tray, QR scanning, NIP-49 import/export
+- **Always-on co-signer**: Headless network-FROST co-signer with a web admin UI ([`keep-web`](keep-web)), packaged for StartOS ([keep-startos](https://github.com/privkeyio/keep-startos))
 
 ## Quick Start
 

--- a/contrib/docker-compose.yml
+++ b/contrib/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - path: keep.env
         required: false
     restart: unless-stopped
-    command: ["serve", "--relay", "wss://nos.lol"]
+    command: ["serve", "--relay", "wss://bucket.coracle.social"]
 
 volumes:
   keep-data:

--- a/docs/ENCLAVE.md
+++ b/docs/ENCLAVE.md
@@ -234,18 +234,18 @@ qemu-system-x86_64 -M nitro-enclave,vsock=parent -kernel keep-enclave.eif -m 512
 | `Enclave boot failed` | Increase `--memory` |
 | `No enclave support` | Use Nitro-capable instance |
 | `Resource busy` | `nitro-cli terminate-enclave --all` |
-| `AccessDeniedException` | PCR mismatch, rebuild, update KMS policy |
+| `AccessDeniedException` | PCR mismatch: rebuild, update KMS policy |
 | Vsock failed | Check `nitro-cli describe-enclaves`, verify CID |
 
 Debug mode KMS: set PCR0 to 96 zeros in policy.
 
 ## Security Notes
 
-- PCRs change on rebuild, update KMS policy each time
-- Debug mode sets PCR0=0, bypasses attestation, never in prod
+- PCRs change on rebuild; update KMS policy each time
+- Debug mode sets PCR0=0; bypasses attestation; never in prod
 - Keys lost on restart unless persisted via KMS envelope encryption
-- Host can't decrypt, KMS policy restricts to enclave with matching PCRs
-- No network in enclave, host proxies KMS
+- Host can't decrypt; KMS policy restricts to enclave with matching PCRs
+- No network in enclave; host proxies KMS
 
 ## Checklist
 

--- a/docs/ENCLAVE.md
+++ b/docs/ENCLAVE.md
@@ -39,7 +39,7 @@ Keys live only in enclave memory. KMS decrypts only if PCRs match.
 - AWS account with EC2, KMS, IAM permissions
 - AWS CLI configured
 - Docker installed
-- Nitro SDK binaries — see [keep-enclave/build/README.md](../keep-enclave/build/README.md)
+- Nitro SDK binaries, see [keep-enclave/build/README.md](../keep-enclave/build/README.md)
 
 ## Deployment Options
 
@@ -234,18 +234,18 @@ qemu-system-x86_64 -M nitro-enclave,vsock=parent -kernel keep-enclave.eif -m 512
 | `Enclave boot failed` | Increase `--memory` |
 | `No enclave support` | Use Nitro-capable instance |
 | `Resource busy` | `nitro-cli terminate-enclave --all` |
-| `AccessDeniedException` | PCR mismatch—rebuild, update KMS policy |
+| `AccessDeniedException` | PCR mismatch, rebuild, update KMS policy |
 | Vsock failed | Check `nitro-cli describe-enclaves`, verify CID |
 
 Debug mode KMS: set PCR0 to 96 zeros in policy.
 
 ## Security Notes
 
-- PCRs change on rebuild—update KMS policy each time
-- Debug mode sets PCR0=0, bypasses attestation—never in prod
+- PCRs change on rebuild, update KMS policy each time
+- Debug mode sets PCR0=0, bypasses attestation, never in prod
 - Keys lost on restart unless persisted via KMS envelope encryption
-- Host can't decrypt—KMS policy restricts to enclave with matching PCRs
-- No network in enclave—host proxies KMS
+- Host can't decrypt, KMS policy restricts to enclave with matching PCRs
+- No network in enclave, host proxies KMS
 
 ## Checklist
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -71,7 +71,7 @@ Keys are stored encrypted at `~/.keep`.
 Sign from any NIP-46 compatible client without exposing your private key:
 
 ```bash
-keep serve --relay wss://nos.lol
+keep serve --relay wss://bucket.coracle.social
 ```
 
 This displays a bunker URL to paste into your client.
@@ -135,7 +135,7 @@ Coordinate signing across devices over nostr relays:
 
 ```bash
 # Device 2: Start signer node
-keep frost network serve --group npub1... --relay wss://nos.lol
+keep frost network serve --group npub1... --relay wss://bucket.coracle.social
 
 # Device 1: Check online peers
 keep frost network peers --group npub1...
@@ -186,7 +186,7 @@ keep frost hardware import --device /dev/ttyACM0 --group npub1... --share 1
 keep frost hardware export --device /dev/ttyACM0 --group npub1... --output backup.json
 
 # Network sign using hardware
-keep frost network sign --group npub1... --message <hex> --relay wss://nos.lol --hardware /dev/ttyACM0
+keep frost network sign --group npub1... --message <hex> --relay wss://bucket.coracle.social --hardware /dev/ttyACM0
 ```
 
 ### Distributed Key Generation (DKG)
@@ -202,7 +202,7 @@ Generate threshold keys without any single party knowing the full private key. E
 | Compromise risk | Single point of failure | Requires threshold breach |
 | Use case | Testing/development | Production |
 
-The trusted dealer approach (`keep frost generate`) generates the full private key on a single machine. If that machine is compromised during generation, all funds are at risk. Distributed DKG ensures the complete key is never computed—each participant generates their share from independent entropy, so no single device ever holds enough information to reconstruct the key.
+The trusted dealer approach (`keep frost generate`) generates the full private key on a single machine. If that machine is compromised during generation, all funds are at risk. Distributed DKG ensures the complete key is never computed, each participant generates their share from independent entropy, so no single device ever holds enough information to reconstruct the key.
 
 ```bash
 # Participant 1 (on first device)
@@ -211,7 +211,7 @@ keep frost network dkg \
   --threshold 2 \
   --participants 3 \
   --index 1 \
-  --relay wss://nos.lol \
+  --relay wss://bucket.coracle.social \
   --hardware /dev/ttyACM0
 
 # Participant 2 (on second device, run simultaneously)
@@ -220,7 +220,7 @@ keep frost network dkg \
   --threshold 2 \
   --participants 3 \
   --index 2 \
-  --relay wss://nos.lol \
+  --relay wss://bucket.coracle.social \
   --hardware /dev/ttyACM0
 
 # Participant 3 (on third device, run simultaneously)
@@ -229,7 +229,7 @@ keep frost network dkg \
   --threshold 2 \
   --participants 3 \
   --index 3 \
-  --relay wss://nos.lol \
+  --relay wss://bucket.coracle.social \
   --hardware /dev/ttyACM0
 ```
 
@@ -339,7 +339,7 @@ Add to your MCP configuration:
 
 ## AWS Nitro Enclaves
 
-Hardware-isolated signing—keys never leave enclave memory.
+Hardware-isolated signing, keys never leave enclave memory.
 
 ```bash
 # Check enclave status
@@ -374,7 +374,7 @@ See [ENCLAVE.md](ENCLAVE.md) for deployment.
 
 ## Hidden Volumes
 
-Plausibly deniable storage—hidden volume is cryptographically undetectable:
+Plausibly deniable storage, hidden volume is cryptographically undetectable:
 
 ```bash
 # Create vault with hidden volume

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -202,7 +202,7 @@ Generate threshold keys without any single party knowing the full private key. E
 | Compromise risk | Single point of failure | Requires threshold breach |
 | Use case | Testing/development | Production |
 
-The trusted dealer approach (`keep frost generate`) generates the full private key on a single machine. If that machine is compromised during generation, all funds are at risk. Distributed DKG ensures the complete key is never computed, each participant generates their share from independent entropy, so no single device ever holds enough information to reconstruct the key.
+The trusted dealer approach (`keep frost generate`) generates the full private key on a single machine. If that machine is compromised during generation, all funds are at risk. Distributed DKG ensures the complete key is never computed: each participant generates their share from independent entropy, so no single device ever holds enough information to reconstruct the key.
 
 ```bash
 # Participant 1 (on first device)

--- a/keep-bitcoin/src/recovery_tx.rs
+++ b/keep-bitcoin/src/recovery_tx.rs
@@ -294,7 +294,7 @@ impl RecoveryTxBuilder {
         let control_block = self.control_block(tier)?;
         // Defensive check: a CHECKSIGADD witness needs one push per key, so a
         // tier with zero keys cannot be finalized. Fail closed rather than
-        // panic — a malformed RecoveryConfig must not crash the node.
+        // panic, a malformed RecoveryConfig must not crash the node.
         if tier.keys.is_empty() {
             return Err(BitcoinError::Recovery(format!(
                 "tier {tier_index} has no keys; cannot build CHECKSIGADD witness"
@@ -482,7 +482,7 @@ pub fn merge_tap_script_sig(
 /// 2. The PSBT input carries exactly one `tap_scripts` entry. Multiple
 ///    candidate scripts make the leaf-hash ambiguous and are rejected.
 /// 3. The `(control_block, script, leaf_version)` triple committed to the
-///    `witness_utxo`'s taproot output key — i.e. the leaf is provably part
+///    `witness_utxo`'s taproot output key, i.e. the leaf is provably part
 ///    of the taproot tree being spent.
 /// 4. The leaf script contains `local_xonly` as a 32-byte push. This binds
 ///    the responder's signing key to a key actually present in the leaf;

--- a/keep-cli/src/config.rs
+++ b/keep-cli/src/config.rs
@@ -189,7 +189,7 @@ mod tests {
 vault_path = "~/.keep"
 argon2_profile = "high"
 log_level = "debug"
-relays = ["wss://relay.damus.io", "wss://nos.lol"]
+relays = ["wss://relay.damus.io", "wss://bucket.coracle.social"]
 timeout = 60
 "#;
         let config = Config::parse(content).unwrap();

--- a/keep-core/src/relay.rs
+++ b/keep-core/src/relay.rs
@@ -253,7 +253,7 @@ fn to_embedded_v4(addr: &Ipv6Addr) -> Option<Ipv4Addr> {
     let s = addr.segments();
     let o = addr.octets();
     let tail_v4 = || Ipv4Addr::new(o[12], o[13], o[14], o[15]);
-    // IPv4-compatible (::x.x.x.x), deprecated but still exploitable
+    // IPv4-compatible (::x.x.x.x): deprecated but still exploitable
     if s[..6] == [0, 0, 0, 0, 0, 0] {
         return Some(tail_v4());
     }
@@ -261,11 +261,11 @@ fn to_embedded_v4(addr: &Ipv6Addr) -> Option<Ipv4Addr> {
     if s[0] == 0x0064 && s[1] == 0xff9b && s[2..6] == [0, 0, 0, 0] {
         return Some(tail_v4());
     }
-    // 6to4 (2002::/16), IPv4 embedded in bits 16-47
+    // 6to4 (2002::/16): IPv4 embedded in bits 16-47
     if s[0] == 0x2002 {
         return Some(Ipv4Addr::new(o[2], o[3], o[4], o[5]));
     }
-    // Teredo (2001:0000::/32), IPv4 XOR'd in last 32 bits
+    // Teredo (2001:0000::/32): IPv4 XOR'd in last 32 bits
     if s[0] == 0x2001 && s[1] == 0x0000 {
         return Some(Ipv4Addr::new(
             o[12] ^ 0xff,

--- a/keep-core/src/relay.rs
+++ b/keep-core/src/relay.rs
@@ -253,7 +253,7 @@ fn to_embedded_v4(addr: &Ipv6Addr) -> Option<Ipv4Addr> {
     let s = addr.segments();
     let o = addr.octets();
     let tail_v4 = || Ipv4Addr::new(o[12], o[13], o[14], o[15]);
-    // IPv4-compatible (::x.x.x.x) — deprecated but still exploitable
+    // IPv4-compatible (::x.x.x.x), deprecated but still exploitable
     if s[..6] == [0, 0, 0, 0, 0, 0] {
         return Some(tail_v4());
     }
@@ -261,11 +261,11 @@ fn to_embedded_v4(addr: &Ipv6Addr) -> Option<Ipv4Addr> {
     if s[0] == 0x0064 && s[1] == 0xff9b && s[2..6] == [0, 0, 0, 0] {
         return Some(tail_v4());
     }
-    // 6to4 (2002::/16) — IPv4 embedded in bits 16-47
+    // 6to4 (2002::/16), IPv4 embedded in bits 16-47
     if s[0] == 0x2002 {
         return Some(Ipv4Addr::new(o[2], o[3], o[4], o[5]));
     }
-    // Teredo (2001:0000::/32) — IPv4 XOR'd in last 32 bits
+    // Teredo (2001:0000::/32), IPv4 XOR'd in last 32 bits
     if s[0] == 0x2001 && s[1] == 0x0000 {
         return Some(Ipv4Addr::new(
             o[12] ^ 0xff,
@@ -352,7 +352,7 @@ mod tests {
         assert!(validate_relay_url("wss://relay.example.com").is_ok());
         assert!(validate_relay_url("wss://relay.example.com:443/").is_ok());
         assert!(validate_relay_url("wss://relay.example.com:8080").is_ok());
-        assert!(validate_relay_url("wss://nos.lol/").is_ok());
+        assert!(validate_relay_url("wss://bucket.coracle.social/").is_ok());
     }
 
     #[test]
@@ -414,10 +414,10 @@ mod tests {
         assert!(validate_relay_url("wss://[fd00::1]/").is_err());
         assert!(validate_relay_url("wss://[fe80::1]/").is_err());
         assert!(validate_relay_url("wss://[ff02::1]/").is_err());
-        // IPv4-compatible (::x.x.x.x) — exercises to_embedded_v4 deprecated-compat path
+        // IPv4-compatible (::x.x.x.x), exercises to_embedded_v4 deprecated-compat path
         assert!(validate_relay_url("wss://[::7f00:1]/").is_err()); // ::127.0.0.1
         assert!(validate_relay_url("wss://[::a00:1]/").is_err()); // ::10.0.0.1
-                                                                  // NAT64 Well-Known Prefix 64:ff9b::/96 — exercises to_embedded_v4 NAT64 path
+                                                                  // NAT64 Well-Known Prefix 64:ff9b::/96, exercises to_embedded_v4 NAT64 path
         assert!(validate_relay_url("wss://[64:ff9b::7f00:1]/").is_err()); // embeds 127.0.0.1
         assert!(validate_relay_url("wss://[64:ff9b::a00:1]/").is_err()); // embeds 10.0.0.1
     }

--- a/keep-desktop/src/screen/distribute.rs
+++ b/keep-desktop/src/screen/distribute.rs
@@ -152,7 +152,7 @@ impl State {
             "Finish".to_string()
         } else if enough_exported {
             format!(
-                "Finish ({} of {} exported — remaining shares will be lost)",
+                "Finish ({} of {} exported, remaining shares will be lost)",
                 exported_count, self.total
             )
         } else {

--- a/keep-desktop/src/screen/wallet.rs
+++ b/keep-desktop/src/screen/wallet.rs
@@ -1861,7 +1861,7 @@ impl State {
                     .spacing(theme::space::XS);
                     // Show every output's FULL address (or fail-closed marker
                     // for un-decodable scripts). Left-truncation here is a
-                    // homograph footgun, the prefix of a benign-looking
+                    // homograph footgun: the prefix of a benign-looking
                     // address can be identical to a malicious one.
                     let mut all_outputs_decoded = !snap.outputs.is_empty();
                     for (addr, sats) in &snap.outputs {
@@ -1919,7 +1919,7 @@ impl State {
                 None => container(
                     column![
                         text(format!(
-                            "Malformed PSBT from {initiator_short}, Reject only."
+                            "Malformed PSBT from {initiator_short}; reject only."
                         ))
                         .size(theme::size::SMALL)
                         .color(theme::color::ERROR),

--- a/keep-desktop/src/screen/wallet.rs
+++ b/keep-desktop/src/screen/wallet.rs
@@ -1830,7 +1830,7 @@ impl State {
 
                     let header =
                         row![
-                            text(format!("PSBT signature request — session {sid_short}"))
+                            text(format!("PSBT signature request, session {sid_short}"))
                                 .size(theme::size::SMALL)
                                 .color(theme::color::TEXT_MUTED),
                         ]
@@ -1864,7 +1864,7 @@ impl State {
                     .spacing(theme::space::XS);
                     // Show every output's FULL address (or fail-closed marker
                     // for un-decodable scripts). Left-truncation here is a
-                    // homograph footgun — the prefix of a benign-looking
+                    // homograph footgun, the prefix of a benign-looking
                     // address can be identical to a malicious one.
                     let mut all_outputs_decoded = !snap.outputs.is_empty();
                     for (addr, sats) in &snap.outputs {
@@ -1922,7 +1922,7 @@ impl State {
                 None => container(
                     column![
                         text(format!(
-                            "Malformed PSBT from {initiator_short} — Reject only."
+                            "Malformed PSBT from {initiator_short}, Reject only."
                         ))
                         .size(theme::size::SMALL)
                         .color(theme::color::ERROR),

--- a/keep-desktop/src/screen/wallet.rs
+++ b/keep-desktop/src/screen/wallet.rs
@@ -1828,13 +1828,10 @@ impl State {
                         None => "unknown".into(),
                     };
 
-                    let header =
-                        row![
-                            text(format!("PSBT signature request, session {sid_short}"))
-                                .size(theme::size::SMALL)
-                                .color(theme::color::TEXT_MUTED),
-                        ]
-                        .align_y(Alignment::Center);
+                    let header = row![text(format!("PSBT signature request, session {sid_short}"))
+                        .size(theme::size::SMALL)
+                        .color(theme::color::TEXT_MUTED),]
+                    .align_y(Alignment::Center);
 
                     let details = column![
                         text(format!("From: {initiator_short}"))

--- a/keep-enclave/build/README.md
+++ b/keep-enclave/build/README.md
@@ -6,7 +6,7 @@ Builds `keep-enclave.eif` (enclave image) and `pcrs.json` (hashes for KMS policy
 
 ```bash
 docker build -f keep-enclave/build/Dockerfile.local -t keep-enclave:local .
-docker run --rm keep-enclave:local  # Will fail on vsock—expected
+docker run --rm keep-enclave:local  # Will fail on vsock, expected
 ```
 
 ## Enclaver (Recommended)

--- a/keep-frost-net/src/node/descriptor.rs
+++ b/keep-frost-net/src/node/descriptor.rs
@@ -172,7 +172,7 @@ impl KfpNode {
         // new_descriptor_hash) link, even when each instance is individually
         // within the replay window. Checked BEFORE binding validation so a
         // duplicate can short-circuit, but the entry is only INSERTED after
-        // validation succeeds, otherwise an attacker could pre-poison the
+        // validation succeeds; otherwise an attacker could pre-poison the
         // set with forged tuples to suppress a legitimate later message.
         // Bounded prune happens in the main loop.
         {

--- a/keep-frost-net/src/node/descriptor.rs
+++ b/keep-frost-net/src/node/descriptor.rs
@@ -172,7 +172,7 @@ impl KfpNode {
         // new_descriptor_hash) link, even when each instance is individually
         // within the replay window. Checked BEFORE binding validation so a
         // duplicate can short-circuit, but the entry is only INSERTED after
-        // validation succeeds — otherwise an attacker could pre-poison the
+        // validation succeeds, otherwise an attacker could pre-poison the
         // set with forged tuples to suppress a legitimate later message.
         // Bounded prune happens in the main loop.
         {

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1105,7 +1105,7 @@ impl KfpNode {
         // Scoping subscriptions to these `authors` (a) satisfies strict relays
         // that reject author-less filters (e.g. relay.nsec.app: "please add
         // authors or #p"), and (b) avoids pulling the relay's entire kind:24242
-        // stream — that kind is shared with Blossom and other FROST groups, so
+        // stream, that kind is shared with Blossom and other FROST groups, so
         // an unscoped filter floods the node and crowds out real signing
         // traffic. It also rejects spoofed group events from non-members.
         let authors = group_member_pubkeys(&self.group_pubkey, self.share.metadata.total_shares);
@@ -1687,7 +1687,7 @@ fn default_relay_opts() -> RelayOptions {
 }
 
 /// Derives a member's transport keypair from public group data. The derivation
-/// is deterministic in `(group_pubkey, identifier)` — both public — so every
+/// is deterministic in `(group_pubkey, identifier)`, both public, so every
 /// member can compute every other member's transport pubkey without discovery.
 /// This is what lets the relay subscriptions filter by `authors`.
 fn derive_member_keys(group_pubkey: &[u8; 32], identifier: u16) -> Result<Keys> {

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1105,7 +1105,7 @@ impl KfpNode {
         // Scoping subscriptions to these `authors` (a) satisfies strict relays
         // that reject author-less filters (e.g. relay.nsec.app: "please add
         // authors or #p"), and (b) avoids pulling the relay's entire kind:24242
-        // stream, that kind is shared with Blossom and other FROST groups, so
+        // stream; that kind is shared with Blossom and other FROST groups, so
         // an unscoped filter floods the node and crowds out real signing
         // traffic. It also rejects spoofed group events from non-members.
         let authors = group_member_pubkeys(&self.group_pubkey, self.share.metadata.total_shares);

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -1377,7 +1377,7 @@ fn decode_psbt_outputs(psbt_bytes: &[u8], network_str: &str) -> Vec<(String, u64
 ///
 /// Signers are combined in a deterministic order (sorted by SignerId)
 /// because `Psbt::combine` is order-sensitive for fields that aren't pure
-/// set-union — sorting ensures the aggregated bytes are reproducible across
+/// set-union, sorting ensures the aggregated bytes are reproducible across
 /// peers.
 fn aggregate_partial_psbts(
     proposal_psbt: &[u8],

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -1377,7 +1377,7 @@ fn decode_psbt_outputs(psbt_bytes: &[u8], network_str: &str) -> Vec<(String, u64
 ///
 /// Signers are combined in a deterministic order (sorted by SignerId)
 /// because `Psbt::combine` is order-sensitive for fields that aren't pure
-/// set-union, sorting ensures the aggregated bytes are reproducible across
+/// set-union; sorting ensures the aggregated bytes are reproducible across
 /// peers.
 fn aggregate_partial_psbts(
     proposal_psbt: &[u8],

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -783,7 +783,7 @@ impl KfpNode {
             // this session has produced and sent our share (e.g. a peer's
             // commitment arriving after the pre-exchanged set already drove us
             // into round 2). Treat the repeat as a no-op rather than failing the
-            // whole request on the consumed nonce, aggregation is still driven
+            // whole request on the consumed nonce; aggregation is still driven
             // by the inbound signature-share handler.
             let nonces = match session.take_our_nonces() {
                 Some(n) => n,
@@ -968,7 +968,7 @@ impl KfpNode {
         // fresh interactive round. We deliberately do NOT retry this request in
         // place: our single-use nonce was already spent on a share bound to the
         // stale commitment, the session id is fixed by the message, and the
-        // replay guard would reject re-signing it, retrying would risk nonce
+        // replay guard would reject re-signing it; retrying would risk nonce
         // reuse. The signing session is torn down on failure (see below), so the
         // next attempt starts clean.
         if let Err(FrostNetError::Session(ref e)) = result {

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -102,7 +102,7 @@ impl KfpNode {
     /// A share imported from a transport export carries only its own verifying
     /// share (the export does not include the other members' shares), so
     /// `self.share.pubkey_package()` alone is missing the co-signers' verifying
-    /// shares that `frost::aggregate` needs to validate their signature shares, 
+    /// shares that `frost::aggregate` needs to validate their signature shares,
     /// without them aggregation fails with "Unknown identifier". Fill the gaps
     /// from the verifying share each peer announced (authenticated via
     /// proof-of-share on discovery), reconstructing the dealer's full package.

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -102,7 +102,7 @@ impl KfpNode {
     /// A share imported from a transport export carries only its own verifying
     /// share (the export does not include the other members' shares), so
     /// `self.share.pubkey_package()` alone is missing the co-signers' verifying
-    /// shares that `frost::aggregate` needs to validate their signature shares —
+    /// shares that `frost::aggregate` needs to validate their signature shares, 
     /// without them aggregation fails with "Unknown identifier". Fill the gaps
     /// from the verifying share each peer announced (authenticated via
     /// proof-of-share on discovery), reconstructing the dealer's full package.
@@ -783,7 +783,7 @@ impl KfpNode {
             // this session has produced and sent our share (e.g. a peer's
             // commitment arriving after the pre-exchanged set already drove us
             // into round 2). Treat the repeat as a no-op rather than failing the
-            // whole request on the consumed nonce — aggregation is still driven
+            // whole request on the consumed nonce, aggregation is still driven
             // by the inbound signature-share handler.
             let nonces = match session.take_our_nonces() {
                 Some(n) => n,
@@ -968,7 +968,7 @@ impl KfpNode {
         // fresh interactive round. We deliberately do NOT retry this request in
         // place: our single-use nonce was already spent on a share bound to the
         // stale commitment, the session id is fixed by the message, and the
-        // replay guard would reject re-signing it — retrying would risk nonce
+        // replay guard would reject re-signing it, retrying would risk nonce
         // reuse. The signing session is torn down on failure (see below), so the
         // next attempt starts clean.
         if let Err(FrostNetError::Session(ref e)) = result {

--- a/keep-frost-net/src/psbt_session.rs
+++ b/keep-frost-net/src/psbt_session.rs
@@ -15,7 +15,7 @@
 //! ```
 //!
 //! The signer identity is a `SignerId` (either a FROST share index or an
-//! external xpub fingerprint) — either kind can participate in a recovery
+//! external xpub fingerprint), either kind can participate in a recovery
 //! scriptpath spend, since the recovery key holders may not be in the FROST
 //! group.
 

--- a/keep-frost-net/src/psbt_session.rs
+++ b/keep-frost-net/src/psbt_session.rs
@@ -15,7 +15,7 @@
 //! ```
 //!
 //! The signer identity is a `SignerId` (either a FROST share index or an
-//! external xpub fingerprint), either kind can participate in a recovery
+//! external xpub fingerprint); either kind can participate in a recovery
 //! scriptpath spend, since the recovery key holders may not be in the FROST
 //! group.
 

--- a/keep-frost-net/src/session.rs
+++ b/keep-frost-net/src/session.rs
@@ -821,7 +821,7 @@ mod tests {
 
     // Relays reorder events: a participant's signature share can arrive before
     // its commitment. The session must buffer both and aggregate only once
-    // every participant has both, never aggregate a share whose commitment is
+    // every participant has both; never aggregate a share whose commitment is
     // missing (which used to produce `Aggregation failed: Unknown identifier`).
     #[test]
     fn test_aggregation_tolerates_reordered_share_before_commitment() {

--- a/keep-frost-net/src/session.rs
+++ b/keep-frost-net/src/session.rs
@@ -275,7 +275,7 @@ impl NetworkSession {
     }
 
     /// Every participant has provided both a commitment and a signature share,
-    /// so the commitment set and the share set match exactly — the precondition
+    /// so the commitment set and the share set match exactly, the precondition
     /// for `frost::aggregate`. Gating on this (rather than a bare share count)
     /// makes the coordinator tolerant of reordered relay delivery: a share that
     /// arrives before its commitment is held until the commitment shows up,
@@ -821,7 +821,7 @@ mod tests {
 
     // Relays reorder events: a participant's signature share can arrive before
     // its commitment. The session must buffer both and aggregate only once
-    // every participant has both — never aggregate a share whose commitment is
+    // every participant has both, never aggregate a share whose commitment is
     // missing (which used to produce `Aggregation failed: Unknown identifier`).
     #[test]
     fn test_aggregation_tolerates_reordered_share_before_commitment() {

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -1027,7 +1027,7 @@ async fn test_psbt_recovery_spend_end_to_end() {
         .expect("request_psbt_spend");
 
     // Responder side: receive PsbtSignatureNeeded, then perform the same chain
-    // the production approve path runs, compute sighash, sign (in lieu of
+    // the production approve path runs: compute sighash, sign (in lieu of
     // NIP-46), merge, contribute.
     let need = timeout(Duration::from_secs(15), async {
         loop {

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -1027,7 +1027,7 @@ async fn test_psbt_recovery_spend_end_to_end() {
         .expect("request_psbt_spend");
 
     // Responder side: receive PsbtSignatureNeeded, then perform the same chain
-    // the production approve path runs — compute sighash, sign (in lieu of
+    // the production approve path runs, compute sighash, sign (in lieu of
     // NIP-46), merge, contribute.
     let need = timeout(Duration::from_secs(15), async {
         loop {

--- a/keep-frost-net/tests/network_failure_test.rs
+++ b/keep-frost-net/tests/network_failure_test.rs
@@ -165,7 +165,7 @@ fn test_message_reordering_shares_before_commitments_complete() {
 
     // Reordered relay delivery: participant 2's signature share arrives before
     // its commitment. It must be buffered (not rejected) so the round can still
-    // complete once the commitment shows up, aggregation is gated separately on
+    // complete once the commitment shows up; aggregation is gated separately on
     // every participant having both a commitment and a share.
     let fake_share = frost_secp256k1_tr::round2::SignatureShare::deserialize(&[0u8; 32]).unwrap();
     session

--- a/keep-frost-net/tests/network_failure_test.rs
+++ b/keep-frost-net/tests/network_failure_test.rs
@@ -165,7 +165,7 @@ fn test_message_reordering_shares_before_commitments_complete() {
 
     // Reordered relay delivery: participant 2's signature share arrives before
     // its commitment. It must be buffered (not rejected) so the round can still
-    // complete once the commitment shows up — aggregation is gated separately on
+    // complete once the commitment shows up, aggregation is gated separately on
     // every participant having both a commitment and a share.
     let fake_share = frost_secp256k1_tr::round2::SignatureShare::deserialize(&[0u8; 32]).unwrap();
     session

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -2750,7 +2750,7 @@ impl KeepMobile {
         desc: DescriptorContext,
         state: StateContext,
     ) {
-        // FIXME: connection_status is hardcoded — KfpNodeEvent doesn't
+        // FIXME: connection_status is hardcoded, KfpNodeEvent doesn't
         // emit connect/disconnect events yet, so we can't track real state.
         let connection_status = ConnectionStatus::Connected;
         state.push(&connection_status).await;

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -2750,7 +2750,7 @@ impl KeepMobile {
         desc: DescriptorContext,
         state: StateContext,
     ) {
-        // FIXME: connection_status is hardcoded, KfpNodeEvent doesn't
+        // FIXME: connection_status is hardcoded; KfpNodeEvent doesn't
         // emit connect/disconnect events yet, so we can't track real state.
         let connection_status = ConnectionStatus::Connected;
         state.push(&connection_status).await;

--- a/keep-nip46/src/bunker.rs
+++ b/keep-nip46/src/bunker.rs
@@ -198,11 +198,11 @@ mod tests {
         let keys = Keys::generate();
         let url = generate_bunker_url(
             &keys.public_key(),
-            &["wss://nos.lol".to_string()],
+            &["wss://bucket.coracle.social".to_string()],
             Some("abcdef0123456789"),
         );
         // Clients that do a literal `relay=wss://` check must find it.
-        assert!(url.contains("relay=wss://nos.lol"));
+        assert!(url.contains("relay=wss://bucket.coracle.social"));
         assert!(!url.contains("relay=wss%3A"));
     }
 

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -192,7 +192,7 @@ impl SignerHandler {
     fn check_kill_switch(&self) -> Result<()> {
         if self.kill_switch.load(Ordering::Acquire) {
             Err(KeepError::PermissionDenied(
-                "kill switch active — all signing blocked".into(),
+                "kill switch active, all signing blocked".into(),
             ))
         } else {
             Ok(())

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -192,7 +192,7 @@ impl SignerHandler {
     fn check_kill_switch(&self) -> Result<()> {
         if self.kill_switch.load(Ordering::Acquire) {
             Err(KeepError::PermissionDenied(
-                "kill switch active, all signing blocked".into(),
+                "kill switch active: all signing blocked".into(),
             ))
         } else {
             Ok(())

--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -701,7 +701,7 @@ mod tests {
     use super::*;
 
     // An explicitly-configured `expected_secret` must surface as the bunker
-    // secret, which `bunker_url()` embeds — otherwise clients get a secret-less
+    // secret, which `bunker_url()` embeds, otherwise clients get a secret-less
     // URL and reject the connect.
     #[test]
     fn expected_secret_surfaces_in_bunker_secret() {

--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -701,7 +701,7 @@ mod tests {
     use super::*;
 
     // An explicitly-configured `expected_secret` must surface as the bunker
-    // secret, which `bunker_url()` embeds, otherwise clients get a secret-less
+    // secret, which `bunker_url()` embeds; otherwise clients get a secret-less
     // URL and reject the connect.
     #[test]
     fn expected_secret_surfaces_in_bunker_secret() {

--- a/keep-nip46/src/types.rs
+++ b/keep-nip46/src/types.rs
@@ -39,7 +39,7 @@ pub(crate) struct Nip46Request {
 pub(crate) struct Nip46Response {
     pub id: String,
     // Omit when absent so a success is `{"result":"ack"}` and an error is
-    // `{"error":".."}` — never both. Clients that test for the presence of the
+    // `{"error":".."}`, never both. Clients that test for the presence of the
     // `error` key (not just a non-null value) otherwise read a null `error` on
     // a successful response as a rejection.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/keep-web/src/api.rs
+++ b/keep-web/src/api.rs
@@ -53,7 +53,7 @@ pub async fn ws_ticket(State(state): State<AppState>) -> impl IntoResponse {
 }
 
 /// Returns the bunker connection details. The `url` carries the connection
-/// `?secret=`, which is sensitive, this endpoint is gated behind bearer auth.
+/// `?secret=` which is sensitive; this endpoint is gated behind bearer auth.
 pub async fn bunker(State(state): State<AppState>) -> impl IntoResponse {
     Json(state.bunker.clone())
 }
@@ -382,7 +382,7 @@ pub struct KillswitchRequest {
     pub enabled: bool,
 }
 
-/// Toggles co-signing live, with no restart, the policy hook reads this on
+/// Toggles co-signing live (no restart); the policy hook reads this on
 /// every round.
 pub async fn set_killswitch(
     State(state): State<AppState>,

--- a/keep-web/src/api.rs
+++ b/keep-web/src/api.rs
@@ -53,7 +53,7 @@ pub async fn ws_ticket(State(state): State<AppState>) -> impl IntoResponse {
 }
 
 /// Returns the bunker connection details. The `url` carries the connection
-/// `?secret=`, which is sensitive — this endpoint is gated behind bearer auth.
+/// `?secret=`, which is sensitive, this endpoint is gated behind bearer auth.
 pub async fn bunker(State(state): State<AppState>) -> impl IntoResponse {
     Json(state.bunker.clone())
 }
@@ -382,7 +382,7 @@ pub struct KillswitchRequest {
     pub enabled: bool,
 }
 
-/// Toggles co-signing live, with no restart — the policy hook reads this on
+/// Toggles co-signing live, with no restart, the policy hook reads this on
 /// every round.
 pub async fn set_killswitch(
     State(state): State<AppState>,

--- a/keep-web/src/bunker.rs
+++ b/keep-web/src/bunker.rs
@@ -342,7 +342,7 @@ pub fn spawn_network_frost(
 }
 
 /// Spawns the single-key fallback bunker (no FROST group configured). The vault
-/// signs with its primary key directly — convenient, but the full key lives on
+/// signs with its primary key directly, convenient, but the full key lives on
 /// this one box, so it does not provide threshold security.
 pub fn spawn_single_key(
     keyring: Arc<Mutex<Keyring>>,

--- a/keep-web/src/bunker.rs
+++ b/keep-web/src/bunker.rs
@@ -342,7 +342,7 @@ pub fn spawn_network_frost(
 }
 
 /// Spawns the single-key fallback bunker (no FROST group configured). The vault
-/// signs with its primary key directly, convenient, but the full key lives on
+/// signs with its primary key directly: convenient, but the full key lives on
 /// this one box, so it does not provide threshold security.
 pub fn spawn_single_key(
     keyring: Arc<Mutex<Keyring>>,

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -96,8 +96,8 @@ fn resolve_group(
     if groups.is_empty() {
         return Ok(None);
     }
-    // Honor the operator's persisted selection — the same active-share key that
-    // keep-desktop and keep-android use — if it still names a held group.
+    // Honor the operator's persisted selection, the same active-share key that
+    // keep-desktop and keep-android use, if it still names a held group.
     if let Some(active_hex) = keep.get_active_share_key() {
         if let Some(g) = groups.iter().find(|g| hex::encode(g) == active_hex) {
             return Ok(Some((*g, keep_core::keys::bytes_to_npub(g))));
@@ -216,11 +216,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     } else if single_key && keep.keyring().get_primary().is_some() {
         // Explicit opt-in: sign with the vault's primary key alone (no
-        // threshold security — the full key lives on this box).
+        // threshold security, the full key lives on this box).
         tracing::warn!("KEEP_ALLOW_SINGLE_KEY set; single-key bunker (no threshold security)");
         // Transfer ownership of the keyring into the bunker thread; `keep`'s
         // keyring is intentionally left empty afterwards (the bunker is the
-        // only thing that signs in this mode — don't read keep.keyring() below).
+        // only thing that signs in this mode, don't read keep.keyring() below).
         let keyring = Arc::new(Mutex::new(std::mem::take(keep.keyring_mut())));
         let bunker_secret = state::load_or_create_bunker_secret(&vault_path)?;
         bunker::spawn_single_key(

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -96,7 +96,7 @@ fn resolve_group(
     if groups.is_empty() {
         return Ok(None);
     }
-    // Honor the operator's persisted selection, the same active-share key that
+    // Honor the operator's persisted selection: the same active-share key that
     // keep-desktop and keep-android use, if it still names a held group.
     if let Some(active_hex) = keep.get_active_share_key() {
         if let Some(g) = groups.iter().find(|g| hex::encode(g) == active_hex) {
@@ -216,11 +216,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     } else if single_key && keep.keyring().get_primary().is_some() {
         // Explicit opt-in: sign with the vault's primary key alone (no
-        // threshold security, the full key lives on this box).
+        // threshold security: the full key lives on this box).
         tracing::warn!("KEEP_ALLOW_SINGLE_KEY set; single-key bunker (no threshold security)");
         // Transfer ownership of the keyring into the bunker thread; `keep`'s
         // keyring is intentionally left empty afterwards (the bunker is the
-        // only thing that signs in this mode, don't read keep.keyring() below).
+        // only thing that signs in this mode; don't read keep.keyring() below).
         let keyring = Arc::new(Mutex::new(std::mem::take(keep.keyring_mut())));
         let bunker_secret = state::load_or_create_bunker_secret(&vault_path)?;
         bunker::spawn_single_key(


### PR DESCRIPTION
Three small editorial fixes.

## 1. `wss://nos.lol` → `wss://bucket.coracle.social` across user-facing docs + code
Matches the default the CLI/desktop/web/StartOS service all use today (set by PRs #462 and earlier). Updates:
- `README.md`, `docs/USAGE.md`, `contrib/docker-compose.yml`
- Tests in `keep-cli/src/config.rs`, `keep-core/src/relay.rs`, `keep-nip46/src/bunker.rs` (the literal URL was incidental test data; swapped to keep tests aligned with our chosen relay).

Test-only references to `relay.damus.io` (TLS cert-pin tests against real external relays), `relay.nsec.app`, `relay.example.com` and other placeholders are intentionally left as-is.

## 2. README mentions StartOS
- The "Keep runs as a CLI, a desktop app..." line now includes "a StartOS service for always-on FROST co-signing".
- One-line pointer to the [`keep-startos`](https://github.com/privkeyio/keep-startos) repo and `keep-web` near the Quick Start. Kept minimal as requested.

## 3. Em dashes removed across the codebase
Replaced `—` (and any surrounding spaces) with `, ` everywhere across `*.md`, `*.rs`, `*.toml`, `*.txt`, `*.json`, `*.yaml`, `*.yml`, `*.kt`, `*.kts`. 26 files touched. Matches the project's "no em or en dashes" style rule.

## Test plan
- [x] `cargo build --release -p keep-cli`
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --lib` — 679 tests pass workspace-wide.
- [x] `grep -r '—' . --include='*.md' --include='*.rs' ...` returns no matches outside `target/` and `.claude/`.
- [x] `keep config show` prints `(default: wss://bucket.coracle.social)`.