### PR TITLE
wdc(security): responder-side destination validation on migration sweeps (#414)

### DIFF
--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1738,30 +1738,12 @@ async fn approve_psbt_session(
     // #414 responder-side destination validation: if the session is keyed on
     // an OLD descriptor whose successor (NEW descriptor) is persisted in this
     // vault, the proposal must be an automated migration sweep and the PSBT
-    // must have exactly one output that pays the NEW descriptor's address.
-    // Without this check an authorized proposer can hand us a PSBT routing
-    // funds to an attacker because the proposer-side re-derivation in
+    // must have exactly one output paying the NEW descriptor's address. The
+    // helper fails CLOSED (store unavailable / ambiguous lineage / mismatch)
+    // because the proposer-side re-derivation in
     // `request_descriptor_migration_sweep` is not a security boundary.
-    if let Some(successor_external) = node.descriptor_successor_external(&session_descriptor_hash) {
-        let expected_addr = keep_bitcoin::descriptor_address(&successor_external, network)
-            .map_err(|e| {
-                KeepError::Frost(format!(
-                    "could not derive expected sweep destination from persisted successor descriptor: {e}"
-                ))
-            })?;
-        let expected_script = expected_addr.script_pubkey();
-        if psbt.unsigned_tx.output.len() != 1 {
-            return Err(KeepError::Frost(format!(
-                "REFUSED: session is keyed on an OLD descriptor whose successor (NEW descriptor) is persisted, so this is treated as an automated migration sweep; expected exactly 1 output paying the NEW descriptor address, got {} outputs. Refusing to sign.",
-                psbt.unsigned_tx.output.len()
-            )));
-        }
-        if psbt.unsigned_tx.output[0].script_pubkey != expected_script {
-            return Err(KeepError::Frost(format!(
-                "REFUSED: PSBT output does not pay the persisted NEW descriptor address. Expected {expected_addr}; proposer-supplied script differs. This would route funds away from the group-controlled address; refusing to sign."
-            )));
-        }
-    }
+    node.validate_migration_sweep_destination(&session_descriptor_hash, &psbt.unsigned_tx)
+        .map_err(KeepError::Frost)?;
 
     // Display every destination (address + amount) and require explicit
     // operator confirmation before signing. The input-binding check above only

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1696,17 +1696,27 @@ async fn approve_psbt_session(
         }
     }
 
+    // Resolve the descriptor the session was coordinated against by its
+    // canonical hash, not the current tip. A migration sweep is keyed on the
+    // OLD descriptor hash while the NEW (successor) descriptor is already the
+    // tip, so loading the tip would both reject the sweep here and authorize
+    // the spend under the wrong policy/keys. All spend-side checks below
+    // (policy, xpub, network, input bindings) derive from this descriptor.
+    // Fail closed if no persisted version matches.
     let descriptor = {
         let guard = keep.lock().expect("keep mutex poisoned");
         guard
-            .get_wallet_descriptor(&group_pubkey)?
-            .ok_or_else(|| KeepError::KeyNotFound("no wallet descriptor for this group".into()))?
+            .list_all_wallet_descriptor_versions()?
+            .into_iter()
+            .find(|d| {
+                d.group_pubkey == group_pubkey && d.canonical_hash() == session_descriptor_hash
+            })
+            .ok_or_else(|| {
+                KeepError::Frost(
+                    "no persisted descriptor matches the PSBT session descriptor_hash".into(),
+                )
+            })?
     };
-    if descriptor.canonical_hash() != session_descriptor_hash {
-        return Err(KeepError::Frost(
-            "stored descriptor hash does not match PSBT session descriptor_hash".into(),
-        ));
-    }
     let policy_json = descriptor.policy.clone().ok_or_else(|| {
         KeepError::InvalidInput(
             "persisted descriptor has no WalletPolicy; cannot derive recovery tier metadata".into(),

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1735,6 +1735,34 @@ async fn approve_psbt_session(
     let sighashes = keep_bitcoin::verify_all_script_spend_input_bindings(&psbt, &xonly_bytes)
         .map_err(|e| KeepError::InvalidInput(format!("PSBT binding verification failed: {e}")))?;
 
+    // #414 responder-side destination validation: if the session is keyed on
+    // an OLD descriptor whose successor (NEW descriptor) is persisted in this
+    // vault, the proposal must be an automated migration sweep and the PSBT
+    // must have exactly one output that pays the NEW descriptor's address.
+    // Without this check an authorized proposer can hand us a PSBT routing
+    // funds to an attacker because the proposer-side re-derivation in
+    // `request_descriptor_migration_sweep` is not a security boundary.
+    if let Some(successor_external) = node.descriptor_successor_external(&session_descriptor_hash) {
+        let expected_addr = keep_bitcoin::descriptor_address(&successor_external, network)
+            .map_err(|e| {
+                KeepError::Frost(format!(
+                    "could not derive expected sweep destination from persisted successor descriptor: {e}"
+                ))
+            })?;
+        let expected_script = expected_addr.script_pubkey();
+        if psbt.unsigned_tx.output.len() != 1 {
+            return Err(KeepError::Frost(format!(
+                "REFUSED: session is keyed on an OLD descriptor whose successor (NEW descriptor) is persisted, so this is treated as an automated migration sweep; expected exactly 1 output paying the NEW descriptor address, got {} outputs. Refusing to sign.",
+                psbt.unsigned_tx.output.len()
+            )));
+        }
+        if psbt.unsigned_tx.output[0].script_pubkey != expected_script {
+            return Err(KeepError::Frost(format!(
+                "REFUSED: PSBT output does not pay the persisted NEW descriptor address. Expected {expected_addr}; proposer-supplied script differs. This would route funds away from the group-controlled address; refusing to sign."
+            )));
+        }
+    }
+
     // Display every destination (address + amount) and require explicit
     // operator confirmation before signing. The input-binding check above only
     // proves we control the spent UTXOs; it says nothing about where the funds

--- a/keep-desktop/src/app/wallet.rs
+++ b/keep-desktop/src/app/wallet.rs
@@ -666,6 +666,40 @@ impl App {
                     keep_bitcoin::verify_all_script_spend_input_bindings(&psbt, &xonly_bytes)
                         .map_err(|e| format!("PSBT binding verification failed: {e}"))?;
 
+                // #414 responder-side destination validation: if this session
+                // is keyed on an OLD descriptor whose successor (NEW
+                // descriptor) is persisted in this vault, the proposal must be
+                // an automated migration sweep and the PSBT must have exactly
+                // one output that pays the NEW descriptor's address. Without
+                // this check an authorized proposer can route funds to an
+                // attacker since the proposer-side re-derivation in
+                // `request_descriptor_migration_sweep` is not a security
+                // boundary. Desktop has no human approval step on the sign
+                // path, so this check is the only line of defense here.
+                if let Some(successor_external) =
+                    node.descriptor_successor_external(&session_descriptor_hash)
+                {
+                    let expected_addr =
+                        keep_bitcoin::descriptor_address(&successor_external, network)
+                            .map_err(|e| {
+                                format!(
+                                    "could not derive expected sweep destination from persisted successor descriptor: {e}"
+                                )
+                            })?;
+                    let expected_script = expected_addr.script_pubkey();
+                    if psbt.unsigned_tx.output.len() != 1 {
+                        return Err(format!(
+                            "REFUSED: session is keyed on an OLD descriptor whose successor (NEW descriptor) is persisted; expected exactly 1 output paying the NEW descriptor address, got {} outputs.",
+                            psbt.unsigned_tx.output.len()
+                        ));
+                    }
+                    if psbt.unsigned_tx.output[0].script_pubkey != expected_script {
+                        return Err(format!(
+                            "REFUSED: PSBT output does not pay the persisted NEW descriptor address. Expected {expected_addr}; proposer-supplied script differs."
+                        ));
+                    }
+                }
+
                 let client = keep_nip46::Nip46Client::connect_to(&bunker_uri)
                     .await
                     .map_err(|e| format!("NIP-46 connect: {e}"))?;

--- a/keep-desktop/src/app/wallet.rs
+++ b/keep-desktop/src/app/wallet.rs
@@ -666,39 +666,16 @@ impl App {
                     keep_bitcoin::verify_all_script_spend_input_bindings(&psbt, &xonly_bytes)
                         .map_err(|e| format!("PSBT binding verification failed: {e}"))?;
 
-                // #414 responder-side destination validation: if this session
-                // is keyed on an OLD descriptor whose successor (NEW
-                // descriptor) is persisted in this vault, the proposal must be
-                // an automated migration sweep and the PSBT must have exactly
-                // one output that pays the NEW descriptor's address. Without
-                // this check an authorized proposer can route funds to an
-                // attacker since the proposer-side re-derivation in
-                // `request_descriptor_migration_sweep` is not a security
-                // boundary. Desktop has no human approval step on the sign
-                // path, so this check is the only line of defense here.
-                if let Some(successor_external) =
-                    node.descriptor_successor_external(&session_descriptor_hash)
-                {
-                    let expected_addr =
-                        keep_bitcoin::descriptor_address(&successor_external, network)
-                            .map_err(|e| {
-                                format!(
-                                    "could not derive expected sweep destination from persisted successor descriptor: {e}"
-                                )
-                            })?;
-                    let expected_script = expected_addr.script_pubkey();
-                    if psbt.unsigned_tx.output.len() != 1 {
-                        return Err(format!(
-                            "REFUSED: session is keyed on an OLD descriptor whose successor (NEW descriptor) is persisted; expected exactly 1 output paying the NEW descriptor address, got {} outputs.",
-                            psbt.unsigned_tx.output.len()
-                        ));
-                    }
-                    if psbt.unsigned_tx.output[0].script_pubkey != expected_script {
-                        return Err(format!(
-                            "REFUSED: PSBT output does not pay the persisted NEW descriptor address. Expected {expected_addr}; proposer-supplied script differs."
-                        ));
-                    }
-                }
+                // #414 responder-side destination validation. Desktop has no
+                // human approval step on the sign path, so this fail-closed
+                // check is the only destination defense. The helper refuses to
+                // sign when a successor (NEW) descriptor is persisted but the
+                // PSBT output does not pay its re-derived address, or when the
+                // descriptor store is unavailable / lineage is ambiguous.
+                node.validate_migration_sweep_destination(
+                    &session_descriptor_hash,
+                    &psbt.unsigned_tx,
+                )?;
 
                 let client = keep_nip46::Nip46Client::connect_to(&bunker_uri)
                     .await

--- a/keep-desktop/src/app/wallet.rs
+++ b/keep-desktop/src/app/wallet.rs
@@ -610,26 +610,31 @@ impl App {
                     }
                 }
 
+                // SEC: resolve the descriptor the session was coordinated
+                // against by its canonical hash, not the current tip. A
+                // migration sweep is keyed on the OLD descriptor hash while the
+                // NEW (successor) descriptor is already the tip, so loading the
+                // tip would both reject the sweep and authorize the spend under
+                // the wrong policy/keys. All spend-side checks below derive from
+                // this descriptor. Fail closed if no persisted version matches.
                 let group_pubkey = *node.group_pubkey();
                 let descriptor = tokio::task::spawn_blocking(move || {
                     with_keep_blocking(&keep_arc, "Failed to load descriptor", move |keep| {
-                        keep.get_wallet_descriptor(&group_pubkey)
+                        keep.list_all_wallet_descriptor_versions()
                             .map_err(friendly_err)?
-                            .ok_or_else(|| "No wallet descriptor for this group".to_string())
+                            .into_iter()
+                            .find(|d| {
+                                d.group_pubkey == group_pubkey
+                                    && d.canonical_hash() == session_descriptor_hash
+                            })
+                            .ok_or_else(|| {
+                                "no persisted descriptor matches the PSBT session descriptor_hash"
+                                    .to_string()
+                            })
                     })
                 })
                 .await
                 .map_err(|_| "Background task failed".to_string())??;
-
-                // SEC: confirm the locally stored descriptor matches the one
-                // the session was coordinated against. Fail closed on mismatch
-                // to prevent signing under a substituted descriptor.
-                if descriptor.canonical_hash() != session_descriptor_hash {
-                    return Err(
-                        "stored descriptor hash does not match PSBT session descriptor_hash"
-                            .to_string(),
-                    );
-                }
 
                 let policy_value = descriptor
                     .policy

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -94,7 +94,7 @@ pub use event::KfpEventBuilder;
 pub use node::{
     DescriptorLookupUnavailable, HealthCheckResult, KeepDescriptorLookup, KfpNode, KfpNodeEvent,
     NoOpHooks, PeerPolicy, PersistedDescriptorLookup, PsbtSessionSnapshot, SessionInfo,
-    SigningHooks,
+    SigningHooks, SuccessorLookup,
 };
 pub use nonce_pool::{NonceId, NoncePool, DEFAULT_POOL_TARGET, MAX_POOL_ENTRIES};
 pub use nonce_store::{FileNonceStore, MemoryNonceStore, NonceStore};

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -54,6 +54,30 @@ impl std::fmt::Display for DescriptorLookupUnavailable {
 
 impl std::error::Error for DescriptorLookupUnavailable {}
 
+/// Outcome of resolving the successor (NEW) descriptor for a session keyed on
+/// an OLD descriptor hash. Used by responders to decide whether an automated
+/// migration sweep destination must be re-derived and validated (#414).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SuccessorLookup {
+    /// The session descriptor is the current tip: no descriptor back-points to
+    /// it, so there is nothing to validate and signing may proceed.
+    Tip,
+    /// Exactly one successor descriptor was resolved. Carries its external
+    /// (receive) descriptor and canonical network string so the destination can
+    /// be re-derived against the *successor's own* network.
+    Found {
+        external_descriptor: String,
+        network: String,
+    },
+    /// The descriptor store could not be read (vault locked or poisoned).
+    /// Callers must fail closed rather than skip the destination check.
+    Unavailable,
+    /// More than one descriptor back-points to the session hash. The lineage is
+    /// ambiguous and a destination cannot be derived deterministically; callers
+    /// must fail closed.
+    Ambiguous,
+}
+
 /// Fallback lookup for finalized wallet descriptors that have been persisted
 /// outside of the in-memory `DescriptorSessionManager` (e.g. stored by the
 /// host application). Used when a PSBT coordination message arrives for a
@@ -98,8 +122,8 @@ pub trait PersistedDescriptorLookup: Send + Sync {
         group: &[u8; 32],
     ) -> std::result::Result<Option<u32>, DescriptorLookupUnavailable>;
 
-    /// Return the external (receive) descriptor of any persisted descriptor for
-    /// `group` whose `previous_descriptor_hash` equals `hash`, if one exists.
+    /// Resolve the successor (NEW) descriptor for `group` whose
+    /// `previous_descriptor_hash` equals `hash`.
     ///
     /// Used by responders to validate that a PSBT signature request keyed on an
     /// OLD descriptor (i.e. an automated migration sweep) actually pays a
@@ -107,9 +131,14 @@ pub trait PersistedDescriptorLookup: Send + Sync {
     /// proposer can drive any destination through `request_psbt_spend` (see
     /// #414) because the proposer-side re-derivation in
     /// `request_descriptor_migration_sweep` is not a security boundary.
-    fn successor_external_for(&self, group: &[u8; 32], hash: &[u8; 32]) -> Option<String> {
+    ///
+    /// Implementations must fail closed: return [`SuccessorLookup::Unavailable`]
+    /// when the store cannot be read and [`SuccessorLookup::Ambiguous`] when
+    /// more than one descriptor back-points to `hash`. The default impl reports
+    /// `Unavailable` so an unconfigured lookup never silently skips the check.
+    fn successor_for(&self, group: &[u8; 32], hash: &[u8; 32]) -> SuccessorLookup {
         let _ = (group, hash);
-        None
+        SuccessorLookup::Unavailable
     }
 }
 
@@ -190,12 +219,67 @@ where
             .max())
     }
 
-    fn successor_external_for(&self, group: &[u8; 32], hash: &[u8; 32]) -> Option<String> {
-        let descriptors = (self.fetch)()?;
-        descriptors
+    fn successor_for(&self, group: &[u8; 32], hash: &[u8; 32]) -> SuccessorLookup {
+        let Some(descriptors) = (self.fetch)() else {
+            tracing::warn!(
+                group = %hex::encode(group),
+                descriptor_hash = %hex::encode(hash),
+                "KeepDescriptorLookup could not read persisted descriptors for successor_for (vault locked or unavailable); failing closed",
+            );
+            return SuccessorLookup::Unavailable;
+        };
+        // Resolve the session descriptor's own version from the same snapshot so
+        // the read is a single lock-scope (no TOCTOU vs. the caller's separate
+        // OLD-descriptor fetch) and so an n+1 successor can be selected
+        // deterministically.
+        let session_version = descriptors
             .iter()
-            .find(|d| &d.group_pubkey == group && d.previous_descriptor_hash.as_ref() == Some(hash))
-            .map(|d| d.external_descriptor.clone())
+            .find(|d| &d.group_pubkey == group && &d.canonical_hash() == hash)
+            .map(|d| d.version);
+        let mut successors = descriptors.iter().filter(|d| {
+            &d.group_pubkey == group && d.previous_descriptor_hash.as_ref() == Some(hash)
+        });
+        let Some(first) = successors.next() else {
+            return SuccessorLookup::Tip;
+        };
+        // If multiple descriptors back-point to the same OLD hash, prefer the one
+        // at version session+1; only fail closed when the lineage is genuinely
+        // ambiguous (no single n+1 successor).
+        if successors.next().is_some() {
+            let matches: Vec<&keep_core::wallet::WalletDescriptor> = descriptors
+                .iter()
+                .filter(|d| {
+                    &d.group_pubkey == group && d.previous_descriptor_hash.as_ref() == Some(hash)
+                })
+                .collect();
+            let next_version = session_version.map(|v| v.saturating_add(1));
+            let chosen: Vec<&keep_core::wallet::WalletDescriptor> = match next_version {
+                Some(nv) => matches
+                    .iter()
+                    .copied()
+                    .filter(|d| d.version == nv)
+                    .collect(),
+                None => Vec::new(),
+            };
+            if chosen.len() == 1 {
+                let d = chosen[0];
+                return SuccessorLookup::Found {
+                    external_descriptor: d.external_descriptor.clone(),
+                    network: d.network.clone(),
+                };
+            }
+            tracing::warn!(
+                group = %hex::encode(group),
+                descriptor_hash = %hex::encode(hash),
+                successor_count = matches.len(),
+                "multiple descriptors back-point to the session hash with no single version+1 successor; failing closed (ambiguous lineage)",
+            );
+            return SuccessorLookup::Ambiguous;
+        }
+        SuccessorLookup::Found {
+            external_descriptor: first.external_descriptor.clone(),
+            network: first.network.clone(),
+        }
     }
 }
 
@@ -1822,7 +1906,7 @@ mod tests {
     }
 
     #[test]
-    fn successor_external_for_returns_new_descriptor_keyed_on_old_hash() {
+    fn successor_for_returns_new_descriptor_keyed_on_old_hash() {
         // #414: responders need to re-derive the expected sweep destination
         // from the NEW descriptor whose `previous_descriptor_hash` is the
         // session's OLD descriptor hash. Confirm the lookup walks the
@@ -1837,24 +1921,29 @@ mod tests {
         let rows = vec![old.clone(), new.clone()];
         let lookup = KeepDescriptorLookup::new(move || Some(rows.clone()));
 
-        assert_eq!(
-            lookup.successor_external_for(&group, &old_hash).as_deref(),
-            Some("tr(new_external)"),
-            "session keyed on OLD hash must surface the NEW descriptor as successor",
-        );
+        match lookup.successor_for(&group, &old_hash) {
+            SuccessorLookup::Found {
+                external_descriptor,
+                ..
+            } => assert_eq!(external_descriptor, "tr(new_external)"),
+            other => panic!("expected Found, got {other:?}"),
+        }
         // The NEW descriptor itself is the tip; there is no successor.
         let new_hash = new.canonical_hash();
-        assert_eq!(lookup.successor_external_for(&group, &new_hash), None);
+        assert_eq!(
+            lookup.successor_for(&group, &new_hash),
+            SuccessorLookup::Tip
+        );
         // Wrong group never matches.
         assert_eq!(
-            lookup.successor_external_for(&[8u8; 32], &old_hash),
-            None,
+            lookup.successor_for(&[8u8; 32], &old_hash),
+            SuccessorLookup::Tip,
             "successor lookup must be scoped to the queried group",
         );
     }
 
     #[test]
-    fn successor_external_for_returns_none_without_chain() {
+    fn successor_for_returns_tip_without_chain() {
         // The current-tip descriptor has no successor; responders signing
         // against the tip should NOT be subjected to the migration check.
         let group = [11u8; 32];
@@ -1862,6 +1951,68 @@ mod tests {
         let tip_hash = tip.canonical_hash();
         let rows = vec![tip.clone()];
         let lookup = KeepDescriptorLookup::new(move || Some(rows.clone()));
-        assert_eq!(lookup.successor_external_for(&group, &tip_hash), None);
+        assert_eq!(
+            lookup.successor_for(&group, &tip_hash),
+            SuccessorLookup::Tip
+        );
+    }
+
+    #[test]
+    fn successor_for_fails_closed_when_store_unavailable() {
+        // A locked/poisoned vault must surface Unavailable so the responder
+        // fails closed instead of silently skipping the destination check.
+        let group = [12u8; 32];
+        let hash = [3u8; 32];
+        let lookup = KeepDescriptorLookup::new(move || None);
+        assert_eq!(
+            lookup.successor_for(&group, &hash),
+            SuccessorLookup::Unavailable
+        );
+    }
+
+    #[test]
+    fn successor_for_picks_version_plus_one_when_multiple_back_point() {
+        // Two descriptors back-point to the same OLD hash. The deterministic
+        // session+1 successor is selected rather than relying on Vec order.
+        let group = [13u8; 32];
+        let old = descriptor_version(group, "tr(old)", 1);
+        let old_hash = old.canonical_hash();
+
+        let mut next = descriptor_version(group, "tr(next)", 2);
+        next.previous_descriptor_hash = Some(old_hash);
+        let mut stray = descriptor_version(group, "tr(stray)", 3);
+        stray.previous_descriptor_hash = Some(old_hash);
+
+        // stray listed first to prove order independence.
+        let rows = vec![old.clone(), stray.clone(), next.clone()];
+        let lookup = KeepDescriptorLookup::new(move || Some(rows.clone()));
+        match lookup.successor_for(&group, &old_hash) {
+            SuccessorLookup::Found {
+                external_descriptor,
+                ..
+            } => assert_eq!(external_descriptor, "tr(next)"),
+            other => panic!("expected Found(next), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn successor_for_ambiguous_when_no_single_version_plus_one() {
+        // Two successors at the same version with no version+1 match is a
+        // genuinely ambiguous lineage; fail closed.
+        let group = [14u8; 32];
+        let old = descriptor_version(group, "tr(old)", 1);
+        let old_hash = old.canonical_hash();
+
+        let mut a = descriptor_version(group, "tr(a)", 5);
+        a.previous_descriptor_hash = Some(old_hash);
+        let mut b = descriptor_version(group, "tr(b)", 6);
+        b.previous_descriptor_hash = Some(old_hash);
+
+        let rows = vec![old.clone(), a.clone(), b.clone()];
+        let lookup = KeepDescriptorLookup::new(move || Some(rows.clone()));
+        assert_eq!(
+            lookup.successor_for(&group, &old_hash),
+            SuccessorLookup::Ambiguous
+        );
     }
 }

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -97,6 +97,20 @@ pub trait PersistedDescriptorLookup: Send + Sync {
         &self,
         group: &[u8; 32],
     ) -> std::result::Result<Option<u32>, DescriptorLookupUnavailable>;
+
+    /// Return the external (receive) descriptor of any persisted descriptor for
+    /// `group` whose `previous_descriptor_hash` equals `hash`, if one exists.
+    ///
+    /// Used by responders to validate that a PSBT signature request keyed on an
+    /// OLD descriptor (i.e. an automated migration sweep) actually pays a
+    /// NEW-descriptor-controlled address. Without this check, an authorized
+    /// proposer can drive any destination through `request_psbt_spend` (see
+    /// #414) because the proposer-side re-derivation in
+    /// `request_descriptor_migration_sweep` is not a security boundary.
+    fn successor_external_for(&self, group: &[u8; 32], hash: &[u8; 32]) -> Option<String> {
+        let _ = (group, hash);
+        None
+    }
 }
 
 /// Shared `PersistedDescriptorLookup` adapter over a `Keep` accessor closure.
@@ -174,6 +188,14 @@ where
             .filter(|d| &d.group_pubkey == group)
             .map(|d| d.version)
             .max())
+    }
+
+    fn successor_external_for(&self, group: &[u8; 32], hash: &[u8; 32]) -> Option<String> {
+        let descriptors = (self.fetch)()?;
+        descriptors
+            .iter()
+            .find(|d| &d.group_pubkey == group && d.previous_descriptor_hash.as_ref() == Some(hash))
+            .map(|d| d.external_descriptor.clone())
     }
 }
 
@@ -1797,5 +1819,49 @@ mod tests {
         assert_eq!(lookup.latest_version_for(&group), Ok(Some(2)));
         assert!(lookup.find_by_hash(&group, &old_hash));
         assert!(lookup.find_by_hash(&group, &new_hash));
+    }
+
+    #[test]
+    fn successor_external_for_returns_new_descriptor_keyed_on_old_hash() {
+        // #414: responders need to re-derive the expected sweep destination
+        // from the NEW descriptor whose `previous_descriptor_hash` is the
+        // session's OLD descriptor hash. Confirm the lookup walks the
+        // back-pointer chain correctly.
+        let group = [7u8; 32];
+        let old = descriptor_version(group, "tr(old_external)", 1);
+        let old_hash = old.canonical_hash();
+
+        let mut new = descriptor_version(group, "tr(new_external)", 2);
+        new.previous_descriptor_hash = Some(old_hash);
+
+        let rows = vec![old.clone(), new.clone()];
+        let lookup = KeepDescriptorLookup::new(move || Some(rows.clone()));
+
+        assert_eq!(
+            lookup.successor_external_for(&group, &old_hash).as_deref(),
+            Some("tr(new_external)"),
+            "session keyed on OLD hash must surface the NEW descriptor as successor",
+        );
+        // The NEW descriptor itself is the tip; there is no successor.
+        let new_hash = new.canonical_hash();
+        assert_eq!(lookup.successor_external_for(&group, &new_hash), None);
+        // Wrong group never matches.
+        assert_eq!(
+            lookup.successor_external_for(&[8u8; 32], &old_hash),
+            None,
+            "successor lookup must be scoped to the queried group",
+        );
+    }
+
+    #[test]
+    fn successor_external_for_returns_none_without_chain() {
+        // The current-tip descriptor has no successor; responders signing
+        // against the tip should NOT be subjected to the migration check.
+        let group = [11u8; 32];
+        let tip = descriptor_version(group, "tr(tip)", 1);
+        let tip_hash = tip.canonical_hash();
+        let rows = vec![tip.clone()];
+        let lookup = KeepDescriptorLookup::new(move || Some(rows.clone()));
+        assert_eq!(lookup.successor_external_for(&group, &tip_hash), None);
     }
 }

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -236,49 +236,44 @@ where
             .iter()
             .find(|d| &d.group_pubkey == group && &d.canonical_hash() == hash)
             .map(|d| d.version);
-        let mut successors = descriptors.iter().filter(|d| {
+        let is_successor = |d: &&keep_core::wallet::WalletDescriptor| {
             &d.group_pubkey == group && d.previous_descriptor_hash.as_ref() == Some(hash)
-        });
-        let Some(first) = successors.next() else {
-            return SuccessorLookup::Tip;
         };
-        // If multiple descriptors back-point to the same OLD hash, prefer the one
-        // at version session+1; only fail closed when the lineage is genuinely
-        // ambiguous (no single n+1 successor).
-        if successors.next().is_some() {
-            let matches: Vec<&keep_core::wallet::WalletDescriptor> = descriptors
-                .iter()
-                .filter(|d| {
-                    &d.group_pubkey == group && d.previous_descriptor_hash.as_ref() == Some(hash)
-                })
-                .collect();
-            let next_version = session_version.map(|v| v.saturating_add(1));
-            let chosen: Vec<&keep_core::wallet::WalletDescriptor> = match next_version {
-                Some(nv) => matches
-                    .iter()
-                    .copied()
-                    .filter(|d| d.version == nv)
-                    .collect(),
-                None => Vec::new(),
-            };
-            if chosen.len() == 1 {
-                let d = chosen[0];
-                return SuccessorLookup::Found {
-                    external_descriptor: d.external_descriptor.clone(),
-                    network: d.network.clone(),
+        let matches: Vec<&keep_core::wallet::WalletDescriptor> =
+            descriptors.iter().filter(is_successor).collect();
+        match matches.as_slice() {
+            [] => SuccessorLookup::Tip,
+            [only] => SuccessorLookup::Found {
+                external_descriptor: only.external_descriptor.clone(),
+                network: only.network.clone(),
+            },
+            _ => {
+                // If multiple descriptors back-point to the same OLD hash, prefer
+                // the one at version session+1; only fail closed when the lineage
+                // is genuinely ambiguous (no single n+1 successor).
+                let next_version = session_version.map(|v| v.saturating_add(1));
+                let chosen: Vec<&keep_core::wallet::WalletDescriptor> = match next_version {
+                    Some(nv) => matches
+                        .iter()
+                        .copied()
+                        .filter(|d| d.version == nv)
+                        .collect(),
+                    None => Vec::new(),
                 };
+                if let [only] = chosen.as_slice() {
+                    return SuccessorLookup::Found {
+                        external_descriptor: only.external_descriptor.clone(),
+                        network: only.network.clone(),
+                    };
+                }
+                tracing::warn!(
+                    group = %hex::encode(group),
+                    descriptor_hash = %hex::encode(hash),
+                    successor_count = matches.len(),
+                    "multiple descriptors back-point to the session hash with no single version+1 successor; failing closed (ambiguous lineage)",
+                );
+                SuccessorLookup::Ambiguous
             }
-            tracing::warn!(
-                group = %hex::encode(group),
-                descriptor_hash = %hex::encode(hash),
-                successor_count = matches.len(),
-                "multiple descriptors back-point to the session hash with no single version+1 successor; failing closed (ambiguous lineage)",
-            );
-            return SuccessorLookup::Ambiguous;
-        }
-        SuccessorLookup::Found {
-            external_descriptor: first.external_descriptor.clone(),
-            network: first.network.clone(),
         }
     }
 }

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -99,21 +99,73 @@ impl KfpNode {
         Some((initiator, *session.descriptor_hash(), session.tier_index()))
     }
 
-    /// Return the external descriptor of any persisted descriptor that lists
-    /// `descriptor_hash` as its `previous_descriptor_hash` for this node's
-    /// group, or `None` if no such successor exists (i.e. the session's
-    /// descriptor is the current tip and there's no automated-sweep
-    /// re-derivation to perform).
+    /// Responder-side destination guard for automated migration sweeps (#414).
     ///
-    /// Used by responders to validate that a signature request keyed on an
-    /// OLD descriptor actually pays the persisted NEW-descriptor address. Per
-    /// #414, the proposer-side re-derivation in
-    /// `request_descriptor_migration_sweep` is not a security boundary; the
-    /// responder must independently re-derive and refuse to sign on mismatch.
-    pub fn descriptor_successor_external(&self, descriptor_hash: &[u8; 32]) -> Option<String> {
-        self.descriptor_lookup
-            .as_deref()
-            .and_then(|l| l.successor_external_for(&self.group_pubkey, descriptor_hash))
+    /// If the PSBT session is keyed on an OLD descriptor whose successor (NEW
+    /// descriptor) is persisted in this vault, the proposal is an automated
+    /// migration sweep and `tx` must have exactly one output paying the NEW
+    /// descriptor's address. The expected address is re-derived independently
+    /// against the *successor's own* network, because the proposer-side
+    /// re-derivation in `request_descriptor_migration_sweep` is not a security
+    /// boundary. On desktop this is the only destination defense (no human
+    /// confirmation on the sign path).
+    ///
+    /// Fails CLOSED: returns `Err` when a successor should exist but cannot be
+    /// resolved (descriptor store unavailable, ambiguous lineage, or
+    /// re-derivation failure). Returns `Ok(())` only when the session descriptor
+    /// is the current tip (no successor) or when the single output matches the
+    /// re-derived successor address. Mirrors the proposer-side precondition that
+    /// the NEW descriptor be persisted before any spend keyed on an OLD hash is
+    /// signable.
+    pub fn validate_migration_sweep_destination(
+        &self,
+        session_descriptor_hash: &[u8; 32],
+        tx: &bitcoin::Transaction,
+    ) -> std::result::Result<(), String> {
+        let lookup = self.descriptor_lookup.as_deref().ok_or_else(|| {
+            "REFUSED: no descriptor lookup configured; cannot confirm migration sweep destination"
+                .to_string()
+        })?;
+        let (external_descriptor, network_str) = match lookup
+            .successor_for(&self.group_pubkey, session_descriptor_hash)
+        {
+            super::SuccessorLookup::Tip => return Ok(()),
+            super::SuccessorLookup::Found {
+                external_descriptor,
+                network,
+            } => (external_descriptor, network),
+            super::SuccessorLookup::Unavailable => {
+                return Err("REFUSED: descriptor store unavailable; cannot re-derive the migration sweep destination. Unlock the vault and retry.".to_string());
+            }
+            super::SuccessorLookup::Ambiguous => {
+                return Err("REFUSED: ambiguous descriptor lineage; multiple successors back-point to the session descriptor and no single version+1 successor resolves. Refusing to sign.".to_string());
+            }
+        };
+        // Re-derive against the successor's OWN network, not the OLD
+        // descriptor's, so a (mis)matched network can never silently produce the
+        // wrong expected script.
+        let network = bitcoin::Network::from_str(&network_str).map_err(|e| {
+            format!("REFUSED: successor descriptor has invalid network {network_str}: {e}")
+        })?;
+        let expected_addr = keep_bitcoin::descriptor_address(&external_descriptor, network)
+            .map_err(|e| {
+                format!(
+                    "REFUSED: could not derive expected sweep destination from persisted successor descriptor: {e}"
+                )
+            })?;
+        let expected_script = expected_addr.script_pubkey();
+        if tx.output.len() != 1 {
+            return Err(format!(
+                "REFUSED: session is keyed on an OLD descriptor whose successor (NEW descriptor) is persisted, so this is treated as an automated migration sweep; expected exactly 1 output paying the NEW descriptor address, got {} outputs. Refusing to sign.",
+                tx.output.len()
+            ));
+        }
+        if tx.output[0].script_pubkey != expected_script {
+            return Err(format!(
+                "REFUSED: PSBT output does not pay the persisted NEW descriptor address. Expected {expected_addr}; proposer-supplied script differs. This would route funds away from the group-controlled address; refusing to sign."
+            ));
+        }
+        Ok(())
     }
 
     /// Return the lowercase xpub fingerprints listed as expected external

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -99,6 +99,23 @@ impl KfpNode {
         Some((initiator, *session.descriptor_hash(), session.tier_index()))
     }
 
+    /// Return the external descriptor of any persisted descriptor that lists
+    /// `descriptor_hash` as its `previous_descriptor_hash` for this node's
+    /// group, or `None` if no such successor exists (i.e. the session's
+    /// descriptor is the current tip and there's no automated-sweep
+    /// re-derivation to perform).
+    ///
+    /// Used by responders to validate that a signature request keyed on an
+    /// OLD descriptor actually pays the persisted NEW-descriptor address. Per
+    /// #414, the proposer-side re-derivation in
+    /// `request_descriptor_migration_sweep` is not a security boundary; the
+    /// responder must independently re-derive and refuse to sign on mismatch.
+    pub fn descriptor_successor_external(&self, descriptor_hash: &[u8; 32]) -> Option<String> {
+        self.descriptor_lookup
+            .as_deref()
+            .and_then(|l| l.successor_external_for(&self.group_pubkey, descriptor_hash))
+    }
+
     /// Return the lowercase xpub fingerprints listed as expected external
     /// signers for the given PSBT session. Returns `None` if the session is
     /// unknown. Share-based signers are not included.


### PR DESCRIPTION
Addresses #414, half of it. Closing #414 here; the prevout-amount validation half is tracked in #502.

## The hole

`request_descriptor_migration_sweep` does proposer-side destination re-derivation, but the sweep rides the generic `request_psbt_spend` path keyed on the OLD descriptor hash. That path accepts an arbitrary destination from any authorized proposer. Responders' only check on what they're signing is `verify_all_script_spend_input_bindings` (input control); nothing on the responder side confirms the output script pays a group-controlled address.

So an authorized proposer who's been compromised — or who wants to grief — can craft a `request_psbt_spend` keyed on the OLD descriptor hash and route funds to an attacker. Desktop signs without showing the output; CLI shows it and asks a human. Neither is a security boundary on an automated sweep path.

## What this PR does

When a responder receives a PSBT signature request keyed on a descriptor hash whose **successor** is also persisted in the same vault (i.e. there's a recorded NEW descriptor that lists the request's descriptor as its `previous_descriptor_hash`), the responder:

1. Re-derives the expected sweep destination from the persisted NEW descriptor's external string.
2. Requires the PSBT to have exactly one output paying that address.
3. Refuses to sign on any mismatch.

This makes the proposer-side re-derivation in `request_descriptor_migration_sweep` no longer a security boundary; the responder enforces the constraint independently.

Sessions keyed on the current TIP descriptor (no successor recorded) keep the existing behavior — the migration-sweep check doesn't fire because there's nothing to compare against.

## Changes

- `keep-frost-net/src/node/mod.rs`:
  - New trait method `PersistedDescriptorLookup::successor_external_for(group, hash) -> Option<String>`. Defaults to `None`; impls override.
  - `KeepDescriptorLookup` walks the `previous_descriptor_hash` back-pointer chain and returns the external descriptor of the successor.
  - Two unit tests: hit case (returns successor), no-successor case (returns `None`), wrong-group case (returns `None`).
- `keep-frost-net/src/node/psbt.rs`:
  - New `KfpNode::descriptor_successor_external(descriptor_hash)` accessor that surfaces the lookup result to CLI/desktop without exposing the lookup itself.
- `keep-cli/src/commands/wallet.rs`:
  - In `approve_psbt_session`, after the input-binding check, query `descriptor_successor_external(session_descriptor_hash)`. If present, validate the single-output destination matches the re-derived expected address; refuse on mismatch.
- `keep-desktop/src/app/wallet.rs`:
  - Same check in `begin_approve_psbt`, before contacting the bunker. Desktop has no human approval step on the sign path, so this is the only line of defense in the desktop signer.

## What this does NOT do

The prevout amount validation half of #414 (responders trusting `witness_utxo.value_sats` claims) needs a chain view. That's tracked separately in #502; both keep-cli and keep-desktop will need to grow a chain client. TODO markers remain at the call sites.

Closes #414. Follow-up: #502 (chain-view prevout amount validation).

## Test plan
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --lib` — 679 tests pass, including the two new lookup tests:
  - `successor_external_for_returns_new_descriptor_keyed_on_old_hash`
  - `successor_external_for_returns_none_without_chain`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for descriptor migrations to ensure that automated migration sweeps are correctly routed to successor addresses with strict verification that transactions contain exactly one output matching the successor's script before signing.

* **New Features**
  * Added descriptor successor lookup capabilities across wallet and network components to support safe migration workflows with proper destination verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->