### PR TITLE
refactor(nip46): dedup grant mapping and permission parsers

### DIFF
--- a/keep-cli/src/commands/nip46.rs
+++ b/keep-cli/src/commands/nip46.rs
@@ -209,32 +209,24 @@ fn parse_pubkey_hex(input: &str) -> Result<String> {
 }
 
 fn parse_permissions(s: &str) -> Result<u32> {
-    use keep_nip46::Permission;
-    let mut bits: u32 = 0;
+    let mut perms = keep_nip46::Permission::empty();
     for token in s.split(',').map(|t| t.trim()).filter(|t| !t.is_empty()) {
-        let lower = token.to_ascii_lowercase();
-        let bit = match lower.as_str() {
-            "all" => return Ok(Permission::ALL.bits()),
-            "get_public_key" | "getpublickey" => Permission::GET_PUBLIC_KEY.bits(),
-            "sign_event" | "signevent" => Permission::SIGN_EVENT.bits(),
-            "nip04_encrypt" | "nip04encrypt" => Permission::NIP04_ENCRYPT.bits(),
-            "nip04_decrypt" | "nip04decrypt" => Permission::NIP04_DECRYPT.bits(),
-            "nip44_encrypt" | "nip44encrypt" => Permission::NIP44_ENCRYPT.bits(),
-            "nip44_decrypt" | "nip44decrypt" => Permission::NIP44_DECRYPT.bits(),
-            other => {
-                return Err(KeepError::InvalidInput(format!(
-                    "unknown permission '{other}'; valid: get_public_key, sign_event, nip04_encrypt, nip04_decrypt, nip44_encrypt, nip44_decrypt, all"
-                )));
-            }
-        };
-        bits |= bit;
+        let flag = keep_nip46::Permission::from_canonical_name(token).ok_or_else(|| {
+            let known = keep_nip46::Permission::NAMES
+                .iter()
+                .map(|(_, n)| *n)
+                .collect::<Vec<_>>()
+                .join(", ");
+            KeepError::InvalidInput(format!("unknown permission '{token}'; valid: {known}, all"))
+        })?;
+        perms |= flag;
     }
-    if bits == 0 {
+    if perms.is_empty() {
         return Err(KeepError::InvalidInput(
             "at least one permission must be granted".into(),
         ));
     }
-    Ok(bits)
+    Ok(perms.bits())
 }
 
 fn parse_auto_approve_kinds(s: &str) -> Result<Vec<u16>> {
@@ -268,25 +260,7 @@ fn parse_duration(s: &str) -> Result<StoredPermissionDuration> {
 }
 
 fn format_permissions(bits: u32) -> String {
-    use keep_nip46::Permission;
-    let names: &[(u32, &str)] = &[
-        (Permission::GET_PUBLIC_KEY.bits(), "get_public_key"),
-        (Permission::SIGN_EVENT.bits(), "sign_event"),
-        (Permission::NIP04_ENCRYPT.bits(), "nip04_encrypt"),
-        (Permission::NIP04_DECRYPT.bits(), "nip04_decrypt"),
-        (Permission::NIP44_ENCRYPT.bits(), "nip44_encrypt"),
-        (Permission::NIP44_DECRYPT.bits(), "nip44_decrypt"),
-    ];
-    let set: Vec<&str> = names
-        .iter()
-        .filter(|(b, _)| bits & b != 0)
-        .map(|(_, n)| *n)
-        .collect();
-    if set.is_empty() {
-        "(none)".to_string()
-    } else {
-        set.join(",")
-    }
+    keep_nip46::Permission::from_bits_truncate(bits).to_names()
 }
 
 fn format_duration(d: &StoredPermissionDuration) -> String {

--- a/keep-cli/src/commands/serve.rs
+++ b/keep-cli/src/commands/serve.rs
@@ -528,62 +528,22 @@ fn cmd_serve_hidden(out: &Output, path: &Path, relay: &str, headless: bool) -> R
 /// accept signing requests from previously authorized clients.
 fn load_pre_grants(keep: &Keep) -> Result<Vec<keep_nip46::PreGrantedApp>> {
     let cfg = keep.get_relay_config_or_default(&keep_core::relay::GLOBAL_RELAY_KEY)?;
-    let mut out = Vec::with_capacity(cfg.bunker_permissions.len());
-    for bp in &cfg.bunker_permissions {
-        let pk_bytes = match hex::decode(&bp.pubkey_hex) {
-            Ok(b) if b.len() == 32 => b,
-            _ => {
-                tracing::warn!(
-                    pubkey_hex = %bp.pubkey_hex,
-                    "skipping malformed bunker_permission pubkey on load"
-                );
-                continue;
-            }
-        };
-        let pubkey = match nostr_sdk::PublicKey::from_slice(&pk_bytes) {
-            Ok(pk) => pk,
-            Err(e) => {
-                tracing::warn!(
-                    pubkey_hex = %bp.pubkey_hex,
-                    error = %e,
-                    "skipping bunker_permission with invalid pubkey on load"
-                );
-                continue;
-            }
-        };
-        // Mirror keep-desktop's restore_bunker_permissions: Session grants are
-        // not meant to survive a restart, and already-expired Seconds grants
-        // must not be reactivated. Forever grants always load.
-        let now = nostr_sdk::Timestamp::now().as_secs();
-        let duration = match &bp.duration {
-            keep_core::relay::StoredPermissionDuration::Session => continue,
-            keep_core::relay::StoredPermissionDuration::Seconds(secs) => {
-                if now > bp.connected_at.saturating_add(*secs) {
-                    continue;
-                }
-                keep_nip46::PermissionDuration::Seconds(*secs)
-            }
-            keep_core::relay::StoredPermissionDuration::Forever => {
-                keep_nip46::PermissionDuration::Forever
-            }
-        };
-        let permissions = keep_nip46::Permission::from_bits_truncate(bp.permissions);
-        let auto_approve_kinds: std::collections::HashSet<nostr_sdk::Kind> = bp
-            .auto_approve_kinds
-            .iter()
-            .copied()
-            .map(nostr_sdk::Kind::from)
-            .collect();
-        out.push(keep_nip46::PreGrantedApp {
-            pubkey,
-            name: bp.name.clone(),
-            permissions,
-            auto_approve_kinds,
-            duration,
-            connected_at: nostr_sdk::Timestamp::from(bp.connected_at),
-        });
-    }
-    Ok(out)
+    Ok(map_stored_to_pregrants(&cfg.bunker_permissions))
+}
+
+/// Pure mapping persisted permissions → runtime `PreGrantedApp`. Separated
+/// from the I/O wrapper so the boundary is testable and shared with the
+/// desktop's restore path. Malformed pubkeys are skipped (`from_stored`
+/// returns `None`); Session/expired Seconds rows are kept here and filtered
+/// downstream by `PermissionManager::restore_persisted`, so this stays a
+/// pure function of the stored bytes.
+fn map_stored_to_pregrants(
+    stored: &[keep_core::relay::StoredBunkerPermission],
+) -> Vec<keep_nip46::PreGrantedApp> {
+    stored
+        .iter()
+        .filter_map(keep_nip46::PreGrantedApp::from_stored)
+        .collect()
 }
 
 /// Read the persisted global auto-approve kinds (`keep nip46 auto-approve`).

--- a/keep-desktop/src/bunker_service.rs
+++ b/keep-desktop/src/bunker_service.rs
@@ -708,38 +708,22 @@ impl App {
         handler: &Arc<keep_nip46::SignerHandler>,
         stored: &[StoredBunkerPermission],
     ) {
-        let now = nostr_sdk::Timestamp::now().as_secs();
-        for perm in stored {
-            match &perm.duration {
-                StoredPermissionDuration::Session => continue,
-                StoredPermissionDuration::Seconds(secs) => {
-                    if now > perm.connected_at.saturating_add(*secs) {
-                        continue;
-                    }
-                }
-                StoredPermissionDuration::Forever => {}
-            }
-            let Ok(pubkey) = nostr_sdk::PublicKey::from_hex(&perm.pubkey_hex) else {
-                continue;
-            };
-            let kinds: std::collections::HashSet<nostr_sdk::Kind> = perm
-                .auto_approve_kinds
-                .iter()
-                .map(|k| nostr_sdk::Kind::from(*k))
-                .collect();
-            let duration = match &perm.duration {
-                StoredPermissionDuration::Session => keep_nip46::PermissionDuration::Session,
-                StoredPermissionDuration::Seconds(s) => keep_nip46::PermissionDuration::Seconds(*s),
-                StoredPermissionDuration::Forever => keep_nip46::PermissionDuration::Forever,
-            };
+        // Pure mapping (malformed pubkey skip) lives in `PreGrantedApp::from_stored`;
+        // the Session/expired/capacity-skip decision lives in
+        // `PermissionManager::restore_persisted` via `SignerHandler::restore_client`.
+        // Keeping both responsibilities out of this loop is what closes #510.
+        for app in stored
+            .iter()
+            .filter_map(keep_nip46::PreGrantedApp::from_stored)
+        {
             handler
                 .restore_client(
-                    pubkey,
-                    perm.name.clone(),
-                    keep_nip46::Permission::from_bits_truncate(perm.permissions),
-                    kinds,
-                    duration,
-                    nostr_sdk::Timestamp::from(perm.connected_at),
+                    app.pubkey,
+                    app.name,
+                    app.permissions,
+                    app.auto_approve_kinds,
+                    app.duration,
+                    app.connected_at,
                 )
                 .await;
         }

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -656,21 +656,15 @@ impl SignerHandler {
         duration: PermissionDuration,
         connected_at: Timestamp,
     ) {
-        if matches!(duration, PermissionDuration::Session) {
-            return;
-        }
         let mut pm = self.permissions.lock().await;
-        if !pm.ensure_capacity(&pubkey) {
-            let app_id = &pubkey.to_hex()[..8];
-            tracing::warn!(app_id, "restore_client: capacity full, skipping");
-            return;
-        }
-        let mut app = AppPermission::new(pubkey, name);
-        app.permissions = permissions & Permission::ALL;
-        app.auto_approve_kinds = auto_kinds;
-        app.duration = duration;
-        app.connected_at = connected_at;
-        pm.insert(app);
+        pm.restore_persisted(
+            pubkey,
+            name,
+            permissions,
+            auto_kinds,
+            duration,
+            connected_at,
+        );
     }
 
     pub async fn update_client_permissions(&self, pubkey: &PublicKey, permissions: Permission) {

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -28,6 +28,51 @@ bitflags::bitflags! {
     }
 }
 
+impl Permission {
+    /// Canonical (flag, snake_case name) table. Single source of truth shared
+    /// by the CLI parser/formatter, desktop UI, and any other caller.
+    pub const NAMES: &'static [(Permission, &'static str)] = &[
+        (Permission::GET_PUBLIC_KEY, "get_public_key"),
+        (Permission::SIGN_EVENT, "sign_event"),
+        (Permission::NIP04_ENCRYPT, "nip04_encrypt"),
+        (Permission::NIP04_DECRYPT, "nip04_decrypt"),
+        (Permission::NIP44_ENCRYPT, "nip44_encrypt"),
+        (Permission::NIP44_DECRYPT, "nip44_decrypt"),
+    ];
+
+    /// Resolve a single canonical name (snake_case, also accepts no-underscore
+    /// aliases) to its `Permission` flag, or `None` if unknown. `"all"`
+    /// returns `ALL`. Distinct from the bitflags-generated `from_name`, which
+    /// only matches the all-caps constant names (`GET_PUBLIC_KEY`, ...).
+    pub fn from_canonical_name(name: &str) -> Option<Permission> {
+        let lower = name.to_ascii_lowercase();
+        if lower == "all" {
+            return Some(Permission::ALL);
+        }
+        for (flag, canonical) in Self::NAMES {
+            if lower == *canonical || lower == canonical.replace('_', "") {
+                return Some(*flag);
+            }
+        }
+        None
+    }
+
+    /// Render this bitset as a comma-separated string of snake_case names,
+    /// or `"(none)"` if no bits are set.
+    pub fn to_names(self) -> String {
+        let set: Vec<&str> = Self::NAMES
+            .iter()
+            .filter(|(flag, _)| self.contains(*flag))
+            .map(|(_, n)| *n)
+            .collect();
+        if set.is_empty() {
+            "(none)".to_string()
+        } else {
+            set.join(",")
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PermissionDuration {
     Session,
@@ -244,6 +289,39 @@ impl PermissionManager {
             }
             app.last_used = Timestamp::now();
         }
+    }
+
+    /// Restore an app from persisted state. Single source of truth for the
+    /// Session-skip / expired-Seconds-skip / capacity-enforced insert path
+    /// shared by `SignerHandler::restore_client` and the `apply_pre_grants`
+    /// startup hook. Returns `true` if the app was inserted, `false` if it
+    /// was skipped (Session, expired, or capacity full).
+    pub fn restore_persisted(
+        &mut self,
+        pubkey: PublicKey,
+        name: String,
+        permissions: Permission,
+        auto_kinds: HashSet<Kind>,
+        duration: PermissionDuration,
+        connected_at: Timestamp,
+    ) -> bool {
+        match duration {
+            PermissionDuration::Session => return false,
+            PermissionDuration::Seconds(_) if duration.is_expired(connected_at) => return false,
+            _ => {}
+        }
+        if !self.ensure_capacity(&pubkey) {
+            let app_id = &pubkey.to_hex()[..8];
+            warn!(app_id, "restore_persisted: capacity full, skipping");
+            return false;
+        }
+        let mut app = AppPermission::new(pubkey, name);
+        app.permissions = permissions & Permission::ALL;
+        app.auto_approve_kinds = auto_kinds;
+        app.duration = duration;
+        app.connected_at = connected_at;
+        self.insert(app);
+        true
     }
 
     pub(crate) fn insert(&mut self, mut app: AppPermission) {

--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -17,7 +17,7 @@ use crate::bunker::generate_bunker_url;
 use crate::error::Result;
 use crate::frost_signer::{FrostSigner, NetworkFrostSigner};
 use crate::handler::SignerHandler;
-use crate::permissions::{AppPermission, Permission, PermissionDuration, PermissionManager};
+use crate::permissions::{Permission, PermissionDuration, PermissionManager};
 use crate::rate_limit::RateLimitConfig;
 use crate::types::{LogEvent, Nip46Request, Nip46Response, PartialEvent, ServerCallbacks};
 use keep_core::relay::TIMESTAMP_TWEAK_RANGE;
@@ -56,6 +56,56 @@ pub struct PreGrantedApp {
     pub auto_approve_kinds: std::collections::HashSet<nostr_sdk::Kind>,
     pub duration: PermissionDuration,
     pub connected_at: Timestamp,
+}
+
+impl PreGrantedApp {
+    /// Build a runtime `PreGrantedApp` from a persisted
+    /// `keep_core::relay::StoredBunkerPermission`. Returns `None` and logs at
+    /// debug-level when the stored row is malformed (bad hex pubkey) so one
+    /// bad row never takes the bunker down. Session / expired Seconds rows
+    /// are kept here and skipped later by `PermissionManager::restore_persisted`,
+    /// so the mapping stays a pure function of the stored bytes.
+    pub fn from_stored(stored: &keep_core::relay::StoredBunkerPermission) -> Option<Self> {
+        let pk_bytes = match hex::decode(&stored.pubkey_hex) {
+            Ok(b) if b.len() == 32 => b,
+            _ => {
+                tracing::debug!(
+                    pubkey_hex = %stored.pubkey_hex,
+                    "PreGrantedApp::from_stored: skipping malformed pubkey hex"
+                );
+                return None;
+            }
+        };
+        let pubkey = PublicKey::from_slice(&pk_bytes).ok().or_else(|| {
+            tracing::debug!(
+                pubkey_hex = %stored.pubkey_hex,
+                "PreGrantedApp::from_stored: skipping invalid pubkey"
+            );
+            None
+        })?;
+        let permissions = Permission::from_bits_truncate(stored.permissions);
+        let auto_approve_kinds: std::collections::HashSet<nostr_sdk::Kind> = stored
+            .auto_approve_kinds
+            .iter()
+            .copied()
+            .map(nostr_sdk::Kind::from)
+            .collect();
+        let duration = match &stored.duration {
+            keep_core::relay::StoredPermissionDuration::Session => PermissionDuration::Session,
+            keep_core::relay::StoredPermissionDuration::Seconds(s) => {
+                PermissionDuration::Seconds(*s)
+            }
+            keep_core::relay::StoredPermissionDuration::Forever => PermissionDuration::Forever,
+        };
+        Some(Self {
+            pubkey,
+            name: stored.name.clone(),
+            permissions,
+            auto_approve_kinds,
+            duration,
+            connected_at: Timestamp::from_secs(stored.connected_at),
+        })
+    }
 }
 
 impl Default for ServerConfig {
@@ -119,27 +169,14 @@ async fn apply_pre_grants(
     }
     let mut pm = permissions.lock().await;
     for app in pre_grants {
-        // Mirror SignerHandler::restore_client: Session grants die at restart,
-        // expired Seconds grants are dropped, and capacity is enforced so a
-        // large stored config cannot defeat MAX_CONNECTED_APPS.
-        match app.duration {
-            PermissionDuration::Session => continue,
-            PermissionDuration::Seconds(_) if app.duration.is_expired(app.connected_at) => continue,
-            _ => {}
-        }
-        if !pm.ensure_capacity(&app.pubkey) {
-            warn!(
-                app_id = &app.pubkey.to_hex()[..8],
-                "apply_pre_grants: capacity full, skipping"
-            );
-            continue;
-        }
-        let mut perm = AppPermission::new(app.pubkey, app.name.clone());
-        perm.permissions = app.permissions & Permission::ALL;
-        perm.auto_approve_kinds = app.auto_approve_kinds.clone();
-        perm.duration = app.duration;
-        perm.connected_at = app.connected_at;
-        pm.insert(perm);
+        pm.restore_persisted(
+            app.pubkey,
+            app.name.clone(),
+            app.permissions,
+            app.auto_approve_kinds.clone(),
+            app.duration,
+            app.connected_at,
+        );
     }
 }
 
@@ -786,5 +823,93 @@ mod tests {
 
         let secret = bunker_secret.expect("expected_secret should surface as bunker secret");
         assert_eq!(secret.as_str(), "my-secret");
+    }
+
+    fn sample_stored(
+        pubkey_hex: &str,
+        duration: keep_core::relay::StoredPermissionDuration,
+        connected_at: u64,
+    ) -> keep_core::relay::StoredBunkerPermission {
+        keep_core::relay::StoredBunkerPermission {
+            pubkey_hex: pubkey_hex.to_string(),
+            name: "test app".to_string(),
+            permissions: Permission::GET_PUBLIC_KEY.bits() | Permission::SIGN_EVENT.bits(),
+            auto_approve_kinds: vec![1, 7],
+            duration,
+            connected_at,
+        }
+    }
+
+    fn good_pubkey_hex() -> String {
+        nostr_sdk::Keys::generate().public_key().to_hex()
+    }
+
+    #[test]
+    fn from_stored_returns_none_on_malformed_pubkey() {
+        let stored = sample_stored(
+            "not-a-pubkey",
+            keep_core::relay::StoredPermissionDuration::Forever,
+            0,
+        );
+        assert!(PreGrantedApp::from_stored(&stored).is_none());
+
+        let stored_short = sample_stored(
+            "1234",
+            keep_core::relay::StoredPermissionDuration::Forever,
+            0,
+        );
+        assert!(PreGrantedApp::from_stored(&stored_short).is_none());
+    }
+
+    #[test]
+    fn from_stored_translates_duration_and_kinds() {
+        let pk_hex = good_pubkey_hex();
+        let stored = sample_stored(
+            &pk_hex,
+            keep_core::relay::StoredPermissionDuration::Seconds(3600),
+            42,
+        );
+        let app = PreGrantedApp::from_stored(&stored).expect("valid stored row");
+        assert_eq!(app.name, "test app");
+        assert_eq!(app.connected_at.as_secs(), 42);
+        assert!(matches!(app.duration, PermissionDuration::Seconds(3600)));
+        assert!(app.auto_approve_kinds.contains(&nostr_sdk::Kind::Custom(1)));
+        assert!(app.permissions.contains(Permission::SIGN_EVENT));
+    }
+
+    #[tokio::test]
+    async fn apply_pre_grants_skips_session_and_expired() {
+        let pm = Arc::new(Mutex::new(PermissionManager::new()));
+
+        // Forever: kept.
+        let forever_stored = sample_stored(
+            &good_pubkey_hex(),
+            keep_core::relay::StoredPermissionDuration::Forever,
+            0,
+        );
+        // Session: dropped by restore_persisted.
+        let session_stored = sample_stored(
+            &good_pubkey_hex(),
+            keep_core::relay::StoredPermissionDuration::Session,
+            0,
+        );
+        // Expired Seconds (connected long ago, very short ttl): dropped.
+        let expired_stored = sample_stored(
+            &good_pubkey_hex(),
+            keep_core::relay::StoredPermissionDuration::Seconds(1),
+            1,
+        );
+
+        let pre_grants: Vec<PreGrantedApp> = [&forever_stored, &session_stored, &expired_stored]
+            .iter()
+            .filter_map(|s| PreGrantedApp::from_stored(s))
+            .collect();
+
+        apply_pre_grants(&pm, &pre_grants).await;
+        let count = pm.lock().await.list_apps().count();
+        assert_eq!(
+            count, 1,
+            "only the Forever grant should land in the manager"
+        );
     }
 }

--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -61,7 +61,7 @@ pub struct PreGrantedApp {
 impl PreGrantedApp {
     /// Build a runtime `PreGrantedApp` from a persisted
     /// `keep_core::relay::StoredBunkerPermission`. Returns `None` and logs at
-    /// debug-level when the stored row is malformed (bad hex pubkey) so one
+    /// warn-level when the stored row is malformed (bad hex pubkey) so one
     /// bad row never takes the bunker down. Session / expired Seconds rows
     /// are kept here and skipped later by `PermissionManager::restore_persisted`,
     /// so the mapping stays a pure function of the stored bytes.
@@ -69,20 +69,20 @@ impl PreGrantedApp {
         let pk_bytes = match hex::decode(&stored.pubkey_hex) {
             Ok(b) if b.len() == 32 => b,
             _ => {
-                tracing::debug!(
+                tracing::warn!(
                     pubkey_hex = %stored.pubkey_hex,
                     "PreGrantedApp::from_stored: skipping malformed pubkey hex"
                 );
                 return None;
             }
         };
-        let pubkey = PublicKey::from_slice(&pk_bytes).ok().or_else(|| {
-            tracing::debug!(
+        let Ok(pubkey) = PublicKey::from_slice(&pk_bytes) else {
+            tracing::warn!(
                 pubkey_hex = %stored.pubkey_hex,
                 "PreGrantedApp::from_stored: skipping invalid pubkey"
             );
-            None
-        })?;
+            return None;
+        };
         let permissions = Permission::from_bits_truncate(stored.permissions);
         let auto_approve_kinds: std::collections::HashSet<nostr_sdk::Kind> = stored
             .auto_approve_kinds


### PR DESCRIPTION
Closes #510.

## Summary
Three independent code paths previously did the same two jobs: translating `StoredBunkerPermission` rows into a runtime grant, and parsing/formatting NIP-46 permission names. This consolidates them.

- `keep_nip46::PreGrantedApp::from_stored(&StoredBunkerPermission)` is the single mapping from persisted row to runtime grant. It is a pure translation: only malformed pubkeys are rejected; Session/expiry/capacity decisions live downstream.
- `keep_nip46::PermissionManager::restore_persisted(...)` is the single insert path. It skips Session grants, expired Seconds grants, and capacity-full states, then upserts via `AppPermission`. Both `apply_pre_grants` (server.rs) and `SignerHandler::restore_client` (handler.rs) now delegate to it.
- `keep_nip46::Permission::NAMES`, `from_canonical_name`, and `to_names` expose the canonical snake_case mapping. The CLI `parse_permissions` / `format_permissions` helpers in `keep-cli/src/commands/nip46.rs` now delegate, removing the hand-rolled match arms.
- `keep-cli/src/commands/serve.rs::load_pre_grants` and `keep-desktop/src/bunker_service.rs::restore_bunker_permissions` collapse to a `filter_map(PreGrantedApp::from_stored)`.

`from_canonical_name` is named to avoid colliding with the bitflags-generated `from_name`, which only matches the all-caps constant names.

## Tests
- `from_stored_returns_none_on_malformed_pubkey` covers non-hex and short-hex inputs.
- `from_stored_translates_duration_and_kinds` checks the field-by-field mapping.
- `apply_pre_grants_skips_session_and_expired` confirms restore semantics (1/3 survive: Forever kept, Session dropped, expired Seconds dropped).

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`