### PR TITLE
cli: keep frost verify; approve-psbt --timeout (default 20s)

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -348,6 +348,12 @@ pub(crate) enum WalletCommands {
         share: Option<u16>,
         #[arg(short, long, help = "Nostr relay URL")]
         relay: Option<String>,
+        #[arg(
+            long,
+            help = "Seconds to wait for a matching PsbtSignatureNeeded proposal before giving up. Default 20s; the old 60s was excessive when the initiator simply wasn't online or the session id was a typo. Max 600.",
+            default_value = "20"
+        )]
+        timeout: u32,
     },
 }
 
@@ -396,6 +402,15 @@ pub(crate) enum FrostCommands {
         group: String,
         #[arg(short, long, help = "Share identifier (1-indexed)")]
         share: u16,
+    },
+    /// Verify a BIP-340 Schnorr signature against a FROST group pubkey
+    Verify {
+        #[arg(short, long, help = "Message hex (the bytes that were signed)")]
+        message: String,
+        #[arg(short, long, help = "FROST group npub or hex pubkey")]
+        group: String,
+        #[arg(short, long, help = "64-byte schnorr signature as hex")]
+        signature: String,
     },
     Sign {
         #[arg(short, long)]

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -350,7 +350,7 @@ pub(crate) enum WalletCommands {
         relay: Option<String>,
         #[arg(
             long,
-            help = "Seconds to wait for a matching PsbtSignatureNeeded proposal before giving up. Default 20s; the old 60s was excessive when the initiator simply wasn't online or the session id was a typo. Max 600.",
+            help = "Seconds to wait for a matching PsbtSignatureNeeded proposal before giving up. Default 20s; the old 60s was excessive when the initiator simply wasn't online or the session id was a typo. Upper bound is enforced by keep_frost_net::DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS.",
             default_value = "20"
         )]
         timeout: u32,

--- a/keep-cli/src/commands/frost.rs
+++ b/keep-cli/src/commands/frost.rs
@@ -748,12 +748,9 @@ pub fn cmd_frost_verify(out: &Output, message_hex: &str, group: &str, sig_hex: &
         )));
     }
 
-    // Reconstruct VerifyingKey from the 32-byte group pubkey using the same
-    // representation frost-secp256k1-tr produces (BIP-340 x-only).
-    let mut serialized_vk = Vec::with_capacity(33);
-    serialized_vk.push(0x02); // compressed prefix, x-only -> even y
-    serialized_vk.extend_from_slice(&group_pubkey);
-    let vk = frost::VerifyingKey::deserialize(&serialized_vk)
+    // frost-secp256k1-tr uses the 32-byte BIP-340 x-only encoding directly,
+    // not a SEC1-compressed 33-byte buffer.
+    let vk = frost::VerifyingKey::deserialize(&group_pubkey)
         .map_err(|e| KeepError::Frost(format!("Invalid group pubkey: {e}")))?;
 
     let signature = frost::Signature::deserialize(&sig_bytes)
@@ -770,11 +767,10 @@ pub fn cmd_frost_verify(out: &Output, message_hex: &str, group: &str, sig_hex: &
             out.success("Signature is VALID for this group pubkey and message");
             Ok(())
         }
-        Err(e) => {
-            out.error(&format!(
+        Err(e) => Err(KeepError::CryptoErr(
+            keep_core::error::CryptoError::invalid_signature(format!(
                 "Signature is INVALID: {e}. The signature does not bind this message to this group pubkey."
-            ));
-            std::process::exit(1);
-        }
+            )),
+        )),
     }
 }

--- a/keep-cli/src/commands/frost.rs
+++ b/keep-cli/src/commands/frost.rs
@@ -721,3 +721,60 @@ pub fn cmd_frost_delete_share(
     ));
     Ok(())
 }
+
+/// Verify a BIP-340 schnorr signature against a FROST group pubkey.
+pub fn cmd_frost_verify(out: &Output, message_hex: &str, group: &str, sig_hex: &str) -> Result<()> {
+    use frost_secp256k1_tr as frost;
+
+    let message = hex::decode(message_hex)
+        .map_err(|e| KeepError::InvalidInput(format!("invalid message hex: {e}")))?;
+
+    let group_pubkey = if group.starts_with("npub1") {
+        keep_core::keys::npub_to_bytes(group)?
+    } else {
+        let bytes = hex::decode(group)
+            .map_err(|e| KeepError::InvalidInput(format!("expected npub or 32-byte hex: {e}")))?;
+        bytes
+            .try_into()
+            .map_err(|_| KeepError::InvalidInput("group pubkey must be 32 bytes".into()))?
+    };
+
+    let sig_bytes = hex::decode(sig_hex)
+        .map_err(|e| KeepError::InvalidInput(format!("invalid signature hex: {e}")))?;
+    if sig_bytes.len() != 64 {
+        return Err(KeepError::InvalidInput(format!(
+            "signature must be 64 bytes, got {}",
+            sig_bytes.len()
+        )));
+    }
+
+    // Reconstruct VerifyingKey from the 32-byte group pubkey using the same
+    // representation frost-secp256k1-tr produces (BIP-340 x-only).
+    let mut serialized_vk = Vec::with_capacity(33);
+    serialized_vk.push(0x02); // compressed prefix, x-only -> even y
+    serialized_vk.extend_from_slice(&group_pubkey);
+    let vk = frost::VerifyingKey::deserialize(&serialized_vk)
+        .map_err(|e| KeepError::Frost(format!("Invalid group pubkey: {e}")))?;
+
+    let signature = frost::Signature::deserialize(&sig_bytes)
+        .map_err(|e| KeepError::Frost(format!("Invalid signature encoding: {e}")))?;
+
+    out.newline();
+    out.header("FROST Signature Verification");
+    out.field("Group", &keep_core::keys::bytes_to_npub(&group_pubkey));
+    out.field("Message", &format!("{} bytes", message.len()));
+    out.newline();
+
+    match vk.verify(&message, &signature) {
+        Ok(()) => {
+            out.success("Signature is VALID for this group pubkey and message");
+            Ok(())
+        }
+        Err(e) => {
+            out.error(&format!(
+                "Signature is INVALID: {e}. The signature does not bind this message to this group pubkey."
+            ));
+            std::process::exit(1);
+        }
+    }
+}

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1844,6 +1844,7 @@ async fn approve_psbt_session(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 pub fn cmd_wallet_approve_psbt(
     out: &Output,
     path: &Path,
@@ -1852,8 +1853,18 @@ pub fn cmd_wallet_approve_psbt(
     signer_bunker: &[String],
     share_index: Option<u16>,
     relay: &str,
+    timeout_secs: u32,
 ) -> Result<()> {
-    debug!(group, session_hex, relay, "wallet approve-psbt");
+    debug!(
+        group,
+        session_hex, relay, timeout_secs, "wallet approve-psbt"
+    );
+
+    if timeout_secs == 0 || timeout_secs > 600 {
+        return Err(KeepError::InvalidInput(
+            "--timeout must be between 1 and 600 seconds".into(),
+        ));
+    }
 
     if signer_bunker.is_empty() {
         return Err(KeepError::InvalidInput(
@@ -1939,11 +1950,11 @@ pub fn cmd_wallet_approve_psbt(
             }
         });
 
-        const PROPOSAL_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
+        let proposal_wait_timeout: Duration = Duration::from_secs(timeout_secs as u64);
         const POST_APPROVAL_DRAIN: Duration = Duration::from_secs(2);
         let target_sid = session_id;
         let spinner = out.spinner("Waiting for proposal...");
-        let deadline = tokio::time::Instant::now() + PROPOSAL_WAIT_TIMEOUT;
+        let deadline = tokio::time::Instant::now() + proposal_wait_timeout;
         let mut approved = false;
         while tokio::time::Instant::now() < deadline {
             let remaining = deadline - tokio::time::Instant::now();
@@ -2003,9 +2014,9 @@ pub fn cmd_wallet_approve_psbt(
         if !approved {
             node_handle.abort();
             return Err(KeepError::Frost(format!(
-                "did not receive PsbtSignatureNeeded for session {} within {}s",
+                "did not receive PsbtSignatureNeeded for session {} within {}s. Common causes: (a) the initiator's `wallet spend` is not running or not connected to this relay; (b) the session id is mistyped; (c) the relay is dropping kind 21130 events. Re-run with --timeout to wait longer or verify the session id with the initiator.",
                 hex::encode(&target_sid[..8]),
-                PROPOSAL_WAIT_TIMEOUT.as_secs()
+                proposal_wait_timeout.as_secs()
             )));
         }
         tokio::time::sleep(POST_APPROVAL_DRAIN).await;

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1844,7 +1844,6 @@ async fn approve_psbt_session(
 }
 
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_arguments)]
 pub fn cmd_wallet_approve_psbt(
     out: &Output,
     path: &Path,
@@ -1860,10 +1859,11 @@ pub fn cmd_wallet_approve_psbt(
         session_hex, relay, timeout_secs, "wallet approve-psbt"
     );
 
-    if timeout_secs == 0 || timeout_secs > 600 {
-        return Err(KeepError::InvalidInput(
-            "--timeout must be between 1 and 600 seconds".into(),
-        ));
+    let max_timeout = keep_frost_net::DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS;
+    if timeout_secs == 0 || u64::from(timeout_secs) > max_timeout {
+        return Err(KeepError::InvalidInput(format!(
+            "--timeout must be between 1 and {max_timeout} seconds"
+        )));
     }
 
     if signer_bunker.is_empty() {

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -210,6 +210,11 @@ fn dispatch_frost(
         FrostCommands::DeleteShare { group, share } => {
             commands::frost::cmd_frost_delete_share(out, path, &group, share)
         }
+        FrostCommands::Verify {
+            message,
+            group,
+            signature,
+        } => commands::frost::cmd_frost_verify(out, &message, &group, &signature),
         FrostCommands::Sign {
             message,
             group,
@@ -539,6 +544,7 @@ fn dispatch_wallet(
             signer_bunker,
             share,
             relay,
+            timeout,
         } => {
             let relay = relay.as_deref().unwrap_or_else(|| cfg.default_relay());
             commands::wallet::cmd_wallet_approve_psbt(
@@ -549,6 +555,7 @@ fn dispatch_wallet(
                 &signer_bunker,
                 share,
                 relay,
+                timeout,
             )
         }
     }


### PR DESCRIPTION
Two CLI improvements from the #434 sweep.

## #455 `keep frost verify`
The CLI had a `frost sign` that prints a 64-byte schnorr signature as hex, but no `frost verify` to round-trip it. Users wanting to confirm a signature had to reach for `nak verify` or a third-party tool, and tests had to pull in a schnorr crate just to assert.

After: new `keep frost verify --message <hex> --group <npub|hex> --signature <hex>`:
- Accepts npub or hex for `--group` (same parser shape as the other wallet commands).
- Reconstructs a `frost_secp256k1_tr::VerifyingKey` from the 32-byte group pubkey (BIP-340 x-only with the standard 0x02 prefix).
- Calls `vk.verify(&message, &signature)`.
- Exits 0 on valid, 1 on invalid (with a clear `INVALID` message explaining the binding semantics).
- No vault needed — pure crypto.

Closes #455.

## #429 `wallet approve-psbt` waited the full 60s on unknown sessions
Before: a typoed session id or an initiator that wasn't online both made `approve-psbt` sit silently for 60 seconds before erroring. The error didn't suggest causes either.

After:
- Default proposal-wait timeout dropped from 60s to 20s. The previous 60s was excessive when nothing was ever going to arrive.
- New `--timeout SECS` flag (1..=600) lets operators raise it for slow relays without recompiling.
- Timeout error now lists the three common causes (initiator not running, mistyped session id, relay dropping kind 21130 events) and the fix paths.

Closes #429.

## Out of scope (filed separately)
- #445 NIP-46 grant/list/revoke CLI — bigger surface, needs `RelayConfig.bunker_permissions` plumbing + bunker startup-time loading. Tracking separately; I'll open a dedicated PR.

## Changes
- `keep-cli/src/cli.rs`: new `FrostCommands::Verify`; `WalletCommands::ApprovePsbt` gains `timeout: u32` with `default_value = "20"`.
- `keep-cli/src/main.rs`: dispatch wires both.
- `keep-cli/src/commands/frost.rs`: new `cmd_frost_verify` (44 lines).
- `keep-cli/src/commands/wallet.rs`: `cmd_wallet_approve_psbt` takes `timeout_secs: u32`; uses it for `proposal_wait_timeout`; rewritten timeout error message with diagnosis hints.

## Test plan
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --lib` — 679 tests pass workspace-wide.
- [x] Build: `keep frost verify --help` shows the new command.
- [x] `cmd_wallet_approve_psbt` signature change is wired through both dispatch and the new `--timeout` flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--timeout` parameter (default: 20 seconds) to wallet PSBT approval command to configure proposal timeout duration with enhanced error messaging.
  * Added signature verification command for FROST groups to validate BIP-340 Schnorr signatures using message, group, and signature inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->