### PR TITLE
cli: add frost delete-share; enumerate hw devices; require restore --target; document subcommands

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -29,29 +29,38 @@ pub(crate) struct Cli {
 
 #[derive(Subcommand)]
 pub(crate) enum Commands {
+    /// Create a new encrypted vault at the given path
     Init {
         #[arg(long, default_value = "100")]
         size: u64,
     },
+    /// Generate a new Nostr keypair and store it in the vault
     Generate {
         #[arg(short, long, default_value = "default")]
         name: String,
     },
+    /// Import an existing Nostr nsec into the vault
     Import {
         #[arg(short, long, default_value = "imported")]
         name: String,
     },
+    /// List keys stored in the vault
     List,
+    /// Print a raw nsec for the named key (prompts for confirmation)
     Export {
         #[arg(short, long)]
         name: String,
     },
+    /// Remove a key from the vault
     Delete {
         #[arg(short, long)]
         name: String,
     },
+    /// Change the vault unlock password
     RotatePassword,
+    /// Rotate the vault data-encryption key (re-encrypts every secret)
     RotateDataKey,
+    /// Start the NIP-46 bunker (and optional FROST network co-signer)
     Serve {
         #[arg(short, long)]
         relay: Option<String>,
@@ -62,47 +71,60 @@ pub(crate) enum Commands {
         #[arg(long)]
         frost_relay: Option<String>,
     },
+    /// Inspect, verify, export, or prune the audit log
     Audit {
         #[command(subcommand)]
         command: AuditCommands,
     },
+    /// FROST threshold-signature operations (generate, sign, network coordination)
     Frost {
         #[command(subcommand)]
         command: FrostCommands,
     },
+    /// Bitcoin address derivation, descriptor management, and PSBT signing
     Bitcoin {
         #[command(subcommand)]
         command: BitcoinCommands,
     },
+    /// AWS Nitro Enclave operations (attest, generate, sign)
     Enclave {
         #[command(subcommand)]
         command: EnclaveCommands,
     },
+    /// Agent integrations (MCP server, etc.)
     Agent {
         #[command(subcommand)]
         command: AgentCommands,
     },
+    /// FROST wallet descriptors, proposals, and PSBT spend coordination
     Wallet {
         #[command(subcommand)]
         command: WalletCommands,
     },
+    /// Inspect or initialize the keep CLI config file
     Config {
         #[command(subcommand)]
         command: ConfigCommands,
     },
+    /// Inspect or apply on-disk schema migrations
     Migrate {
         #[command(subcommand)]
         command: Option<MigrateCommands>,
     },
+    /// Write a passphrase-encrypted backup of the vault to a file
     Backup {
         #[arg(short, long, help = "Output file path")]
         output: Option<PathBuf>,
     },
+    /// Restore a backup file into a NEW vault at --target
     Restore {
         #[arg(help = "Backup file to restore from")]
         file: PathBuf,
-        #[arg(long, help = "Target vault path")]
-        target: Option<PathBuf>,
+        #[arg(
+            long,
+            help = "Target vault path. Required; no default to avoid restoring over the active ~/.keep vault."
+        )]
+        target: PathBuf,
     },
 }
 
@@ -358,6 +380,13 @@ pub(crate) enum FrostCommands {
         format: ExportFormat,
     },
     Import,
+    /// Delete a stored FROST share from the vault (audit-logged)
+    DeleteShare {
+        #[arg(short, long, help = "FROST group npub or hex")]
+        group: String,
+        #[arg(short, long, help = "Share identifier (1-indexed)")]
+        share: u16,
+    },
     Sign {
         #[arg(short, long)]
         message: String,
@@ -510,9 +539,14 @@ pub(crate) enum FrostHardwareCommands {
         #[arg(short, long)]
         device: String,
     },
+    /// Probe attached devices and report which are keep hardware signers
     List {
-        #[arg(short, long)]
-        device: String,
+        #[arg(
+            short,
+            long,
+            help = "Probe a specific device path. If omitted, scan /dev/ttyACM*, /dev/ttyUSB*, /dev/cu.usbmodem*."
+        )]
+        device: Option<String>,
     },
     Import {
         #[arg(short, long)]

--- a/keep-cli/src/commands/frost.rs
+++ b/keep-cli/src/commands/frost.rs
@@ -675,3 +675,49 @@ fn cmd_frost_sign_interactive(
 
     Ok(())
 }
+
+#[tracing::instrument(skip(out), fields(path = %path.display()))]
+pub fn cmd_frost_delete_share(
+    out: &Output,
+    path: &Path,
+    group_id: &str,
+    identifier: u16,
+) -> Result<()> {
+    debug!(group = group_id, identifier, "deleting FROST share");
+
+    let group_pubkey = if group_id.starts_with("npub1") {
+        keep_core::keys::npub_to_bytes(group_id)?
+    } else {
+        let bytes = hex::decode(group_id)
+            .map_err(|e| KeepError::InvalidInput(format!("expected npub or 32-byte hex: {e}")))?;
+        bytes
+            .try_into()
+            .map_err(|_| KeepError::InvalidInput("group pubkey must be 32 bytes".into()))?
+    };
+
+    let mut keep = Keep::open(path)?;
+    let password = get_password("Enter password")?;
+
+    let spinner = out.spinner("Unlocking vault...");
+    keep.unlock(password.expose_secret())?;
+    spinner.finish();
+
+    if !get_confirm(&format!(
+        "Delete FROST share {identifier} for group {}? This cannot be undone.",
+        keep_core::keys::bytes_to_npub(&group_pubkey)
+    ))? {
+        out.info("Cancelled.");
+        return Ok(());
+    }
+
+    let spinner = out.spinner("Deleting share...");
+    keep.frost_delete_share(&group_pubkey, identifier)?;
+    spinner.finish();
+
+    out.newline();
+    out.success(&format!(
+        "Deleted FROST share {identifier} for group {}",
+        keep_core::keys::bytes_to_npub(&group_pubkey)
+    ));
+    Ok(())
+}

--- a/keep-cli/src/commands/frost_hardware.rs
+++ b/keep-cli/src/commands/frost_hardware.rs
@@ -118,9 +118,7 @@ fn enumerate_and_list(out: &Output) -> Result<()> {
                                 }
                             }
                         }
-                        Err(e) => out.info(&format!(
-                            "  Could not list shares on {candidate}: {e}"
-                        )),
+                        Err(e) => out.info(&format!("  Could not list shares on {candidate}: {e}")),
                     }
                 }
                 Err(e) => out.info(&format!("  Not a keep hardware signer: {e}")),

--- a/keep-cli/src/commands/frost_hardware.rs
+++ b/keep-cli/src/commands/frost_hardware.rs
@@ -81,6 +81,14 @@ fn list_one(out: &Output, device: &str) -> Result<()> {
 }
 
 fn enumerate_and_list(out: &Output) -> Result<()> {
+    use std::time::Duration;
+
+    // Short per-probe timeout so a stuck or non-keep serial device fails fast
+    // rather than blocking the entire scan ~30s. The default constructor's 30s
+    // timeout is still used by `cmd_frost_hardware_list` (single-device path)
+    // and by other hardware commands.
+    const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
     out.newline();
     out.header("Hardware Signer Devices");
     out.newline();
@@ -94,20 +102,25 @@ fn enumerate_and_list(out: &Output) -> Result<()> {
     let mut found = 0usize;
     for candidate in &candidates {
         out.field("Probing", candidate);
-        match HardwareSigner::new(candidate) {
+        match HardwareSigner::with_timeout(candidate, PROBE_TIMEOUT) {
             Ok(mut signer) => match signer.ping() {
                 Ok(version) => {
                     found += 1;
                     out.field("  Version", &version);
-                    if let Ok(shares) = signer.list_shares() {
-                        if shares.is_empty() {
-                            out.info("  No shares stored");
-                        } else {
-                            out.info(&format!("  {} share(s):", shares.len()));
-                            for share in shares {
-                                out.field("    Group", &share);
+                    match signer.list_shares() {
+                        Ok(shares) => {
+                            if shares.is_empty() {
+                                out.info("  No shares stored");
+                            } else {
+                                out.info(&format!("  {} share(s):", shares.len()));
+                                for share in shares {
+                                    out.field("    Group", &share);
+                                }
                             }
                         }
+                        Err(e) => out.info(&format!(
+                            "  Could not list shares on {candidate}: {e}"
+                        )),
                     }
                 }
                 Err(e) => out.info(&format!("  Not a keep hardware signer: {e}")),

--- a/keep-cli/src/commands/frost_hardware.rs
+++ b/keep-cli/src/commands/frost_hardware.rs
@@ -40,7 +40,14 @@ pub fn cmd_frost_hardware_ping(out: &Output, device: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn cmd_frost_hardware_list(out: &Output, device: &str) -> Result<()> {
+pub fn cmd_frost_hardware_list(out: &Output, device: Option<&str>) -> Result<()> {
+    match device {
+        Some(d) => list_one(out, d),
+        None => enumerate_and_list(out),
+    }
+}
+
+fn list_one(out: &Output, device: &str) -> Result<()> {
     out.newline();
     out.header("Hardware Signer Shares");
     out.field("Device", device);
@@ -71,6 +78,79 @@ pub fn cmd_frost_hardware_list(out: &Output, device: &str) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn enumerate_and_list(out: &Output) -> Result<()> {
+    out.newline();
+    out.header("Hardware Signer Devices");
+    out.newline();
+
+    let candidates = candidate_serial_devices();
+    if candidates.is_empty() {
+        out.info("No candidate serial devices found (looked for /dev/ttyACM*, /dev/ttyUSB*, /dev/cu.usbmodem*).");
+        return Ok(());
+    }
+
+    let mut found = 0usize;
+    for candidate in &candidates {
+        out.field("Probing", candidate);
+        match HardwareSigner::new(candidate) {
+            Ok(mut signer) => match signer.ping() {
+                Ok(version) => {
+                    found += 1;
+                    out.field("  Version", &version);
+                    if let Ok(shares) = signer.list_shares() {
+                        if shares.is_empty() {
+                            out.info("  No shares stored");
+                        } else {
+                            out.info(&format!("  {} share(s):", shares.len()));
+                            for share in shares {
+                                out.field("    Group", &share);
+                            }
+                        }
+                    }
+                }
+                Err(e) => out.info(&format!("  Not a keep hardware signer: {e}")),
+            },
+            Err(e) => out.info(&format!("  Cannot open: {e}")),
+        }
+    }
+    out.newline();
+    out.info(&format!(
+        "{} keep hardware signer(s) responded out of {} candidate(s).",
+        found,
+        candidates.len()
+    ));
+    Ok(())
+}
+
+fn candidate_serial_devices() -> Vec<String> {
+    let mut out = Vec::new();
+    for pattern in ["/dev/ttyACM", "/dev/ttyUSB", "/dev/cu.usbmodem"] {
+        let dir = std::path::Path::new(pattern)
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("/dev"));
+        let prefix = std::path::Path::new(pattern)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("");
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                let Some(name_str) = name.to_str() else {
+                    continue;
+                };
+                if name_str.starts_with(prefix) {
+                    if let Some(p) = entry.path().to_str() {
+                        out.push(p.to_string());
+                    }
+                }
+            }
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
 }
 
 pub fn cmd_frost_hardware_import(

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -130,10 +130,7 @@ fn run(out: &Output) -> Result<()> {
         Commands::Config { command } => dispatch_config(out, &cfg, command),
         Commands::Migrate { command } => dispatch_migrate(out, &path, command, hidden),
         Commands::Backup { output } => commands::vault::cmd_backup(out, &path, output.as_deref()),
-        Commands::Restore { file, target } => {
-            let target = target.as_deref().unwrap_or(&path);
-            commands::vault::cmd_restore(out, &file, target)
-        }
+        Commands::Restore { file, target } => commands::vault::cmd_restore(out, &file, &target),
     }
 }
 
@@ -206,6 +203,9 @@ fn dispatch_frost(
             format,
         } => commands::frost::cmd_frost_export(out, path, share, &group, format),
         FrostCommands::Import => commands::frost::cmd_frost_import(out, path),
+        FrostCommands::DeleteShare { group, share } => {
+            commands::frost::cmd_frost_delete_share(out, path, &group, share)
+        }
         FrostCommands::Sign {
             message,
             group,
@@ -372,7 +372,7 @@ fn dispatch_frost_hardware(
             commands::frost_hardware::cmd_frost_hardware_ping(out, &device)
         }
         FrostHardwareCommands::List { device } => {
-            commands::frost_hardware::cmd_frost_hardware_list(out, &device)
+            commands::frost_hardware::cmd_frost_hardware_list(out, device.as_deref())
         }
         FrostHardwareCommands::Import {
             device,

--- a/keep-cli/src/signer/hardware.rs
+++ b/keep-cli/src/signer/hardware.rs
@@ -37,8 +37,16 @@ pub struct HardwareSigner {
 
 impl HardwareSigner {
     pub fn new(device: &str) -> Result<Self> {
+        Self::with_timeout(device, Duration::from_secs(30))
+    }
+
+    /// Open a hardware signer with a custom serial read/write timeout.
+    /// Used by the `frost hardware list` enumeration path so unresponsive
+    /// devices fail fast (1-3s) instead of blocking the full ~30s default
+    /// per candidate.
+    pub fn with_timeout(device: &str, timeout: Duration) -> Result<Self> {
         let port = serialport::new(device, 115200)
-            .timeout(Duration::from_secs(30))
+            .timeout(timeout)
             .open()
             .with_context(|| format!("Failed to open serial port: {device}"))?;
 


### PR DESCRIPTION
Four small UX/safety fixes from the #434 sweep.

## #421 `keep frost delete-share`
New CLI command wraps the existing `Keep::frost_delete_share` API. Accepts npub or hex group, requires `--share <id>`, prompts for confirmation (skippable via `KEEP_YES=1`), emits an audit event for the delete.

```
$ keep frost delete-share --group npub1... --share 2
```

## #431 top-level subcommand descriptions
`keep --help` previously showed blank descriptions for every subcommand (e.g. `init`, `generate`, `serve`, `frost`, `wallet`, ...). All 19 top-level `Commands` variants now have a one-line `///` doc comment that clap surfaces in `--help`.

## #448 `restore --target` is now required
Previously `keep restore <backup>` defaulted to `~/.keep`, which is the user's active production vault. Refused via the "Keep already exists" check, but one `--force` change away from disaster. Made `--target` required so the user has to consciously pick a destination.

```
$ keep restore vault.bk
error: the following required arguments were not provided:
  --target <TARGET>
```

## #459 `frost hardware list` enumerates when `--device` is omitted
`list` used to require `--device <DEVICE>`, which defeats the point of listing. Now: with `--device`, probes that one device (old behavior). Without, scans `/dev/ttyACM*`, `/dev/ttyUSB*`, `/dev/cu.usbmodem*` and probes each, reporting which respond as a keep hardware signer.

```
$ keep frost hardware list
Hardware Signer Devices
No candidate serial devices found (looked for /dev/ttyACM*, /dev/ttyUSB*, /dev/cu.usbmodem*).
```

## Changes
- `keep-cli/src/cli.rs`: doc comments on every `Commands` variant; `Restore::target` switched from `Option<PathBuf>` to `PathBuf`; `FrostHardwareCommands::List::device` switched from `String` to `Option<String>` with a help string explaining the scan; new `FrostCommands::DeleteShare { group, share }`.
- `keep-cli/src/main.rs`: dispatch wires up the new `delete-share`; `restore` no longer needs `.as_deref().unwrap_or(&path)`; `hardware list` passes `device.as_deref()`.
- `keep-cli/src/commands/frost.rs`: new `cmd_frost_delete_share` that parses npub-or-hex, unlocks, confirms, deletes, audits.
- `keep-cli/src/commands/frost_hardware.rs`: split `cmd_frost_hardware_list` into `list_one` (existing behavior) and `enumerate_and_list` (new); helper `candidate_serial_devices` scans the three common prefixes.

Closes #421. Closes #431. Closes #448. Closes #459.

## Test plan
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test -p keep-cli` — 44 passed.
- [x] Manual: `keep --help` shows a one-line description for every subcommand.
- [x] Manual: `keep restore vault.bk` rejects with the required-arg error; `keep restore vault.bk --target /tmp/dst` succeeds.
- [x] Manual: `keep frost delete-share --group <npub> --share 2` deletes share 2; `frost list` then shows only shares 1 and 3.
- [x] Manual: `keep frost hardware list` (no flag) prints "No candidate serial devices found (looked for /dev/ttyACM*, /dev/ttyUSB*, /dev/cu.usbmodem*)." on a system with no hw connected; with `--device /dev/ttyACM0` falls back to the single-device probe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to delete FROST shares from the local vault via new CLI command.
  * Improved hardware device discovery—auto-detects connected devices when device selection is omitted.

* **Breaking Changes**
  * The restore command now requires the `--target` flag to be explicitly specified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->