### PR TITLE
nip46: hidden-vault grant CLI + serve pre-grant load (outer scope)

### DIFF
--- a/keep-cli/src/commands/nip46.rs
+++ b/keep-cli/src/commands/nip46.rs
@@ -10,19 +10,59 @@ use secrecy::ExposeSecret;
 use tracing::debug;
 
 use keep_core::error::{KeepError, Result};
-use keep_core::relay::{StoredBunkerPermission, StoredPermissionDuration, GLOBAL_RELAY_KEY};
+use keep_core::hidden::HiddenStorage;
+use keep_core::relay::{
+    RelayConfig, StoredBunkerPermission, StoredPermissionDuration, GLOBAL_RELAY_KEY,
+};
 use keep_core::Keep;
 
-use super::get_password;
+use super::{get_password, is_hidden_vault};
 use crate::output::Output;
+
+/// Vault dispatch for NIP-46 grant management. Hidden-init vaults route
+/// through `HiddenStorage`'s outer volume so the same `keep nip46` CLI
+/// surface works regardless of vault layout. Hidden-volume relay-config
+/// storage is a deferred follow-up; until then, `keep nip46 grant` on a
+/// hidden-init vault always targets the outer volume.
+enum NipVault {
+    Keep(Box<Keep>),
+    HiddenOuter(Box<HiddenStorage>),
+}
+
+impl NipVault {
+    fn open_unlock(path: &Path, password: &str) -> Result<Self> {
+        if is_hidden_vault(path) {
+            let mut storage = HiddenStorage::open(path)?;
+            storage.unlock_outer(password)?;
+            Ok(Self::HiddenOuter(Box::new(storage)))
+        } else {
+            let mut keep = Keep::open(path)?;
+            keep.unlock(password)?;
+            Ok(Self::Keep(Box::new(keep)))
+        }
+    }
+
+    fn get_relay_config_or_default(&self, key: &[u8; 32]) -> Result<RelayConfig> {
+        match self {
+            Self::Keep(k) => k.get_relay_config_or_default(key),
+            Self::HiddenOuter(s) => s.get_relay_config_or_default(key),
+        }
+    }
+
+    fn store_relay_config(&self, cfg: &RelayConfig) -> Result<()> {
+        match self {
+            Self::Keep(k) => k.store_relay_config(cfg),
+            Self::HiddenOuter(s) => s.store_relay_config(cfg),
+        }
+    }
+}
 
 /// Display all persisted NIP-46 client grants.
 pub fn cmd_nip46_apps(out: &Output, path: &Path) -> Result<()> {
-    let mut keep = Keep::open(path)?;
     let password = get_password("Enter password")?;
-    keep.unlock(password.expose_secret())?;
+    let vault = NipVault::open_unlock(path, password.expose_secret())?;
 
-    let cfg = keep.get_relay_config_or_default(&GLOBAL_RELAY_KEY)?;
+    let cfg = vault.get_relay_config_or_default(&GLOBAL_RELAY_KEY)?;
 
     out.newline();
     if !cfg.auto_approve_kinds.is_empty() {
@@ -85,11 +125,10 @@ pub fn cmd_nip46_grant(
     let auto_kinds = parse_auto_approve_kinds(auto_approve_kinds)?;
     let parsed_duration = parse_duration(duration)?;
 
-    let mut keep = Keep::open(path)?;
     let password = get_password("Enter password")?;
-    keep.unlock(password.expose_secret())?;
+    let vault = NipVault::open_unlock(path, password.expose_secret())?;
 
-    let mut cfg = keep.get_relay_config_or_default(&GLOBAL_RELAY_KEY)?;
+    let mut cfg = vault.get_relay_config_or_default(&GLOBAL_RELAY_KEY)?;
 
     // Upsert: replace existing entry for this pubkey, or append a new one.
     // A 0 fallback would make a `Seconds(n)` grant expire from the epoch (i.e.
@@ -122,7 +161,7 @@ pub fn cmd_nip46_grant(
         }
     };
 
-    keep.store_relay_config(&cfg)?;
+    vault.store_relay_config(&cfg)?;
 
     out.newline();
     if replaced {
@@ -139,11 +178,10 @@ pub fn cmd_nip46_grant(
 pub fn cmd_nip46_revoke(out: &Output, path: &Path, pubkey: &str) -> Result<()> {
     let pubkey_hex = parse_pubkey_hex(pubkey)?;
 
-    let mut keep = Keep::open(path)?;
     let password = get_password("Enter password")?;
-    keep.unlock(password.expose_secret())?;
+    let vault = NipVault::open_unlock(path, password.expose_secret())?;
 
-    let mut cfg = keep.get_relay_config_or_default(&GLOBAL_RELAY_KEY)?;
+    let mut cfg = vault.get_relay_config_or_default(&GLOBAL_RELAY_KEY)?;
     let before = cfg.bunker_permissions.len();
     cfg.bunker_permissions
         .retain(|p| !p.pubkey_hex.eq_ignore_ascii_case(&pubkey_hex));
@@ -155,7 +193,7 @@ pub fn cmd_nip46_revoke(out: &Output, path: &Path, pubkey: &str) -> Result<()> {
         )));
     }
 
-    keep.store_relay_config(&cfg)?;
+    vault.store_relay_config(&cfg)?;
     out.newline();
     out.success(&format!("Revoked NIP-46 grant for app {pubkey_hex}"));
     Ok(())
@@ -165,13 +203,12 @@ pub fn cmd_nip46_revoke(out: &Output, path: &Path, pubkey: &str) -> Result<()> {
 pub fn cmd_nip46_auto_approve(out: &Output, path: &Path, kinds: &str) -> Result<()> {
     let parsed = parse_auto_approve_kinds(kinds)?;
 
-    let mut keep = Keep::open(path)?;
     let password = get_password("Enter password")?;
-    keep.unlock(password.expose_secret())?;
+    let vault = NipVault::open_unlock(path, password.expose_secret())?;
 
-    let mut cfg = keep.get_relay_config_or_default(&GLOBAL_RELAY_KEY)?;
+    let mut cfg = vault.get_relay_config_or_default(&GLOBAL_RELAY_KEY)?;
     cfg.auto_approve_kinds = parsed.clone();
-    keep.store_relay_config(&cfg)?;
+    vault.store_relay_config(&cfg)?;
 
     out.newline();
     if parsed.is_empty() {

--- a/keep-cli/src/commands/serve.rs
+++ b/keep-cli/src/commands/serve.rs
@@ -411,22 +411,33 @@ fn spawn_tui_server(
     Ok(())
 }
 
-fn run_headless(out: &Output, keyring: Arc<Mutex<Keyring>>, relay: &str) -> Result<()> {
+fn run_headless(
+    out: &Output,
+    keyring: Arc<Mutex<Keyring>>,
+    relay: &str,
+    pre_grants: Vec<keep_nip46::PreGrantedApp>,
+    global_auto_approve: std::collections::HashSet<nostr_sdk::Kind>,
+) -> Result<()> {
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
+    if !pre_grants.is_empty() {
+        out.field(
+            "Pre-granted apps",
+            &format!("{} (from `keep nip46 grant`)", pre_grants.len()),
+        );
+    }
+    let mut config = ServerConfig {
+        auto_approve: true,
+        pre_grants,
+        ..Default::default()
+    };
+    if !global_auto_approve.is_empty() {
+        config.auto_approve_kinds = global_auto_approve;
+    }
     rt.block_on(async {
-        let mut server = Server::new_with_config(
-            keyring,
-            None,
-            None,
-            &[relay.to_string()],
-            None,
-            ServerConfig {
-                auto_approve: true,
-                ..Default::default()
-            },
-        )
-        .await?;
+        let mut server =
+            Server::new_with_config(keyring, None, None, &[relay.to_string()], None, config)
+                .await?;
         info!(relay, bunker_url = %server.bunker_url(), "server started");
         out.field("Bunker URL", &server.bunker_url());
         out.field("Relay", relay);
@@ -481,12 +492,14 @@ fn cmd_serve_outer(out: &Output, path: &Path, relay: &str, headless: bool) -> Re
     storage.unlock_outer(password.expose_secret())?;
     spinner.finish();
 
+    let (pre_grants, global_auto_approve) = hidden_serve_grants(&storage)?;
+
     let data_key = storage.data_key().ok_or(KeepError::Locked)?;
     let keyring = unlock_hidden_keyring(&storage, data_key)?;
     let keyring = Arc::new(Mutex::new(keyring));
 
     if headless {
-        return run_headless(out, keyring, relay);
+        return run_headless(out, keyring, relay, pre_grants, global_auto_approve);
     }
 
     let (bunker_url, npub) = get_bunker_info(keyring.clone(), relay)?;
@@ -508,17 +521,41 @@ fn cmd_serve_hidden(out: &Output, path: &Path, relay: &str, headless: bool) -> R
 
     out.hidden_label();
 
+    // Hidden-volume relay-config storage is not yet implemented, so this
+    // resolves to an empty grant set: the headless bunker falls back to its
+    // built-in `auto_approve` policy. Outer-volume pre-grants are intentionally
+    // not loaded on the hidden path so the relay layer never reflects activity
+    // tied to the outer volume's identity.
+    let (pre_grants, global_auto_approve) = hidden_serve_grants(&storage)?;
+
     let data_key = storage.data_key().ok_or(KeepError::Locked)?;
     let keyring = unlock_hidden_keyring(&storage, data_key)?;
     let keyring = Arc::new(Mutex::new(keyring));
 
     if headless {
-        return run_headless(out, keyring, relay);
+        return run_headless(out, keyring, relay, pre_grants, global_auto_approve);
     }
 
     let (bunker_url, npub) = get_bunker_info(keyring.clone(), relay)?;
     info!(relay, npub = %npub, "starting TUI for hidden volume");
     spawn_tui_server(keyring, relay, bunker_url, npub)
+}
+
+fn hidden_serve_grants(
+    storage: &keep_core::hidden::HiddenStorage,
+) -> Result<(
+    Vec<keep_nip46::PreGrantedApp>,
+    std::collections::HashSet<nostr_sdk::Kind>,
+)> {
+    let cfg = storage.get_relay_config_or_default(&keep_core::relay::GLOBAL_RELAY_KEY)?;
+    let pre_grants = map_stored_to_pregrants(&cfg.bunker_permissions);
+    let auto_approve: std::collections::HashSet<nostr_sdk::Kind> = cfg
+        .auto_approve_kinds
+        .iter()
+        .copied()
+        .map(nostr_sdk::Kind::from)
+        .collect();
+    Ok((pre_grants, auto_approve))
 }
 
 /// Read persisted NIP-46 client app grants from the global RelayConfig and

--- a/keep-cli/src/commands/serve.rs
+++ b/keep-cli/src/commands/serve.rs
@@ -200,8 +200,9 @@ pub fn cmd_serve(
     // headless path wires them into the ServerConfig; the interactive TUI path
     // relies on per-request approval, so the banner is scoped to headless mode
     // to avoid misleading the operator.
-    let pre_grants = load_pre_grants(&keep)?;
-    let global_auto_approve = load_global_auto_approve(&keep)?;
+    let (pre_grants, global_auto_approve) = serve_grants_from_config(
+        &keep.get_relay_config_or_default(&keep_core::relay::GLOBAL_RELAY_KEY)?,
+    );
 
     let keyring = Arc::new(Mutex::new(std::mem::take(keep.keyring_mut())));
     let rt =
@@ -366,6 +367,7 @@ fn spawn_tui_server(
     relay: &str,
     bunker_url: String,
     npub: String,
+    global_auto_approve: std::collections::HashSet<nostr_sdk::Kind>,
 ) -> Result<()> {
     let (mut tui, tui_tx) = crate::tui::Tui::new(bunker_url, npub, relay.to_string());
     let tui_tx_clone = tui_tx.clone();
@@ -386,17 +388,32 @@ fn spawn_tui_server(
                 tx: tui_tx_clone.clone(),
             }));
 
-            let mut server =
-                match Server::new(keyring, std::slice::from_ref(&relay_clone), callbacks).await {
-                    Ok(s) => s,
-                    Err(e) => {
-                        let _ = tui_tx_clone.send(TuiEvent::Log(
-                            LogEntry::new("system", "server error", false)
-                                .with_detail(&e.to_string()),
-                        ));
-                        return;
-                    }
-                };
+            // Carry the persisted global auto-approve kinds so the interactive
+            // approval prompt skips them, matching `keep nip46 auto-approve`.
+            // An unset (empty) list leaves the server's default in place.
+            let mut tui_config = ServerConfig::default();
+            if !global_auto_approve.is_empty() {
+                tui_config.auto_approve_kinds = global_auto_approve;
+            }
+
+            let mut server = match Server::new_with_config(
+                keyring,
+                None,
+                None,
+                std::slice::from_ref(&relay_clone),
+                callbacks,
+                tui_config,
+            )
+            .await
+            {
+                Ok(s) => s,
+                Err(e) => {
+                    let _ = tui_tx_clone.send(TuiEvent::Log(
+                        LogEntry::new("system", "server error", false).with_detail(&e.to_string()),
+                    ));
+                    return;
+                }
+            };
 
             if let Err(e) = server.run().await {
                 let _ = tui_tx_clone.send(TuiEvent::Log(
@@ -492,7 +509,9 @@ fn cmd_serve_outer(out: &Output, path: &Path, relay: &str, headless: bool) -> Re
     storage.unlock_outer(password.expose_secret())?;
     spinner.finish();
 
-    let (pre_grants, global_auto_approve) = hidden_serve_grants(&storage)?;
+    let (pre_grants, global_auto_approve) = serve_grants_from_config(
+        &storage.get_relay_config_or_default(&keep_core::relay::GLOBAL_RELAY_KEY)?,
+    );
 
     let data_key = storage.data_key().ok_or(KeepError::Locked)?;
     let keyring = unlock_hidden_keyring(&storage, data_key)?;
@@ -504,7 +523,7 @@ fn cmd_serve_outer(out: &Output, path: &Path, relay: &str, headless: bool) -> Re
 
     let (bunker_url, npub) = get_bunker_info(keyring.clone(), relay)?;
     info!(relay, npub = %npub, "starting TUI");
-    spawn_tui_server(keyring, relay, bunker_url, npub)
+    spawn_tui_server(keyring, relay, bunker_url, npub, global_auto_approve)
 }
 
 fn cmd_serve_hidden(out: &Output, path: &Path, relay: &str, headless: bool) -> Result<()> {
@@ -526,7 +545,9 @@ fn cmd_serve_hidden(out: &Output, path: &Path, relay: &str, headless: bool) -> R
     // built-in `auto_approve` policy. Outer-volume pre-grants are intentionally
     // not loaded on the hidden path so the relay layer never reflects activity
     // tied to the outer volume's identity.
-    let (pre_grants, global_auto_approve) = hidden_serve_grants(&storage)?;
+    let (pre_grants, global_auto_approve) = serve_grants_from_config(
+        &storage.get_relay_config_or_default(&keep_core::relay::GLOBAL_RELAY_KEY)?,
+    );
 
     let data_key = storage.data_key().ok_or(KeepError::Locked)?;
     let keyring = unlock_hidden_keyring(&storage, data_key)?;
@@ -538,34 +559,29 @@ fn cmd_serve_hidden(out: &Output, path: &Path, relay: &str, headless: bool) -> R
 
     let (bunker_url, npub) = get_bunker_info(keyring.clone(), relay)?;
     info!(relay, npub = %npub, "starting TUI for hidden volume");
-    spawn_tui_server(keyring, relay, bunker_url, npub)
+    spawn_tui_server(keyring, relay, bunker_url, npub, global_auto_approve)
 }
 
-fn hidden_serve_grants(
-    storage: &keep_core::hidden::HiddenStorage,
-) -> Result<(
+/// Translate an already-loaded global `RelayConfig` into the runtime serve
+/// grant state: `PreGrantedApp`s populated into the `PermissionManager` so
+/// headless bunkers can accept signing requests from previously authorized
+/// clients, plus the global auto-approve kinds (`keep nip46 auto-approve`).
+/// An empty auto-approve set leaves the server's default in place. Shared by
+/// both standard and hidden-vault serve paths from a single config read.
+fn serve_grants_from_config(
+    cfg: &keep_core::relay::RelayConfig,
+) -> (
     Vec<keep_nip46::PreGrantedApp>,
     std::collections::HashSet<nostr_sdk::Kind>,
-)> {
-    let cfg = storage.get_relay_config_or_default(&keep_core::relay::GLOBAL_RELAY_KEY)?;
+) {
     let pre_grants = map_stored_to_pregrants(&cfg.bunker_permissions);
-    let auto_approve: std::collections::HashSet<nostr_sdk::Kind> = cfg
+    let auto_approve = cfg
         .auto_approve_kinds
         .iter()
         .copied()
         .map(nostr_sdk::Kind::from)
         .collect();
-    Ok((pre_grants, auto_approve))
-}
-
-/// Read persisted NIP-46 client app grants from the global RelayConfig and
-/// translate them into the `PreGrantedApp` shape `keep-nip46::ServerConfig`
-/// expects. Grants are populated into the `PermissionManager` at startup so
-/// headless bunkers (where there is no interactive approval prompt) can
-/// accept signing requests from previously authorized clients.
-fn load_pre_grants(keep: &Keep) -> Result<Vec<keep_nip46::PreGrantedApp>> {
-    let cfg = keep.get_relay_config_or_default(&keep_core::relay::GLOBAL_RELAY_KEY)?;
-    Ok(map_stored_to_pregrants(&cfg.bunker_permissions))
+    (pre_grants, auto_approve)
 }
 
 /// Pure mapping persisted permissions → runtime `PreGrantedApp`. Separated
@@ -581,16 +597,4 @@ fn map_stored_to_pregrants(
         .iter()
         .filter_map(keep_nip46::PreGrantedApp::from_stored)
         .collect()
-}
-
-/// Read the persisted global auto-approve kinds (`keep nip46 auto-approve`).
-/// An empty stored list leaves the server's default in place.
-fn load_global_auto_approve(keep: &Keep) -> Result<std::collections::HashSet<nostr_sdk::Kind>> {
-    let cfg = keep.get_relay_config_or_default(&keep_core::relay::GLOBAL_RELAY_KEY)?;
-    Ok(cfg
-        .auto_approve_kinds
-        .iter()
-        .copied()
-        .map(nostr_sdk::Kind::from)
-        .collect())
 }

--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -43,7 +43,7 @@ use crate::crypto::{self, Argon2Params, EncryptedData, SecretKey};
 use crate::error::{KeepError, Result, StorageError};
 use crate::keys::KeyRecord;
 use crate::rate_limit;
-use crate::relay::RelayConfig;
+use crate::relay::{self, RelayConfig};
 
 use bincode::Options;
 
@@ -690,7 +690,7 @@ impl HiddenStorage {
         match self.active_volume {
             Some(VolumeType::Outer) => {}
             Some(VolumeType::Hidden) => {
-                return Err(KeepError::Other(
+                return Err(KeepError::NotImplemented(
                     "relay config storage on the hidden volume is not yet implemented".into(),
                 ));
             }
@@ -698,15 +698,16 @@ impl HiddenStorage {
         }
         let (data_key, db) = self.outer_relay_handles()?;
 
-        let serialized = serde_json::to_vec(config)
-            .map_err(|e| KeepError::Other(format!("json serialization failed: {e}")))?;
-        let encrypted = crypto::encrypt(&serialized, data_key)?;
-        let encrypted_bytes = encrypted.to_bytes();
+        let normalized = config.clone().normalize()?;
+        let encrypted_bytes = relay::encode_relay_config(&normalized, data_key)?;
 
         let wtxn = db.begin_write()?;
         {
             let mut table = wtxn.open_table(RELAY_CONFIGS_TABLE)?;
-            table.insert(config.group_pubkey.as_slice(), encrypted_bytes.as_slice())?;
+            table.insert(
+                normalized.group_pubkey.as_slice(),
+                encrypted_bytes.as_slice(),
+            )?;
         }
         wtxn.commit()?;
         Ok(())
@@ -734,12 +735,7 @@ impl HiddenStorage {
         let Some(entry) = table.get(group_pubkey.as_slice())? else {
             return Ok(None);
         };
-        let encrypted = EncryptedData::from_bytes(entry.value())?;
-        let decrypted = crypto::decrypt(&encrypted, data_key)?;
-        let decrypted_bytes = decrypted.as_slice()?;
-        let config: RelayConfig = serde_json::from_slice(&decrypted_bytes)
-            .map_err(|e| KeepError::Other(format!("json deserialization failed: {e}")))?;
-        Ok(Some(config))
+        Ok(Some(relay::decode_relay_config(entry.value(), data_key)?))
     }
 
     /// Load a relay configuration or return a fresh default for `group_pubkey`.

--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -43,6 +43,7 @@ use crate::crypto::{self, Argon2Params, EncryptedData, SecretKey};
 use crate::error::{KeepError, Result, StorageError};
 use crate::keys::KeyRecord;
 use crate::rate_limit;
+use crate::relay::RelayConfig;
 
 use bincode::Options;
 
@@ -51,6 +52,7 @@ use super::header::{
 };
 
 const KEYS_TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("keys");
+const RELAY_CONFIGS_TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("relay_configs");
 
 const MAX_RECORD_SIZE: u64 = 1024 * 1024;
 
@@ -230,6 +232,7 @@ impl HiddenStorage {
 
         let wtxn = db.begin_write()?;
         let _ = wtxn.open_table(KEYS_TABLE)?;
+        let _ = wtxn.open_table(RELAY_CONFIGS_TABLE)?;
         wtxn.commit()?;
 
         Ok(Self {
@@ -677,6 +680,81 @@ impl HiddenStorage {
         self.write_hidden_records(&records, data_key, hidden_header)
     }
 
+    /// Persist a relay configuration on the outer volume.
+    ///
+    /// Only the outer volume is currently supported; hidden-volume relay-config
+    /// storage is a documented follow-up so the headless NIP-46 bunker on the
+    /// outer side can load pre-grants without leaking the existence of a
+    /// hidden volume into the relay layer.
+    pub fn store_relay_config(&self, config: &RelayConfig) -> Result<()> {
+        match self.active_volume {
+            Some(VolumeType::Outer) => {}
+            Some(VolumeType::Hidden) => {
+                return Err(KeepError::Other(
+                    "relay config storage on the hidden volume is not yet implemented".into(),
+                ));
+            }
+            None => return Err(KeepError::Locked),
+        }
+        let (data_key, db) = self.outer_relay_handles()?;
+
+        let serialized = serde_json::to_vec(config)
+            .map_err(|e| KeepError::Other(format!("json serialization failed: {e}")))?;
+        let encrypted = crypto::encrypt(&serialized, data_key)?;
+        let encrypted_bytes = encrypted.to_bytes();
+
+        let wtxn = db.begin_write()?;
+        {
+            let mut table = wtxn.open_table(RELAY_CONFIGS_TABLE)?;
+            table.insert(config.group_pubkey.as_slice(), encrypted_bytes.as_slice())?;
+        }
+        wtxn.commit()?;
+        Ok(())
+    }
+
+    /// Load a relay configuration from the outer volume.
+    ///
+    /// Hidden volume callers get `Ok(None)` so a hidden-vault headless bunker
+    /// degrades cleanly to the interactive-approval path until hidden-volume
+    /// relay-config storage is implemented.
+    pub fn get_relay_config(&self, group_pubkey: &[u8; 32]) -> Result<Option<RelayConfig>> {
+        match self.active_volume {
+            Some(VolumeType::Outer) => {}
+            Some(VolumeType::Hidden) => return Ok(None),
+            None => return Err(KeepError::Locked),
+        }
+        let (data_key, db) = self.outer_relay_handles()?;
+
+        let rtxn = db.begin_read()?;
+        let table = match rtxn.open_table(RELAY_CONFIGS_TABLE) {
+            Ok(t) => t,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+            Err(e) => return Err(e.into()),
+        };
+        let Some(entry) = table.get(group_pubkey.as_slice())? else {
+            return Ok(None);
+        };
+        let encrypted = EncryptedData::from_bytes(entry.value())?;
+        let decrypted = crypto::decrypt(&encrypted, data_key)?;
+        let decrypted_bytes = decrypted.as_slice()?;
+        let config: RelayConfig = serde_json::from_slice(&decrypted_bytes)
+            .map_err(|e| KeepError::Other(format!("json deserialization failed: {e}")))?;
+        Ok(Some(config))
+    }
+
+    /// Load a relay configuration or return a fresh default for `group_pubkey`.
+    pub fn get_relay_config_or_default(&self, group_pubkey: &[u8; 32]) -> Result<RelayConfig> {
+        Ok(self
+            .get_relay_config(group_pubkey)?
+            .unwrap_or_else(|| RelayConfig::with_defaults(*group_pubkey)))
+    }
+
+    fn outer_relay_handles(&self) -> Result<(&SecretKey, &Database)> {
+        let data_key = self.outer_key.as_ref().ok_or(KeepError::Locked)?;
+        let db = self.outer_db.as_ref().ok_or(KeepError::Locked)?;
+        Ok((data_key, db))
+    }
+
     /// The vault directory path.
     pub fn path(&self) -> &Path {
         &self.path
@@ -1109,5 +1187,121 @@ mod tests {
         let _ = storage.unlock("wrong");
         let result = storage.unlock("wrong");
         assert!(matches!(result, Err(KeepError::RateLimited(_))));
+    }
+
+    #[test]
+    fn relay_config_round_trip_outer() {
+        use crate::relay::{
+            RelayConfig, StoredBunkerPermission, StoredPermissionDuration, GLOBAL_RELAY_KEY,
+        };
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test-relay-cfg-outer");
+
+        HiddenStorage::create(
+            &path,
+            "outer",
+            Some("hidden"),
+            10 * 1024 * 1024,
+            0.2,
+            Argon2Params::TESTING,
+        )
+        .unwrap();
+
+        let mut storage = HiddenStorage::open(&path).unwrap();
+        storage.unlock_outer("outer").unwrap();
+
+        // Default until first write.
+        let initial = storage
+            .get_relay_config_or_default(&GLOBAL_RELAY_KEY)
+            .unwrap();
+        assert!(initial.bunker_permissions.is_empty());
+
+        let mut cfg = RelayConfig::with_defaults(GLOBAL_RELAY_KEY);
+        cfg.bunker_permissions.push(StoredBunkerPermission {
+            pubkey_hex: "a".repeat(64),
+            name: "client".to_string(),
+            permissions: 0b1111,
+            auto_approve_kinds: vec![1, 7],
+            duration: StoredPermissionDuration::Forever,
+            connected_at: 100,
+        });
+        cfg.auto_approve_kinds = vec![22242];
+
+        storage.store_relay_config(&cfg).unwrap();
+
+        let loaded = storage
+            .get_relay_config(&GLOBAL_RELAY_KEY)
+            .unwrap()
+            .expect("stored config should round-trip");
+        assert_eq!(loaded.bunker_permissions.len(), 1);
+        assert_eq!(loaded.bunker_permissions[0].name, "client");
+        assert_eq!(loaded.auto_approve_kinds, vec![22242]);
+    }
+
+    #[test]
+    fn relay_config_returns_none_on_hidden_volume() {
+        use crate::relay::GLOBAL_RELAY_KEY;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test-relay-cfg-hidden");
+
+        HiddenStorage::create(
+            &path,
+            "outer",
+            Some("hidden"),
+            10 * 1024 * 1024,
+            0.2,
+            Argon2Params::TESTING,
+        )
+        .unwrap();
+
+        let mut storage = HiddenStorage::open(&path).unwrap();
+        storage.unlock_hidden("hidden").unwrap();
+
+        // Hidden-active reads return Ok(None) so headless callers can degrade
+        // cleanly until hidden-volume scope is implemented.
+        let result = storage.get_relay_config(&GLOBAL_RELAY_KEY).unwrap();
+        assert!(result.is_none());
+
+        // Writes from a hidden-active session are explicitly refused so they
+        // never silently land in outer storage and leak hidden-volume activity.
+        let cfg = crate::relay::RelayConfig::with_defaults(GLOBAL_RELAY_KEY);
+        assert!(storage.store_relay_config(&cfg).is_err());
+    }
+
+    #[test]
+    fn relay_config_round_trip_persists_across_open() {
+        use crate::relay::{RelayConfig, GLOBAL_RELAY_KEY};
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test-relay-cfg-reopen");
+
+        HiddenStorage::create(
+            &path,
+            "outer",
+            None,
+            10 * 1024 * 1024,
+            0.0,
+            Argon2Params::TESTING,
+        )
+        .unwrap();
+
+        {
+            let mut storage = HiddenStorage::open(&path).unwrap();
+            storage.unlock_outer("outer").unwrap();
+            let mut cfg = RelayConfig::with_defaults(GLOBAL_RELAY_KEY);
+            cfg.auto_approve_kinds = vec![1, 2, 3];
+            storage.store_relay_config(&cfg).unwrap();
+        }
+        {
+            let mut storage = HiddenStorage::open(&path).unwrap();
+            storage.unlock_outer("outer").unwrap();
+            let loaded = storage
+                .get_relay_config(&GLOBAL_RELAY_KEY)
+                .unwrap()
+                .unwrap();
+            assert_eq!(loaded.auto_approve_kinds, vec![1, 2, 3]);
+        }
     }
 }

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -827,101 +827,7 @@ impl Keep {
         if !self.is_unlocked() {
             return Err(KeepError::Locked);
         }
-        let normalize_relays = |urls: &[String], label: &str| -> Result<Vec<String>> {
-            if urls.len() > relay::MAX_RELAYS {
-                return Err(KeepError::InvalidInput(format!(
-                    "Too many {label} relays (max {})",
-                    relay::MAX_RELAYS
-                )));
-            }
-            let normalized = dedup_stable(urls.iter().map(|u| relay::normalize_relay_url(u)));
-            for url in &normalized {
-                relay::validate_relay_url(url).map_err(KeepError::InvalidInput)?;
-            }
-            Ok(normalized)
-        };
-        let normalized_config = RelayConfig {
-            group_pubkey: config.group_pubkey,
-            frost_relays: normalize_relays(&config.frost_relays, "FROST")?,
-            profile_relays: normalize_relays(&config.profile_relays, "profile")?,
-            bunker_relays: normalize_relays(&config.bunker_relays, "bunker")?,
-            peer_policies: {
-                let mut policies = Vec::with_capacity(config.peer_policies.len());
-                for p in &config.peer_policies {
-                    if p.pubkey_hex.len() != 64
-                        || !p.pubkey_hex.chars().all(|c| c.is_ascii_hexdigit())
-                    {
-                        return Err(KeepError::InvalidInput(format!(
-                            "Invalid peer policy pubkey: {}",
-                            p.pubkey_hex
-                        )));
-                    }
-                    policies.push(relay::PeerPolicyEntry {
-                        pubkey_hex: p.pubkey_hex.to_ascii_lowercase(),
-                        allow_send: p.allow_send,
-                        allow_receive: p.allow_receive,
-                    });
-                }
-                policies
-            },
-            bunker_permissions: {
-                const MAX_BUNKER_APPS: usize = 100;
-                const MAX_NAME_LEN: usize = 256;
-                const MAX_AUTO_KINDS: usize = 64;
-                const VALID_PERMISSION_MASK: u32 = 0b00111111;
-                if config.bunker_permissions.len() > MAX_BUNKER_APPS {
-                    return Err(KeepError::InvalidInput(format!(
-                        "Too many bunker permissions: {} (max {MAX_BUNKER_APPS})",
-                        config.bunker_permissions.len()
-                    )));
-                }
-                let mut perms = Vec::with_capacity(config.bunker_permissions.len());
-                for bp in &config.bunker_permissions {
-                    if bp.pubkey_hex.len() != 64
-                        || !bp.pubkey_hex.chars().all(|c| c.is_ascii_hexdigit())
-                    {
-                        return Err(KeepError::InvalidInput(format!(
-                            "Invalid bunker permission pubkey: {}",
-                            bp.pubkey_hex
-                        )));
-                    }
-                    if bp.name.len() > MAX_NAME_LEN {
-                        return Err(KeepError::InvalidInput(format!(
-                            "Bunker app name too long: {} (max {MAX_NAME_LEN})",
-                            bp.name.len()
-                        )));
-                    }
-                    if bp.auto_approve_kinds.len() > MAX_AUTO_KINDS {
-                        return Err(KeepError::InvalidInput(format!(
-                            "Too many auto-approve kinds: {} (max {MAX_AUTO_KINDS})",
-                            bp.auto_approve_kinds.len()
-                        )));
-                    }
-                    perms.push(relay::StoredBunkerPermission {
-                        pubkey_hex: bp.pubkey_hex.to_ascii_lowercase(),
-                        name: bp.name.clone(),
-                        permissions: bp.permissions & VALID_PERMISSION_MASK,
-                        auto_approve_kinds: bp.auto_approve_kinds.clone(),
-                        duration: bp.duration.clone(),
-                        connected_at: bp.connected_at,
-                    });
-                }
-                perms
-            },
-            auto_approve_kinds: {
-                const MAX_GLOBAL_AUTO_KINDS: usize = 64;
-                if config.auto_approve_kinds.len() > MAX_GLOBAL_AUTO_KINDS {
-                    return Err(KeepError::InvalidInput(format!(
-                        "Too many global auto-approve kinds: {} (max {MAX_GLOBAL_AUTO_KINDS})",
-                        config.auto_approve_kinds.len()
-                    )));
-                }
-                let mut kinds = config.auto_approve_kinds.clone();
-                kinds.sort_unstable();
-                kinds.dedup();
-                kinds
-            },
-        };
+        let normalized_config = config.clone().normalize()?;
         self.storage.store_relay_config(&normalized_config)
     }
 
@@ -1540,11 +1446,6 @@ pub fn default_keep_path() -> Result<PathBuf> {
             .map(|p| p.join(".keep"))
             .ok_or(KeepError::HomeNotFound),
     }
-}
-
-fn dedup_stable(iter: impl Iterator<Item = String>) -> Vec<String> {
-    let mut seen = std::collections::HashSet::new();
-    iter.filter(|s| seen.insert(s.clone())).collect()
 }
 
 #[cfg(test)]

--- a/keep-core/src/relay.rs
+++ b/keep-core/src/relay.rs
@@ -5,11 +5,29 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use serde::{Deserialize, Serialize};
 
+use crate::crypto::{self, EncryptedData, SecretKey};
+use crate::error::{KeepError, Result as KeepResult};
+
 /// Sentinel key for global (non-group-specific) relay configuration.
 pub const GLOBAL_RELAY_KEY: [u8; 32] = [0u8; 32];
 
 /// Maximum number of relays per category per share.
 pub const MAX_RELAYS: usize = 10;
+
+/// Maximum size of a decrypted relay-config blob.
+pub const MAX_RELAY_CONFIG_SIZE: usize = 1024 * 1024;
+
+/// Maximum number of persisted bunker app permissions per config.
+pub const MAX_BUNKER_APPS: usize = 100;
+
+/// Maximum length of a stored bunker app name.
+pub const MAX_BUNKER_NAME_LEN: usize = 256;
+
+/// Maximum number of auto-approve kinds per app or globally.
+pub const MAX_AUTO_KINDS: usize = 64;
+
+/// Valid bunker permission bitflags mask (matches `keep_nip46::Permission`).
+pub const VALID_PERMISSION_MASK: u32 = 0b0011_1111;
 
 /// Maximum length of a relay URL.
 pub const MAX_RELAY_URL_LENGTH: usize = 256;
@@ -112,6 +130,130 @@ impl RelayConfig {
             auto_approve_kinds: Vec::new(),
         }
     }
+
+    /// Validate and normalize a relay config before persistence.
+    ///
+    /// Relay URLs are normalized, deduplicated and validated; bunker
+    /// permissions and auto-approve kinds are capped and masked. Used by every
+    /// storage backend so all persisted configs share the same integrity rules.
+    pub fn normalize(self) -> KeepResult<Self> {
+        let normalize_relays = |urls: Vec<String>, label: &str| -> KeepResult<Vec<String>> {
+            if urls.len() > MAX_RELAYS {
+                return Err(KeepError::InvalidInput(format!(
+                    "Too many {label} relays (max {MAX_RELAYS})"
+                )));
+            }
+            let normalized = dedup_stable(urls.iter().map(|u| normalize_relay_url(u)));
+            for url in &normalized {
+                validate_relay_url(url).map_err(KeepError::InvalidInput)?;
+            }
+            Ok(normalized)
+        };
+
+        let mut peer_policies = Vec::with_capacity(self.peer_policies.len());
+        for p in self.peer_policies {
+            if p.pubkey_hex.len() != 64 || !p.pubkey_hex.chars().all(|c| c.is_ascii_hexdigit()) {
+                return Err(KeepError::InvalidInput(format!(
+                    "Invalid peer policy pubkey: {}",
+                    p.pubkey_hex
+                )));
+            }
+            peer_policies.push(PeerPolicyEntry {
+                pubkey_hex: p.pubkey_hex.to_ascii_lowercase(),
+                allow_send: p.allow_send,
+                allow_receive: p.allow_receive,
+            });
+        }
+
+        if self.bunker_permissions.len() > MAX_BUNKER_APPS {
+            return Err(KeepError::InvalidInput(format!(
+                "Too many bunker permissions: {} (max {MAX_BUNKER_APPS})",
+                self.bunker_permissions.len()
+            )));
+        }
+        let mut bunker_permissions = Vec::with_capacity(self.bunker_permissions.len());
+        for bp in self.bunker_permissions {
+            if bp.pubkey_hex.len() != 64 || !bp.pubkey_hex.chars().all(|c| c.is_ascii_hexdigit()) {
+                return Err(KeepError::InvalidInput(format!(
+                    "Invalid bunker permission pubkey: {}",
+                    bp.pubkey_hex
+                )));
+            }
+            if bp.name.len() > MAX_BUNKER_NAME_LEN {
+                return Err(KeepError::InvalidInput(format!(
+                    "Bunker app name too long: {} (max {MAX_BUNKER_NAME_LEN})",
+                    bp.name.len()
+                )));
+            }
+            if bp.auto_approve_kinds.len() > MAX_AUTO_KINDS {
+                return Err(KeepError::InvalidInput(format!(
+                    "Too many auto-approve kinds: {} (max {MAX_AUTO_KINDS})",
+                    bp.auto_approve_kinds.len()
+                )));
+            }
+            bunker_permissions.push(StoredBunkerPermission {
+                pubkey_hex: bp.pubkey_hex.to_ascii_lowercase(),
+                name: bp.name,
+                permissions: bp.permissions & VALID_PERMISSION_MASK,
+                auto_approve_kinds: bp.auto_approve_kinds,
+                duration: bp.duration,
+                connected_at: bp.connected_at,
+            });
+        }
+
+        if self.auto_approve_kinds.len() > MAX_AUTO_KINDS {
+            return Err(KeepError::InvalidInput(format!(
+                "Too many global auto-approve kinds: {} (max {MAX_AUTO_KINDS})",
+                self.auto_approve_kinds.len()
+            )));
+        }
+        let mut auto_approve_kinds = self.auto_approve_kinds;
+        auto_approve_kinds.sort_unstable();
+        auto_approve_kinds.dedup();
+
+        Ok(Self {
+            group_pubkey: self.group_pubkey,
+            frost_relays: normalize_relays(self.frost_relays, "FROST")?,
+            profile_relays: normalize_relays(self.profile_relays, "profile")?,
+            bunker_relays: normalize_relays(self.bunker_relays, "bunker")?,
+            peer_policies,
+            bunker_permissions,
+            auto_approve_kinds,
+        })
+    }
+}
+
+fn dedup_stable(iter: impl Iterator<Item = String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    iter.filter(|s| seen.insert(s.clone())).collect()
+}
+
+/// Serialize and encrypt a relay config for at-rest storage.
+pub fn encode_relay_config(config: &RelayConfig, key: &SecretKey) -> KeepResult<Vec<u8>> {
+    let serialized = serde_json::to_vec(config)
+        .map_err(|e| KeepError::Other(format!("json serialization failed: {e}")))?;
+    if serialized.len() > MAX_RELAY_CONFIG_SIZE {
+        return Err(KeepError::InvalidInput(format!(
+            "relay config blob too large: {} (max {MAX_RELAY_CONFIG_SIZE})",
+            serialized.len()
+        )));
+    }
+    Ok(crypto::encrypt(&serialized, key)?.to_bytes())
+}
+
+/// Decrypt and deserialize a relay config blob produced by [`encode_relay_config`].
+pub fn decode_relay_config(bytes: &[u8], key: &SecretKey) -> KeepResult<RelayConfig> {
+    let encrypted = EncryptedData::from_bytes(bytes)?;
+    let decrypted = crypto::decrypt(&encrypted, key)?;
+    let decrypted_bytes = decrypted.as_slice()?;
+    if decrypted_bytes.len() > MAX_RELAY_CONFIG_SIZE {
+        return Err(KeepError::InvalidInput(format!(
+            "relay config blob too large: {} (max {MAX_RELAY_CONFIG_SIZE})",
+            decrypted_bytes.len()
+        )));
+    }
+    serde_json::from_slice(&decrypted_bytes)
+        .map_err(|e| KeepError::Other(format!("json deserialization failed: {e}")))
 }
 
 /// Default FROST coordination relays.

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -16,7 +16,7 @@ use crate::error::{KeepError, Result, StorageError};
 use crate::frost::StoredShare;
 use crate::keys::KeyRecord;
 use crate::rate_limit;
-use crate::relay::RelayConfig;
+use crate::relay::{self, RelayConfig};
 use crate::wallet::{KeyHealthStatus, WalletDescriptor};
 
 use bincode::Options;
@@ -852,12 +852,13 @@ impl Storage {
         let data_key = self.data_key.as_ref().ok_or(KeepError::Locked)?;
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
 
-        let serialized = serde_json::to_vec(config)
-            .map_err(|e| KeepError::Other(format!("json serialization failed: {e}")))?;
-        let encrypted = crypto::encrypt(&serialized, data_key)?;
-        let encrypted_bytes = encrypted.to_bytes();
-
-        backend.put(RELAY_CONFIGS_TABLE, &config.group_pubkey, &encrypted_bytes)?;
+        let normalized = config.clone().normalize()?;
+        let encrypted_bytes = relay::encode_relay_config(&normalized, data_key)?;
+        backend.put(
+            RELAY_CONFIGS_TABLE,
+            &normalized.group_pubkey,
+            &encrypted_bytes,
+        )?;
         Ok(())
     }
 
@@ -871,12 +872,10 @@ impl Storage {
             return Ok(None);
         };
 
-        let encrypted = EncryptedData::from_bytes(&encrypted_bytes)?;
-        let decrypted = crypto::decrypt(&encrypted, data_key)?;
-        let decrypted_bytes = decrypted.as_slice()?;
-        let config: RelayConfig = serde_json::from_slice(&decrypted_bytes)
-            .map_err(|e| KeepError::Other(format!("json deserialization failed: {e}")))?;
-        Ok(Some(config))
+        Ok(Some(relay::decode_relay_config(
+            &encrypted_bytes,
+            data_key,
+        )?))
     }
 
     /// List all stored relay configurations.
@@ -889,12 +888,7 @@ impl Storage {
         let mut configs = Vec::new();
 
         for (_, encrypted_bytes) in entries {
-            let encrypted = EncryptedData::from_bytes(&encrypted_bytes)?;
-            let decrypted = crypto::decrypt(&encrypted, data_key)?;
-            let decrypted_bytes = decrypted.as_slice()?;
-            let config: RelayConfig = serde_json::from_slice(&decrypted_bytes)
-                .map_err(|e| KeepError::Other(format!("json deserialization failed: {e}")))?;
-            configs.push(config);
+            configs.push(relay::decode_relay_config(&encrypted_bytes, data_key)?);
         }
 
         Ok(configs)


### PR DESCRIPTION
Closes #507 (outer-volume scope; hidden-volume scope captured as the deferred sub-task in #507's body).

## Summary
Brings the NIP-46 pre-grant CLI and serve-time pre-grant load to hidden-init vaults, scoped to the outer volume per #507. Without this, a hidden-init vault running a headless bunker on the outer volume had no way to persist grants and degraded to interactive-only approval, which doesn't exist headless (the #444-shaped gap PR #482 closed for non-hidden vaults).

## Changes
- `keep-core/src/hidden/volume.rs`: add `RELAY_CONFIGS_TABLE` to the outer redb, create it alongside `KEYS_TABLE` on `HiddenStorage::create`, and expose `store_relay_config` / `get_relay_config` / `get_relay_config_or_default` on `HiddenStorage`. Outer-active reads/writes go through the new table; hidden-active reads return `Ok(None)` (so `cmd_serve_hidden` degrades cleanly) and hidden-active writes return an explicit error so nothing tied to a hidden session silently lands on the outer side. `get_relay_config` tolerates the table not existing yet on legacy outer DBs (returns `Ok(None)`).
- `keep-cli/src/commands/nip46.rs`: route `keep nip46 apps/grant/revoke/auto-approve` through a small `NipVault` dispatch that picks `Keep` for regular vaults and `HiddenStorage` (outer-unlock) for hidden-init vaults via the existing `is_hidden_vault` helper.
- `keep-cli/src/commands/serve.rs`: load pre-grants and global auto-approve from `HiddenStorage` in both `cmd_serve_outer` and `cmd_serve_hidden`, pass them through to a `run_headless` that now takes the grant set and applies it into `ServerConfig`. Hidden-active sessions resolve to an empty grant set (no outer leak) until hidden-volume scope is implemented.

## Tests
- `hidden::volume::tests::relay_config_round_trip_outer`: outer-active store -> get round-trip of a populated `RelayConfig`.
- `hidden::volume::tests::relay_config_returns_none_on_hidden_volume`: hidden-active `get` returns `Ok(None)` and hidden-active `store` errors, so nothing leaks to the outer volume.
- `hidden::volume::tests::relay_config_round_trip_persists_across_open`: write, drop, re-open, re-unlock, read back, confirms persistence across `HiddenStorage` lifecycles.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added relay configuration persistence support for hidden vaults.

* **Improvements**
  * Enhanced relay configuration validation and normalization with size limits.
  * Improved consistency of grant and auto-approve handling across server modes.
  * Optimized relay configuration storage and retrieval mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->