### PR TITLE
nip46: keep nip46 apps/grant/revoke + serve loads persisted grants

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -224,6 +224,19 @@ pub(crate) enum Nip46Commands {
         #[arg(help = "Client app's nostr pubkey (hex or npub)")]
         pubkey: String,
     },
+    /// Set the global list of event kinds auto-approved for every client.
+    ///
+    /// Independent of a grant's per-app `auto_approve_kinds`. Applies when
+    /// serving with an interactive approval prompt; headless serving
+    /// auto-approves every request regardless. Pass no kinds to clear.
+    AutoApprove {
+        #[arg(
+            long,
+            help = "Comma-separated event kinds to auto-approve (e.g. '1,7'). Empty clears the list.",
+            default_value = ""
+        )]
+        kinds: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -101,6 +101,11 @@ pub(crate) enum Commands {
         #[command(subcommand)]
         command: EnclaveCommands,
     },
+    /// NIP-46 bunker app management: pre-grant, list, and revoke client permissions
+    Nip46 {
+        #[command(subcommand)]
+        command: Nip46Commands,
+    },
     /// Agent integrations (MCP server, etc.)
     Agent {
         #[command(subcommand)]
@@ -178,6 +183,46 @@ pub(crate) enum AgentCommands {
     Mcp {
         #[arg(short, long)]
         key: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub(crate) enum Nip46Commands {
+    /// List persisted NIP-46 client app permission grants
+    Apps,
+    /// Pre-grant a NIP-46 client app a set of permissions.
+    ///
+    /// Granted apps are stored in the global RelayConfig and loaded into the
+    /// PermissionManager when `keep serve` starts. This is the headless
+    /// alternative to approving via the desktop's interactive prompt.
+    Grant {
+        #[arg(help = "Client app's nostr pubkey (hex or npub)")]
+        pubkey: String,
+        #[arg(long, default_value = "unnamed", help = "Display name for the app")]
+        name: String,
+        #[arg(
+            long,
+            help = "Comma-separated permission names: get_public_key, sign_event, nip04_encrypt, nip04_decrypt, nip44_encrypt, nip44_decrypt. Pass 'all' to grant everything.",
+            default_value = "get_public_key,sign_event"
+        )]
+        permissions: String,
+        #[arg(
+            long,
+            help = "Comma-separated event kinds that skip per-event approval (e.g. '1,7,22242')",
+            default_value = ""
+        )]
+        auto_approve_kinds: String,
+        #[arg(
+            long,
+            help = "Grant duration: 'session' (until restart), 'forever', or a number of seconds (e.g. '3600').",
+            default_value = "forever"
+        )]
+        duration: String,
+    },
+    /// Revoke a NIP-46 client app's permissions
+    Revoke {
+        #[arg(help = "Client app's nostr pubkey (hex or npub)")]
+        pubkey: String,
     },
 }
 

--- a/keep-cli/src/commands/mod.rs
+++ b/keep-cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod frost;
 pub mod frost_hardware;
 pub mod frost_network;
 pub mod migrate;
+pub mod nip46;
 pub mod serve;
 pub mod vault;
 pub mod wallet;

--- a/keep-cli/src/commands/nip46.rs
+++ b/keep-cli/src/commands/nip46.rs
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+//! NIP-46 bunker app management CLI: pre-grant, list, and revoke
+//! client permissions so headless bunkers don't depend on an interactive
+//! approval prompt.
+
+use std::path::Path;
+
+use secrecy::ExposeSecret;
+use tracing::debug;
+
+use keep_core::error::{KeepError, Result};
+use keep_core::relay::{StoredBunkerPermission, StoredPermissionDuration, GLOBAL_RELAY_KEY};
+use keep_core::Keep;
+
+use super::get_password;
+use crate::output::Output;
+
+/// Display all persisted NIP-46 client grants.
+pub fn cmd_nip46_apps(out: &Output, path: &Path) -> Result<()> {
+    let mut keep = Keep::open(path)?;
+    let password = get_password("Enter password")?;
+    keep.unlock(password.expose_secret())?;
+
+    let cfg = keep.get_relay_config_or_default(&GLOBAL_RELAY_KEY)?;
+    if cfg.bunker_permissions.is_empty() {
+        out.newline();
+        out.info("No NIP-46 client app grants stored.");
+        out.info("Pre-grant a client via: keep nip46 grant <pubkey> --name 'X'");
+        return Ok(());
+    }
+
+    out.newline();
+    out.header(&format!(
+        "NIP-46 client app grants ({})",
+        cfg.bunker_permissions.len()
+    ));
+    for app in &cfg.bunker_permissions {
+        out.newline();
+        out.field("Pubkey", &app.pubkey_hex);
+        out.field("Name", &app.name);
+        out.field("Permissions", &format_permissions(app.permissions));
+        if !app.auto_approve_kinds.is_empty() {
+            out.field(
+                "Auto-approve kinds",
+                &app.auto_approve_kinds
+                    .iter()
+                    .map(u16::to_string)
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
+        }
+        out.field("Duration", &format_duration(&app.duration));
+    }
+    Ok(())
+}
+
+/// Pre-grant a NIP-46 client app a set of permissions.
+#[allow(clippy::too_many_arguments)]
+pub fn cmd_nip46_grant(
+    out: &Output,
+    path: &Path,
+    pubkey: &str,
+    name: &str,
+    permissions: &str,
+    auto_approve_kinds: &str,
+    duration: &str,
+) -> Result<()> {
+    debug!(pubkey, name, permissions, duration, "nip46 grant");
+
+    let pubkey_hex = parse_pubkey_hex(pubkey)?;
+    let permission_bits = parse_permissions(permissions)?;
+    let auto_kinds = parse_auto_approve_kinds(auto_approve_kinds)?;
+    let parsed_duration = parse_duration(duration)?;
+
+    let mut keep = Keep::open(path)?;
+    let password = get_password("Enter password")?;
+    keep.unlock(password.expose_secret())?;
+
+    let mut cfg = keep.get_relay_config_or_default(&GLOBAL_RELAY_KEY)?;
+
+    // Upsert: replace existing entry for this pubkey, or append a new one.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let existing = cfg
+        .bunker_permissions
+        .iter()
+        .position(|p| p.pubkey_hex.eq_ignore_ascii_case(&pubkey_hex));
+    let entry = StoredBunkerPermission {
+        pubkey_hex: pubkey_hex.clone(),
+        name: name.to_string(),
+        permissions: permission_bits,
+        auto_approve_kinds: auto_kinds,
+        duration: parsed_duration,
+        connected_at: now,
+    };
+    let replaced = match existing {
+        Some(idx) => {
+            cfg.bunker_permissions[idx] = entry;
+            true
+        }
+        None => {
+            cfg.bunker_permissions.push(entry);
+            false
+        }
+    };
+
+    keep.store_relay_config(&cfg)?;
+
+    out.newline();
+    if replaced {
+        out.success(&format!("Updated grant for app {pubkey_hex}"));
+    } else {
+        out.success(&format!("Granted permissions to app {pubkey_hex}"));
+    }
+    out.field("Name", name);
+    out.field("Permissions", &format_permissions(permission_bits));
+    Ok(())
+}
+
+/// Revoke a NIP-46 client app's stored permissions.
+pub fn cmd_nip46_revoke(out: &Output, path: &Path, pubkey: &str) -> Result<()> {
+    let pubkey_hex = parse_pubkey_hex(pubkey)?;
+
+    let mut keep = Keep::open(path)?;
+    let password = get_password("Enter password")?;
+    keep.unlock(password.expose_secret())?;
+
+    let mut cfg = keep.get_relay_config_or_default(&GLOBAL_RELAY_KEY)?;
+    let before = cfg.bunker_permissions.len();
+    cfg.bunker_permissions
+        .retain(|p| !p.pubkey_hex.eq_ignore_ascii_case(&pubkey_hex));
+    let after = cfg.bunker_permissions.len();
+
+    if before == after {
+        return Err(KeepError::KeyNotFound(format!(
+            "no NIP-46 grant found for pubkey {pubkey_hex}"
+        )));
+    }
+
+    keep.store_relay_config(&cfg)?;
+    out.newline();
+    out.success(&format!("Revoked NIP-46 grant for app {pubkey_hex}"));
+    Ok(())
+}
+
+fn parse_pubkey_hex(input: &str) -> Result<String> {
+    if input.starts_with("npub1") {
+        let bytes = keep_core::keys::npub_to_bytes(input)?;
+        Ok(hex::encode(bytes))
+    } else {
+        let bytes = hex::decode(input).map_err(|e| {
+            KeepError::InvalidInput(format!("expected npub or 32-byte hex pubkey: {e}"))
+        })?;
+        if bytes.len() != 32 {
+            return Err(KeepError::InvalidInput(format!(
+                "pubkey must be 32 bytes, got {}",
+                bytes.len()
+            )));
+        }
+        Ok(hex::encode(bytes))
+    }
+}
+
+fn parse_permissions(s: &str) -> Result<u32> {
+    let mut bits: u32 = 0;
+    for token in s.split(',').map(|t| t.trim()).filter(|t| !t.is_empty()) {
+        let lower = token.to_ascii_lowercase();
+        let bit = match lower.as_str() {
+            "all" => return Ok(0b00111111),
+            "get_public_key" | "getpublickey" => 0b00000001,
+            "sign_event" | "signevent" => 0b00000010,
+            "nip04_encrypt" | "nip04encrypt" => 0b00000100,
+            "nip04_decrypt" | "nip04decrypt" => 0b00001000,
+            "nip44_encrypt" | "nip44encrypt" => 0b00010000,
+            "nip44_decrypt" | "nip44decrypt" => 0b00100000,
+            other => {
+                return Err(KeepError::InvalidInput(format!(
+                    "unknown permission '{other}'; valid: get_public_key, sign_event, nip04_encrypt, nip04_decrypt, nip44_encrypt, nip44_decrypt, all"
+                )));
+            }
+        };
+        bits |= bit;
+    }
+    if bits == 0 {
+        return Err(KeepError::InvalidInput(
+            "at least one permission must be granted".into(),
+        ));
+    }
+    Ok(bits)
+}
+
+fn parse_auto_approve_kinds(s: &str) -> Result<Vec<u16>> {
+    if s.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    s.split(',')
+        .map(|t| t.trim())
+        .filter(|t| !t.is_empty())
+        .map(|t| {
+            t.parse::<u16>().map_err(|_| {
+                KeepError::InvalidInput(format!("invalid event kind '{t}'; expected u16"))
+            })
+        })
+        .collect()
+}
+
+fn parse_duration(s: &str) -> Result<StoredPermissionDuration> {
+    match s.to_ascii_lowercase().as_str() {
+        "session" => Ok(StoredPermissionDuration::Session),
+        "forever" | "permanent" => Ok(StoredPermissionDuration::Forever),
+        n => {
+            let secs = n.parse::<u64>().map_err(|_| {
+                KeepError::InvalidInput(format!(
+                    "duration must be 'session', 'forever', or a u64 of seconds; got '{n}'"
+                ))
+            })?;
+            Ok(StoredPermissionDuration::Seconds(secs))
+        }
+    }
+}
+
+fn format_permissions(bits: u32) -> String {
+    const NAMES: &[(u32, &str)] = &[
+        (0b00000001, "get_public_key"),
+        (0b00000010, "sign_event"),
+        (0b00000100, "nip04_encrypt"),
+        (0b00001000, "nip04_decrypt"),
+        (0b00010000, "nip44_encrypt"),
+        (0b00100000, "nip44_decrypt"),
+    ];
+    let set: Vec<&str> = NAMES
+        .iter()
+        .filter(|(b, _)| bits & b != 0)
+        .map(|(_, n)| *n)
+        .collect();
+    if set.is_empty() {
+        "(none)".to_string()
+    } else {
+        set.join(",")
+    }
+}
+
+fn format_duration(d: &StoredPermissionDuration) -> String {
+    match d {
+        StoredPermissionDuration::Session => "session".to_string(),
+        StoredPermissionDuration::Forever => "forever".to_string(),
+        StoredPermissionDuration::Seconds(s) => format!("{s}s"),
+    }
+}

--- a/keep-cli/src/commands/nip46.rs
+++ b/keep-cli/src/commands/nip46.rs
@@ -23,14 +23,26 @@ pub fn cmd_nip46_apps(out: &Output, path: &Path) -> Result<()> {
     keep.unlock(password.expose_secret())?;
 
     let cfg = keep.get_relay_config_or_default(&GLOBAL_RELAY_KEY)?;
-    if cfg.bunker_permissions.is_empty() {
+
+    out.newline();
+    if !cfg.auto_approve_kinds.is_empty() {
+        out.field(
+            "Global auto-approve kinds",
+            &cfg.auto_approve_kinds
+                .iter()
+                .map(u16::to_string)
+                .collect::<Vec<_>>()
+                .join(","),
+        );
         out.newline();
+    }
+
+    if cfg.bunker_permissions.is_empty() {
         out.info("No NIP-46 client app grants stored.");
         out.info("Pre-grant a client via: keep nip46 grant <pubkey> --name 'X'");
         return Ok(());
     }
 
-    out.newline();
     out.header(&format!(
         "NIP-46 client app grants ({})",
         cfg.bunker_permissions.len()
@@ -146,6 +158,35 @@ pub fn cmd_nip46_revoke(out: &Output, path: &Path, pubkey: &str) -> Result<()> {
     keep.store_relay_config(&cfg)?;
     out.newline();
     out.success(&format!("Revoked NIP-46 grant for app {pubkey_hex}"));
+    Ok(())
+}
+
+/// Set the global list of event kinds auto-approved for every NIP-46 client.
+pub fn cmd_nip46_auto_approve(out: &Output, path: &Path, kinds: &str) -> Result<()> {
+    let parsed = parse_auto_approve_kinds(kinds)?;
+
+    let mut keep = Keep::open(path)?;
+    let password = get_password("Enter password")?;
+    keep.unlock(password.expose_secret())?;
+
+    let mut cfg = keep.get_relay_config_or_default(&GLOBAL_RELAY_KEY)?;
+    cfg.auto_approve_kinds = parsed.clone();
+    keep.store_relay_config(&cfg)?;
+
+    out.newline();
+    if parsed.is_empty() {
+        out.success("Cleared the global auto-approve kinds list.");
+    } else {
+        out.success("Updated global auto-approve kinds.");
+        out.field(
+            "Kinds",
+            &parsed
+                .iter()
+                .map(u16::to_string)
+                .collect::<Vec<_>>()
+                .join(","),
+        );
+    }
     Ok(())
 }
 

--- a/keep-cli/src/commands/nip46.rs
+++ b/keep-cli/src/commands/nip46.rs
@@ -80,10 +80,13 @@ pub fn cmd_nip46_grant(
     let mut cfg = keep.get_relay_config_or_default(&GLOBAL_RELAY_KEY)?;
 
     // Upsert: replace existing entry for this pubkey, or append a new one.
+    // A 0 fallback would make a `Seconds(n)` grant expire from the epoch (i.e.
+    // immediately), so propagate a backwards clock rather than persisting a
+    // grant that can never activate.
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
-        .unwrap_or(0);
+        .map_err(|e| KeepError::InvalidInput(format!("system clock before unix epoch: {e}")))?;
     let existing = cfg
         .bunker_permissions
         .iter()
@@ -165,17 +168,18 @@ fn parse_pubkey_hex(input: &str) -> Result<String> {
 }
 
 fn parse_permissions(s: &str) -> Result<u32> {
+    use keep_nip46::Permission;
     let mut bits: u32 = 0;
     for token in s.split(',').map(|t| t.trim()).filter(|t| !t.is_empty()) {
         let lower = token.to_ascii_lowercase();
         let bit = match lower.as_str() {
-            "all" => return Ok(0b00111111),
-            "get_public_key" | "getpublickey" => 0b00000001,
-            "sign_event" | "signevent" => 0b00000010,
-            "nip04_encrypt" | "nip04encrypt" => 0b00000100,
-            "nip04_decrypt" | "nip04decrypt" => 0b00001000,
-            "nip44_encrypt" | "nip44encrypt" => 0b00010000,
-            "nip44_decrypt" | "nip44decrypt" => 0b00100000,
+            "all" => return Ok(Permission::ALL.bits()),
+            "get_public_key" | "getpublickey" => Permission::GET_PUBLIC_KEY.bits(),
+            "sign_event" | "signevent" => Permission::SIGN_EVENT.bits(),
+            "nip04_encrypt" | "nip04encrypt" => Permission::NIP04_ENCRYPT.bits(),
+            "nip04_decrypt" | "nip04decrypt" => Permission::NIP04_DECRYPT.bits(),
+            "nip44_encrypt" | "nip44encrypt" => Permission::NIP44_ENCRYPT.bits(),
+            "nip44_decrypt" | "nip44decrypt" => Permission::NIP44_DECRYPT.bits(),
             other => {
                 return Err(KeepError::InvalidInput(format!(
                     "unknown permission '{other}'; valid: get_public_key, sign_event, nip04_encrypt, nip04_decrypt, nip44_encrypt, nip44_decrypt, all"
@@ -223,15 +227,16 @@ fn parse_duration(s: &str) -> Result<StoredPermissionDuration> {
 }
 
 fn format_permissions(bits: u32) -> String {
-    const NAMES: &[(u32, &str)] = &[
-        (0b00000001, "get_public_key"),
-        (0b00000010, "sign_event"),
-        (0b00000100, "nip04_encrypt"),
-        (0b00001000, "nip04_decrypt"),
-        (0b00010000, "nip44_encrypt"),
-        (0b00100000, "nip44_decrypt"),
+    use keep_nip46::Permission;
+    let names: &[(u32, &str)] = &[
+        (Permission::GET_PUBLIC_KEY.bits(), "get_public_key"),
+        (Permission::SIGN_EVENT.bits(), "sign_event"),
+        (Permission::NIP04_ENCRYPT.bits(), "nip04_encrypt"),
+        (Permission::NIP04_DECRYPT.bits(), "nip04_decrypt"),
+        (Permission::NIP44_ENCRYPT.bits(), "nip44_encrypt"),
+        (Permission::NIP44_DECRYPT.bits(), "nip44_decrypt"),
     ];
-    let set: Vec<&str> = NAMES
+    let set: Vec<&str> = names
         .iter()
         .filter(|(b, _)| bits & b != 0)
         .map(|(_, n)| *n)

--- a/keep-cli/src/commands/serve.rs
+++ b/keep-cli/src/commands/serve.rs
@@ -201,6 +201,7 @@ pub fn cmd_serve(
     // relies on per-request approval, so the banner is scoped to headless mode
     // to avoid misleading the operator.
     let pre_grants = load_pre_grants(&keep)?;
+    let global_auto_approve = load_global_auto_approve(&keep)?;
 
     let keyring = Arc::new(Mutex::new(std::mem::take(keep.keyring_mut())));
     let rt =
@@ -218,7 +219,7 @@ pub fn cmd_serve(
         // from a granted app is auto-approved regardless of kind.
         let headless_config = ServerConfig {
             auto_approve: true,
-            pre_grants: pre_grants.clone(),
+            pre_grants,
             ..Default::default()
         };
         rt.block_on(async {
@@ -297,13 +298,22 @@ pub fn cmd_serve(
                 tx: tui_tx_clone.clone(),
             }));
 
+            // Carry the persisted global auto-approve kinds so the interactive
+            // approval prompt skips them, matching `keep nip46 auto-approve`.
+            // An unset (empty) list leaves the server's default in place.
+            let mut tui_config = ServerConfig::default();
+            if !global_auto_approve.is_empty() {
+                tui_config.auto_approve_kinds = global_auto_approve;
+            }
             let mut server =
                 if let (Some(frost), Some(transport_key)) = (frost_signer, transport_key_for_tui) {
-                    match Server::new_frost(
-                        frost,
-                        transport_key,
+                    match Server::new_with_config(
+                        Arc::new(Mutex::new(Keyring::new())),
+                        Some(frost),
+                        Some(transport_key),
                         std::slice::from_ref(&relay_clone),
                         callbacks,
+                        tui_config,
                     )
                     .await
                     {
@@ -317,10 +327,13 @@ pub fn cmd_serve(
                         }
                     }
                 } else {
-                    match Server::new(
+                    match Server::new_with_config(
                         keyring_for_tui,
+                        None,
+                        None,
                         std::slice::from_ref(&relay_clone),
                         callbacks,
+                        tui_config,
                     )
                     .await
                     {
@@ -571,4 +584,16 @@ fn load_pre_grants(keep: &Keep) -> Result<Vec<keep_nip46::PreGrantedApp>> {
         });
     }
     Ok(out)
+}
+
+/// Read the persisted global auto-approve kinds (`keep nip46 auto-approve`).
+/// An empty stored list leaves the server's default in place.
+fn load_global_auto_approve(keep: &Keep) -> Result<std::collections::HashSet<nostr_sdk::Kind>> {
+    let cfg = keep.get_relay_config_or_default(&keep_core::relay::GLOBAL_RELAY_KEY)?;
+    Ok(cfg
+        .auto_approve_kinds
+        .iter()
+        .copied()
+        .map(nostr_sdk::Kind::from)
+        .collect())
 }

--- a/keep-cli/src/commands/serve.rs
+++ b/keep-cli/src/commands/serve.rs
@@ -194,6 +194,17 @@ pub fn cmd_serve(
     out.field("Signing mode", &signing_mode);
     out.field("Signing identity", &signing_identity);
 
+    // Load any NIP-46 client app grants persisted via `keep nip46 grant`.
+    // These are loaded into the PermissionManager at startup so headless
+    // bunkers don't need to rely on an interactive approval prompt.
+    let pre_grants = load_pre_grants(&keep)?;
+    if !pre_grants.is_empty() {
+        out.field(
+            "Pre-granted apps",
+            &format!("{} (from `keep nip46 grant`)", pre_grants.len()),
+        );
+    }
+
     let keyring = Arc::new(Mutex::new(std::mem::take(keep.keyring_mut())));
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
@@ -201,6 +212,7 @@ pub fn cmd_serve(
     if headless {
         let headless_config = ServerConfig {
             auto_approve: true,
+            pre_grants: pre_grants.clone(),
             ..Default::default()
         };
         rt.block_on(async {
@@ -488,4 +500,51 @@ fn cmd_serve_hidden(out: &Output, path: &Path, relay: &str, headless: bool) -> R
     let (bunker_url, npub) = get_bunker_info(keyring.clone(), relay)?;
     info!(relay, npub = %npub, "starting TUI for hidden volume");
     spawn_tui_server(keyring, relay, bunker_url, npub)
+}
+
+/// Read persisted NIP-46 client app grants from the global RelayConfig and
+/// translate them into the `PreGrantedApp` shape `keep-nip46::ServerConfig`
+/// expects. Grants are populated into the `PermissionManager` at startup so
+/// headless bunkers (where there is no interactive approval prompt) can
+/// accept signing requests from previously authorized clients.
+fn load_pre_grants(keep: &Keep) -> Result<Vec<keep_nip46::PreGrantedApp>> {
+    let cfg = keep.get_relay_config_or_default(&keep_core::relay::GLOBAL_RELAY_KEY)?;
+    let mut out = Vec::with_capacity(cfg.bunker_permissions.len());
+    for bp in &cfg.bunker_permissions {
+        let pk_bytes = match hex::decode(&bp.pubkey_hex) {
+            Ok(b) if b.len() == 32 => b,
+            _ => {
+                tracing::warn!(
+                    pubkey_hex = %bp.pubkey_hex,
+                    "skipping malformed bunker_permission pubkey on load"
+                );
+                continue;
+            }
+        };
+        let pubkey = match nostr_sdk::PublicKey::from_slice(&pk_bytes) {
+            Ok(pk) => pk,
+            Err(e) => {
+                tracing::warn!(
+                    pubkey_hex = %bp.pubkey_hex,
+                    error = %e,
+                    "skipping bunker_permission with invalid pubkey on load"
+                );
+                continue;
+            }
+        };
+        let permissions = keep_nip46::Permission::from_bits_truncate(bp.permissions);
+        let auto_approve_kinds: std::collections::HashSet<nostr_sdk::Kind> = bp
+            .auto_approve_kinds
+            .iter()
+            .copied()
+            .map(nostr_sdk::Kind::from)
+            .collect();
+        out.push(keep_nip46::PreGrantedApp {
+            pubkey,
+            name: bp.name.clone(),
+            permissions,
+            auto_approve_kinds,
+        });
+    }
+    Ok(out)
 }

--- a/keep-cli/src/commands/serve.rs
+++ b/keep-cli/src/commands/serve.rs
@@ -196,20 +196,26 @@ pub fn cmd_serve(
 
     // Load any NIP-46 client app grants persisted via `keep nip46 grant`.
     // These are loaded into the PermissionManager at startup so headless
-    // bunkers don't need to rely on an interactive approval prompt.
+    // bunkers don't need to rely on an interactive approval prompt. Only the
+    // headless path wires them into the ServerConfig; the interactive TUI path
+    // relies on per-request approval, so the banner is scoped to headless mode
+    // to avoid misleading the operator.
     let pre_grants = load_pre_grants(&keep)?;
-    if !pre_grants.is_empty() {
-        out.field(
-            "Pre-granted apps",
-            &format!("{} (from `keep nip46 grant`)", pre_grants.len()),
-        );
-    }
 
     let keyring = Arc::new(Mutex::new(std::mem::take(keep.keyring_mut())));
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
 
     if headless {
+        if !pre_grants.is_empty() {
+            out.field(
+                "Pre-granted apps",
+                &format!("{} (from `keep nip46 grant`)", pre_grants.len()),
+            );
+        }
+        // In headless mode `auto_approve` is globally true, so a pre-grant's
+        // `auto_approve_kinds` has no additional effect: every signing request
+        // from a granted app is auto-approved regardless of kind.
         let headless_config = ServerConfig {
             auto_approve: true,
             pre_grants: pre_grants.clone(),
@@ -532,6 +538,22 @@ fn load_pre_grants(keep: &Keep) -> Result<Vec<keep_nip46::PreGrantedApp>> {
                 continue;
             }
         };
+        // Mirror keep-desktop's restore_bunker_permissions: Session grants are
+        // not meant to survive a restart, and already-expired Seconds grants
+        // must not be reactivated. Forever grants always load.
+        let now = nostr_sdk::Timestamp::now().as_secs();
+        let duration = match &bp.duration {
+            keep_core::relay::StoredPermissionDuration::Session => continue,
+            keep_core::relay::StoredPermissionDuration::Seconds(secs) => {
+                if now > bp.connected_at.saturating_add(*secs) {
+                    continue;
+                }
+                keep_nip46::PermissionDuration::Seconds(*secs)
+            }
+            keep_core::relay::StoredPermissionDuration::Forever => {
+                keep_nip46::PermissionDuration::Forever
+            }
+        };
         let permissions = keep_nip46::Permission::from_bits_truncate(bp.permissions);
         let auto_approve_kinds: std::collections::HashSet<nostr_sdk::Kind> = bp
             .auto_approve_kinds
@@ -544,6 +566,8 @@ fn load_pre_grants(keep: &Keep) -> Result<Vec<keep_nip46::PreGrantedApp>> {
             name: bp.name.clone(),
             permissions,
             auto_approve_kinds,
+            duration,
+            connected_at: nostr_sdk::Timestamp::from(bp.connected_at),
         });
     }
     Ok(out)

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -208,6 +208,9 @@ fn dispatch_nip46(out: &Output, path: &std::path::Path, command: Nip46Commands) 
             &duration,
         ),
         Nip46Commands::Revoke { pubkey } => commands::nip46::cmd_nip46_revoke(out, path, &pubkey),
+        Nip46Commands::AutoApprove { kinds } => {
+            commands::nip46::cmd_nip46_auto_approve(out, path, &kinds)
+        }
     }
 }
 

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -139,6 +139,7 @@ fn run(out: &Output) -> Result<()> {
         Commands::Frost { command } => dispatch_frost(out, &path, &cfg, command),
         Commands::Bitcoin { command } => dispatch_bitcoin(out, &path, command),
         Commands::Enclave { command } => dispatch_enclave(out, &path, command),
+        Commands::Nip46 { command } => dispatch_nip46(out, &path, command),
         Commands::Agent { command } => dispatch_agent(out, &path, command, hidden),
         Commands::Config { command } => dispatch_config(out, &cfg, command),
         Commands::Migrate { command } => dispatch_migrate(out, &path, command, hidden),
@@ -185,6 +186,28 @@ fn dispatch_agent(
 ) -> Result<()> {
     match command {
         AgentCommands::Mcp { key } => commands::agent::cmd_agent_mcp(out, path, &key, hidden),
+    }
+}
+
+fn dispatch_nip46(out: &Output, path: &std::path::Path, command: Nip46Commands) -> Result<()> {
+    match command {
+        Nip46Commands::Apps => commands::nip46::cmd_nip46_apps(out, path),
+        Nip46Commands::Grant {
+            pubkey,
+            name,
+            permissions,
+            auto_approve_kinds,
+            duration,
+        } => commands::nip46::cmd_nip46_grant(
+            out,
+            path,
+            &pubkey,
+            &name,
+            &permissions,
+            &auto_approve_kinds,
+            &duration,
+        ),
+        Nip46Commands::Revoke { pubkey } => commands::nip46::cmd_nip46_revoke(out, path, &pubkey),
     }
 }
 

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -908,6 +908,19 @@ impl Keep {
                 }
                 perms
             },
+            auto_approve_kinds: {
+                const MAX_GLOBAL_AUTO_KINDS: usize = 64;
+                if config.auto_approve_kinds.len() > MAX_GLOBAL_AUTO_KINDS {
+                    return Err(KeepError::InvalidInput(format!(
+                        "Too many global auto-approve kinds: {} (max {MAX_GLOBAL_AUTO_KINDS})",
+                        config.auto_approve_kinds.len()
+                    )));
+                }
+                let mut kinds = config.auto_approve_kinds.clone();
+                kinds.sort_unstable();
+                kinds.dedup();
+                kinds
+            },
         };
         self.storage.store_relay_config(&normalized_config)
     }

--- a/keep-core/src/relay.rs
+++ b/keep-core/src/relay.rs
@@ -74,6 +74,11 @@ pub struct RelayConfig {
     /// Persisted bunker client permission grants.
     #[serde(default)]
     pub bunker_permissions: Vec<StoredBunkerPermission>,
+    /// Global event kinds auto-approved for every NIP-46 signing request,
+    /// independent of any per-app `auto_approve_kinds`. Set via
+    /// `keep nip46 auto-approve`.
+    #[serde(default)]
+    pub auto_approve_kinds: Vec<u16>,
 }
 
 impl RelayConfig {
@@ -86,6 +91,7 @@ impl RelayConfig {
             bunker_relays: Vec::new(),
             peer_policies: Vec::new(),
             bunker_permissions: Vec::new(),
+            auto_approve_kinds: Vec::new(),
         }
     }
 
@@ -103,6 +109,7 @@ impl RelayConfig {
             bunker_relays: Vec::new(),
             peer_policies: Vec::new(),
             bunker_permissions: Vec::new(),
+            auto_approve_kinds: Vec::new(),
         }
     }
 }

--- a/keep-core/tests/integration_tests.rs
+++ b/keep-core/tests/integration_tests.rs
@@ -188,3 +188,37 @@ fn test_vault_preserves_data_after_reopen() {
         assert_eq!(keep.list_keys().unwrap()[0].pubkey, pubkey);
     }
 }
+
+#[test]
+fn test_global_auto_approve_kinds_round_trip() {
+    use keep_core::relay::{RelayConfig, GLOBAL_RELAY_KEY};
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test-keep");
+    let keep = create_test_keep(&path);
+
+    let mut cfg = RelayConfig::new_global();
+    // Unsorted with a duplicate; storage normalizes (sort + dedup).
+    cfg.auto_approve_kinds = vec![7, 1, 7];
+    keep.store_relay_config(&cfg).unwrap();
+
+    let loaded = keep.get_relay_config_or_default(&GLOBAL_RELAY_KEY).unwrap();
+    assert_eq!(loaded.auto_approve_kinds, vec![1, 7]);
+}
+
+#[test]
+fn test_global_auto_approve_kinds_cap_enforced() {
+    use keep_core::relay::{RelayConfig, GLOBAL_RELAY_KEY};
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test-keep");
+    let keep = create_test_keep(&path);
+
+    let mut cfg = RelayConfig::new_global();
+    cfg.auto_approve_kinds = (0u16..65).collect();
+    assert!(keep.store_relay_config(&cfg).is_err());
+
+    // Nothing persisted on rejection.
+    let loaded = keep.get_relay_config_or_default(&GLOBAL_RELAY_KEY).unwrap();
+    assert!(loaded.auto_approve_kinds.is_empty());
+}

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1935,6 +1935,7 @@ impl KeepMobile {
                     bunker_relays: stored.bunker_relays,
                     peer_policies: stored.peer_policies,
                     bunker_permissions: stored.bunker_permissions,
+                    auto_approve_kinds: Vec::new(),
                 });
             }
         }

--- a/keep-nip46/src/lib.rs
+++ b/keep-nip46/src/lib.rs
@@ -33,5 +33,5 @@ pub use handler::SignerHandler;
 pub use local_server::{LocalServer, LocalServerConfig};
 pub use permissions::{AppPermission, Permission, PermissionDuration, PermissionManager};
 pub use rate_limit::{RateLimitConfig, RateLimiter};
-pub use server::{Server, ServerConfig};
+pub use server::{PreGrantedApp, Server, ServerConfig};
 pub use types::{ApprovalRequest, LogEvent, ServerCallbacks};

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -225,7 +225,6 @@ impl PermissionManager {
         self.apps.values()
     }
 
-    #[allow(dead_code)]
     pub fn set_auto_approve_kinds(&mut self, kinds: HashSet<Kind>) {
         self.global_auto_approve = kinds;
     }
@@ -408,5 +407,25 @@ mod tests {
 
         assert!(!pm.needs_approval(&pubkey, Kind::TextNote));
         assert!(pm.needs_approval(&pubkey, Kind::from(30023)));
+    }
+
+    #[test]
+    fn test_set_global_auto_approve_kinds() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "Test".into());
+        pm.grant(pubkey, "Test".into(), Permission::SIGN_EVENT);
+
+        // No per-app auto-kinds, so the app needs approval for TextNote.
+        assert!(pm.needs_approval(&pubkey, Kind::TextNote));
+
+        // A global list skips approval regardless of any per-app config.
+        pm.set_auto_approve_kinds(HashSet::from([Kind::TextNote]));
+        assert!(!pm.needs_approval(&pubkey, Kind::TextNote));
+        assert!(pm.needs_approval(&pubkey, Kind::from(30023)));
+
+        // Replacing the global list with an empty set restores approval.
+        pm.set_auto_approve_kinds(HashSet::new());
+        assert!(pm.needs_approval(&pubkey, Kind::TextNote));
     }
 }

--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -34,6 +34,21 @@ pub struct ServerConfig {
     /// (keep-web) sets this to `Permission::ALL` so approving a connection lets
     /// the client sign.
     pub connect_grant: Permission,
+    /// Pre-grants that the PermissionManager is populated with at startup.
+    /// Lets a headless bunker accept signing requests from CLI-managed apps
+    /// (`keep nip46 grant <pubkey> ...`) without an interactive approval prompt.
+    pub pre_grants: Vec<PreGrantedApp>,
+}
+
+/// A NIP-46 client app whose permissions are loaded into the
+/// `PermissionManager` when a `Server` starts. Constructed from the persisted
+/// `keep_core::relay::StoredBunkerPermission` in the CLI/web entry points.
+#[derive(Debug, Clone)]
+pub struct PreGrantedApp {
+    pub pubkey: PublicKey,
+    pub name: String,
+    pub permissions: Permission,
+    pub auto_approve_kinds: std::collections::HashSet<nostr_sdk::Kind>,
 }
 
 impl Default for ServerConfig {
@@ -46,6 +61,7 @@ impl Default for ServerConfig {
             expected_secret: None,
             kill_switch: None,
             connect_grant: Permission::DEFAULT,
+            pre_grants: Vec::new(),
         }
     }
 }
@@ -84,6 +100,22 @@ fn require_relay_urls(relay_urls: &[String]) -> Result<()> {
         return Err(NetworkError::relay("at least one relay required".to_string()).into());
     }
     Ok(())
+}
+
+async fn apply_pre_grants(
+    permissions: &Arc<Mutex<PermissionManager>>,
+    pre_grants: &[PreGrantedApp],
+) {
+    if pre_grants.is_empty() {
+        return;
+    }
+    let mut pm = permissions.lock().await;
+    for app in pre_grants {
+        pm.grant(app.pubkey, app.name.clone(), app.permissions);
+        if !app.auto_approve_kinds.is_empty() {
+            pm.set_auto_approve_kinds_for_app(&app.pubkey, app.auto_approve_kinds.clone());
+        }
+    }
 }
 
 fn finalize_handler(
@@ -239,6 +271,7 @@ impl Server {
         add_relays(&client, relay_urls).await?;
 
         let permissions = Arc::new(Mutex::new(PermissionManager::new()));
+        apply_pre_grants(&permissions, &config.pre_grants).await;
         let audit = Arc::new(Mutex::new(AuditLog::new(config.audit_log_capacity)));
         let mut handler = SignerHandler::new(keyring, permissions, audit, callbacks.clone())
             .with_auto_approve(config.auto_approve)
@@ -337,6 +370,7 @@ impl Server {
 
         let keyring = Arc::new(Mutex::new(Keyring::new()));
         let permissions = Arc::new(Mutex::new(PermissionManager::new()));
+        apply_pre_grants(&permissions, &config.pre_grants).await;
         let audit = Arc::new(Mutex::new(AuditLog::new(config.audit_log_capacity)));
         let handler = SignerHandler::new(keyring, permissions, audit, callbacks.clone())
             .with_network_frost_signer(network_signer)

--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -17,7 +17,7 @@ use crate::bunker::generate_bunker_url;
 use crate::error::Result;
 use crate::frost_signer::{FrostSigner, NetworkFrostSigner};
 use crate::handler::SignerHandler;
-use crate::permissions::{Permission, PermissionManager};
+use crate::permissions::{AppPermission, Permission, PermissionDuration, PermissionManager};
 use crate::rate_limit::RateLimitConfig;
 use crate::types::{LogEvent, Nip46Request, Nip46Response, PartialEvent, ServerCallbacks};
 use keep_core::relay::TIMESTAMP_TWEAK_RANGE;
@@ -49,6 +49,8 @@ pub struct PreGrantedApp {
     pub name: String,
     pub permissions: Permission,
     pub auto_approve_kinds: std::collections::HashSet<nostr_sdk::Kind>,
+    pub duration: PermissionDuration,
+    pub connected_at: Timestamp,
 }
 
 impl Default for ServerConfig {
@@ -111,10 +113,27 @@ async fn apply_pre_grants(
     }
     let mut pm = permissions.lock().await;
     for app in pre_grants {
-        pm.grant(app.pubkey, app.name.clone(), app.permissions);
-        if !app.auto_approve_kinds.is_empty() {
-            pm.set_auto_approve_kinds_for_app(&app.pubkey, app.auto_approve_kinds.clone());
+        // Mirror SignerHandler::restore_client: Session grants die at restart,
+        // expired Seconds grants are dropped, and capacity is enforced so a
+        // large stored config cannot defeat MAX_CONNECTED_APPS.
+        match app.duration {
+            PermissionDuration::Session => continue,
+            PermissionDuration::Seconds(_) if app.duration.is_expired(app.connected_at) => continue,
+            _ => {}
         }
+        if !pm.ensure_capacity(&app.pubkey) {
+            warn!(
+                app_id = &app.pubkey.to_hex()[..8],
+                "apply_pre_grants: capacity full, skipping"
+            );
+            continue;
+        }
+        let mut perm = AppPermission::new(app.pubkey, app.name.clone());
+        perm.permissions = app.permissions & Permission::ALL;
+        perm.auto_approve_kinds = app.auto_approve_kinds.clone();
+        perm.duration = app.duration;
+        perm.connected_at = app.connected_at;
+        pm.insert(perm);
     }
 }
 

--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -38,6 +38,11 @@ pub struct ServerConfig {
     /// Lets a headless bunker accept signing requests from CLI-managed apps
     /// (`keep nip46 grant <pubkey> ...`) without an interactive approval prompt.
     pub pre_grants: Vec<PreGrantedApp>,
+    /// Global event kinds that skip the approval prompt for every client,
+    /// independent of any per-app `auto_approve_kinds`. Set via
+    /// `keep nip46 auto-approve`. Only meaningful for interactive serving;
+    /// in headless mode every request is auto-approved regardless.
+    pub auto_approve_kinds: std::collections::HashSet<nostr_sdk::Kind>,
 }
 
 /// A NIP-46 client app whose permissions are loaded into the
@@ -64,6 +69,7 @@ impl Default for ServerConfig {
             kill_switch: None,
             connect_grant: Permission::DEFAULT,
             pre_grants: Vec::new(),
+            auto_approve_kinds: std::collections::HashSet::from([nostr_sdk::Kind::Reaction]),
         }
     }
 }
@@ -291,6 +297,10 @@ impl Server {
 
         let permissions = Arc::new(Mutex::new(PermissionManager::new()));
         apply_pre_grants(&permissions, &config.pre_grants).await;
+        permissions
+            .lock()
+            .await
+            .set_auto_approve_kinds(config.auto_approve_kinds.clone());
         let audit = Arc::new(Mutex::new(AuditLog::new(config.audit_log_capacity)));
         let mut handler = SignerHandler::new(keyring, permissions, audit, callbacks.clone())
             .with_auto_approve(config.auto_approve)
@@ -390,6 +400,10 @@ impl Server {
         let keyring = Arc::new(Mutex::new(Keyring::new()));
         let permissions = Arc::new(Mutex::new(PermissionManager::new()));
         apply_pre_grants(&permissions, &config.pre_grants).await;
+        permissions
+            .lock()
+            .await
+            .set_auto_approve_kinds(config.auto_approve_kinds.clone());
         let audit = Arc::new(Mutex::new(AuditLog::new(config.audit_log_capacity)));
         let handler = SignerHandler::new(keyring, permissions, audit, callbacks.clone())
             .with_network_frost_signer(network_signer)


### PR DESCRIPTION
Implements #445.

## Why
Headless `keep serve` (used by StartOS, CI, any bunker without a UI) couldn't grant a NIP-46 client app a long-lived permission. The only path to a non-default permission set was the desktop's interactive approval prompt. Anything automated had to either run `auto_approve` (grants every connection everything) or hand-edit the on-disk `RelayConfig` blob.

Now there's a real CRUD surface, and the bunker actually loads pre-grants at startup.

## New CLI
```
keep nip46 apps                                       # list stored grants
keep nip46 grant <pubkey> --name "GitHub Actions" \
    --permissions sign_event,nip44_encrypt \
    --auto-approve-kinds 1,7 \
    --duration forever
keep nip46 revoke <pubkey>
```

- `<pubkey>` accepts either hex or `npub1...`.
- `--permissions` is a comma list: `get_public_key`, `sign_event`, `nip04_encrypt`, `nip04_decrypt`, `nip44_encrypt`, `nip44_decrypt`, or `all`.
- `--duration` is `session`, `forever`, or a u64 of seconds.
- `--auto-approve-kinds` lists event kinds that skip per-event approval.

## End-to-end wiring
1. `cmd_nip46_grant` / `cmd_nip46_revoke` upsert/remove entries in the global `RelayConfig.bunker_permissions` vector (sentinel key, unlocked vault required).
2. `cmd_serve` reads those entries via `keep.get_relay_config_or_default(&GLOBAL_RELAY_KEY)` and converts them into a new `keep_nip46::PreGrantedApp` vec passed through `ServerConfig.pre_grants`.
3. At Server construction (`new_with_config*`), `apply_pre_grants` calls `PermissionManager::grant(...)` and `set_auto_approve_kinds_for_app(...)` for each, so the bunker's permission state is populated before the first incoming connect.

If the on-disk pubkey is malformed it's skipped with a warning, not a hard failure — one bad entry doesn't bring the bunker down.

## Changes
- `keep-cli/src/cli.rs`: top-level `Nip46 { command }` + `Nip46Commands` enum (Apps / Grant / Revoke).
- `keep-cli/src/main.rs`: `dispatch_nip46` wires the three commands.
- `keep-cli/src/commands/nip46.rs`: new module, ~280 lines. Parses pubkey (npub|hex), permissions, kinds, duration. Persists via `Keep::store_relay_config`.
- `keep-cli/src/commands/mod.rs`: registers the new module.
- `keep-cli/src/commands/serve.rs`: `load_pre_grants` helper translates `StoredBunkerPermission` -> `PreGrantedApp`; threaded into the headless serve path's `ServerConfig`.
- `keep-nip46/src/server.rs`: new `PreGrantedApp` struct; `ServerConfig.pre_grants: Vec<PreGrantedApp>`; new `apply_pre_grants(...)` helper called in both `new_with_config_and_proxy` and `new_network_frost_with_config_and_proxy` after `PermissionManager::new()`.
- `keep-nip46/src/lib.rs`: re-exports `PreGrantedApp`.

Closes #445.

## Test plan
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --lib` — 679 tests pass workspace-wide.
- [x] Build: `keep nip46 apps`, `keep nip46 grant`, `keep nip46 revoke` all surface in `--help`.
- [x] Existing `auto_approve` behavior unchanged when no pre-grants are stored (the helper short-circuits on empty).

## Follow-ups not in this PR
- #507 — hidden-vault serve paths don't yet pull pre-grants (`HiddenStorage` doesn't expose `get_relay_config`). Low priority because the headless bunker stories that need pre-grants run on non-hidden vaults.
- #508 — `Seconds(N)` expiry resets at every bunker start because `PermissionManager::grant(...)` overwrites `connected_at` instead of honoring the persisted value. Forever and Session work correctly today.