### PR TITLE
cli: case-insensitive timelock parser; structured npub errors; bitcoin analyze fee warnings

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -270,7 +270,7 @@ pub(crate) enum WalletCommands {
         share: Option<u16>,
         #[arg(
             long,
-            help = "Recovery tier, e.g. '2of3@6mo' (threshold-of-keys@timelock). Repeat for multiple tiers.",
+            help = "Recovery tier, e.g. '2of3@6mo' (threshold-of-keys@timelock). Timelock units: mo/month/months or y/year/years; case-insensitive. Repeat for multiple tiers.",
             required = true
         )]
         recovery: Vec<String>,

--- a/keep-cli/src/commands/bitcoin.rs
+++ b/keep-cli/src/commands/bitcoin.rs
@@ -202,6 +202,34 @@ pub fn cmd_bitcoin_analyze(out: &Output, psbt_path: &str, network: &str) -> Resu
         &format!("{} sats", analysis.total_output_sats),
     );
     out.field("Fee", &format!("{} sats", analysis.fee_sats));
+
+    // Loud abnormal-fee warning. A bogus PSBT with garbage witness_utxo values
+    // produces a giant fee that the user might miss; surface it explicitly.
+    if analysis.total_input_sats > 0 {
+        let ratio = analysis.fee_sats as f64 / analysis.total_input_sats as f64;
+        let pct = ratio * 100.0;
+        if ratio >= 0.5 {
+            out.warn(&format!(
+                "ABNORMAL FEE: {:.1}% of total input ({} sats fee / {} sats input). Possible fee-burn attack or malformed PSBT; REVIEW CAREFULLY before signing.",
+                pct, analysis.fee_sats, analysis.total_input_sats,
+            ));
+        } else if ratio >= 0.1 {
+            out.warn(&format!(
+                "HIGH FEE: {:.1}% of total input ({} sats fee / {} sats input). Review before signing.",
+                pct, analysis.fee_sats, analysis.total_input_sats,
+            ));
+        } else if ratio >= 0.01 {
+            out.warn(&format!(
+                "Elevated fee: {:.2}% of total input ({} sats fee).",
+                pct, analysis.fee_sats,
+            ));
+        }
+    } else if analysis.fee_sats > 100_000 {
+        out.warn(&format!(
+            "Large fee {} sats with no input amount data; cannot compute fee ratio.",
+            analysis.fee_sats,
+        ));
+    }
     out.newline();
 
     out.info("Outputs:");

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -631,7 +631,63 @@ pub fn cmd_wallet_delete(out: &Output, path: &Path, group_hex: &str) -> Result<(
 }
 
 const BLOCKS_PER_MONTH: u32 = 144 * 30;
+const BLOCKS_PER_YEAR: u32 = BLOCKS_PER_MONTH * 12;
 const MAX_CSV_BLOCKS: u32 = 0xFFFF;
+
+/// Parse a timelock expression and return the count in **months** (the unit
+/// the FROST descriptor protocol uses, see `keep_frost_net::PolicyTier`).
+///
+/// Accepts `Nmo`, `Nmonth`, `Nmonths`, `Ny`, `Nyear`, `Nyears` (case-insensitive).
+/// Sub-month units (days, weeks) are deliberately not accepted because the
+/// stored protocol unit is months and we want to refuse, not round silently.
+fn parse_timelock_to_months(spec: &str) -> Result<u32> {
+    let normalized = spec.trim().to_ascii_lowercase();
+    let (n_str, multiplier) = if let Some(n) = normalized
+        .strip_suffix("months")
+        .or_else(|| normalized.strip_suffix("month"))
+        .or_else(|| normalized.strip_suffix("mo"))
+    {
+        (n, 1u32)
+    } else if let Some(n) = normalized
+        .strip_suffix("years")
+        .or_else(|| normalized.strip_suffix("year"))
+        .or_else(|| normalized.strip_suffix('y'))
+    {
+        (n, 12u32)
+    } else {
+        return Err(KeepError::InvalidInput(
+            "Invalid timelock, use e.g. '6mo', '6months', '1y', '1year' (case-insensitive). Sub-month units are not supported by the descriptor protocol.".into(),
+        ));
+    };
+    let n: u32 = n_str
+        .trim()
+        .parse()
+        .map_err(|_| KeepError::InvalidInput(format!("Invalid timelock count: '{n_str}'")))?;
+    if n == 0 {
+        return Err(KeepError::InvalidInput(
+            "Timelock must be at least 1 month".into(),
+        ));
+    }
+    let months = n
+        .checked_mul(multiplier)
+        .ok_or_else(|| KeepError::InvalidInput(format!("Timelock '{spec}' overflows")))?;
+    let blocks = months.checked_mul(BLOCKS_PER_MONTH).ok_or_else(|| {
+        KeepError::InvalidInput(format!("Timelock '{spec}' overflows block count"))
+    })?;
+    if blocks > MAX_CSV_BLOCKS {
+        return Err(KeepError::InvalidInput(format!(
+            "Timelock '{spec}' ({blocks} blocks) exceeds Bitcoin CSV maximum ({MAX_CSV_BLOCKS} blocks, ~{} months)",
+            MAX_CSV_BLOCKS / BLOCKS_PER_MONTH
+        )));
+    }
+    Ok(months)
+}
+
+#[allow(dead_code)]
+const _: () = {
+    // Compile-time sanity check.
+    assert!(BLOCKS_PER_YEAR == BLOCKS_PER_MONTH * 12);
+};
 
 fn parse_recovery_tier(spec: &str, total_shares: u16) -> Result<keep_frost_net::PolicyTier> {
     let parts: Vec<&str> = spec.split('@').collect();
@@ -746,30 +802,7 @@ fn parse_recovery_tier(spec: &str, total_shares: u16) -> Result<keep_frost_net::
         )));
     }
 
-    let timelock_months: u32 = timelock_part
-        .trim_end_matches("mo")
-        .parse()
-        .map_err(|_| KeepError::InvalidInput("Invalid timelock, use e.g. '6mo'".into()))?;
-
-    if timelock_months == 0 {
-        return Err(KeepError::InvalidInput(
-            "Timelock must be at least 1 month".into(),
-        ));
-    }
-
-    let timelock_blocks = timelock_months
-        .checked_mul(BLOCKS_PER_MONTH)
-        .ok_or_else(|| {
-            KeepError::InvalidInput(format!(
-                "Timelock {timelock_months} months overflows block count"
-            ))
-        })?;
-    if timelock_blocks > MAX_CSV_BLOCKS {
-        return Err(KeepError::InvalidInput(format!(
-            "Timelock {timelock_months} months ({timelock_blocks} blocks) exceeds Bitcoin CSV maximum ({MAX_CSV_BLOCKS} blocks, ~{} months)",
-            MAX_CSV_BLOCKS / BLOCKS_PER_MONTH
-        )));
-    }
+    let timelock_months = parse_timelock_to_months(timelock_part)?;
 
     let key_slots: Vec<keep_frost_net::KeySlot> = explicit_slots.unwrap_or_else(|| {
         (1..=key_count)

--- a/keep-core/src/error.rs
+++ b/keep-core/src/error.rs
@@ -490,8 +490,8 @@ pub enum KeepError {
     InvalidMnemonic(String),
     #[error("Invalid nsec format")]
     InvalidNsec,
-    #[error("Invalid npub format")]
-    InvalidNpub,
+    #[error("Invalid npub: {0}")]
+    InvalidNpub(String),
     #[error("Keyring full (max {0} keys)")]
     KeyringFull(usize),
     #[error("Keep is locked")]

--- a/keep-core/src/keys.rs
+++ b/keep-core/src/keys.rs
@@ -234,14 +234,24 @@ impl KeyRecord {
 ///
 /// Returns [`KeepError::InvalidNpub`] if the string is not a valid npub.
 pub fn npub_to_bytes(npub: &str) -> Result<[u8; 32]> {
-    let (hrp, data) = bech32::decode(npub).map_err(|_| KeepError::InvalidNpub)?;
+    let (hrp, data) = bech32::decode(npub).map_err(|e| {
+        KeepError::InvalidNpub(format!(
+            "not valid bech32 ({e}); expected an npub of the form 'npub1...' (63 chars)"
+        ))
+    })?;
 
     if hrp.as_str() != "npub" {
-        return Err(KeepError::InvalidNpub);
+        return Err(KeepError::InvalidNpub(format!(
+            "wrong prefix '{}' (expected 'npub'). Did you paste an nsec or another bech32 entity?",
+            hrp.as_str()
+        )));
     }
 
     if data.len() != 32 {
-        return Err(KeepError::InvalidNpub);
+        return Err(KeepError::InvalidNpub(format!(
+            "decoded payload is {} bytes (expected 32). The npub is bech32-valid but wrong length.",
+            data.len()
+        )));
     }
 
     let mut pubkey = [0u8; 32];

--- a/keep-desktop/src/app/util.rs
+++ b/keep-desktop/src/app/util.rs
@@ -66,7 +66,7 @@ pub(crate) fn friendly_err(e: keep_core::error::KeepError) -> String {
         KeepError::NotFound(_) => "Vault not found".into(),
         KeepError::InvalidInput(msg) => format!("Invalid input: {msg}"),
         KeepError::InvalidNsec => "Invalid secret key format".into(),
-        KeepError::InvalidNpub => "Invalid public key format".into(),
+        KeepError::InvalidNpub(detail) => format!("Invalid public key: {detail}"),
         KeepError::KeyAlreadyExists(_) => "A key with this name already exists".into(),
         KeepError::KeyNotFound(_) => "Key not found".into(),
         KeepError::KeyringFull(_) => "Keyring is full".into(),

--- a/keep-nip46/src/error.rs
+++ b/keep-nip46/src/error.rs
@@ -11,7 +11,7 @@ pub(crate) fn sanitize_error_for_client(e: &KeepError) -> &'static str {
         KeepError::DecryptionFailed | KeepError::RotationFailed(_) => "Operation failed",
         KeepError::KeyNotFound(_) => "Key not found",
         KeepError::KeyAlreadyExists(_) => "Key already exists",
-        KeepError::InvalidNsec | KeepError::InvalidNpub => "Invalid key format",
+        KeepError::InvalidNsec | KeepError::InvalidNpub(_) => "Invalid key format",
         KeepError::KeyringFull(_) => "Storage limit reached",
         KeepError::Locked => "Signer locked",
         KeepError::AlreadyExists(_) | KeepError::NotFound(_) => "Resource error",


### PR DESCRIPTION
Three small parsing/UX fixes from the #434 sweep.

## #427 Timelock parser only accepts `Nmo` and is case-sensitive
Before: `keep wallet propose --recovery 2of3@6Mo` (capital M) failed silently with "Invalid timelock"; `--recovery 2of3@1year` likewise; `--recovery 2of3@6months` likewise. Only the exact form `Nmo` worked.

After: new `parse_timelock_to_months` helper accepts:
- `Nmo`, `Nmonth`, `Nmonths` (months)
- `Ny`, `Nyear`, `Nyears` (years, converted to months)

Case-insensitive throughout. Sub-month units (days, weeks) are NOT accepted because the descriptor protocol stores months (`PolicyTier.timelock_months`); accepting them would silently round and produce a different on-chain script than the user expressed. Error message advises the supported forms.

```
$ keep wallet propose ... --recovery 2of3@6Months
ok (parses as 6 months)

$ keep wallet propose ... --recovery 2of3@1Y
ok (parses as 12 months)

$ keep wallet propose ... --recovery 2of3@2w
✗ Invalid input: Invalid timelock, use e.g. '6mo', '6months', '1y', '1year' (case-insensitive). Sub-month units are not supported by the descriptor protocol.
```

Closes #427.

## #430 Well-formed but unknown npub indistinguishable from malformed
Before: every failure mode of `npub_to_bytes` returned the same `KeepError::InvalidNpub` with the same `"Invalid npub format"` message. An operator who pasted an `nsec1...`, an `nprofile1...`, or a truncated `npub1...` got the same one-liner with no clue what was wrong.

After: `InvalidNpub` carries a String payload with the specific failure reason:
- Bech32 decode failure: `"not valid bech32 (<reason>); expected an npub of the form 'npub1...' (63 chars)"`.
- Wrong prefix: `"wrong prefix 'nsec' (expected 'npub'). Did you paste an nsec or another bech32 entity?"`.
- Wrong length: `"decoded payload is N bytes (expected 32). The npub is bech32-valid but wrong length."`.

Pattern-match sites in `keep-desktop` and `keep-nip46` updated to the new variant.

Closes #430.

## #464 `bitcoin analyze` does not flag abnormally high fees
Before: a malformed PSBT with bogus `witness_utxo` amounts produced a ~2.4 BTC fee in the analyze output with no warning. A reviewer scanning the output could miss it.

After: after the fee line, `cmd_bitcoin_analyze` computes `fee / total_input` and prints:
- `fee/input >= 50%`: red `ABNORMAL FEE: ... Possible fee-burn attack or malformed PSBT; REVIEW CAREFULLY before signing.`
- `fee/input >= 10%`: `HIGH FEE: ... Review before signing.`
- `fee/input >= 1%`: `Elevated fee: ...`.
- `total_input == 0`: if fee > 100k sats, note that ratio cannot be computed.

Closes #464.

## Changes
- `keep-cli/src/commands/wallet.rs`: new `parse_timelock_to_months` helper; existing inline parser replaced; `BLOCKS_PER_YEAR` constant added.
- `keep-cli/src/cli.rs`: `--recovery` help text mentions the new units.
- `keep-core/src/error.rs`: `InvalidNpub` → `InvalidNpub(String)`.
- `keep-core/src/keys.rs`: `npub_to_bytes` emits specific reason per failure mode.
- `keep-desktop/src/app/util.rs` and `keep-nip46/src/error.rs`: pattern match updated.
- `keep-cli/src/commands/bitcoin.rs`: fee-ratio warning ladder in `cmd_bitcoin_analyze`.

## Test plan
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test -p keep-cli -p keep-core -p keep-nip46 --lib` — 313 passed.
- [x] Existing `parse_recovery_tier` tests in `wallet.rs` still pass (they use `2of3@6mo` form).
- [x] Manual: `keep --help` shows the broader timelock units in the `--recovery` help.
- [x] Manual: bogus PSBT shows the ABNORMAL FEE banner with computed percentage.