### PR TITLE
security: 0o600 vault file perms; gate enclave --local mock; clearer rate-limit message

### DIFF
--- a/keep-cli/src/commands/enclave.rs
+++ b/keep-cli/src/commands/enclave.rs
@@ -14,11 +14,28 @@ use crate::output::Output;
 
 use super::get_password;
 
+/// Gate the mock-enclave path behind a loud, deliberate env var so it cannot
+/// be invoked accidentally in scripts that meant to talk to a real Nitro
+/// Enclave. The mock produces fake attestations and signatures that pass
+/// the local CLI smoke test, but a downstream caller that scrapes the output
+/// has no way to tell the difference from a real signature.
+fn check_local_gate() -> Result<()> {
+    if std::env::var("KEEP_ENCLAVE_MOCK").as_deref() == Ok("1") {
+        Ok(())
+    } else {
+        Err(KeepError::InvalidInput(
+            "--local uses an in-process MOCK enclave that produces fake attestations and signatures (NOT cryptographically verifiable). Set KEEP_ENCLAVE_MOCK=1 to confirm you intend to run the mock path; never set this in production."
+                .into(),
+        ))
+    }
+}
+
 pub fn cmd_enclave_status(out: &Output, cid: u32, local: bool) -> Result<()> {
     out.newline();
     out.header("Enclave Status");
 
     if local {
+        check_local_gate()?;
         out.field("Mode", "Local (Mock)");
         let client = keep_enclave_host::MockEnclaveClient::new();
         let mut nonce = [0u8; 32];
@@ -77,6 +94,7 @@ pub fn cmd_enclave_verify(
     out.header("Enclave Attestation Verification");
 
     if local {
+        check_local_gate()?;
         out.field("Mode", "Local (Mock)");
         let client = keep_enclave_host::MockEnclaveClient::new();
         let mut nonce = [0u8; 32];
@@ -158,6 +176,7 @@ pub fn cmd_enclave_generate_key(out: &Output, name: &str, cid: u32, local: bool)
     out.header("Generate Key in Enclave");
 
     if local {
+        check_local_gate()?;
         out.field("Mode", "Local (Mock)");
         let client = keep_enclave_host::MockEnclaveClient::new();
 
@@ -240,6 +259,7 @@ pub fn cmd_enclave_sign(
         hex::decode(message).map_err(|_| KeepError::InvalidInput("invalid message hex".into()))?;
 
     if local {
+        check_local_gate()?;
         out.field("Mode", "Local (Mock)");
         let client = keep_enclave_host::MockEnclaveClient::new();
 
@@ -349,6 +369,7 @@ pub fn cmd_enclave_import_key(
     };
 
     if local {
+        check_local_gate()?;
         out.field("Mode", "Local (Mock)");
         let client = keep_enclave_host::MockEnclaveClient::new();
 

--- a/keep-core/src/error.rs
+++ b/keep-core/src/error.rs
@@ -478,7 +478,7 @@ impl NetworkError {
 pub enum KeepError {
     #[error("Invalid password")]
     InvalidPassword,
-    #[error("Rate limited: try again in {0} seconds")]
+    #[error("Rate limited after repeated unlock failures; try again in {0}s. Exponential backoff is active (1s, 2s, 4s, ..., capped at 300s).")]
     RateLimited(u64),
     #[error("Decryption failed - wrong password or corrupted data")]
     DecryptionFailed,

--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -184,8 +184,27 @@ impl HiddenStorage {
             };
 
         fs::create_dir_all(path)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o700));
+        }
         let vault_path = path.join("keep.vault");
-        let mut file = File::create(&vault_path)?;
+        let mut file = {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .mode(0o600)
+                    .open(&vault_path)?
+            }
+            #[cfg(not(unix))]
+            {
+                File::create(&vault_path)?
+            }
+        };
 
         file.write_all(&outer_header.to_bytes())?;
 
@@ -203,6 +222,11 @@ impl HiddenStorage {
 
         let db_path = path.join("keep.db");
         let db = Database::create(&db_path)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(&db_path, fs::Permissions::from_mode(0o600));
+        }
 
         let wtxn = db.begin_write()?;
         let _ = wtxn.open_table(KEYS_TABLE)?;

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -223,11 +223,43 @@ fn create_storage_dir(path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Write a vault data file with 0o600 perms on Unix. Defense-in-depth: even
+/// if the containing 0o700 directory is ever loosened (umask, restore-from-tar,
+/// rsync to a less-strict filesystem), the file itself stays owner-readable.
+fn write_vault_file_secure(path: &Path, data: &[u8]) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        std::io::Write::write_all(&mut file, data)?;
+        file.sync_all()?;
+    }
+    #[cfg(not(unix))]
+    fs::write(path, data)?;
+    Ok(())
+}
+
+/// Apply 0o600 perms to an existing file (best-effort). Used to bring
+/// pre-existing redb-created files in line with the rest of the vault.
+#[cfg(unix)]
+fn chmod_secure(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+}
+
 impl Storage {
     /// Create new storage with the given password.
     pub fn create(path: &Path, password: &str, params: Argon2Params) -> Result<Self> {
         create_storage_dir(path)?;
-        let backend = RedbBackend::create(&path.join("keep.db"))?;
+        let db_path = path.join("keep.db");
+        let backend = RedbBackend::create(&db_path)?;
+        #[cfg(unix)]
+        let _ = chmod_secure(&db_path);
         Self::create_inner(path, password, params, Box::new(backend))
     }
 
@@ -262,7 +294,7 @@ impl Storage {
             .encrypted_data_key
             .copy_from_slice(&encrypted.ciphertext);
 
-        fs::write(path.join("keep.hdr"), header.to_bytes())?;
+        write_vault_file_secure(&path.join("keep.hdr"), &header.to_bytes())?;
 
         backend.create_table(KEYS_TABLE)?;
         backend.create_table(SHARES_TABLE)?;


### PR DESCRIPTION
Three small security-defaults fixes from the #434 sweep.

## #474 Vault data files written with 0o664 instead of 0o600
Before: `keep.db`, `keep.hdr`, and `keep.vault` were created with the process's default umask (commonly 0o664), so the files themselves were group/other-readable. The containing dir is 0o700 today, so under normal circumstances nothing leaked, but any change that loosens the directory (umask, restore-from-tar without preserving perms, rsync to a less-strict filesystem, scp default) would have made every byte of the encrypted vault world-readable.

After: defense-in-depth. Every keep-managed vault file is written with 0o600 on Unix at create time.

- `keep-core/src/storage.rs`: new `write_vault_file_secure` helper (`OpenOptions::mode(0o600).create.truncate.open`) replaces the bare `fs::write` for `keep.hdr`; a `chmod_secure` post-`RedbBackend::create` brings `keep.db` to 0o600.
- `keep-core/src/hidden/volume.rs`: `keep.vault` created via `OpenOptions::mode(0o600).create_new`; the redb `keep.db` chmoded to 0o600 right after `Database::create`; the directory itself explicitly chmod 0o700 on the hidden-init path (was inheriting umask).

Closes #474.

## #460 enclave --local mock is in release builds with no gate
Before: `keep enclave verify --local`, `keep enclave sign --local`, etc. were callable directly. They produce fake attestations and signatures that pass the CLI smoke test but mean nothing cryptographically. A higher-layer caller (script, dashboard) scraping the output has no way to distinguish a real signature from a mock.

After: every `--local` path now calls a `check_local_gate` helper. It refuses with a loud error unless `KEEP_ENCLAVE_MOCK=1` is set in the environment:
```
$ keep enclave sign --local -k mock-key -m deadbeef
✗ Invalid input: --local uses an in-process MOCK enclave that produces fake attestations and signatures (NOT cryptographically verifiable). Set KEEP_ENCLAVE_MOCK=1 to confirm you intend to run the mock path; never set this in production.

$ KEEP_ENCLAVE_MOCK=1 keep enclave sign --local -k mock-key -m deadbeef
✓ Signature generated in mock enclave!
```

- `keep-cli/src/commands/enclave.rs`: `check_local_gate()` helper called at the top of all 5 `if local { .. }` branches.

Closes #460.

## #466 Unlock rate limiter messaging
The original report flagged "short cooldown, misleading message, no audit trail". On inspection the rate limiter already has exponential backoff (`BASE_DELAY_SECS = 1`, `MAX_DELAY_SECS = 300`, doubling per excess attempt up to a 1 << 8 cap), so the "short cooldown" part doesn't hold. The misleading message is the actionable piece here.

- `keep-core/src/error.rs`: `RateLimited(u64)` `Display` impl now reads:
  ```
  Rate limited after repeated unlock failures; try again in Ns. Exponential backoff is active (1s, 2s, 4s, ..., capped at 300s).
  ```
  instead of the old `Rate limited: try again in 1 seconds` (which also had a singular/plural bug).

The "audit trail on trip" piece needs Storage→audit-log plumbing because `record_failure` runs before the data key is decrypted. I'll file a follow-up issue for it. Follow-up filed: #495 ("Emit RateLimitTripped audit event on next successful unlock"). Closing #466 with this PR; #495 tracks the audit-event work.

Closes #466.

## Test plan
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --lib` — 679 tests pass workspace-wide (rate_limit suite included).
- [x] Manual: `ls -la <new vault dir>` shows `keep.db`, `keep.hdr` with `-rw-------` (0o600); `keep.vault` on hidden vault likewise.
- [x] Manual: `keep enclave sign --local ...` (no env var) refuses; `KEEP_ENCLAVE_MOCK=1 keep enclave sign --local ...` proceeds (same as before).
- [x] Manual: trip rate limit with 5+ wrong passwords; new message reads cleanly.