### PR TITLE
cli/docs: human timestamps; poll-with-early-exit for frost peers; FROST share threat model

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -32,6 +32,18 @@ To fix: ulimit -l unlimited (or increase RLIMIT_MEMLOCK)
   ```
 - Containers: Use `--no-mlock` flag to disable (accepts degraded security)
 
+## FROST Threat Model
+
+A FROST share is more than a cryptographic blinding factor: any device holding share `i` of a `t-of-n` group can act as that share for the lifetime of the share. There is no per-signing-round binding to a specific physical device.
+
+This means:
+
+- **A copied share is a permanent compromise.** If an attacker exfiltrates share `i` from a vault, they can sign as share `i` from anywhere until the group rotates (`keep frost refresh`). Treat each share file with the same care you would treat an unsplit private key.
+- **`keep frost export` produces a transferable identity.** Anyone with the exported share (and the export passphrase) can sign as that share's identity. Do not export shares to long-lived files unless those files are themselves protected to the same standard as the vault.
+- **`keep frost split` retains the original key by default unless `--keep-original` is passed.** After `frost split`, the original single-key Nostr identity is deleted. Use `--keep-original` only when you explicitly want to retain it as a separate identity.
+- **Share number leaks operational structure.** A peer-discovered announce reveals which share index a device claims. Pair this with relay metadata and an attacker can map your topology even without breaking any crypto. Run announces on a dedicated FROST relay (`--frost-relay`) when that matters.
+- **Rotate shares with `keep frost refresh` after suspected compromise of any device, even if the group pubkey doesn't need to change.** Refresh invalidates the old share bundle without producing a new group identity.
+
 ## Reporting Vulnerabilities
 
 If you discover a security vulnerability, please report it privately via [GitHub Security Advisories](https://github.com/privkeyio/keep/security/advisories/new) rather than opening a public issue.

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -355,14 +355,24 @@ pub fn cmd_frost_network_peers(
             }
         });
 
-        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        // Peers announce every 20s. A bare 3s sleep was missing most announces.
+        // Poll for up to 25s, exit early as soon as we see anyone.
+        const PEER_DISCOVERY_WINDOW: std::time::Duration = std::time::Duration::from_secs(25);
+        const PEER_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+        let deadline = tokio::time::Instant::now() + PEER_DISCOVERY_WINDOW;
+        while tokio::time::Instant::now() < deadline {
+            if node.online_peers() > 0 {
+                break;
+            }
+            tokio::time::sleep(PEER_POLL_INTERVAL).await;
+        }
         spinner.finish();
         node_handle.abort();
 
         let status = node.peer_status();
 
         if status.is_empty() {
-            out.info("No peers discovered yet.");
+            out.info("No peers discovered yet (waited up to 25s; announce interval is 20s).");
             out.info("Run 'keep frost network serve' on other devices first.");
         } else {
             out.table_header(&[("SHARE", 8), ("STATUS", 10), ("NAME", 20)]);

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -101,7 +101,12 @@ pub fn cmd_wallet_show(out: &Output, path: &Path, group_hex: &str) -> Result<()>
     out.header("Wallet Descriptor");
     out.field("Group", &hex::encode(desc.group_pubkey));
     out.field("Network", &desc.network);
-    out.field("Created", &desc.created_at.to_string());
+    let created_human = i64::try_from(desc.created_at)
+        .ok()
+        .and_then(|t| chrono::DateTime::<chrono::Utc>::from_timestamp(t, 0))
+        .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+        .unwrap_or_else(|| format!("epoch {}", desc.created_at));
+    out.field("Created", &created_human);
     out.newline();
     out.field("External (receive)", &desc.external_descriptor);
     out.newline();


### PR DESCRIPTION
Three small wins from the #434 sweep.

## #480 `wallet show` displays raw epoch timestamp
Before:
```
Wallet Descriptor
  Created: 1780111209
```

After:
```
Wallet Descriptor
  Created: 2026-05-30 03:20:09 UTC
```

`cmd_wallet_show` now formats `desc.created_at` through `chrono::DateTime::<Utc>::from_timestamp`. Falls back to `epoch <n>` if the timestamp is somehow out of range.

Closes #480.

## #419 `frost network peers` 3s wait misses most 20s announces
Before: a static `sleep(3)` after node startup meant that on the typical case (announces every 20s) we missed ~85% of announces and printed "no peers" even when peers were online.

After: poll-with-early-exit. Total budget 25s (covering one full announce interval plus startup jitter), sleep 500ms between checks, exit the loop the moment `node.online_peers() > 0`. The fast path (peers already there) returns in well under a second; the slow path still finishes well inside the announce window.

The "no peers" message now also tells the user the window length and announce interval so they don't have to guess.

Closes #419.

## #432 `docs/SECURITY.md`: FROST share threat model
Adds a new "FROST Threat Model" section to `docs/SECURITY.md` covering:
- A share is a transferable, long-lived signing identity (not a per-round nonce).
- Exporting a share via `keep frost export` is equivalent to handing someone the share's permission to sign.
- `keep frost split --keep-original` semantics (default is delete).
- Share-index leakage via peer-discovery announces.
- `keep frost refresh` as the post-compromise rotation primitive.

Closes #432.

## Changes
- `keep-cli/src/commands/wallet.rs`: timestamp format helper inline at `cmd_wallet_show`.
- `keep-cli/src/commands/frost_network/mod.rs`: bare `sleep(3)` replaced with poll loop; "no peers" message expanded.
- `docs/SECURITY.md`: new section before `## Reporting Vulnerabilities`.

## Test plan
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --lib` — 679 tests pass workspace-wide.
- [x] Manual: `keep wallet show --group <hex>` shows a human-readable date.
- [x] Manual: `keep frost network peers --group <npub>` returns immediately when peers are already online; waits up to 25s otherwise with informative message.