### PR TITLE
test: exercise NIP-46 permission scoping with auto_approve=false + callback (#509)

### DIFF
--- a/keep-nip46/tests/bunker_integration.rs
+++ b/keep-nip46/tests/bunker_integration.rs
@@ -7,7 +7,20 @@ use tokio::sync::Mutex;
 
 use keep_core::keyring::Keyring;
 use keep_core::keys::{KeyType, NostrKeypair};
+use keep_nip46::types::{ApprovalRequest, LogEvent, ServerCallbacks};
 use keep_nip46::{Server, ServerConfig};
+
+/// Test-only `ServerCallbacks` that approves every request. Used by tests
+/// that need the connect handshake to succeed (and the per-method approval
+/// gate to fire) WITHOUT enabling `auto_approve: true`, which would override
+/// the client's requested permissions with `Permission::ALL`.
+struct AlwaysApprove;
+impl ServerCallbacks for AlwaysApprove {
+    fn on_log(&self, _event: LogEvent) {}
+    fn request_approval(&self, _request: ApprovalRequest) -> bool {
+        true
+    }
+}
 
 fn extract_bunker_secret(bunker_url: &str) -> Option<String> {
     let url = url::Url::parse(bunker_url).ok()?;
@@ -219,14 +232,19 @@ async fn test_bunker_permission_scoping() {
     let relay_url = mock_relay.url().await.to_string();
     let (keyring, signer_pubkey) = setup_keyring();
 
+    // `auto_approve: false` here, with an `AlwaysApprove` callback. This
+    // exercises the real per-permission scoping path: the client's requested
+    // permissions are honored as-is, not silently widened to `Permission::ALL`
+    // by `auto_approve` (see #444 / `handler.rs:351`). The callback lets the
+    // connect handshake succeed in a test that has no human in the loop.
     let server = Server::new_with_config(
         keyring,
         None,
         None,
         std::slice::from_ref(&relay_url),
-        None,
+        Some(Arc::new(AlwaysApprove)),
         ServerConfig {
-            auto_approve: true,
+            auto_approve: false,
             ..Default::default()
         },
     )


### PR DESCRIPTION
Fixes #509.

## Why it was red
`test_bunker_permission_scoping` set `auto_approve: true` and asserted that `sign_event` is denied when only `get_public_key` was requested. The #444 fix (PR #482) made `auto_approve` grant `Permission::ALL` on connect (`keep-nip46/src/handler.rs:351`), so the requested-permissions string is overwritten and the assertion no longer holds. Headless bunkers want "approved means everything"; per-permission scoping is a separate axis tested via the approval-callback path.

## The fix
Switch the test to `auto_approve: false` with an `AlwaysApprove` `ServerCallbacks` impl. This exercises the real scoping path:
- The connect handshake succeeds because the callback returns `true` (no human in the loop, no auto_approve overwrite).
- The client's requested permissions string is honored as-is — `get_public_key` only.
- `sign_event` is properly denied because the permission bit was never set.

Closes #509.

## Changes
- `keep-nip46/tests/bunker_integration.rs`: new module-scoped `AlwaysApprove` `ServerCallbacks` impl + test rewritten to use it.

## Test plan
- [x] `cargo test -p keep-nip46 --test bunker_integration` — 3 passed (including the previously-red one).
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace` — all green (lib + integration).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for permission scoping validation by replacing simplified auto-approval with explicit callback-based approval logic, ensuring permission requests are correctly honored without unnecessary expansion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/keep/pull/511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->