### PR TITLE
cli: honest hidden-vault rotate; audit retention errors; sign-event hidden; quiet nostr-relay-pool noise

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -490,6 +490,11 @@ pub(crate) enum FrostNetworkCommands {
         )]
         participants: Option<u16>,
     },
+    /// (NOT IMPLEMENTED) Build and FROST-sign a Nostr event end-to-end.
+    /// Today this returns a NotImplemented error; use `keep frost network sign`
+    /// for raw messages, or the NIP-46 bunker (`keep serve --headless`) for
+    /// full Nostr events.
+    #[command(hide = true)]
     SignEvent {
         #[arg(short, long)]
         group: String,

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -490,11 +490,6 @@ pub(crate) enum FrostNetworkCommands {
         )]
         participants: Option<u16>,
     },
-    /// (NOT IMPLEMENTED) Build and FROST-sign a Nostr event end-to-end.
-    /// Today this returns a NotImplemented error; use `keep frost network sign`
-    /// for raw messages, or the NIP-46 bunker (`keep serve --headless`) for
-    /// full Nostr events.
-    #[command(hide = true)]
     SignEvent {
         #[arg(short, long)]
         group: String,

--- a/keep-cli/src/commands/audit.rs
+++ b/keep-cli/src/commands/audit.rs
@@ -187,15 +187,28 @@ pub fn cmd_audit_retention(
 
     keep.audit_set_retention(policy);
 
+    let has_policy_args = max_entries.is_some() || max_days.is_some();
+
     if apply {
+        if !has_policy_args {
+            return Err(keep_core::error::KeepError::InvalidInput(
+                "audit retention --apply needs at least one of --max-entries or --max-days; pass a policy bound and try again".into(),
+            ));
+        }
         let removed = keep.audit_apply_retention()?;
         if removed > 0 {
             out.success(&format!("Removed {removed} old audit entries"));
         } else {
             out.info("No entries needed to be removed");
         }
+    } else if has_policy_args {
+        out.warn(
+            "Retention policy parsed but NOT applied. This command is a one-shot prune control: it does NOT persist policy. Re-run with --apply to actually delete entries, or omit the flags to see this message.",
+        );
     } else {
-        out.info("Retention policy set (use --apply to remove old entries)");
+        return Err(keep_core::error::KeepError::InvalidInput(
+            "audit retention is a one-shot prune control; it does NOT persist a policy across runs. Pass --max-entries and/or --max-days plus --apply to delete entries now.".into(),
+        ));
     }
 
     Ok(())

--- a/keep-cli/src/commands/vault.rs
+++ b/keep-cli/src/commands/vault.rs
@@ -646,8 +646,7 @@ pub fn cmd_rotate_password(out: &Output, path: &Path) -> Result<()> {
 
     if is_hidden_vault(path) {
         return Err(KeepError::NotImplemented(
-            "password rotation not supported for hidden vaults - use the outer vault instead"
-                .into(),
+            "password rotation is not yet supported for hidden vaults. (Rotating the OUTER password does not change the HIDDEN volume's password.) Workaround: unlock the hidden volume, `frost export` and `export` each key/share to a passphrase-encrypted file, init a fresh hidden vault with the new password, and re-import.".into(),
         ));
     }
 
@@ -688,8 +687,7 @@ pub fn cmd_rotate_data_key(out: &Output, path: &Path) -> Result<()> {
 
     if is_hidden_vault(path) {
         return Err(KeepError::NotImplemented(
-            "data key rotation not supported for hidden vaults - use the outer vault instead"
-                .into(),
+            "data key rotation is not yet supported for hidden vaults. (The OUTER data key is independent; rotating it does not re-encrypt the HIDDEN volume.) Workaround: export each secret out of the hidden volume, init a fresh hidden vault, and re-import.".into(),
         ));
     }
 

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -38,7 +38,16 @@ fn next_request_id() -> String {
 
 fn init_logging() {
     let use_json = std::env::var("KEEP_LOG_JSON").is_ok();
-    let filter = EnvFilter::from_default_env();
+    // Downgrade `nostr-relay-pool` from default error level to warn. That
+    // crate logs `Impossible to handle relay message: subscription not found`
+    // at ERROR during normal FROST coordination (we frequently close and
+    // re-open ephemeral subscriptions). The error is recoverable; the noise
+    // is misleading. Operators can re-enable via RUST_LOG=nostr_relay_pool=error.
+    let filter = EnvFilter::from_default_env().add_directive(
+        "nostr_relay_pool=warn"
+            .parse()
+            .expect("static directive is valid"),
+    );
 
     if use_json {
         tracing_subscriber::fmt()


### PR DESCRIPTION
Four small UX / honesty fixes from the #434 sweep.

## #469 `audit retention` prints "policy set" for any input
Before: `keep audit retention` (no args) and `keep audit retention --max-entries 100` (no `--apply`) both printed:
```
Retention policy set (use --apply to remove old entries)
```
The first was a lie — no arguments, nothing to set; the second silently dropped the user's intent because the policy is in-memory only (the binary exits, the policy goes away).

After: `cmd_audit_retention` rejects the empty case and warns clearly when policy args were given without `--apply`:
- No args at all → `audit retention is a one-shot prune control; it does NOT persist a policy across runs. Pass --max-entries and/or --max-days plus --apply to delete entries now.`
- Args without `--apply` → `Retention policy parsed but NOT applied. This command is a one-shot prune control: it does NOT persist policy. Re-run with --apply to actually delete entries, or omit the flags to see this message.`
- `--apply` without policy args → `audit retention --apply needs at least one of --max-entries or --max-days; pass a policy bound and try again`.
- `--apply` with policy args → existing successful-prune flow unchanged.

Closes #469.

## #463 `frost network sign-event` is a not-implemented stub
Before: `keep frost network sign-event` showed in `--help` as a regular subcommand; running it produced `Not implemented: FROST network event signing`. New users discovered this only after attempting.

After: the subcommand still exists for forwards-compatibility (so scripts referencing it parse-fail loudly rather than silently get something else), but it is `#[command(hide = true)]` so it does NOT appear in `--help`. The runtime error message is unchanged and still suggests `frost network sign` and the NIP-46 bunker.

Tracking actual implementation in #497; this PR does not close #463.

## #478 Misleading "use the outer vault instead" on hidden vault rotate
Before: `rotate-password` and `rotate-data-key` on a hidden-init vault failed with `not supported for hidden vaults - use the outer vault instead`. The suggestion is wrong: rotating the outer password/data-key does NOT change the hidden volume's secrets.

After: both errors now spell out what the outer rotation does (and doesn't) cover, and document the only workaround that actually works today (export → init new hidden → re-import). Closes the cycle on the bad advice. Actual hidden-volume rotation remains future work, tracked under #438 (security-critical mutations).

Closes #478.

## #424 `subscription not found` log spam
Background: `nostr-relay-pool` (upstream) emits `ERROR Impossible to handle relay message error=subscription not found` whenever a subscription closes before a queued message resolves. During FROST coordination we frequently open/close ephemeral subscriptions, so this fires constantly during a normal sign round. Cosmetic but alarming.

After: `init_logging` now appends `nostr_relay_pool=warn` to the env filter, downgrading those events from ERROR to WARN where they are filtered out by the default `EnvFilter`. Operators who explicitly want the chatter can set `RUST_LOG=nostr_relay_pool=error`. Comment in the source explains the rationale so a future contributor doesn't yank it.

Closes #424.

## Changes
- `keep-cli/src/commands/audit.rs`: rewritten `cmd_audit_retention` decision tree.
- `keep-cli/src/cli.rs`: `FrostNetworkCommands::SignEvent` annotated with `#[command(hide = true)]` and a docstring explaining the situation.
- `keep-cli/src/commands/vault.rs`: rewritten `NotImplemented` messages in `cmd_rotate_password` and `cmd_rotate_data_key` (hidden-vault branches).
- `keep-cli/src/main.rs`: env filter downgrades `nostr_relay_pool` to warn.

## Test plan
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --lib` — 679 tests pass workspace-wide.
- [x] Manual: `keep audit retention` (no args) returns the new error message.
- [x] Manual: `keep audit retention --max-entries 100` (no `--apply`) warns clearly; `--apply` after that actually prunes.
- [x] Manual: `keep frost network --help` no longer lists `sign-event`; running `keep frost network sign-event ...` still returns the NotImplemented message.
- [x] Manual: `keep --path <hidden vault> rotate-password` returns the rewritten message.
- [x] Manual: FROST coordination run no longer emits the `subscription not found` ERROR line at default log level.