### PR TITLE
WDC: opt-in KEEP_ALLOW_WS env; excluded peers skip key-proof + ACK

### DIFF
--- a/keep-core/src/relay.rs
+++ b/keep-core/src/relay.rs
@@ -154,16 +154,22 @@ fn validate_relay_url_inner(url: &str, allow_internal: bool) -> Result<(), Strin
         return Err("URL too long".into());
     }
 
+    // `ws://` is normally rejected in release builds. It can be opted into via
+    // the `allow-ws` Cargo feature (for tests) or the `KEEP_ALLOW_WS=1` runtime
+    // env (for local development against `nak serve`). Both knobs are intended
+    // for non-production use; production deployments should always speak wss://.
+    let ws_allowed_at_runtime =
+        cfg!(feature = "allow-ws") || std::env::var("KEEP_ALLOW_WS").as_deref() == Ok("1");
     let rest = url
         .strip_prefix("wss://")
         .or_else(|| {
-            if cfg!(feature = "allow-ws") {
+            if ws_allowed_at_runtime {
                 url.strip_prefix("ws://")
             } else {
                 None
             }
         })
-        .ok_or("Must use wss:// protocol")?;
+        .ok_or("Must use wss:// protocol (set KEEP_ALLOW_WS=1 for local-only ws:// testing)")?;
 
     if rest.is_empty() {
         return Err("Missing host".into());

--- a/keep-frost-net/src/node/descriptor.rs
+++ b/keep-frost-net/src/node/descriptor.rs
@@ -1013,59 +1013,80 @@ impl KfpNode {
         )
         .map_err(|e| FrostNetError::Session(e.to_string()))?;
 
-        let key_proof_psbt_bytes = match self.build_key_proof(
-            &payload.session_id,
-            our_index,
-            our_xpub.as_deref(),
-            &session_network,
-        ) {
-            Ok(bytes) => bytes,
-            Err(e) => {
-                let reason = format!("Key proof failed: {e}");
-                self.descriptor_sessions
-                    .write()
-                    .remove_session(&payload.session_id);
-                self.send_descriptor_nack(payload.session_id, &sender, &reason)
-                    .await;
-                let _ = self.event_tx.send(KfpNodeEvent::DescriptorFailed {
-                    session_id: payload.session_id,
-                    error: reason.clone(),
-                });
-                return Err(FrostNetError::Session(reason));
-            }
-        };
+        // #423: only contributing peers need to prove ownership of an xpub and
+        // ACK; peers not selected as contributors (`our_xpub == None`) have no
+        // xpub to prove and the proposer's `expected_acks` already excludes
+        // them (see `cmd_frost_network_propose_descriptor`'s contributor-filtered
+        // expected_acks construction). Without this gate, the excluded peer
+        // tried to build a key-proof, failed with "Missing own xpub
+        // contribution for key proof", sent a NACK, removed its session, and
+        // surfaced a `DescriptorFailed` event — even though the proposer's view
+        // was successful. Now: skip the ACK round entirely when we're not a
+        // contributor and proceed straight to local finalization.
+        let we_are_contributor = our_xpub.is_some();
+        if we_are_contributor {
+            let key_proof_psbt_bytes = match self.build_key_proof(
+                &payload.session_id,
+                our_index,
+                our_xpub.as_deref(),
+                &session_network,
+            ) {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    let reason = format!("Key proof failed: {e}");
+                    self.descriptor_sessions
+                        .write()
+                        .remove_session(&payload.session_id);
+                    self.send_descriptor_nack(payload.session_id, &sender, &reason)
+                        .await;
+                    let _ = self.event_tx.send(KfpNodeEvent::DescriptorFailed {
+                        session_id: payload.session_id,
+                        error: reason.clone(),
+                    });
+                    return Err(FrostNetError::Session(reason));
+                }
+            };
 
-        let ack = DescriptorAckPayload::new(
-            payload.session_id,
-            self.group_pubkey,
-            descriptor_hash,
-            key_proof_psbt_bytes,
-        );
-        let msg = KfpMessage::DescriptorAck(ack);
-        let json = msg.to_json()?;
+            let ack = DescriptorAckPayload::new(
+                payload.session_id,
+                self.group_pubkey,
+                descriptor_hash,
+                key_proof_psbt_bytes,
+            );
+            let msg = KfpMessage::DescriptorAck(ack);
+            let json = msg.to_json()?;
 
-        let encrypted = nip44::encrypt(self.keys.secret_key(), &sender, &json, nip44::Version::V2)
-            .map_err(|e| FrostNetError::Crypto(e.to_string()))?;
+            let encrypted =
+                nip44::encrypt(self.keys.secret_key(), &sender, &json, nip44::Version::V2)
+                    .map_err(|e| FrostNetError::Crypto(e.to_string()))?;
 
-        let event = EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), encrypted)
-            .custom_created_at(Timestamp::tweaked(TIMESTAMP_TWEAK_RANGE))
-            .tag(Tag::public_key(sender))
-            .tag(Tag::custom(
-                TagKind::custom("g"),
-                [hex::encode(self.group_pubkey)],
-            ))
-            .tag(Tag::custom(
-                TagKind::custom("s"),
-                [hex::encode(payload.session_id)],
-            ))
-            .tag(Tag::custom(TagKind::custom("t"), ["descriptor_ack"]))
-            .sign_with_keys(&self.keys)
-            .map_err(|e| FrostNetError::Nostr(e.to_string()))?;
+            let event = EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), encrypted)
+                .custom_created_at(Timestamp::tweaked(TIMESTAMP_TWEAK_RANGE))
+                .tag(Tag::public_key(sender))
+                .tag(Tag::custom(
+                    TagKind::custom("g"),
+                    [hex::encode(self.group_pubkey)],
+                ))
+                .tag(Tag::custom(
+                    TagKind::custom("s"),
+                    [hex::encode(payload.session_id)],
+                ))
+                .tag(Tag::custom(TagKind::custom("t"), ["descriptor_ack"]))
+                .sign_with_keys(&self.keys)
+                .map_err(|e| FrostNetError::Nostr(e.to_string()))?;
 
-        self.client
-            .send_event(&event)
-            .await
-            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+            self.client
+                .send_event(&event)
+                .await
+                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+        } else {
+            let _ = descriptor_hash; // silence unused-variable warning when no ACK is sent
+            debug!(
+                session_id = %hex::encode(payload.session_id),
+                our_index,
+                "not a contributor for this tier; skipping key-proof and ACK"
+            );
+        }
 
         {
             let mut sessions = self.descriptor_sessions.write();


### PR DESCRIPTION
Two WDC fixes from the #418/#434 sweep.

## #423 Excluded peers fail with "Missing own xpub contribution for key proof"

On a 2-of-3 group running a `1of1@1mo` or `2of2@1mo` recovery tier (i.e. any tier where `keys < share_count`), the proposer's view was successful but every non-contributor peer logged:
```
Key proof failed: Missing own xpub contribution for key proof
```
removed its session, and emitted a `DescriptorFailed` event. The proposer never expected the excluded peer's ACK (`expected_acks` is already filtered to contributors at the propose site), but the excluded peer ran the key-proof unconditionally and self-destructed the session anyway.

After: `handle_descriptor_finalize` gates the key-proof + ACK round on `we_are_contributor = our_xpub.is_some()`. When we're not a contributor, we skip the key-proof and don't send an ACK; the local session still finalizes (saves the descriptor, emits `DescriptorComplete`) so the excluded peer ends up with consistent state. The proposer doesn't care because it never expected our ACK.

Closes #423.

## #479 `wallet announce-keys` rejects `ws://` even when other commands accept it

`keep_core::relay::validate_relay_url` enforced `wss://` in non-`allow-ws` builds, but `keep serve` and `frost network serve` accept `ws://` via different code paths. WDC commands (`wallet announce-keys`, `wallet propose`) route through the strict validator, so the developer can't run an end-to-end WDC test against a local `nak serve` relay without recompiling with `--features allow-ws`.

After: the validator also honors `KEEP_ALLOW_WS=1` at runtime. The `allow-ws` Cargo feature is preserved (tests rely on it). Error message now says `Must use wss:// protocol (set KEEP_ALLOW_WS=1 for local-only ws:// testing)` so the escape hatch is discoverable. Production deployments unchanged.

Closes #479.

## Also closed by audit

- **#457** (`frost refresh` cannot run without TTY): verified that `cmd_frost_refresh` already routes through `get_confirm`, which honors `KEEP_YES` (`keep-cli/src/commands/mod.rs:95-97`). The original report predated PR #482's surfacing of `KEEP_YES`. Closed directly with a usage note.

## Changes
- `keep-core/src/relay.rs`: `validate_relay_url_inner` reads `KEEP_ALLOW_WS=1` env at runtime; error message points at the env var.
- `keep-frost-net/src/node/descriptor.rs`: `handle_descriptor_finalize` only runs the key-proof + ACK branch when `our_xpub.is_some()`; otherwise debug-logs `not a contributor for this tier; skipping key-proof and ACK` and falls through to the local finalize block.

## Test plan
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --lib` — 679 tests pass workspace-wide.
- [x] Manual review: on a `1of1@1mo` tier in a 2-of-3 group, both non-contributor peers' daemon logs no longer show the "Missing own xpub contribution" error and the proposer sees success.
- [x] Manual: `KEEP_ALLOW_WS=1 keep wallet announce-keys --relay ws://localhost:10547 ...` no longer errors at the validator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Relay URL validation now supports local websocket connections via the `KEEP_ALLOW_WS` environment variable for testing purposes.

* **Bug Fixes**
  * Improved node behavior for non-contributor participants by gracefully skipping validation steps instead of failing, reducing unnecessary errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->