### PR TITLE
cli: require --network on bitcoin and wallet commands; wallet accepts npub or hex

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -172,9 +172,12 @@ pub(crate) enum WalletCommands {
     },
     /// Create a simple descriptor from a FROST group (no recovery tiers)
     Descriptor {
-        #[arg(short, long, help = "FROST group pubkey hex")]
+        #[arg(short, long, help = "FROST group npub or hex")]
         group: String,
-        #[arg(long, default_value = "testnet")]
+        #[arg(
+            long,
+            help = "Bitcoin network: mainnet, testnet, signet, regtest. Required; no default to prevent silent testnet outputs."
+        )]
         network: String,
         #[arg(
             long,
@@ -234,7 +237,10 @@ pub(crate) enum WalletCommands {
     Propose {
         #[arg(short, long, help = "FROST group npub or hex")]
         group: String,
-        #[arg(long, default_value = "signet")]
+        #[arg(
+            long,
+            help = "Bitcoin network: mainnet, testnet, signet, regtest. Required; no default to prevent silent signet proposals."
+        )]
         network: String,
         #[arg(short, long, help = "Nostr relay URL")]
         relay: Option<String>,
@@ -549,7 +555,10 @@ pub(crate) enum BitcoinCommands {
         key: String,
         #[arg(short, long, default_value = "1")]
         count: u32,
-        #[arg(long, default_value = "testnet")]
+        #[arg(
+            long,
+            help = "Bitcoin network: mainnet, testnet, signet, regtest. Required; no default to prevent silent testnet outputs (fund-loss risk if treated as mainnet)."
+        )]
         network: String,
     },
     Descriptor {
@@ -557,7 +566,10 @@ pub(crate) enum BitcoinCommands {
         key: String,
         #[arg(long, default_value = "0")]
         account: u32,
-        #[arg(long, default_value = "testnet")]
+        #[arg(
+            long,
+            help = "Bitcoin network: mainnet, testnet, signet, regtest. Required; no default."
+        )]
         network: String,
     },
     Sign {
@@ -567,13 +579,19 @@ pub(crate) enum BitcoinCommands {
         psbt: String,
         #[arg(short, long)]
         output: Option<String>,
-        #[arg(long, default_value = "testnet")]
+        #[arg(
+            long,
+            help = "Bitcoin network: mainnet, testnet, signet, regtest. Required; no default."
+        )]
         network: String,
     },
     Analyze {
         #[arg(short, long)]
         psbt: String,
-        #[arg(long, default_value = "testnet")]
+        #[arg(
+            long,
+            help = "Bitcoin network: mainnet, testnet, signet, regtest. Required; no default."
+        )]
         network: String,
     },
 }
@@ -595,6 +613,8 @@ mod tests {
             "main",
             "--psbt",
             "/tmp/unsigned.psbt",
+            "--network",
+            "mainnet",
         ])
         .expect("parse bitcoin sign args");
 

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -30,13 +30,19 @@ fn descriptor_lookup_for(
     })
 }
 
-fn parse_group_hex(group_hex: &str) -> Result<[u8; 32]> {
-    let bytes = hex::decode(group_hex)
-        .map_err(|e| KeepError::InvalidInput(format!("invalid group hex: {e}")))?;
-    let arr: [u8; 32] = bytes
+/// Parse a FROST group identifier as either bech32 npub or 32-byte hex.
+///
+/// CLI help for every wallet `--group` argument advertises "npub or hex"; this
+/// makes both inputs work.
+fn parse_group_hex(group_id: &str) -> Result<[u8; 32]> {
+    if group_id.starts_with("npub1") {
+        return keep_core::keys::npub_to_bytes(group_id);
+    }
+    let bytes = hex::decode(group_id)
+        .map_err(|e| KeepError::InvalidInput(format!("expected npub or 32-byte hex: {e}")))?;
+    bytes
         .try_into()
-        .map_err(|_| KeepError::InvalidInput("group pubkey must be 32 bytes".into()))?;
-    Ok(arr)
+        .map_err(|_| KeepError::InvalidInput("group pubkey must be 32 bytes".into()))
 }
 
 pub fn cmd_wallet_list(out: &Output, path: &Path) -> Result<()> {


### PR DESCRIPTION
Three related CLI safety fixes from the #434 sweep.

## #452 bitcoin commands defaulted to testnet silently
`keep bitcoin address`, `descriptor`, `sign`, and `analyze` all defaulted `--network` to `testnet`. A user running `keep bitcoin address -k mykey` and copying the output got a testnet address; sending mainnet BTC to it strands the funds. Same shape for the other three.

Fix: drop the default. `--network` is now required. Clap rejects the call with `the following required arguments were not provided: --network <NETWORK>`. Forces a conscious choice.

## #468 wallet propose defaulted to signet silently
Same shape as #452 but on `keep wallet propose --network`, which defaulted to `signet`. The CLI used to have THREE different default networks: testnet on `bitcoin`, signet on `wallet propose`, undocumented coral on `wallet descriptor` output. Fix: drop the default; require explicit `--network`. Same canonical values (`mainnet`/`bitcoin`/`testnet`/`signet`/`regtest`) accepted via `parse_network`.

Same treatment applied to `wallet descriptor --network` for consistency (was also defaulting to testnet).

## #470 wallet --group rejected npub despite help text saying "npub or hex"
Every `wallet` subcommand's `--group` arg help text said "FROST group npub or hex", but `parse_group_hex` only accepted hex and emitted "invalid group hex: Odd number of digits" on npub input. Fix: try bech32 first when the input starts with `npub1`; fall back to hex otherwise. Error message now says `expected npub or 32-byte hex` instead of the misleading hex-parser detail.

Also fixed `wallet descriptor --group` help text (it was the lone one saying "FROST group pubkey hex"); now matches the rest with "FROST group npub or hex".

## Changes
- `keep-cli/src/cli.rs`:
  - `BitcoinCommands::Address`/`Descriptor`/`Sign`/`Analyze`: drop `default_value` from `--network`.
  - `WalletCommands::Descriptor`/`Propose`: drop `default_value` from `--network`; fix `Descriptor` help text.
  - Updated `bitcoin_sign_short_p_is_global_path_not_psbt` test to pass `--network mainnet` (it relied on the dropped default).
- `keep-cli/src/commands/wallet.rs`: `parse_group_hex` now tries `keep_core::keys::npub_to_bytes` first when the input starts with `npub1`.

Closes #452. Closes #468. Closes #470.

## Test plan
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test -p keep-cli` — 44 passed, 0 failed.
- [x] Manual: `keep bitcoin address -k k` without `--network` rejects with `the following required arguments were not provided: --network <NETWORK>`.
- [x] Manual: `keep bitcoin address -k k --network mainnet` produces `bc1p...` mainnet addresses; testnet still works with `--network testnet`.
- [x] Manual: `keep wallet propose --group <npub> --recovery 2of3@1mo` without `--network` rejects with the same error.
- [x] Manual: `keep wallet show --group <npub>` succeeds (npub accepted, same code path as hex).