### PR TITLE
Fast failover: auto-retry signing round on co-signer timeout

### DIFF
--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -123,7 +123,7 @@ pub fn cmd_frost_network_serve(
                         let sig = hex::encode(signature);
                         tracing::info!(session, signature = sig, "signature complete");
                     }
-                    Ok(keep_frost_net::KfpNodeEvent::SigningFailed { session_id, error }) => {
+                    Ok(keep_frost_net::KfpNodeEvent::SigningFailed { session_id, error, .. }) => {
                         let session = hex::encode(&session_id[..8]);
                         tracing::error!(session, error, "signing failed");
                     }

--- a/keep-desktop/src/frost.rs
+++ b/keep-desktop/src/frost.rs
@@ -589,7 +589,7 @@ pub(crate) async fn frost_event_listener(
                         }
                         push_frost_event(&frost_events, FrostNodeMsg::SignRequestRemoved(id));
                     }
-                    Ok(KfpNodeEvent::SigningFailed { session_id, ref error }) => {
+                    Ok(KfpNodeEvent::SigningFailed { session_id, ref error, .. }) => {
                         log!(EventLogType::SignFailed, format!("Signing failed: {}", truncate_peer_string(error)));
                         let id = hex::encode(session_id);
                         if let Ok(mut guard) = pending_requests.lock() {

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -127,7 +127,9 @@ pub use psbt_session::{
 pub use recovery_signers::{
     InMemoryRecoverySignerRegistry, RecoverySignerHandle, RecoverySignerRegistry,
 };
-pub use session::{derive_session_id, NetworkSession, SessionManager, SessionState};
+pub use session::{
+    derive_session_id, derive_session_id_salted, NetworkSession, SessionManager, SessionState,
+};
 
 pub fn install_default_crypto_provider() {
     rustls::crypto::ring::default_provider()

--- a/keep-frost-net/src/node/ecdh.rs
+++ b/keep-frost-net/src/node/ecdh.rs
@@ -211,7 +211,8 @@ impl KfpNode {
     pub async fn request_ecdh(&self, recipient_pubkey: &[u8; 33]) -> Result<Zeroizing<[u8; 32]>> {
         let threshold = self.share.metadata.threshold;
 
-        let (participants, participant_peers) = self.select_eligible_peers(threshold as usize)?;
+        let (participants, participant_peers) =
+            self.select_eligible_peers(threshold as usize, &[])?;
 
         let session_id = derive_ecdh_session_id(recipient_pubkey, &participants);
 

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -386,6 +386,14 @@ pub enum KfpNodeEvent {
     SigningFailed {
         session_id: [u8; 32],
         error: String,
+        /// Peer-reported error code (e.g. `stale_nonce`), used by the requester
+        /// to decide whether the failure is recoverable in place or whether the
+        /// offending peer should be excluded and the round failed over.
+        code: String,
+        /// Share index of the peer that reported the error, when resolvable.
+        /// Carried structurally so failover can exclude exactly that peer
+        /// without parsing it back out of the human-readable `error` string.
+        offending_index: Option<u16>,
     },
     EcdhComplete {
         session_id: [u8; 32],
@@ -513,10 +521,17 @@ impl std::fmt::Debug for KfpNodeEvent {
                 .field("session_id", &hex::encode(session_id))
                 .field("signature", &hex::encode(signature))
                 .finish(),
-            Self::SigningFailed { session_id, error } => f
+            Self::SigningFailed {
+                session_id,
+                error,
+                code,
+                offending_index,
+            } => f
                 .debug_struct("SigningFailed")
                 .field("session_id", &hex::encode(session_id))
                 .field("error", error)
+                .field("code", code)
+                .field("offending_index", offending_index)
                 .finish(),
             Self::EcdhFailed { session_id, error } => f
                 .debug_struct("EcdhFailed")
@@ -1513,23 +1528,27 @@ impl KfpNode {
                             None => None,
                         }
                     };
-                    if let Some(offending_index) = offending_index {
-                        // Future improvement: on `stale_nonce` /
-                        // `incomplete_pre_exchange` the requester could retry
-                        // this session with a fresh interactive commitment round
-                        // instead of failing, since these are recoverable
-                        // pre-exchange misses rather than fatal errors. For now
-                        // we fail fast so the caller can decide to retry. The
-                        // peer index is appended so the requester can clear only
-                        // the offending peer's pooled commitments.
-                        let _ = self.event_tx.send(KfpNodeEvent::SigningFailed {
-                            session_id,
-                            error: format!(
-                                "Peer reported error: {} (peer {offending_index})",
-                                payload.code
-                            ),
-                        });
-                    }
+                    // Recoverable pre-exchange misses (`stale_nonce` /
+                    // `incomplete_pre_exchange`) keep their fast-fail + pool-clear
+                    // handling in `request_signature`. Any other peer-reported
+                    // error is treated like an unresponsive peer there: the
+                    // offending index is excluded and the round fails over to
+                    // live co-signers instead of returning fatally, so a faulty
+                    // or malicious peer cannot reliably block signing. The index
+                    // is carried structurally; the human-readable string still
+                    // embeds it for logs and external consumers.
+                    let error = match offending_index {
+                        Some(idx) => {
+                            format!("Peer reported error: {} (peer {idx})", payload.code)
+                        }
+                        None => format!("Peer reported error: {}", payload.code),
+                    };
+                    let _ = self.event_tx.send(KfpNodeEvent::SigningFailed {
+                        session_id,
+                        error,
+                        code: payload.code.clone(),
+                        offending_index,
+                    });
                 }
             }
         }
@@ -1690,7 +1709,7 @@ impl KfpNode {
     }
 
     async fn handle_pong(&self, from: PublicKey, _payload: PongPayload) -> Result<()> {
-        self.peers.write().touch_by_pubkey(&from);
+        self.peers.write().touch_pong_by_pubkey(&from);
         Ok(())
     }
 
@@ -1701,12 +1720,12 @@ impl KfpNode {
                 timeout.as_secs()
             )));
         }
-        let peers_snapshot: Vec<(u16, PublicKey, std::time::Instant)> = self
+        let peers_snapshot: Vec<(u16, PublicKey, Option<std::time::Instant>)> = self
             .peers
             .read()
             .all_peers()
             .iter()
-            .map(|p| (p.share_index, p.pubkey, p.last_seen))
+            .map(|p| (p.share_index, p.pubkey, p.last_pong))
             .collect();
 
         let responsive = self
@@ -1733,12 +1752,12 @@ impl KfpNode {
     }
 
     pub async fn ping_peers(&self, timeout: Duration) -> Result<Vec<u16>> {
-        let peers_snapshot: Vec<(u16, PublicKey, std::time::Instant)> = self
+        let peers_snapshot: Vec<(u16, PublicKey, Option<std::time::Instant>)> = self
             .peers
             .read()
             .all_peers()
             .iter()
-            .map(|p| (p.share_index, p.pubkey, p.last_seen))
+            .map(|p| (p.share_index, p.pubkey, p.last_pong))
             .collect();
 
         self.ping_peers_snapshot(&peers_snapshot, timeout, None)
@@ -1747,7 +1766,7 @@ impl KfpNode {
 
     async fn ping_peers_snapshot(
         &self,
-        peers_snapshot: &[(u16, PublicKey, std::time::Instant)],
+        peers_snapshot: &[(u16, PublicKey, Option<std::time::Instant>)],
         timeout: Duration,
         early_exit_at: Option<usize>,
     ) -> Result<Vec<u16>> {
@@ -1778,14 +1797,25 @@ impl KfpNode {
             }
         }
 
-        let responsive = |snapshot: &[(u16, PublicKey, std::time::Instant)]| -> Vec<u16> {
+        // A peer counts as responsive only when a *new* Pong arrived after this
+        // snapshot was taken. Comparing `last_pong` against the captured baseline
+        // (rather than generic `last_seen`) prevents a peer that merely
+        // re-announced, without answering our ping, from being classified live,
+        // which is exactly the partial-connectivity case the pre-round ping
+        // targets. A peer with no prior pong (`None` baseline) is responsive once
+        // it has any `last_pong`.
+        let responsive = |snapshot: &[(u16, PublicKey, Option<std::time::Instant>)]| -> Vec<u16> {
             let peers = self.peers.read();
             snapshot
                 .iter()
-                .filter_map(|(share_index, _, initial_last_seen)| {
+                .filter_map(|(share_index, _, baseline_pong)| {
                     peers
                         .get_peer(*share_index)
-                        .filter(|p| p.last_seen > *initial_last_seen)
+                        .filter(|p| match (p.last_pong, baseline_pong) {
+                            (Some(current), Some(baseline)) => current > *baseline,
+                            (Some(_), None) => true,
+                            (None, _) => false,
+                        })
                         .map(|_| *share_index)
                 })
                 .collect()

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1111,12 +1111,14 @@ impl KfpNode {
     pub(crate) fn select_eligible_peers(
         &self,
         threshold: usize,
+        exclude: &[u16],
     ) -> Result<(Vec<u16>, Vec<(u16, PublicKey)>)> {
         let selected_peers: Vec<Peer> = {
             let peers = self.peers.read();
             let eligible_peers: Vec<_> = peers
                 .get_signing_peers()
                 .into_iter()
+                .filter(|p| !exclude.contains(&p.share_index))
                 .filter(|p| self.can_send_to(&p.pubkey) && self.can_receive_from(&p.pubkey))
                 .collect();
 

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -6,6 +6,7 @@ mod psbt;
 mod signing;
 
 pub use psbt::PsbtSessionSnapshot;
+pub(crate) use signing::{MAX_FAILOVER_ATTEMPTS, SIGNING_ROUND_TIMEOUT};
 
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
@@ -1277,11 +1278,16 @@ impl KfpNode {
         // Re-announce often enough that an initiator with a short discovery
         // window reliably catches a periodic announce even if the immediate
         // reciprocal announce (see handle_announce) is missed. Must stay well
-        // under PEER_OFFLINE_THRESHOLD so peers don't flap offline.
-        let mut announce_interval = tokio::time::interval(Duration::from_secs(20));
+        // under the peer offline threshold so peers don't flap offline.
+        let mut announce_interval = tokio::time::interval(crate::peer::PEER_ANNOUNCE_INTERVAL);
         announce_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-        let mut cleanup_interval = tokio::time::interval(Duration::from_secs(120));
+        // Reap expired sessions on roughly the signing round cadence so an
+        // abandoned co-signer session (and its consumed single-use nonce) is
+        // released promptly instead of lingering until lazy cleanup, which keeps
+        // the session table and nonce pool from filling under a burst of
+        // failovers where requesters abandon rounds after SIGNING_ROUND_TIMEOUT.
+        let mut cleanup_interval = tokio::time::interval(SIGNING_ROUND_TIMEOUT);
         cleanup_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         let mut replenish_interval = tokio::time::interval(Duration::from_secs(30));
@@ -1487,31 +1493,39 @@ impl KfpNode {
                 // referenced pre-exchanged nonce). Surface it so an in-flight
                 // `request_signature` fails fast instead of waiting for timeout.
                 if let Some(session_id) = payload.session_id {
-                    let is_participant = {
+                    // Resolve the offending peer's share index so the requester
+                    // can scope any pool cleanup to just that peer instead of
+                    // wiping every peer's pooled commitments.
+                    let offending_index = {
                         let sessions = self.sessions.read();
                         match sessions.get_session(&session_id) {
                             Some(session) => {
                                 let peers = self.peers.read();
-                                session.participants().iter().any(|&idx| {
+                                session.participants().iter().copied().find(|&idx| {
                                     peers
                                         .get_peer(idx)
                                         .map(|p| p.pubkey == event.pubkey)
                                         .unwrap_or(false)
                                 })
                             }
-                            None => false,
+                            None => None,
                         }
                     };
-                    if is_participant {
+                    if let Some(offending_index) = offending_index {
                         // Future improvement: on `stale_nonce` /
                         // `incomplete_pre_exchange` the requester could retry
                         // this session with a fresh interactive commitment round
                         // instead of failing, since these are recoverable
                         // pre-exchange misses rather than fatal errors. For now
-                        // we fail fast so the caller can decide to retry.
+                        // we fail fast so the caller can decide to retry. The
+                        // peer index is appended so the requester can clear only
+                        // the offending peer's pooled commitments.
                         let _ = self.event_tx.send(KfpNodeEvent::SigningFailed {
                             session_id,
-                            error: format!("Peer reported error: {}", payload.code),
+                            error: format!(
+                                "Peer reported error: {} (peer {offending_index})",
+                                payload.code
+                            ),
                         });
                     }
                 }

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -6,7 +6,7 @@ mod psbt;
 mod signing;
 
 pub use psbt::PsbtSessionSnapshot;
-pub(crate) use signing::{MAX_FAILOVER_ATTEMPTS, SIGNING_ROUND_TIMEOUT};
+pub(crate) use signing::SIGNING_ROUND_TIMEOUT;
 
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
@@ -364,6 +364,8 @@ pub struct HealthCheckResult {
 pub(crate) const ANNOUNCE_MAX_AGE_SECS: u64 = 300;
 /// Maximum clock skew tolerance for future timestamps (30 seconds)
 pub(crate) const ANNOUNCE_MAX_FUTURE_SECS: u64 = 30;
+/// How often the early-exit liveness ping re-checks for pongs while waiting.
+const LIVENESS_PING_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 #[derive(Clone)]
 pub enum KfpNodeEvent {
@@ -1682,17 +1684,13 @@ impl KfpNode {
             .await
             .map_err(|e| FrostNetError::Transport(e.to_string()))?;
 
-        if let Some(peer) = self.peers.read().get_peer_by_pubkey(&from) {
-            self.peers.write().update_last_seen(peer.share_index);
-        }
+        self.peers.write().touch_by_pubkey(&from);
 
         Ok(())
     }
 
     async fn handle_pong(&self, from: PublicKey, _payload: PongPayload) -> Result<()> {
-        if let Some(peer) = self.peers.read().get_peer_by_pubkey(&from) {
-            self.peers.write().update_last_seen(peer.share_index);
-        }
+        self.peers.write().touch_by_pubkey(&from);
         Ok(())
     }
 
@@ -1711,7 +1709,9 @@ impl KfpNode {
             .map(|p| (p.share_index, p.pubkey, p.last_seen))
             .collect();
 
-        let responsive = self.ping_peers_snapshot(&peers_snapshot, timeout).await?;
+        let responsive = self
+            .ping_peers_snapshot(&peers_snapshot, timeout, None)
+            .await?;
         let unresponsive: Vec<u16> = peers_snapshot
             .iter()
             .map(|(idx, _, _)| *idx)
@@ -1741,13 +1741,15 @@ impl KfpNode {
             .map(|p| (p.share_index, p.pubkey, p.last_seen))
             .collect();
 
-        self.ping_peers_snapshot(&peers_snapshot, timeout).await
+        self.ping_peers_snapshot(&peers_snapshot, timeout, None)
+            .await
     }
 
     async fn ping_peers_snapshot(
         &self,
         peers_snapshot: &[(u16, PublicKey, std::time::Instant)],
         timeout: Duration,
+        early_exit_at: Option<usize>,
     ) -> Result<Vec<u16>> {
         if peers_snapshot.is_empty() {
             return Ok(Vec::new());
@@ -1776,20 +1778,36 @@ impl KfpNode {
             }
         }
 
-        tokio::time::sleep(timeout).await;
+        let responsive = |snapshot: &[(u16, PublicKey, std::time::Instant)]| -> Vec<u16> {
+            let peers = self.peers.read();
+            snapshot
+                .iter()
+                .filter_map(|(share_index, _, initial_last_seen)| {
+                    peers
+                        .get_peer(*share_index)
+                        .filter(|p| p.last_seen > *initial_last_seen)
+                        .map(|_| *share_index)
+                })
+                .collect()
+        };
 
-        let responsive: Vec<u16> = peers_snapshot
-            .iter()
-            .filter_map(|(share_index, _, initial_last_seen)| {
-                self.peers
-                    .read()
-                    .get_peer(*share_index)
-                    .filter(|p| p.last_seen > *initial_last_seen)
-                    .map(|_| *share_index)
-            })
-            .collect();
+        // Without an early-exit target, classify every peer after the full
+        // timeout (health check). With one, poll and return as soon as that many
+        // peers have ponged so the all-online path resolves in roughly one
+        // round-trip instead of waiting out the whole timeout.
+        let Some(target) = early_exit_at else {
+            tokio::time::sleep(timeout).await;
+            return Ok(responsive(peers_snapshot));
+        };
 
-        Ok(responsive)
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            let current = responsive(peers_snapshot);
+            if current.len() >= target || std::time::Instant::now() >= deadline {
+                return Ok(current);
+            }
+            tokio::time::sleep(LIVENESS_PING_POLL_INTERVAL).await;
+        }
     }
 }
 

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -12,7 +12,7 @@ use crate::audit::SigningOperation;
 use crate::error::{FrostNetError, Result};
 use crate::event::KfpEventBuilder;
 use crate::protocol::*;
-use crate::session::derive_session_id;
+use crate::session::{derive_session_id, derive_session_id_salted};
 
 use super::{KfpNode, KfpNodeEvent, NonceId, SessionInfo};
 use crate::nonce_pool::{serialize_commitment, NoncePool};
@@ -54,6 +54,25 @@ impl From<FrostNetError> for SigningRoundError {
     fn from(error: FrostNetError) -> Self {
         Self::fatal(error)
     }
+}
+
+/// A peer-reported failure for the in-flight signing session, carried out of the
+/// round receive loop with the structured error code and offending share index
+/// so the failover logic can decide whether the failure is recoverable in place
+/// or whether the peer should be excluded and the round retried.
+struct PeerRoundFailure {
+    error: String,
+    code: String,
+    offending_index: Option<u16>,
+}
+
+/// Peer-reported error codes that the requester handles in place (clearing the
+/// offending peer's pooled commitments and falling back to an interactive round
+/// on the next request) rather than excluding the peer and failing over. Any
+/// other code is treated like an unresponsive peer so a faulty or malicious
+/// co-signer cannot reliably block signing.
+fn is_recoverable_peer_error(code: &str) -> bool {
+    code == "stale_nonce" || code == "incomplete_pre_exchange"
 }
 
 /// Extract the offending peer's share index from a peer-reported session error,
@@ -586,11 +605,12 @@ impl KfpNode {
         let commit_result = {
             let mut sessions = self.sessions.write();
 
-            let session = sessions.get_or_create_session(
+            let session = sessions.get_or_create_session_salted(
                 request.session_id,
                 request.message.clone(),
                 self.share.metadata.threshold,
                 request.participants.clone(),
+                &request.session_salt,
             )?;
 
             // All nonce_refs have now been validated above, and a pre-exchange
@@ -1016,13 +1036,13 @@ impl KfpNode {
     /// normal round and failover should decide rather than a flaky ping.
     async fn prune_unresponsive_cosigners(&self) -> Vec<u16> {
         let needed = (self.share.metadata.threshold as usize).saturating_sub(1);
-        let snapshot: Vec<(u16, PublicKey, std::time::Instant)> = {
+        let snapshot: Vec<(u16, PublicKey, Option<std::time::Instant>)> = {
             let peers = self.peers.read();
             peers
                 .get_signing_peers()
                 .into_iter()
                 .filter(|p| self.can_send_to(&p.pubkey) && self.can_receive_from(&p.pubkey))
-                .map(|p| (p.share_index, p.pubkey, p.last_seen))
+                .map(|p| (p.share_index, p.pubkey, p.last_pong))
                 .collect()
         };
         if snapshot.len() <= needed {
@@ -1201,7 +1221,19 @@ impl KfpNode {
 
         let attempted: Vec<u16> = participant_peers.iter().map(|(idx, _)| *idx).collect();
 
-        let session_id = derive_session_id(&message, &participants, threshold);
+        // Salt the session id with the attempt index so a re-sample over an
+        // unchanged participant set (everyone responded but no signature was
+        // produced) derives a distinct id and fresh nonce instead of colliding
+        // with the just-completed attempt and tripping the replay guard. Attempt
+        // 0 uses an empty salt to keep the common single-attempt id stable and
+        // wire-compatible with peers that predate salted failover.
+        let session_salt: Vec<u8> = if attempt == 0 {
+            Vec::new()
+        } else {
+            (attempt as u64).to_be_bytes().to_vec()
+        };
+        let session_id =
+            derive_session_id_salted(&message, &participants, threshold, &session_salt);
 
         info!(
             logical_id = %hex::encode(logical_id),
@@ -1269,7 +1301,8 @@ impl KfpNode {
             message_type,
             participants.clone(),
         )
-        .with_nonce_refs(nonce_refs);
+        .with_nonce_refs(nonce_refs)
+        .with_session_salt(session_salt.clone());
 
         let session_info = SessionInfo {
             session_id,
@@ -1283,11 +1316,12 @@ impl KfpNode {
 
         {
             let mut sessions = self.sessions.write();
-            let session = sessions.create_session(
+            let session = sessions.create_session_salted(
                 session_id,
                 message,
                 self.share.metadata.threshold,
                 participants.clone(),
+                &session_salt,
             )?;
 
             session.set_our_nonces(nonces);
@@ -1383,13 +1417,23 @@ impl KfpNode {
                     Ok(KfpNodeEvent::SigningFailed {
                         session_id: sid,
                         error,
+                        code,
+                        offending_index,
                     }) => {
                         if sid == session_id {
-                            return Err(FrostNetError::Session(error));
+                            return Err(PeerRoundFailure {
+                                error,
+                                code,
+                                offending_index,
+                            });
                         }
                     }
                     Err(_) => {
-                        return Err(FrostNetError::Transport("Event channel closed".into()));
+                        return Err(PeerRoundFailure {
+                            error: "Event channel closed".into(),
+                            code: "channel_closed".into(),
+                            offending_index: None,
+                        });
                     }
                     _ => {}
                 }
@@ -1402,9 +1446,42 @@ impl KfpNode {
         // request and our consumed nonce can't be reused.
         match result {
             Ok(Ok(signature)) => Ok(signature),
-            Ok(Err(e)) => {
+            Ok(Err(failure)) => {
                 self.sessions.write().complete_session(&session_id);
-                Err(e.into())
+                if failure.code == "channel_closed" {
+                    // The event channel closed (node shutting down); not a peer
+                    // fault, so surface it fatally rather than burning failover
+                    // attempts re-subscribing to a dead channel.
+                    Err(SigningRoundError::fatal(FrostNetError::Transport(
+                        failure.error,
+                    )))
+                } else if is_recoverable_peer_error(&failure.code) {
+                    // Recoverable pre-exchange miss: keep the fatal Session error
+                    // so `request_signature` clears the offending peer's pooled
+                    // commitments and the next request falls back to interactive.
+                    Err(SigningRoundError::fatal(FrostNetError::Session(
+                        failure.error,
+                    )))
+                } else {
+                    // A peer actively errored on this session for a
+                    // non-recoverable reason. Treat it like an unresponsive peer:
+                    // exclude it (by share index when known, else the whole
+                    // attempted set) and fail over instead of returning fatally,
+                    // so the offender cannot reliably block signing.
+                    let attempted = match failure.offending_index {
+                        Some(idx) => vec![idx],
+                        None => attempted.clone(),
+                    };
+                    warn!(
+                        code = %failure.code,
+                        offending = ?failure.offending_index,
+                        "peer reported non-recoverable signing error; excluding and failing over"
+                    );
+                    Err(SigningRoundError {
+                        error: FrostNetError::Timeout(failure.error),
+                        attempted,
+                    })
+                }
             }
             Err(_) => {
                 // Exclude only peers that never responded; responsive peers stay

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -20,12 +20,12 @@ use crate::nonce_pool::{serialize_commitment, NoncePool};
 /// Per-round wait for the aggregated signature. Below the 20s peer announce
 /// interval so a round resolves within one announce cycle, and comfortably
 /// above honest co-signer response time including TEE attestation latency.
-const SIGNING_ROUND_TIMEOUT: Duration = Duration::from_secs(15);
+pub(crate) const SIGNING_ROUND_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Upper bound on failover retries for a single signing request. Caps the
 /// worst-case wall-clock cost of repeated round timeouts (each up to
 /// `SIGNING_ROUND_TIMEOUT`) under a partition or latency event.
-const MAX_FAILOVER_ATTEMPTS: usize = 3;
+pub(crate) const MAX_FAILOVER_ATTEMPTS: usize = 3;
 
 /// Error from a single signing round. `attempted` lists the non-self peers that
 /// failed to respond in this round, so a timed-out round can exclude them and
@@ -48,6 +48,17 @@ impl From<FrostNetError> for SigningRoundError {
     fn from(error: FrostNetError) -> Self {
         Self::fatal(error)
     }
+}
+
+/// Extract the offending peer's share index from a peer-reported session error,
+/// which the message handler annotates with a trailing "(peer N)". Returns
+/// `None` when the index is absent or unparseable so the caller can fall back
+/// to clearing the whole pool.
+fn parse_offending_peer(msg: &str) -> Option<u16> {
+    let start = msg.rfind("(peer ")? + "(peer ".len();
+    let rest = &msg[start..];
+    let end = rest.find(')')?;
+    rest[..end].trim().parse().ok()
 }
 
 /// Restores peer commitments reserved from the [`NoncePool`] back into the pool
@@ -1004,8 +1015,12 @@ impl KfpNode {
         // latency event cannot stall the caller for round_timeout × eligible
         // peers; the final attempt surfaces its error to the caller.
         //
-        // Stable id correlating all failover attempts of one logical request in
-        // the audit log; independent of the per-attempt participant set.
+        // Log-correlation id ONLY, not a cryptographic session id: it ties the
+        // failover attempts of one logical request together in the audit log and
+        // is independent of the per-attempt participant set. It is never used to
+        // gate the replay guard or index the nonce store (each attempt derives a
+        // real per-participant session id for that). Two requests for the same
+        // message intentionally share this id; do not treat it as unique.
         let logical_id = derive_session_id(&message, &[], self.share.metadata.threshold);
         let mut excluded: Vec<u16> = Vec::new();
         for attempt in 0..MAX_FAILOVER_ATTEMPTS {
@@ -1024,13 +1039,42 @@ impl KfpNode {
                 Err(SigningRoundError {
                     error: FrostNetError::Timeout(_),
                     attempted,
-                }) if !attempted.is_empty() && !last => {
+                }) if !last => {
+                    // Fail over on ANY round timeout while retries remain. The
+                    // unresponsive set only decides WHICH peers to drop: when it
+                    // is non-empty exclude those peers, otherwise (e.g. everyone
+                    // committed/responded but aggregation never produced a
+                    // SignatureComplete) retry without excluding anyone so the
+                    // next attempt re-samples a fresh participant set.
+                    if attempted.is_empty() {
+                        warn!(
+                            attempt = attempt,
+                            "signing round timed out with no unresponsive peers; re-sampling and retrying"
+                        );
+                    } else {
+                        warn!(
+                            excluded = ?attempted,
+                            attempt = attempt,
+                            "signing round timed out; excluding unresponsive peers and retrying"
+                        );
+                        excluded.extend(attempted);
+                    }
+                }
+                Err(SigningRoundError {
+                    error: FrostNetError::InsufficientPeers { .. },
+                    ..
+                }) if !excluded.is_empty() => {
+                    // Failover has exhausted the eligible set: each retry after
+                    // the first excludes more peers until fewer than threshold
+                    // remain. Surfacing InsufficientPeers here would mislead the
+                    // caller into thinking the group was undersized, when the
+                    // real cause is co-signers timing out during failover. Break
+                    // to surface the aggregate failover timeout instead.
                     warn!(
-                        excluded = ?attempted,
                         attempt = attempt,
-                        "signing round timed out; excluding unresponsive peers and retrying"
+                        "failover exhausted the eligible peer set; surfacing aggregate timeout"
                     );
-                    excluded.extend(attempted);
+                    break;
                 }
                 Err(e) => {
                     // If a peer reported a stale pre-exchanged nonce (it
@@ -1047,10 +1091,27 @@ impl KfpNode {
                     // the next request starts clean.
                     if let FrostNetError::Session(ref msg) = e.error {
                         if msg.contains("stale_nonce") || msg.contains("incomplete_pre_exchange") {
-                            self.nonce_pool.clear_all_peers();
-                            warn!(
-                                "peer reported stale pre-exchanged nonce; cleared pool, next round is interactive"
-                            );
+                            // Scope the cleanup to the offending peer when its
+                            // index is identifiable from the error (the handler
+                            // appends "(peer N)"), so other peers keep their
+                            // pooled commitments and don't fall back to slow
+                            // interactive rounds. Only when the peer cannot be
+                            // identified do we clear the whole pool.
+                            match parse_offending_peer(msg) {
+                                Some(idx) => {
+                                    self.nonce_pool.clear_peer(idx);
+                                    warn!(
+                                        peer = idx,
+                                        "peer reported stale pre-exchanged nonce; cleared its pooled commitments"
+                                    );
+                                }
+                                None => {
+                                    self.nonce_pool.clear_all_peers();
+                                    warn!(
+                                        "peer reported stale pre-exchanged nonce (peer unidentified); cleared pool, next round is interactive"
+                                    );
+                                }
+                            }
                         }
                     }
                     return Err(e.error);

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -17,8 +17,19 @@ use crate::session::derive_session_id;
 use super::{KfpNode, KfpNodeEvent, NonceId, SessionInfo};
 use crate::nonce_pool::{serialize_commitment, NoncePool};
 
-/// Error from a single signing round. `attempted` lists the non-self peers the
-/// round selected, so a timed-out round can exclude them and fail over.
+/// Per-round wait for the aggregated signature. Below the 20s peer announce
+/// interval so a round resolves within one announce cycle, and comfortably
+/// above honest co-signer response time including TEE attestation latency.
+const SIGNING_ROUND_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Upper bound on failover retries for a single signing request. Caps the
+/// worst-case wall-clock cost of repeated round timeouts (each up to
+/// `SIGNING_ROUND_TIMEOUT`) under a partition or latency event.
+const MAX_FAILOVER_ATTEMPTS: usize = 3;
+
+/// Error from a single signing round. `attempted` lists the non-self peers that
+/// failed to respond in this round, so a timed-out round can exclude them and
+/// fail over to other live co-signers.
 struct SigningRoundError {
     error: FrostNetError,
     attempted: Vec<u16>,
@@ -979,19 +990,33 @@ impl KfpNode {
 
     pub async fn request_signature(
         &self,
-        message: Vec<u8>,
+        mut message: Vec<u8>,
         message_type: &str,
     ) -> Result<[u8; 64]> {
-        // On a round timeout the selected co-signer is treated as unresponsive
-        // and excluded, then we re-select from the remaining online peers and
-        // retry. This fails over to another live co-signer in seconds instead of
-        // surfacing the timeout to the caller. The session id is rederived per
-        // attempt from the (changed) participant set, so each retry is a fresh
-        // session with a fresh nonce.
+        // On a round timeout the co-signers that failed to commit are treated as
+        // unresponsive and excluded, then we re-select from the remaining online
+        // peers and retry. This fails over to other live co-signers in seconds
+        // instead of surfacing the timeout to the caller. The session id is
+        // rederived per attempt from the (changed) participant set, so each retry
+        // is a fresh session with a fresh nonce.
+        //
+        // The retry count is capped by MAX_FAILOVER_ATTEMPTS so a partition or
+        // latency event cannot stall the caller for round_timeout × eligible
+        // peers; the final attempt surfaces its error to the caller.
+        //
+        // Stable id correlating all failover attempts of one logical request in
+        // the audit log; independent of the per-attempt participant set.
+        let logical_id = derive_session_id(&message, &[], self.share.metadata.threshold);
         let mut excluded: Vec<u16> = Vec::new();
-        loop {
+        for attempt in 0..MAX_FAILOVER_ATTEMPTS {
+            let last = attempt + 1 == MAX_FAILOVER_ATTEMPTS;
+            let round_message = if last {
+                std::mem::take(&mut message)
+            } else {
+                message.clone()
+            };
             let result = self
-                .signing_round(message.clone(), message_type, &excluded)
+                .signing_round(round_message, message_type, &excluded, logical_id, attempt)
                 .await;
 
             // If a peer reported a stale pre-exchanged nonce (it rotated/restarted, so
@@ -1001,8 +1026,10 @@ impl KfpNode {
             // place: our single-use nonce was already spent on a share bound to the
             // stale commitment, the session id is fixed by the message, and the
             // replay guard would reject re-signing it; retrying would risk nonce
-            // reuse. The signing session is torn down on failure (see below), so the
-            // next attempt starts clean.
+            // reuse. The stale_nonce/incomplete_pre_exchange branch is a fatal
+            // Session error (not a Timeout), so it intentionally bypasses the
+            // failover retry below and returns to the caller. The signing session
+            // is torn down on failure (see below), so the next attempt starts clean.
             if let Err(SigningRoundError {
                 error: FrostNetError::Session(ref e),
                 ..
@@ -1021,9 +1048,10 @@ impl KfpNode {
                 Err(SigningRoundError {
                     error: FrostNetError::Timeout(_),
                     attempted,
-                }) if !attempted.is_empty() => {
+                }) if !attempted.is_empty() && !last => {
                     warn!(
                         excluded = ?attempted,
+                        attempt = attempt,
                         "signing round timed out; excluding unresponsive peers and retrying"
                     );
                     excluded.extend(attempted);
@@ -1031,6 +1059,9 @@ impl KfpNode {
                 Err(e) => return Err(e.error),
             }
         }
+        Err(FrostNetError::Timeout(
+            "Signing request timed out after failover".into(),
+        ))
     }
 
     async fn signing_round(
@@ -1038,6 +1069,8 @@ impl KfpNode {
         message: Vec<u8>,
         message_type: &str,
         exclude: &[u16],
+        logical_id: [u8; 32],
+        attempt: usize,
     ) -> std::result::Result<[u8; 64], SigningRoundError> {
         let threshold = self.share.metadata.threshold;
 
@@ -1050,8 +1083,10 @@ impl KfpNode {
         let session_id = derive_session_id(&message, &participants, threshold);
 
         info!(
+            logical_id = %hex::encode(logical_id),
             session_id = %hex::encode(session_id),
             participants = ?participants,
+            attempt = attempt,
             "Initiating signing request"
         );
 
@@ -1213,9 +1248,7 @@ impl KfpNode {
             }
         }
 
-        let timeout = Duration::from_secs(15);
-
-        let result = tokio::time::timeout(timeout, async {
+        let result = tokio::time::timeout(SIGNING_ROUND_TIMEOUT, async {
             loop {
                 match rx.recv().await {
                     Ok(KfpNodeEvent::SignatureComplete {
@@ -1253,10 +1286,21 @@ impl KfpNode {
                 Err(e.into())
             }
             Err(_) => {
+                // Exclude only peers that never committed; responsive peers stay
+                // eligible for the failover retry so we don't drain the eligible
+                // set or waste healthy peers' single-use nonces. If the session is
+                // already gone, fall back to excluding the whole attempted set.
+                let unresponsive = {
+                    let sessions = self.sessions.read();
+                    sessions
+                        .get_session(&session_id)
+                        .map(|s| s.uncommitted_participants(self.share.metadata.identifier))
+                        .unwrap_or_else(|| attempted.clone())
+                };
                 self.sessions.write().complete_session(&session_id);
                 Err(SigningRoundError {
                     error: FrostNetError::Timeout("Signing request timed out".into()),
-                    attempted,
+                    attempted: unresponsive,
                 })
             }
         }

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -17,6 +17,28 @@ use crate::session::derive_session_id;
 use super::{KfpNode, KfpNodeEvent, NonceId, SessionInfo};
 use crate::nonce_pool::{serialize_commitment, NoncePool};
 
+/// Error from a single signing round. `attempted` lists the non-self peers the
+/// round selected, so a timed-out round can exclude them and fail over.
+struct SigningRoundError {
+    error: FrostNetError,
+    attempted: Vec<u16>,
+}
+
+impl SigningRoundError {
+    fn fatal(error: FrostNetError) -> Self {
+        Self {
+            error,
+            attempted: Vec::new(),
+        }
+    }
+}
+
+impl From<FrostNetError> for SigningRoundError {
+    fn from(error: FrostNetError) -> Self {
+        Self::fatal(error)
+    }
+}
+
 /// Restores peer commitments reserved from the [`NoncePool`] back into the pool
 /// if a signing request aborts before the reservation is committed to a live
 /// session. Disarm once the commitments are recorded so successful flows do not
@@ -960,32 +982,70 @@ impl KfpNode {
         message: Vec<u8>,
         message_type: &str,
     ) -> Result<[u8; 64]> {
-        let result = self.signing_round(message, message_type).await;
+        // On a round timeout the selected co-signer is treated as unresponsive
+        // and excluded, then we re-select from the remaining online peers and
+        // retry. This fails over to another live co-signer in seconds instead of
+        // surfacing the timeout to the caller. The session id is rederived per
+        // attempt from the (changed) participant set, so each retry is a fresh
+        // session with a fresh nonce.
+        let mut excluded: Vec<u16> = Vec::new();
+        loop {
+            let result = self
+                .signing_round(message.clone(), message_type, &excluded)
+                .await;
 
-        // If a peer reported a stale pre-exchanged nonce (it rotated/restarted, so
-        // a pooled commitment we referenced no longer maps to a live secret), drop
-        // the suspect pooled commitments so the *next* request falls back to a
-        // fresh interactive round. We deliberately do NOT retry this request in
-        // place: our single-use nonce was already spent on a share bound to the
-        // stale commitment, the session id is fixed by the message, and the
-        // replay guard would reject re-signing it; retrying would risk nonce
-        // reuse. The signing session is torn down on failure (see below), so the
-        // next attempt starts clean.
-        if let Err(FrostNetError::Session(ref e)) = result {
-            if e.contains("stale_nonce") || e.contains("incomplete_pre_exchange") {
-                self.nonce_pool.clear_all_peers();
-                warn!(
-                    "peer reported stale pre-exchanged nonce; cleared pool, next round is interactive"
-                );
+            // If a peer reported a stale pre-exchanged nonce (it rotated/restarted, so
+            // a pooled commitment we referenced no longer maps to a live secret), drop
+            // the suspect pooled commitments so the *next* request falls back to a
+            // fresh interactive round. We deliberately do NOT retry this request in
+            // place: our single-use nonce was already spent on a share bound to the
+            // stale commitment, the session id is fixed by the message, and the
+            // replay guard would reject re-signing it; retrying would risk nonce
+            // reuse. The signing session is torn down on failure (see below), so the
+            // next attempt starts clean.
+            if let Err(SigningRoundError {
+                error: FrostNetError::Session(ref e),
+                ..
+            }) = result
+            {
+                if e.contains("stale_nonce") || e.contains("incomplete_pre_exchange") {
+                    self.nonce_pool.clear_all_peers();
+                    warn!(
+                        "peer reported stale pre-exchanged nonce; cleared pool, next round is interactive"
+                    );
+                }
+            }
+
+            match result {
+                Ok(sig) => return Ok(sig),
+                Err(SigningRoundError {
+                    error: FrostNetError::Timeout(_),
+                    attempted,
+                }) if !attempted.is_empty() => {
+                    warn!(
+                        excluded = ?attempted,
+                        "signing round timed out; excluding unresponsive peers and retrying"
+                    );
+                    excluded.extend(attempted);
+                }
+                Err(e) => return Err(e.error),
             }
         }
-        result
     }
 
-    async fn signing_round(&self, message: Vec<u8>, message_type: &str) -> Result<[u8; 64]> {
+    async fn signing_round(
+        &self,
+        message: Vec<u8>,
+        message_type: &str,
+        exclude: &[u16],
+    ) -> std::result::Result<[u8; 64], SigningRoundError> {
         let threshold = self.share.metadata.threshold;
 
-        let (participants, participant_peers) = self.select_eligible_peers(threshold as usize)?;
+        let (participants, participant_peers) = self
+            .select_eligible_peers(threshold as usize, exclude)
+            .map_err(SigningRoundError::fatal)?;
+
+        let attempted: Vec<u16> = participant_peers.iter().map(|(idx, _)| *idx).collect();
 
         let session_id = derive_session_id(&message, &participants, threshold);
 
@@ -1004,15 +1064,17 @@ impl KfpNode {
             SigningOperation::SignRequestInitiated,
         );
 
-        let key_package = self.share.key_package()?;
+        let key_package = self
+            .share
+            .key_package()
+            .map_err(|e| SigningRoundError::fatal(e.into()))?;
         let (nonces, our_commitment) =
             frost_secp256k1_tr::round1::commit(key_package.signing_share(), &mut OsRng);
 
         // Try to use pre-exchanged commitments for the selected peers. If every
         // peer has a pooled commitment, reserve them (single-use; removed from
         // the pool) so the interactive commitment round can be skipped.
-        let peer_indices: Vec<u16> = participant_peers.iter().map(|(idx, _)| *idx).collect();
-        let reserved = self.nonce_pool.reserve_for(&peer_indices);
+        let reserved = self.nonce_pool.reserve_for(&attempted);
         // If any step below fails after reservation, the reserved commitments
         // must go back into the pool so they are not leaked permanently.
         let mut reservation_guard = ReservationGuard::new(&self.nonce_pool, reserved.clone());
@@ -1128,7 +1190,7 @@ impl KfpNode {
         .await;
         if let Err(e) = send_result {
             self.sessions.write().complete_session(&session_id);
-            return Err(e);
+            return Err(e.into());
         }
 
         let mut rx = self.event_tx.subscribe();
@@ -1147,11 +1209,11 @@ impl KfpNode {
         if all_committed {
             if let Err(e) = self.generate_and_send_share(&session_id).await {
                 self.sessions.write().complete_session(&session_id);
-                return Err(e);
+                return Err(e.into());
             }
         }
 
-        let timeout = Duration::from_secs(30);
+        let timeout = Duration::from_secs(15);
 
         let result = tokio::time::timeout(timeout, async {
             loop {
@@ -1188,11 +1250,14 @@ impl KfpNode {
             Ok(Ok(signature)) => Ok(signature),
             Ok(Err(e)) => {
                 self.sessions.write().complete_session(&session_id);
-                Err(e)
+                Err(e.into())
             }
             Err(_) => {
                 self.sessions.write().complete_session(&session_id);
-                Err(FrostNetError::Timeout("Signing request timed out".into()))
+                Err(SigningRoundError {
+                    error: FrostNetError::Timeout("Signing request timed out".into()),
+                    attempted,
+                })
             }
         }
     }

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -1019,30 +1019,6 @@ impl KfpNode {
                 .signing_round(round_message, message_type, &excluded, logical_id, attempt)
                 .await;
 
-            // If a peer reported a stale pre-exchanged nonce (it rotated/restarted, so
-            // a pooled commitment we referenced no longer maps to a live secret), drop
-            // the suspect pooled commitments so the *next* request falls back to a
-            // fresh interactive round. We deliberately do NOT retry this request in
-            // place: our single-use nonce was already spent on a share bound to the
-            // stale commitment, the session id is fixed by the message, and the
-            // replay guard would reject re-signing it; retrying would risk nonce
-            // reuse. The stale_nonce/incomplete_pre_exchange branch is a fatal
-            // Session error (not a Timeout), so it intentionally bypasses the
-            // failover retry below and returns to the caller. The signing session
-            // is torn down on failure (see below), so the next attempt starts clean.
-            if let Err(SigningRoundError {
-                error: FrostNetError::Session(ref e),
-                ..
-            }) = result
-            {
-                if e.contains("stale_nonce") || e.contains("incomplete_pre_exchange") {
-                    self.nonce_pool.clear_all_peers();
-                    warn!(
-                        "peer reported stale pre-exchanged nonce; cleared pool, next round is interactive"
-                    );
-                }
-            }
-
             match result {
                 Ok(sig) => return Ok(sig),
                 Err(SigningRoundError {
@@ -1056,7 +1032,29 @@ impl KfpNode {
                     );
                     excluded.extend(attempted);
                 }
-                Err(e) => return Err(e.error),
+                Err(e) => {
+                    // If a peer reported a stale pre-exchanged nonce (it
+                    // rotated/restarted, so a pooled commitment we referenced no
+                    // longer maps to a live secret), drop the suspect pooled
+                    // commitments so the *next* request falls back to a fresh
+                    // interactive round. We deliberately do NOT retry this request
+                    // in place: our single-use nonce was already spent on a share
+                    // bound to the stale commitment, the session id is fixed by the
+                    // message, and the replay guard would reject re-signing it;
+                    // retrying would risk nonce reuse. This is a fatal Session error
+                    // (not a Timeout), so it returns to the caller rather than
+                    // failing over. The signing session is torn down on failure, so
+                    // the next request starts clean.
+                    if let FrostNetError::Session(ref msg) = e.error {
+                        if msg.contains("stale_nonce") || msg.contains("incomplete_pre_exchange") {
+                            self.nonce_pool.clear_all_peers();
+                            warn!(
+                                "peer reported stale pre-exchanged nonce; cleared pool, next round is interactive"
+                            );
+                        }
+                    }
+                    return Err(e.error);
+                }
             }
         }
         Err(FrostNetError::Timeout(

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -1284,15 +1284,28 @@ impl KfpNode {
                 Err(e.into())
             }
             Err(_) => {
-                // Exclude only peers that never committed; responsive peers stay
+                // Exclude only peers that never responded; responsive peers stay
                 // eligible for the failover retry so we don't drain the eligible
-                // set or waste healthy peers' single-use nonces. If the session is
-                // already gone, fall back to excluding the whole attempted set.
+                // set or waste healthy peers' single-use nonces. A peer is
+                // unresponsive if it failed to deliver either its commitment or
+                // its signature share -- the latter matters when commitments were
+                // pre-exchanged, so `uncommitted_participants` would be empty even
+                // though shares never arrived. If the session is already gone,
+                // fall back to excluding the whole attempted set.
                 let unresponsive = {
                     let sessions = self.sessions.read();
                     sessions
                         .get_session(&session_id)
-                        .map(|s| s.uncommitted_participants(self.share.metadata.identifier))
+                        .map(|s| {
+                            let our = self.share.metadata.identifier;
+                            let mut idxs = s.uncommitted_participants(our);
+                            for idx in s.participants_missing_shares(our) {
+                                if !idxs.contains(&idx) {
+                                    idxs.push(idx);
+                                }
+                            }
+                            idxs
+                        })
                         .unwrap_or_else(|| attempted.clone())
                 };
                 self.sessions.write().complete_session(&session_id);

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -27,6 +27,12 @@ pub(crate) const SIGNING_ROUND_TIMEOUT: Duration = Duration::from_secs(15);
 /// `SIGNING_ROUND_TIMEOUT`) under a partition or latency event.
 pub(crate) const MAX_FAILOVER_ATTEMPTS: usize = 3;
 
+/// Wait for the pre-round liveness ping. A co-signer that dropped since its last
+/// announce is excluded after at most this long, instead of burning a full
+/// `SIGNING_ROUND_TIMEOUT` round. The ping returns as soon as every co-signer
+/// pongs, so the all-online path is bounded by one round-trip, not this value.
+const LIVENESS_PING_TIMEOUT: Duration = Duration::from_secs(3);
+
 /// Error from a single signing round. `attempted` lists the non-self peers that
 /// failed to respond in this round, so a timed-out round can exclude them and
 /// fail over to other live co-signers.
@@ -999,6 +1005,58 @@ impl KfpNode {
         Ok(())
     }
 
+    /// Pings every eligible co-signer before the first round and returns the
+    /// ones that fail to pong, so a peer that dropped since its last announce is
+    /// excluded up front instead of being selected and burning a full round
+    /// timeout before failover kicks in (the slow case in issue #412). The ping
+    /// resolves as soon as all co-signers answer, so the all-online happy path
+    /// only pays one round-trip. It is skipped entirely when the group has no
+    /// spare co-signers (single-peer / exactly-threshold), and its result is
+    /// ignored if too few peers answer to still reach threshold, since then the
+    /// normal round and failover should decide rather than a flaky ping.
+    async fn prune_unresponsive_cosigners(&self) -> Vec<u16> {
+        let needed = (self.share.metadata.threshold as usize).saturating_sub(1);
+        let snapshot: Vec<(u16, PublicKey, std::time::Instant)> = {
+            let peers = self.peers.read();
+            peers
+                .get_signing_peers()
+                .into_iter()
+                .filter(|p| self.can_send_to(&p.pubkey) && self.can_receive_from(&p.pubkey))
+                .map(|p| (p.share_index, p.pubkey, p.last_seen))
+                .collect()
+        };
+        if snapshot.len() <= needed {
+            return Vec::new();
+        }
+
+        let responsive = match self
+            .ping_peers_snapshot(&snapshot, LIVENESS_PING_TIMEOUT, Some(snapshot.len()))
+            .await
+        {
+            Ok(responsive) => responsive,
+            Err(e) => {
+                warn!(error = %e, "liveness ping failed; proceeding without pre-exclusion");
+                return Vec::new();
+            }
+        };
+        if responsive.len() < needed {
+            return Vec::new();
+        }
+
+        let unresponsive: Vec<u16> = snapshot
+            .iter()
+            .map(|(idx, _, _)| *idx)
+            .filter(|idx| !responsive.contains(idx))
+            .collect();
+        if !unresponsive.is_empty() {
+            warn!(
+                excluded = ?unresponsive,
+                "excluding co-signers that failed the pre-round liveness ping"
+            );
+        }
+        unresponsive
+    }
+
     pub async fn request_signature(
         &self,
         mut message: Vec<u8>,
@@ -1022,7 +1080,11 @@ impl KfpNode {
         // real per-participant session id for that). Two requests for the same
         // message intentionally share this id; do not treat it as unique.
         let logical_id = derive_session_id(&message, &[], self.share.metadata.threshold);
-        let mut excluded: Vec<u16> = Vec::new();
+        // Drop co-signers that are already unreachable before committing, so the
+        // first round goes straight to live peers instead of timing out on a
+        // dead one. Peers that drop mid-round are still caught by the failover
+        // exclusion below.
+        let mut excluded: Vec<u16> = self.prune_unresponsive_cosigners().await;
         for attempt in 0..MAX_FAILOVER_ATTEMPTS {
             let last = attempt + 1 == MAX_FAILOVER_ATTEMPTS;
             let round_message = if last {

--- a/keep-frost-net/src/nonce_pool.rs
+++ b/keep-frost-net/src/nonce_pool.rs
@@ -233,6 +233,16 @@ impl NoncePool {
         inner.peer_order.clear();
     }
 
+    /// Drop every stored commitment for a single peer. Used when exactly one
+    /// peer reports a stale pre-exchanged nonce, so other peers' pooled
+    /// commitments are preserved and they need not fall back to interactive
+    /// rounds.
+    pub fn clear_peer(&self, share_index: u16) {
+        let mut inner = self.inner.lock();
+        inner.peer.retain(|(idx, _), _| *idx != share_index);
+        inner.peer_order.retain(|(idx, _)| *idx != share_index);
+    }
+
     /// Reserve one available commitment per requested peer for a signing
     /// request, returning the chosen `nonce_id`s. The commitments are *removed*
     /// from the pool so they cannot be reused.

--- a/keep-frost-net/src/peer.rs
+++ b/keep-frost-net/src/peer.rs
@@ -116,7 +116,7 @@ impl PeerManager {
         Self {
             peers: HashMap::new(),
             our_share_index,
-            offline_threshold: Duration::from_secs(60),
+            offline_threshold: Duration::from_secs(40),
         }
     }
 

--- a/keep-frost-net/src/peer.rs
+++ b/keep-frost-net/src/peer.rs
@@ -37,6 +37,11 @@ pub struct Peer {
     pub capabilities: Vec<String>,
     pub name: Option<String>,
     pub last_seen: Instant,
+    /// Last time a Pong was received from this peer in reply to our Ping.
+    /// Tracked separately from `last_seen` (which any announce also bumps) so
+    /// the pre-round liveness check classifies a peer as responsive only when it
+    /// actually answered a ping, not merely re-announced.
+    pub last_pong: Option<Instant>,
     pub status: PeerStatus,
     pub protocol_version: u8,
     pub attestation_status: AttestationStatus,
@@ -52,6 +57,7 @@ impl Peer {
             capabilities: vec!["sign".into()],
             name: None,
             last_seen: Instant::now(),
+            last_pong: None,
             status: PeerStatus::Online,
             protocol_version: crate::KFP_VERSION,
             attestation_status: AttestationStatus::NotProvided,
@@ -142,10 +148,14 @@ impl PeerManager {
             // PeerAnnounce carries no recovery xpubs; preserve any previously
             // announced (and replay-validated) xpubs across re-announcements so
             // a duplicate PeerAnnounce does not wipe stored recovery xpubs.
-            if peer.recovery_xpubs.is_empty() {
-                if let Some(existing) = self.peers.get(&peer.share_index) {
+            if let Some(existing) = self.peers.get(&peer.share_index) {
+                if peer.recovery_xpubs.is_empty() {
                     peer.recovery_xpubs = existing.recovery_xpubs.clone();
                 }
+                // Preserve pong history across re-announcements so a later
+                // announce does not wipe the liveness signal the pre-round check
+                // relies on.
+                peer.last_pong = existing.last_pong;
             }
             self.peers.insert(peer.share_index, peer);
         }
@@ -163,6 +173,17 @@ impl PeerManager {
     pub fn touch_by_pubkey(&mut self, pubkey: &PublicKey) {
         if let Some(peer) = self.peers.values_mut().find(|p| &p.pubkey == pubkey) {
             peer.touch();
+        }
+    }
+
+    /// Record receipt of a Pong from this peer in reply to our Ping. Bumps
+    /// `last_seen` like any other contact and additionally stamps `last_pong`,
+    /// which the pre-round liveness check uses to distinguish an actual ping
+    /// reply from a periodic announce.
+    pub fn touch_pong_by_pubkey(&mut self, pubkey: &PublicKey) {
+        if let Some(peer) = self.peers.values_mut().find(|p| &p.pubkey == pubkey) {
+            peer.touch();
+            peer.last_pong = Some(Instant::now());
         }
     }
 

--- a/keep-frost-net/src/peer.rs
+++ b/keep-frost-net/src/peer.rs
@@ -4,7 +4,12 @@ use nostr_sdk::PublicKey;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
+use crate::node::{MAX_FAILOVER_ATTEMPTS, SIGNING_ROUND_TIMEOUT};
 use crate::protocol::AnnouncedXpub;
+
+/// How often a node re-announces itself to peers. The offline threshold and the
+/// node's announce loop are both derived from this so they stay in lockstep.
+pub(crate) const PEER_ANNOUNCE_INTERVAL: Duration = Duration::from_secs(20);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PeerStatus {
@@ -116,10 +121,14 @@ impl PeerManager {
         Self {
             peers: HashMap::new(),
             our_share_index,
-            // Two missed 20s announce cycles before a peer is considered
-            // offline, so peers don't flap offline on a single missed announce
-            // mid-failover yet stale peers leave the eligible set promptly.
-            offline_threshold: Duration::from_secs(40),
+            // Stay comfortably above the worst-case failover duration
+            // (MAX_FAILOVER_ATTEMPTS rounds, each up to SIGNING_ROUND_TIMEOUT)
+            // plus one announce interval of margin, so a healthy peer can't flap
+            // to offline and be dropped from the eligible set mid-failover while
+            // stale peers still leave promptly.
+            offline_threshold: SIGNING_ROUND_TIMEOUT
+                .saturating_mul(MAX_FAILOVER_ATTEMPTS as u32)
+                .saturating_add(PEER_ANNOUNCE_INTERVAL),
         }
     }
 

--- a/keep-frost-net/src/peer.rs
+++ b/keep-frost-net/src/peer.rs
@@ -4,7 +4,6 @@ use nostr_sdk::PublicKey;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-use crate::node::{MAX_FAILOVER_ATTEMPTS, SIGNING_ROUND_TIMEOUT};
 use crate::protocol::AnnouncedXpub;
 
 /// How often a node re-announces itself to peers. The offline threshold and the
@@ -121,14 +120,11 @@ impl PeerManager {
         Self {
             peers: HashMap::new(),
             our_share_index,
-            // Stay comfortably above the worst-case failover duration
-            // (MAX_FAILOVER_ATTEMPTS rounds, each up to SIGNING_ROUND_TIMEOUT)
-            // plus one announce interval of margin, so a healthy peer can't flap
-            // to offline and be dropped from the eligible set mid-failover while
-            // stale peers still leave promptly.
-            offline_threshold: SIGNING_ROUND_TIMEOUT
-                .saturating_mul(MAX_FAILOVER_ATTEMPTS as u32)
-                .saturating_add(PEER_ANNOUNCE_INTERVAL),
+            // Tolerate exactly one missed announce so a freshly-dropped peer
+            // stops being selected quickly instead of lingering for a full
+            // minute (issue #412). A peer that drops mid-round is still caught
+            // by the signing-round timeout and failover exclusion.
+            offline_threshold: PEER_ANNOUNCE_INTERVAL.saturating_mul(2),
         }
     }
 
@@ -157,6 +153,15 @@ impl PeerManager {
 
     pub fn update_last_seen(&mut self, share_index: u16) {
         if let Some(peer) = self.peers.get_mut(&share_index) {
+            peer.touch();
+        }
+    }
+
+    /// Mark the peer with this pubkey as just-seen. Resolving by pubkey under a
+    /// single write lock avoids a read-then-write on `peers` from the same task,
+    /// which would self-deadlock the (non-reentrant) lock.
+    pub fn touch_by_pubkey(&mut self, pubkey: &PublicKey) {
+        if let Some(peer) = self.peers.values_mut().find(|p| &p.pubkey == pubkey) {
             peer.touch();
         }
     }
@@ -308,5 +313,16 @@ mod tests {
         pm.add_peer(self_peer);
 
         assert_eq!(pm.peer_count(), 0);
+    }
+
+    #[test]
+    fn test_default_offline_threshold_tolerates_one_missed_announce() {
+        // A freshly-dropped peer should leave the eligible set quickly: the
+        // threshold tolerates exactly one missed announce, not several (issue
+        // #412 regressed when this drifted up to a full minute).
+        let pm = PeerManager::new(1);
+        assert_eq!(pm.offline_threshold(), PEER_ANNOUNCE_INTERVAL * 2);
+        assert!(pm.offline_threshold() > PEER_ANNOUNCE_INTERVAL);
+        assert!(pm.offline_threshold() < PEER_ANNOUNCE_INTERVAL * 3);
     }
 }

--- a/keep-frost-net/src/peer.rs
+++ b/keep-frost-net/src/peer.rs
@@ -116,6 +116,9 @@ impl PeerManager {
         Self {
             peers: HashMap::new(),
             our_share_index,
+            // Two missed 20s announce cycles before a peer is considered
+            // offline, so peers don't flap offline on a single missed announce
+            // mid-failover yet stale peers leave the eligible set promptly.
             offline_threshold: Duration::from_secs(40),
         }
     }

--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -834,6 +834,13 @@ pub struct SignRequestPayload {
     /// for wire compatibility with peers that predate nonce pre-exchange.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub nonce_refs: Vec<NonceRef>,
+    /// Per-attempt salt folded into the session id derivation so a failover
+    /// re-sample over the same participant set yields a distinct session.
+    /// Responders echo it into their own derivation when validating the id.
+    /// Kept `#[serde(default)]` for wire compatibility with peers that predate
+    /// salted failover (an empty salt reproduces the original derivation).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub session_salt: Vec<u8>,
 }
 
 /// A reference to a single pre-exchanged nonce/commitment pair.
@@ -869,6 +876,7 @@ impl SignRequestPayload {
             created_at: Timestamp::now().as_secs(),
             metadata: None,
             nonce_refs: Vec::new(),
+            session_salt: Vec::new(),
         }
     }
 
@@ -879,6 +887,11 @@ impl SignRequestPayload {
 
     pub fn with_nonce_refs(mut self, nonce_refs: Vec<NonceRef>) -> Self {
         self.nonce_refs = nonce_refs;
+        self
+    }
+
+    pub fn with_session_salt(mut self, salt: Vec<u8>) -> Self {
+        self.session_salt = salt;
         self
     }
 

--- a/keep-frost-net/src/session.rs
+++ b/keep-frost-net/src/session.rs
@@ -226,6 +226,23 @@ impl NetworkSession {
             .collect()
     }
 
+    /// Participant indices (excluding `our_index`) that have not submitted a
+    /// signature share. Used by failover when commitments were pre-exchanged
+    /// (so `uncommitted_participants` is empty) but some signers never produced
+    /// a share before the round timed out.
+    pub fn participants_missing_shares(&self, our_index: u16) -> Vec<u16> {
+        self.participants
+            .iter()
+            .copied()
+            .filter(|&idx| idx != our_index)
+            .filter(|&idx| {
+                Identifier::try_from(idx)
+                    .map(|id| !self.signature_shares.contains_key(&id))
+                    .unwrap_or(true)
+            })
+            .collect()
+    }
+
     /// Build the FROST signing package from the collected commitments.
     ///
     /// Correctness invariant (load-bearing now that delivery order is relaxed):

--- a/keep-frost-net/src/session.rs
+++ b/keep-frost-net/src/session.rs
@@ -210,6 +210,22 @@ impl NetworkSession {
         self.commitments.len() >= self.threshold as usize
     }
 
+    /// Participant indices (excluding `our_index`) that have not submitted a
+    /// commitment. Used by failover to exclude only peers that demonstrably
+    /// failed to respond, leaving responsive peers eligible for the retry.
+    pub fn uncommitted_participants(&self, our_index: u16) -> Vec<u16> {
+        self.participants
+            .iter()
+            .copied()
+            .filter(|&idx| idx != our_index)
+            .filter(|&idx| {
+                Identifier::try_from(idx)
+                    .map(|id| !self.commitments.contains_key(&id))
+                    .unwrap_or(true)
+            })
+            .collect()
+    }
+
     /// Build the FROST signing package from the collected commitments.
     ///
     /// Correctness invariant (load-bearing now that delivery order is relaxed):
@@ -571,7 +587,12 @@ impl SessionManager {
             completed_sessions: HashSet::new(),
             completed_order: VecDeque::new(),
             max_completed_history: 1000,
-            session_timeout: Duration::from_secs(300),
+            // Co-signer sessions are not torn down explicitly when the
+            // initiator abandons a round, so keep this close to the initiator's
+            // round timeout. A consumed single-use nonce held by an abandoned
+            // session is released within ~60s, bounding session-table and nonce
+            // exhaustion under a burst of failovers.
+            session_timeout: Duration::from_secs(60),
             nonce_store: None,
             max_rehydrations: 3,
         }

--- a/keep-frost-net/src/session.rs
+++ b/keep-frost-net/src/session.rs
@@ -210,20 +210,34 @@ impl NetworkSession {
         self.commitments.len() >= self.threshold as usize
     }
 
-    /// Participant indices (excluding `our_index`) that have not submitted a
-    /// commitment. Used by failover to exclude only peers that demonstrably
-    /// failed to respond, leaving responsive peers eligible for the retry.
-    pub fn uncommitted_participants(&self, our_index: u16) -> Vec<u16> {
+    /// Participant indices (excluding `our_index`) for which `has_entry`
+    /// reports no contribution. A participant index that fails `Identifier`
+    /// conversion (only index 0, which is invalid for FROST and is rejected by
+    /// `add_commitment`/`add_signature_share`, so it can't appear in a valid
+    /// session) is treated as missing: it could never have contributed, and
+    /// reporting it to failover just adds it to the excluded set where it
+    /// matches no real peer, so this is harmless rather than a silent error.
+    fn participants_missing<F>(&self, our_index: u16, has_entry: F) -> Vec<u16>
+    where
+        F: Fn(&Identifier) -> bool,
+    {
         self.participants
             .iter()
             .copied()
             .filter(|&idx| idx != our_index)
             .filter(|&idx| {
                 Identifier::try_from(idx)
-                    .map(|id| !self.commitments.contains_key(&id))
+                    .map(|id| !has_entry(&id))
                     .unwrap_or(true)
             })
             .collect()
+    }
+
+    /// Participant indices (excluding `our_index`) that have not submitted a
+    /// commitment. Used by failover to exclude only peers that demonstrably
+    /// failed to respond, leaving responsive peers eligible for the retry.
+    pub fn uncommitted_participants(&self, our_index: u16) -> Vec<u16> {
+        self.participants_missing(our_index, |id| self.commitments.contains_key(id))
     }
 
     /// Participant indices (excluding `our_index`) that have not submitted a
@@ -231,16 +245,7 @@ impl NetworkSession {
     /// (so `uncommitted_participants` is empty) but some signers never produced
     /// a share before the round timed out.
     pub fn participants_missing_shares(&self, our_index: u16) -> Vec<u16> {
-        self.participants
-            .iter()
-            .copied()
-            .filter(|&idx| idx != our_index)
-            .filter(|&idx| {
-                Identifier::try_from(idx)
-                    .map(|id| !self.signature_shares.contains_key(&id))
-                    .unwrap_or(true)
-            })
-            .collect()
+        self.participants_missing(our_index, |id| self.signature_shares.contains_key(id))
     }
 
     /// Build the FROST signing package from the collected commitments.
@@ -604,12 +609,17 @@ impl SessionManager {
             completed_sessions: HashSet::new(),
             completed_order: VecDeque::new(),
             max_completed_history: 1000,
-            // Co-signer sessions are not torn down explicitly when the
-            // initiator abandons a round, so keep this close to the initiator's
-            // round timeout. A consumed single-use nonce held by an abandoned
-            // session is released within ~60s, bounding session-table and nonce
-            // exhaustion under a burst of failovers.
-            session_timeout: Duration::from_secs(60),
+            // A responder creates a fresh session per failover attempt (each
+            // attempt rederives a distinct session id from its participant set),
+            // so a responder session only needs to outlive a single requester
+            // round, not the whole failover window. Bound it to the round
+            // timeout plus margin for clock skew and relay latency. A consumed
+            // single-use nonce held by an abandoned session is then released in
+            // ~SIGNING_ROUND_TIMEOUT rather than ~60s, so a burst of failovers
+            // can't drain responder nonce pools or fill the session table while
+            // requesters abandon rounds after SIGNING_ROUND_TIMEOUT.
+            session_timeout: crate::node::SIGNING_ROUND_TIMEOUT
+                .saturating_add(Duration::from_secs(5)),
             nonce_store: None,
             max_rehydrations: 3,
         }

--- a/keep-frost-net/src/session.rs
+++ b/keep-frost-net/src/session.rs
@@ -17,10 +17,25 @@ use crate::nonce_store::NonceStore;
 use crate::protocol::KFP_VERSION;
 
 pub fn derive_session_id(message: &[u8], participants: &[u16], threshold: u16) -> [u8; 32] {
+    derive_session_id_salted(message, participants, threshold, &[])
+}
+
+/// Like [`derive_session_id`] but folds an extra `salt` into the preimage.
+/// Signing failover uses a per-attempt salt so a re-sample over the same
+/// participant set produces a distinct session id (and a distinct fresh nonce)
+/// instead of colliding with the just-completed attempt's id and tripping the
+/// replay guard. The salt is still bound to message+participants+threshold, so
+/// it does not weaken replay protection against genuine external replays.
+pub fn derive_session_id_salted(
+    message: &[u8],
+    participants: &[u16],
+    threshold: u16,
+    salt: &[u8],
+) -> [u8; 32] {
     let mut sorted_participants = participants.to_vec();
     sorted_participants.sort();
 
-    let mut preimage = Vec::with_capacity(64 + message.len() + participants.len() * 2);
+    let mut preimage = Vec::with_capacity(64 + message.len() + participants.len() * 2 + salt.len());
     preimage.extend_from_slice(b"keep-frost-session-v1");
     preimage.push(KFP_VERSION);
     preimage.extend_from_slice(&threshold.to_be_bytes());
@@ -30,6 +45,10 @@ pub fn derive_session_id(message: &[u8], participants: &[u16], threshold: u16) -
     }
     preimage.extend_from_slice(&(message.len() as u32).to_be_bytes());
     preimage.extend_from_slice(message);
+    if !salt.is_empty() {
+        preimage.extend_from_slice(&(salt.len() as u32).to_be_bytes());
+        preimage.extend_from_slice(salt);
+    }
 
     keep_core::crypto::blake2b_256(&preimage)
 }
@@ -588,8 +607,9 @@ fn validate_session_id(
     message: &[u8],
     participants: &[u16],
     threshold: u16,
+    salt: &[u8],
 ) -> Result<()> {
-    let expected_id = derive_session_id(message, participants, threshold);
+    let expected_id = derive_session_id_salted(message, participants, threshold, salt);
     if session_id != expected_id {
         return Err(FrostNetError::Session(format!(
             "Session ID mismatch: expected {}, got {}",
@@ -647,7 +667,18 @@ impl SessionManager {
         threshold: u16,
         participants: Vec<u16>,
     ) -> Result<&mut NetworkSession> {
-        validate_session_id(session_id, &message, &participants, threshold)?;
+        self.create_session_salted(session_id, message, threshold, participants, &[])
+    }
+
+    pub fn create_session_salted(
+        &mut self,
+        session_id: [u8; 32],
+        message: Vec<u8>,
+        threshold: u16,
+        participants: Vec<u16>,
+        salt: &[u8],
+    ) -> Result<&mut NetworkSession> {
+        validate_session_id(session_id, &message, &participants, threshold, salt)?;
 
         if self.completed_sessions.contains(&session_id) {
             return Err(FrostNetError::ReplayDetected(hex::encode(session_id)));
@@ -696,7 +727,18 @@ impl SessionManager {
         threshold: u16,
         participants: Vec<u16>,
     ) -> Result<&mut NetworkSession> {
-        validate_session_id(session_id, &message, &participants, threshold)?;
+        self.get_or_create_session_salted(session_id, message, threshold, participants, &[])
+    }
+
+    pub fn get_or_create_session_salted(
+        &mut self,
+        session_id: [u8; 32],
+        message: Vec<u8>,
+        threshold: u16,
+        participants: Vec<u16>,
+        salt: &[u8],
+    ) -> Result<&mut NetworkSession> {
+        validate_session_id(session_id, &message, &participants, threshold, salt)?;
 
         if self.completed_sessions.contains(&session_id) {
             return Err(FrostNetError::ReplayDetected(hex::encode(session_id)));

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -390,6 +390,195 @@ async fn test_full_signing_flow() {
     }
 }
 
+/// Regression for the ping/pong self-deadlock: `handle_ping`/`handle_pong`
+/// previously held a `peers.read()` guard across a `peers.write()` in the same
+/// task, which deadlocks the non-reentrant lock once ping traffic flows. Calling
+/// `health_check` (which pings every peer) while the node loop is running, then
+/// signing, must both complete rather than hang.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore] // Needs running nodes on a MockRelay - run with: cargo test -- --ignored
+async fn test_health_check_then_sign_no_deadlock() {
+    use std::sync::Arc;
+
+    let mock_relay = MockRelay::run().await.expect("Failed to start mock relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pubkey_pkg) = dealer.generate("test-health").unwrap();
+    let share1 = shares.remove(0);
+    let share2 = shares.remove(0);
+    let share3 = shares.remove(0);
+
+    let mut node1 = KfpNode::new(share1, vec![relay.clone()]).await.unwrap();
+    let mut node2 = KfpNode::new(share2, vec![relay.clone()]).await.unwrap();
+    let mut node3 = KfpNode::new(share3, vec![relay]).await.unwrap();
+
+    let mut rx3 = node3.subscribe();
+    let shutdown1 = node1.take_shutdown_handle();
+    let shutdown2 = node2.take_shutdown_handle();
+    let shutdown3 = node3.take_shutdown_handle();
+
+    let node3 = Arc::new(node3);
+    let node3_for_run = Arc::clone(&node3);
+
+    let node1_handle = tokio::spawn(async move {
+        let _ = node1.run().await;
+    });
+    let node2_handle = tokio::spawn(async move {
+        let _ = node2.run().await;
+    });
+    let node3_handle = tokio::spawn(async move {
+        let _ = node3_for_run.run().await;
+    });
+
+    let mut peers_discovered = 0u32;
+    let discovery = timeout(Duration::from_secs(45), async {
+        while peers_discovered < 2 {
+            if let Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx3.recv().await {
+                peers_discovered += 1;
+            }
+        }
+    })
+    .await;
+    if discovery.is_err() {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        graceful_shutdown(shutdown3, node3_handle).await;
+        panic!("Peer discovery timed out: only {peers_discovered} peers discovered");
+    }
+
+    // The deadlock manifested here: before the fix this never returned.
+    let health = timeout(
+        Duration::from_secs(15),
+        node3.health_check(Duration::from_secs(2)),
+    )
+    .await;
+
+    // Signing after the ping round-trip must also still complete.
+    let sign_result = timeout(Duration::from_secs(60), async {
+        node3
+            .request_signature(b"health-then-sign".to_vec(), "raw")
+            .await
+    })
+    .await;
+
+    graceful_shutdown(shutdown1, node1_handle).await;
+    graceful_shutdown(shutdown2, node2_handle).await;
+    graceful_shutdown(shutdown3, node3_handle).await;
+
+    let health = health
+        .expect("health_check deadlocked (did not return within 15s)")
+        .expect("health_check returned an error");
+    assert_eq!(
+        health.responsive.len(),
+        2,
+        "both co-signers should answer the liveness ping"
+    );
+    match sign_result {
+        Ok(Ok(signature)) => assert_eq!(signature.len(), 64),
+        Ok(Err(e)) => panic!("Signing after health check failed: {e:?}"),
+        Err(_) => panic!("Signing after health check timed out"),
+    }
+}
+
+/// Issue #412 acceptance: a co-signer taken offline mid-session must fail over
+/// to the surviving co-signer within a few seconds, not tens of seconds. The
+/// pre-round liveness ping excludes the freshly-dropped peer (still "online" by
+/// its recent announce) before committing, so signing goes straight to the live
+/// peer. The 12s bound is comfortably above the ~3s ping budget + one round, but
+/// below the ~15s a single doomed round would cost without the pre-ping.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore] // Needs running nodes on a MockRelay - run with: cargo test -- --ignored
+async fn test_failover_when_cosigner_dropped_mid_session() {
+    use std::sync::Arc;
+
+    let mock_relay = MockRelay::run().await.expect("Failed to start mock relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pubkey_pkg) = dealer.generate("test-failover").unwrap();
+    let share1 = shares.remove(0);
+    let share2 = shares.remove(0);
+    let share3 = shares.remove(0);
+
+    let mut node1 = KfpNode::new(share1, vec![relay.clone()]).await.unwrap();
+    let mut node2 = KfpNode::new(share2, vec![relay.clone()]).await.unwrap();
+    let mut node3 = KfpNode::new(share3, vec![relay]).await.unwrap();
+
+    let mut rx3 = node3.subscribe();
+    let shutdown1 = node1.take_shutdown_handle();
+    let shutdown2 = node2.take_shutdown_handle();
+    let shutdown3 = node3.take_shutdown_handle();
+
+    let node3 = Arc::new(node3);
+    let node3_for_run = Arc::clone(&node3);
+
+    let node1_handle = tokio::spawn(async move {
+        let _ = node1.run().await;
+    });
+    let node2_handle = tokio::spawn(async move {
+        let _ = node2.run().await;
+    });
+    let node3_handle = tokio::spawn(async move {
+        let _ = node3_for_run.run().await;
+    });
+
+    let mut peers_discovered = 0u32;
+    let discovery = timeout(Duration::from_secs(45), async {
+        while peers_discovered < 2 {
+            if let Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx3.recv().await {
+                peers_discovered += 1;
+            }
+        }
+    })
+    .await;
+    if discovery.is_err() {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        graceful_shutdown(shutdown3, node3_handle).await;
+        panic!("Peer discovery timed out: only {peers_discovered} peers discovered");
+    }
+
+    // Warm up with one all-online signature first. This mirrors the issue #412
+    // scenario (repeated signing after approvals) and ensures the relay
+    // connections/ping path are warm so the liveness pong is prompt.
+    let warmup = timeout(Duration::from_secs(60), async {
+        node3.request_signature(b"warmup".to_vec(), "raw").await
+    })
+    .await;
+    if !matches!(warmup, Ok(Ok(_))) {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        graceful_shutdown(shutdown3, node3_handle).await;
+        panic!("Warm-up signing failed: {warmup:?}");
+    }
+
+    // Take co-signer node2 offline. It stays "online" in node3's peer table for
+    // up to offline_threshold, so without the pre-ping node3 may still select it
+    // and burn a full round timeout. node1 remains live.
+    graceful_shutdown(shutdown2, node2_handle).await;
+
+    let started = std::time::Instant::now();
+    let sign_result = timeout(Duration::from_secs(30), async {
+        node3.request_signature(b"failover".to_vec(), "raw").await
+    })
+    .await;
+    let elapsed = started.elapsed();
+
+    graceful_shutdown(shutdown1, node1_handle).await;
+    graceful_shutdown(shutdown3, node3_handle).await;
+
+    match sign_result {
+        Ok(Ok(signature)) => assert_eq!(signature.len(), 64),
+        Ok(Err(e)) => panic!("Failover signing failed: {e:?}"),
+        Err(_) => panic!("Failover signing timed out after 30s"),
+    }
+    assert!(
+        elapsed < Duration::from_secs(12),
+        "failover took {elapsed:?}, expected a few seconds (pre-ping should exclude the dead co-signer up front)"
+    );
+}
+
 /// Regression: a share imported from a transport export carries only its own
 /// verifying share, so its `pubkey_package` is missing the co-signers' shares
 /// that `frost::aggregate` needs. The initiator must reconstruct the full


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounded-signing retries with per-round timeouts and targeted exclusion of unresponsive peers.
  * Peer-specific nonce clearing to avoid poisoning by a single peer.

* **Improvements**
  * Session timeout shortened (now tied to signing round timeout, much shorter than before).
  * Faster liveness checks and earlier health-check exit when enough peers respond.
  * Peer offline threshold reduced (announce interval 20s → offline ≈40s); peer-touch updates last-seen.

* **Tests**
  * Added multinode regression tests for health-check and mid-session failover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->