### PR TITLE
cli: refuse duplicate key names; clearer restore + audit verify errors

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -38,11 +38,21 @@ pub(crate) enum Commands {
     Generate {
         #[arg(short, long, default_value = "default")]
         name: String,
+        #[arg(
+            long,
+            help = "Allow generating a second key under an existing name. Default refuses so name-based operations stay unambiguous."
+        )]
+        force: bool,
     },
     /// Import an existing Nostr nsec into the vault
     Import {
         #[arg(short, long, default_value = "imported")]
         name: String,
+        #[arg(
+            long,
+            help = "Allow importing under an existing name. Default refuses so name-based operations stay unambiguous."
+        )]
+        force: bool,
     },
     /// List keys stored in the vault
     List,

--- a/keep-cli/src/commands/audit.rs
+++ b/keep-cli/src/commands/audit.rs
@@ -4,7 +4,7 @@ use chrono::{TimeZone, Utc};
 use secrecy::ExposeSecret;
 
 use keep_core::audit::{AuditEventType, RetentionPolicy};
-use keep_core::error::Result;
+use keep_core::error::{KeepError, Result};
 use keep_core::Keep;
 
 use crate::commands::get_password;
@@ -137,16 +137,35 @@ pub fn cmd_audit_verify(out: &Output, path: &Path, hidden: bool) -> Result<()> {
     let password = get_password("Password")?;
     keep.unlock(password.expose_secret())?;
 
-    let valid = keep.audit_verify_chain()?;
+    let valid = keep.audit_verify_chain().map_err(map_verify_error)?;
 
     if valid {
         out.success("Audit log integrity verified - hash chain is valid");
     } else {
-        out.error("Audit log integrity check FAILED - hash chain is broken");
+        out.error(
+            "Audit log integrity check FAILED: hash chain is broken. The audit log was modified after writing. Do NOT trust this vault for anything authoritative until you investigate.",
+        );
         std::process::exit(1);
     }
 
     Ok(())
+}
+
+/// Rewrap low-level audit-decode errors with a clear tamper-vs-corruption
+/// category instead of leaking parser details that mislead operators.
+fn map_verify_error(e: KeepError) -> KeepError {
+    let detail = e.to_string();
+    if detail.contains("Decryption failed") {
+        KeepError::InvalidInput(format!(
+            "Audit log integrity check FAILED: an entry could not be decrypted with the vault data key. This indicates tampering (entry rewritten or truncated mid-entry) or file corruption, NOT a wrong password. Details: {detail}"
+        ))
+    } else if detail.contains("audit line") || detail.contains("Invalid file format") {
+        KeepError::InvalidInput(format!(
+            "Audit log integrity check FAILED: an entry could not be parsed. This indicates tampering or file corruption. Details: {detail}"
+        ))
+    } else {
+        e
+    }
 }
 
 pub fn cmd_audit_retention(

--- a/keep-cli/src/commands/vault.rs
+++ b/keep-cli/src/commands/vault.rs
@@ -116,15 +116,21 @@ pub fn cmd_init(out: &Output, path: &Path, hidden: bool, size_mb: u64) -> Result
 }
 
 #[tracing::instrument(skip(out), fields(path = %path.display()))]
-pub fn cmd_generate(out: &Output, path: &Path, name: &str, hidden: bool) -> Result<()> {
+pub fn cmd_generate(
+    out: &Output,
+    path: &Path,
+    name: &str,
+    hidden: bool,
+    force: bool,
+) -> Result<()> {
     if hidden {
-        return cmd_generate_hidden(out, path, name);
+        return cmd_generate_hidden(out, path, name, force);
     }
     if is_hidden_vault(path) {
-        return cmd_generate_outer(out, path, name);
+        return cmd_generate_outer(out, path, name, force);
     }
 
-    debug!(name, "generating key");
+    debug!(name, force, "generating key");
 
     let mut keep = Keep::open(path)?;
     let password = get_password("Enter password")?;
@@ -132,6 +138,12 @@ pub fn cmd_generate(out: &Output, path: &Path, name: &str, hidden: bool) -> Resu
     let spinner = out.spinner("Unlocking vault...");
     keep.unlock(password.expose_secret())?;
     spinner.finish();
+
+    if !force && keep.keyring().get_by_name(name).is_some() {
+        return Err(KeepError::InvalidInput(format!(
+            "key with name '{name}' already exists; pick a different --name or pass --force to allow duplicates"
+        )));
+    }
 
     let spinner = out.spinner("Generating key...");
     let pubkey = keep.generate_key(name)?;
@@ -148,12 +160,12 @@ pub fn cmd_generate(out: &Output, path: &Path, name: &str, hidden: bool) -> Resu
     Ok(())
 }
 
-fn cmd_generate_outer(out: &Output, path: &Path, name: &str) -> Result<()> {
+fn cmd_generate_outer(out: &Output, path: &Path, name: &str, force: bool) -> Result<()> {
     use keep_core::crypto;
     use keep_core::hidden::HiddenStorage;
     use keep_core::keys::{KeyRecord, KeyType, NostrKeypair};
 
-    debug!(name, "generating key in outer volume");
+    debug!(name, force, "generating key in outer volume");
 
     let mut storage = HiddenStorage::open(path)?;
     let password = get_password("Enter password")?;
@@ -161,6 +173,12 @@ fn cmd_generate_outer(out: &Output, path: &Path, name: &str) -> Result<()> {
     let spinner = out.spinner("Unlocking vault...");
     storage.unlock_outer(password.expose_secret())?;
     spinner.finish();
+
+    if !force && storage.list_keys()?.iter().any(|k| k.name == name) {
+        return Err(KeepError::InvalidInput(format!(
+            "key with name '{name}' already exists; pick a different --name or pass --force to allow duplicates"
+        )));
+    }
 
     let spinner = out.spinner("Generating key...");
     let keypair = NostrKeypair::generate()?;
@@ -187,12 +205,12 @@ fn cmd_generate_outer(out: &Output, path: &Path, name: &str) -> Result<()> {
     Ok(())
 }
 
-fn cmd_generate_hidden(out: &Output, path: &Path, name: &str) -> Result<()> {
+fn cmd_generate_hidden(out: &Output, path: &Path, name: &str, force: bool) -> Result<()> {
     use keep_core::crypto;
     use keep_core::hidden::HiddenStorage;
     use keep_core::keys::{KeyRecord, KeyType, NostrKeypair};
 
-    debug!(name, "generating key in hidden volume");
+    debug!(name, force, "generating key in hidden volume");
 
     let mut storage = HiddenStorage::open(path)?;
     let password = get_hidden_password("Enter HIDDEN password")?;
@@ -200,6 +218,12 @@ fn cmd_generate_hidden(out: &Output, path: &Path, name: &str) -> Result<()> {
     let spinner = out.spinner("Unlocking hidden volume...");
     storage.unlock_hidden(password.expose_secret())?;
     spinner.finish();
+
+    if !force && storage.list_keys()?.iter().any(|k| k.name == name) {
+        return Err(KeepError::InvalidInput(format!(
+            "key with name '{name}' already exists in hidden volume; pick a different --name or pass --force to allow duplicates"
+        )));
+    }
 
     let spinner = out.spinner("Generating key...");
     let keypair = NostrKeypair::generate()?;
@@ -227,15 +251,15 @@ fn cmd_generate_hidden(out: &Output, path: &Path, name: &str) -> Result<()> {
 }
 
 #[tracing::instrument(skip(out), fields(path = %path.display()))]
-pub fn cmd_import(out: &Output, path: &Path, name: &str, hidden: bool) -> Result<()> {
+pub fn cmd_import(out: &Output, path: &Path, name: &str, hidden: bool, force: bool) -> Result<()> {
     if hidden {
-        return cmd_import_hidden(out, path, name);
+        return cmd_import_hidden(out, path, name, force);
     }
     if is_hidden_vault(path) {
-        return cmd_import_outer(out, path, name);
+        return cmd_import_outer(out, path, name, force);
     }
 
-    debug!(name, "importing key");
+    debug!(name, force, "importing key");
 
     let mut keep = Keep::open(path)?;
     let password = get_password("Enter password")?;
@@ -243,6 +267,12 @@ pub fn cmd_import(out: &Output, path: &Path, name: &str, hidden: bool) -> Result
     let spinner = out.spinner("Unlocking vault...");
     keep.unlock(password.expose_secret())?;
     spinner.finish();
+
+    if !force && keep.keyring().get_by_name(name).is_some() {
+        return Err(KeepError::InvalidInput(format!(
+            "key with name '{name}' already exists; pick a different --name or pass --force to allow duplicates"
+        )));
+    }
 
     let nsec = get_nsec("Enter nsec")?;
 
@@ -261,12 +291,12 @@ pub fn cmd_import(out: &Output, path: &Path, name: &str, hidden: bool) -> Result
     Ok(())
 }
 
-fn cmd_import_outer(out: &Output, path: &Path, name: &str) -> Result<()> {
+fn cmd_import_outer(out: &Output, path: &Path, name: &str, force: bool) -> Result<()> {
     use keep_core::crypto;
     use keep_core::hidden::HiddenStorage;
     use keep_core::keys::{KeyRecord, KeyType, NostrKeypair};
 
-    debug!(name, "importing key to outer volume");
+    debug!(name, force, "importing key to outer volume");
 
     let mut storage = HiddenStorage::open(path)?;
     let password = get_password("Enter password")?;
@@ -274,6 +304,12 @@ fn cmd_import_outer(out: &Output, path: &Path, name: &str) -> Result<()> {
     let spinner = out.spinner("Unlocking vault...");
     storage.unlock_outer(password.expose_secret())?;
     spinner.finish();
+
+    if !force && storage.list_keys()?.iter().any(|k| k.name == name) {
+        return Err(KeepError::InvalidInput(format!(
+            "key with name '{name}' already exists; pick a different --name or pass --force to allow duplicates"
+        )));
+    }
 
     let nsec = get_nsec("Enter nsec")?;
 
@@ -302,12 +338,12 @@ fn cmd_import_outer(out: &Output, path: &Path, name: &str) -> Result<()> {
     Ok(())
 }
 
-fn cmd_import_hidden(out: &Output, path: &Path, name: &str) -> Result<()> {
+fn cmd_import_hidden(out: &Output, path: &Path, name: &str, force: bool) -> Result<()> {
     use keep_core::crypto;
     use keep_core::hidden::HiddenStorage;
     use keep_core::keys::{KeyRecord, KeyType, NostrKeypair};
 
-    debug!(name, "importing key to hidden volume");
+    debug!(name, force, "importing key to hidden volume");
 
     let mut storage = HiddenStorage::open(path)?;
     let password = get_hidden_password("Enter HIDDEN password")?;
@@ -315,6 +351,12 @@ fn cmd_import_hidden(out: &Output, path: &Path, name: &str) -> Result<()> {
     let spinner = out.spinner("Unlocking hidden volume...");
     storage.unlock_hidden(password.expose_secret())?;
     spinner.finish();
+
+    if !force && storage.list_keys()?.iter().any(|k| k.name == name) {
+        return Err(KeepError::InvalidInput(format!(
+            "key with name '{name}' already exists in hidden volume; pick a different --name or pass --force to allow duplicates"
+        )));
+    }
 
     let nsec = get_nsec("Enter nsec")?;
 
@@ -854,6 +896,31 @@ pub fn cmd_backup(out: &Output, path: &Path, output: Option<&Path>) -> Result<()
     Ok(())
 }
 
+/// Rewrap parse-stage errors from `restore_backup` with a user-level headline.
+///
+/// The underlying parser surfaces low-level details like "backup argon2
+/// iterations out of range" when the file is just garbage. That reads like a
+/// keep bug; lead with the actual diagnosis and keep the technical detail as
+/// a "Details:" hint.
+fn map_restore_error(e: KeepError) -> KeepError {
+    let detail = e.to_string();
+    let is_parse_stage = detail.contains("backup file too small")
+        || detail.contains("backup file too large")
+        || detail.contains("invalid backup file magic")
+        || detail.contains("unsupported backup version")
+        || detail.contains("unsupported backup flags")
+        || detail.contains("backup header truncated")
+        || detail.contains("backup argon2")
+        || detail.contains("backup deserialization failed");
+    if is_parse_stage {
+        KeepError::InvalidInput(format!(
+            "backup file appears corrupted or is not a valid keep backup (details: {detail})"
+        ))
+    } else {
+        e
+    }
+}
+
 #[tracing::instrument(skip(out), fields(file = %file.display(), target = %target.display()))]
 pub fn cmd_restore(out: &Output, file: &Path, target: &Path) -> Result<()> {
     debug!("restoring backup");
@@ -889,7 +956,8 @@ pub fn cmd_restore(out: &Output, file: &Path, target: &Path) -> Result<()> {
         backup_passphrase.expose_secret(),
         target,
         vault_password.expose_secret(),
-    )?;
+    )
+    .map_err(map_restore_error)?;
     spinner.finish();
 
     out.newline();

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -96,8 +96,12 @@ fn run(out: &Output) -> Result<()> {
 
     match cli.command {
         Commands::Init { size } => commands::vault::cmd_init(out, &path, hidden, size),
-        Commands::Generate { name } => commands::vault::cmd_generate(out, &path, &name, hidden),
-        Commands::Import { name } => commands::vault::cmd_import(out, &path, &name, hidden),
+        Commands::Generate { name, force } => {
+            commands::vault::cmd_generate(out, &path, &name, hidden, force)
+        }
+        Commands::Import { name, force } => {
+            commands::vault::cmd_import(out, &path, &name, hidden, force)
+        }
         Commands::List => commands::vault::cmd_list(out, &path, hidden),
         Commands::Export { name } => commands::vault::cmd_export(out, &path, &name, hidden),
         Commands::Delete { name } => commands::vault::cmd_delete(out, &path, &name, hidden),


### PR DESCRIPTION
Three small error-clarity / safety fixes from the #434 sweep.

## #481 Duplicate key names allowed
Before: `keep generate -n main` + `keep generate -n main` both succeeded, leaving two distinct keys with the same name. Subsequent name-based ops (`export`, `delete`, `sign`) targeted one of them at random.

After: `cmd_generate` and `cmd_import` refuse when a key with the same name already exists, with a clear error pointing at `--name` or `--force`. New `--force` flag preserves the old behavior for users who explicitly want duplicates. Same guard applied to `cmd_generate_outer`/`cmd_generate_hidden`/`cmd_import_outer`/`cmd_import_hidden` (HiddenStorage paths).

```
$ keep generate -n main
✓ Generated new key!
$ keep generate -n main
✗ Invalid input: key with name 'main' already exists; pick a different --name or pass --force to allow duplicates
$ keep generate -n main --force
✓ Generated new key!     (duplicate, audit-logged)
```

Closes #481.

## #472 Restore errors leak internal format details
Before: a single-byte-flip in a backup file produced `Invalid input: backup argon2 iterations out of range: 2634350596 (min 2, max 64)`. Reads as a keep bug or "wrong argon2", not "this file is junk".

After: `cmd_restore` wraps the underlying `restore_backup` error through a small `map_restore_error` helper that detects parse-stage failures and surfaces the user-level diagnosis with technical detail as a hint:

```
✗ Invalid input: backup file appears corrupted or is not a valid keep backup (details: backup argon2 iterations out of range: 2634350596 (min 2, max 64))
```

Decrypt-stage failures (wrong passphrase) and storage-stage failures (target exists, etc.) pass through unchanged.

Closes #472.

## #450 audit verify error messages mislabel tampering
Before: tampering on the audit log produced `Decryption failed - wrong password or corrupted data` (truncation) or `Invalid file format` (byte flip). Both lead operators down wrong remediation paths (try other passwords / restore from backup).

After: `cmd_audit_verify` rewraps the underlying error through `map_verify_error` that categorizes the failure and prints an explicit tamper message instead. The "wrong password" wording is gone because the audit log is keyed off the data key, not the user password.

```
✗ Invalid input: Audit log integrity check FAILED: an entry could not be decrypted with the vault data key. This indicates tampering (entry rewritten or truncated mid-entry) or file corruption, NOT a wrong password. Details: ...
```

The all-good chain-broken-at-boundary case (`hash chain is broken`) now also says "Do NOT trust this vault for anything authoritative until you investigate."

Closes #450.

## Changes
- `keep-cli/src/cli.rs`: `Generate { name, force }`, `Import { name, force }` add the `--force` flag.
- `keep-cli/src/main.rs`: dispatch wires `force` through.
- `keep-cli/src/commands/vault.rs`: 6 functions take a `force` parameter; new `map_restore_error` helper.
- `keep-cli/src/commands/audit.rs`: new `map_verify_error` helper; verify output now explicit about consequences.

## Test plan
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test -p keep-cli` — 44 passed.
- [x] Manual: second `keep generate -n main` rejects with the new message; `--force` overrides.
- [x] Manual: byte-flip on backup file → `backup file appears corrupted or is not a valid keep backup (details: ...)`.
- [x] Manual: byte-flip on audit.log → "tampering (entry rewritten or truncated mid-entry) or file corruption, NOT a wrong password."