### PR TITLE
audit: emit RateLimitTripped on next successful unlock

### DIFF
--- a/keep-core/src/audit.rs
+++ b/keep-core/src/audit.rs
@@ -71,6 +71,10 @@ pub enum AuditEventType {
     VaultLock = 18,
     /// FROST shares refreshed.
     FrostShareRefresh = 19,
+    /// Rate limiter tripped on a failed unlock attempt. Recorded at unlock
+    /// time on the NEXT successful unlock, since the data key needed to
+    /// encrypt audit entries is not available while the vault is locked.
+    RateLimitTripped = 20,
 }
 
 impl std::fmt::Display for AuditEventType {
@@ -96,6 +100,7 @@ impl std::fmt::Display for AuditEventType {
             Self::VaultUnlock => write!(f, "vault_unlock"),
             Self::VaultLock => write!(f, "vault_lock"),
             Self::FrostShareRefresh => write!(f, "frost_share_refresh"),
+            Self::RateLimitTripped => write!(f, "rate_limit_tripped"),
         }
     }
 }

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -168,6 +168,24 @@ impl Keep {
         let data_key = self.get_data_key()?;
         self.audit = Some(AuditLog::open(self.storage.path(), &data_key)?);
         self.signing_audit = Some(SigningAuditLog::open(self.storage.path(), &data_key)?);
+
+        // Flush any rate-limit trip events queued by prior failed unlocks
+        // before recording this success, so the audit chain reflects the
+        // chronological order: lock-out events first, then the successful
+        // unlock that observed and cleared them.
+        let trips = self.storage.drain_pending_trips();
+        for trip in trips {
+            let trip_ts = trip.timestamp as i64;
+            let reason = format!(
+                "rate limit threshold reached after {} failed attempts",
+                trip.failed_attempts
+            );
+            self.audit_event(AuditEventType::RateLimitTripped, |mut e| {
+                e.timestamp = trip_ts;
+                e.with_success(false).with_reason(&reason)
+            });
+        }
+
         self.audit_event(AuditEventType::VaultUnlock, |e| e);
         debug!("loading keys to keyring");
         self.load_keys_to_keyring()
@@ -1458,6 +1476,74 @@ mod tests {
         let mut keep = Keep::open(path).unwrap();
         keep.unlock("testpass").unwrap();
         keep
+    }
+
+    #[test]
+    fn rate_limit_trip_emits_audit_entry_on_next_unlock() {
+        // The rate limiter trips after MAX_ATTEMPTS (5) failed unlocks. The
+        // trip event must surface as a `RateLimitTripped` audit entry the
+        // next time the operator successfully unlocks (#495).
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("keep");
+
+        Storage::create(&path, "right-password", crypto::Argon2Params::TESTING).unwrap();
+
+        // Five failed attempts trips the limiter.
+        for _ in 0..5 {
+            let mut keep = Keep::open(&path).unwrap();
+            let _ = keep.unlock("wrong-password");
+        }
+
+        // The sixth attempt would hit the back-off; wait it out by clearing
+        // the active rate-limit counter (the trip event lives in a separate
+        // file that record_success deliberately does NOT touch).
+        crate::rate_limit::record_success(&path);
+
+        let mut keep = Keep::open(&path).unwrap();
+        keep.unlock("right-password").unwrap();
+
+        let entries = keep.audit_read_all().unwrap();
+        let trips: Vec<_> = entries
+            .iter()
+            .filter(|e| matches!(e.event_type, AuditEventType::RateLimitTripped))
+            .collect();
+        assert_eq!(trips.len(), 1, "expected one trip entry, got {trips:#?}");
+        assert!(!trips[0].success, "trip entry must record success=false");
+        assert!(
+            trips[0]
+                .reason
+                .as_deref()
+                .is_some_and(|r| r.contains("rate limit")),
+            "trip entry must carry a descriptive reason, got {:?}",
+            trips[0].reason
+        );
+
+        // Chronological order: RateLimitTripped precedes the VaultUnlock it
+        // was discovered by, so the audit chain reflects the actual sequence
+        // of lockout then recovery.
+        let trip_idx = entries
+            .iter()
+            .position(|e| matches!(e.event_type, AuditEventType::RateLimitTripped))
+            .unwrap();
+        let unlock_idx = entries
+            .iter()
+            .rposition(|e| matches!(e.event_type, AuditEventType::VaultUnlock))
+            .unwrap();
+        assert!(trip_idx < unlock_idx);
+
+        // Subsequent unlocks don't re-emit the same trip.
+        keep.lock();
+        let mut keep = Keep::open(&path).unwrap();
+        keep.unlock("right-password").unwrap();
+        let entries = keep.audit_read_all().unwrap();
+        let trip_count = entries
+            .iter()
+            .filter(|e| matches!(e.event_type, AuditEventType::RateLimitTripped))
+            .count();
+        assert_eq!(
+            trip_count, 1,
+            "trip entry must not duplicate on later unlocks"
+        );
     }
 
     #[test]

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -172,10 +172,12 @@ impl Keep {
         // Flush any rate-limit trip events queued by prior failed unlocks
         // before recording this success, so the audit chain reflects the
         // chronological order: lock-out events first, then the successful
-        // unlock that observed and cleared them.
+        // unlock that observed and cleared them. The drain consumes the trip
+        // file before the audit writes, so emission is best-effort: a failed
+        // audit write loses that event at-most-once with no retry.
         let trips = self.storage.drain_pending_trips();
         for trip in trips {
-            let trip_ts = trip.timestamp as i64;
+            let trip_ts = i64::try_from(trip.timestamp).unwrap_or(i64::MAX);
             let reason = format!(
                 "rate limit threshold reached after {} failed attempts",
                 trip.failed_attempts

--- a/keep-core/src/rate_limit.rs
+++ b/keep-core/src/rate_limit.rs
@@ -203,6 +203,12 @@ pub(crate) fn record_success(path: &Path) {
 }
 
 /// A persisted rate-limit trip event awaiting flush to the audit log.
+///
+/// Records are authenticated with an HMAC key derived from the PUBLIC header
+/// salt, so they are tamper-evident against corruption but NOT forgery by an
+/// attacker with read access to the vault directory. Trip audit events are
+/// therefore best-effort and sit outside the password-keyed audit chain's
+/// cryptographic tamper-evidence boundary.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PendingTrip {
     pub failed_attempts: u32,
@@ -259,6 +265,7 @@ fn record_trip(path: &Path, hmac_key: &[u8; 32], failed_attempts: u32, timestamp
     // flushes (e.g. hidden-volume unlock paths that don't open an audit log).
     if let Ok(meta) = file.metadata() {
         if meta.len() as usize >= TRIP_RECORD_SIZE * MAX_TRIP_RECORDS {
+            tracing::warn!("rate-limit trip log at capacity; dropping trip event");
             return;
         }
     }
@@ -268,16 +275,23 @@ fn record_trip(path: &Path, hmac_key: &[u8; 32], failed_attempts: u32, timestamp
         timestamp,
     };
     let mut file = file;
-    let _ = file.write_all(&trip.to_bytes(hmac_key));
+    if file.write_all(&trip.to_bytes(hmac_key)).is_err() {
+        tracing::debug!("failed to write rate-limit trip event");
+    }
     let _ = file.sync_all();
 }
 
-/// Read and remove all pending trip events for `path`. Records with invalid
+/// Read and clear all pending trip events for `path`. Records with invalid
 /// HMAC tags are silently skipped (cannot be attributed to a real trip).
+///
+/// The read and the clear both happen under the exclusive lock so the drain is
+/// atomic: a concurrent unlock cannot double-read, and a trip appended after
+/// this returns is preserved. As with [`PendingTrip`], the HMAC key is derived
+/// from the public salt, so this guards against corruption, not forgery.
 pub(crate) fn drain_pending_trips(path: &Path, hmac_key: &[u8; 32]) -> Vec<PendingTrip> {
     let trip_path = trip_log_path(path);
 
-    let Ok(mut file) = File::open(&trip_path) else {
+    let Ok(mut file) = OpenOptions::new().read(true).write(true).open(&trip_path) else {
         return Vec::new();
     };
 
@@ -297,8 +311,10 @@ pub(crate) fn drain_pending_trips(path: &Path, hmac_key: &[u8; 32]) -> Vec<Pendi
         }
     }
 
+    // Truncate while still holding the lock so the drain is atomic; the file is
+    // left empty rather than removed (a later record_trip re-appends to it).
+    let _ = file.set_len(0);
     drop(file);
-    let _ = fs::remove_file(&trip_path);
     out
 }
 
@@ -460,7 +476,7 @@ mod tests {
         assert_eq!(trips.len(), 1);
         assert_eq!(trips[0].failed_attempts, MAX_ATTEMPTS);
 
-        // After draining, the trip file is gone.
+        // After draining, the trip file is empty and drains to nothing.
         assert!(drain_pending_trips(&path, &TEST_KEY).is_empty());
     }
 

--- a/keep-core/src/rate_limit.rs
+++ b/keep-core/src/rate_limit.rs
@@ -29,6 +29,16 @@ fn rate_limit_path(storage_path: &Path) -> PathBuf {
     }
 }
 
+fn trip_log_path(storage_path: &Path) -> PathBuf {
+    let mut rl = rate_limit_path(storage_path);
+    let new_name = match rl.file_name() {
+        Some(n) => format!("{}.trips", n.to_string_lossy()),
+        None => ".ratelimit.trips".to_string(),
+    };
+    rl.set_file_name(new_name);
+    rl
+}
+
 pub(crate) fn derive_hmac_key(salt: &[u8; 32]) -> [u8; 32] {
     use blake2::digest::consts::U32;
     use blake2::{Blake2b, Digest};
@@ -168,17 +178,128 @@ pub(crate) fn record_failure(path: &Path, hmac_key: &[u8; 32]) {
     }
 
     let mut record = read_record_from_file(&mut file, hmac_key);
+    let prior_attempts = record.failed_attempts;
     record.failed_attempts = record.failed_attempts.saturating_add(1);
     record.last_failure = now_secs();
 
     let _ = file.seek(SeekFrom::Start(0));
     let _ = file.write_all(&record.to_bytes(hmac_key));
     let _ = file.sync_all();
+
+    // Queue a trip event the first time this failure crosses the rate-limit
+    // threshold. Successive failures while already tripped do not enqueue
+    // additional events. The trip log persists across the failed-attempt
+    // cycle and is drained by the next successful unlock when the audit log
+    // is available (the data key required to write encrypted audit entries
+    // is not available at this point in the flow, see #495).
+    if prior_attempts < MAX_ATTEMPTS && record.failed_attempts >= MAX_ATTEMPTS {
+        record_trip(path, hmac_key, record.failed_attempts, record.last_failure);
+    }
 }
 
 pub(crate) fn record_success(path: &Path) {
     let rl_path = rate_limit_path(path);
     let _ = fs::remove_file(rl_path);
+}
+
+/// A persisted rate-limit trip event awaiting flush to the audit log.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PendingTrip {
+    pub failed_attempts: u32,
+    pub timestamp: u64,
+}
+
+const TRIP_RECORD_SIZE: usize = 20;
+const MAX_TRIP_RECORDS: usize = 256;
+
+impl PendingTrip {
+    fn to_bytes(&self, hmac_key: &[u8; 32]) -> [u8; TRIP_RECORD_SIZE] {
+        let mut data = [0u8; TRIP_RECORD_SIZE];
+        data[0..4].copy_from_slice(&self.failed_attempts.to_le_bytes());
+        data[4..12].copy_from_slice(&self.timestamp.to_le_bytes());
+        let tag = compute_hmac(&data[0..12], hmac_key);
+        data[12..20].copy_from_slice(&tag);
+        data
+    }
+
+    fn from_bytes(data: &[u8], hmac_key: &[u8; 32]) -> Option<Self> {
+        if data.len() != TRIP_RECORD_SIZE {
+            return None;
+        }
+        let tag = compute_hmac(&data[0..12], hmac_key);
+        if !bool::from(data[12..20].ct_eq(&tag)) {
+            return None;
+        }
+        Some(Self {
+            failed_attempts: u32::from_le_bytes(data[0..4].try_into().ok()?),
+            timestamp: u64::from_le_bytes(data[4..12].try_into().ok()?),
+        })
+    }
+}
+
+fn record_trip(path: &Path, hmac_key: &[u8; 32], failed_attempts: u32, timestamp: u64) {
+    let trip_path = trip_log_path(path);
+
+    let mut opts = OpenOptions::new();
+    opts.read(true).write(true).append(true).create(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let Ok(file) = opts.open(&trip_path) else {
+        return;
+    };
+
+    if FileExt::lock_exclusive(&file).is_err() {
+        return;
+    }
+
+    // Cap the file at MAX_TRIP_RECORDS to bound disk usage when nothing
+    // flushes (e.g. hidden-volume unlock paths that don't open an audit log).
+    if let Ok(meta) = file.metadata() {
+        if meta.len() as usize >= TRIP_RECORD_SIZE * MAX_TRIP_RECORDS {
+            return;
+        }
+    }
+
+    let trip = PendingTrip {
+        failed_attempts,
+        timestamp,
+    };
+    let mut file = file;
+    let _ = file.write_all(&trip.to_bytes(hmac_key));
+    let _ = file.sync_all();
+}
+
+/// Read and remove all pending trip events for `path`. Records with invalid
+/// HMAC tags are silently skipped (cannot be attributed to a real trip).
+pub(crate) fn drain_pending_trips(path: &Path, hmac_key: &[u8; 32]) -> Vec<PendingTrip> {
+    let trip_path = trip_log_path(path);
+
+    let Ok(mut file) = File::open(&trip_path) else {
+        return Vec::new();
+    };
+
+    if FileExt::lock_exclusive(&file).is_err() {
+        return Vec::new();
+    }
+
+    let mut buf = Vec::new();
+    if file.read_to_end(&mut buf).is_err() {
+        return Vec::new();
+    }
+
+    let mut out = Vec::with_capacity(buf.len() / TRIP_RECORD_SIZE);
+    for chunk in buf.chunks_exact(TRIP_RECORD_SIZE) {
+        if let Some(trip) = PendingTrip::from_bytes(chunk, hmac_key) {
+            out.push(trip);
+        }
+    }
+
+    drop(file);
+    let _ = fs::remove_file(&trip_path);
+    out
 }
 
 #[cfg(test)]
@@ -319,5 +440,110 @@ mod tests {
         let bytes = record.to_bytes(&TEST_KEY);
         let wrong_key = [0xCD; 32];
         assert!(RateLimitRecord::from_bytes(&bytes, &wrong_key).is_none());
+    }
+
+    #[test]
+    fn trip_recorded_exactly_once_on_threshold_crossing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test-storage");
+        fs::create_dir(&path).unwrap();
+
+        // Drive the counter up to MAX_ATTEMPTS - 1 with no trip recorded.
+        for _ in 0..(MAX_ATTEMPTS - 1) {
+            record_failure(&path, &TEST_KEY);
+        }
+        assert!(drain_pending_trips(&path, &TEST_KEY).is_empty());
+
+        // This failure crosses the threshold and must queue exactly one trip.
+        record_failure(&path, &TEST_KEY);
+        let trips = drain_pending_trips(&path, &TEST_KEY);
+        assert_eq!(trips.len(), 1);
+        assert_eq!(trips[0].failed_attempts, MAX_ATTEMPTS);
+
+        // After draining, the trip file is gone.
+        assert!(drain_pending_trips(&path, &TEST_KEY).is_empty());
+    }
+
+    #[test]
+    fn additional_failures_past_threshold_do_not_requeue() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test-storage");
+        fs::create_dir(&path).unwrap();
+
+        for _ in 0..=MAX_ATTEMPTS {
+            record_failure(&path, &TEST_KEY);
+        }
+
+        // We expect exactly one trip (the first to cross), regardless of how
+        // many failures piled on after.
+        let trips = drain_pending_trips(&path, &TEST_KEY);
+        assert_eq!(trips.len(), 1);
+    }
+
+    #[test]
+    fn success_does_not_clear_trip_file() {
+        // record_success clears the rate-limit counter so the user can keep
+        // trying, but the trip event must survive to be flushed by the
+        // next unlock that opens an audit log.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test-storage");
+        fs::create_dir(&path).unwrap();
+
+        for _ in 0..=MAX_ATTEMPTS {
+            record_failure(&path, &TEST_KEY);
+        }
+        record_success(&path);
+
+        let trips = drain_pending_trips(&path, &TEST_KEY);
+        assert_eq!(trips.len(), 1);
+    }
+
+    #[test]
+    fn drain_skips_tampered_records() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test-storage");
+        fs::create_dir(&path).unwrap();
+
+        for _ in 0..=MAX_ATTEMPTS {
+            record_failure(&path, &TEST_KEY);
+        }
+
+        let trip_path = trip_log_path(&path);
+        let mut bytes = fs::read(&trip_path).unwrap();
+        // Flip a bit in the failed_attempts field; HMAC over the data will
+        // no longer match, so drain must reject this record.
+        bytes[0] ^= 0xFF;
+        fs::write(&trip_path, &bytes).unwrap();
+
+        let trips = drain_pending_trips(&path, &TEST_KEY);
+        assert!(trips.is_empty(), "tampered record must be silently skipped");
+    }
+
+    #[test]
+    fn trip_file_capped_at_max_records() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test-storage");
+        fs::create_dir(&path).unwrap();
+
+        // Synthesize MAX_TRIP_RECORDS valid records by repeatedly tripping
+        // and resetting the counter so each call crosses the threshold.
+        for _ in 0..MAX_TRIP_RECORDS {
+            // Drive up to MAX_ATTEMPTS then reset.
+            for _ in 0..MAX_ATTEMPTS {
+                record_failure(&path, &TEST_KEY);
+            }
+            record_success(&path);
+        }
+        // One more cycle must not push the file past the cap.
+        for _ in 0..MAX_ATTEMPTS {
+            record_failure(&path, &TEST_KEY);
+        }
+
+        let trip_path = trip_log_path(&path);
+        let size = fs::metadata(&trip_path).unwrap().len() as usize;
+        assert!(
+            size <= TRIP_RECORD_SIZE * MAX_TRIP_RECORDS,
+            "trip file size {size} exceeded cap"
+        );
     }
 }

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -445,6 +445,14 @@ impl Storage {
         self.backend = None;
     }
 
+    /// Drain rate-limit trip events queued by failed unlock attempts on this
+    /// vault. The caller is expected to be holding an open audit log so the
+    /// trips can be flushed as `RateLimitTripped` entries.
+    pub(crate) fn drain_pending_trips(&self) -> Vec<crate::rate_limit::PendingTrip> {
+        let hmac_key = crate::rate_limit::derive_hmac_key(&self.header.salt);
+        crate::rate_limit::drain_pending_trips(&self.path, &hmac_key)
+    }
+
     /// Returns true if unlocked.
     pub fn is_unlocked(&self) -> bool {
         self.data_key.is_some()


### PR DESCRIPTION
Closes #495.

## Summary
Today nothing surfaces in the audit log when the unlock rate limiter trips. An operator reviewing a vault after a suspected attack can see lockout state on disk (\`.ratelimit\`), but no timestamped, hash-chained audit record. Writing directly when the trip happens is not possible: \`rate_limit::record_failure\` runs before password verification, and the data key needed to encrypt audit entries isn't available yet.

This PR queues a trip event to a separate on-disk file at the moment the rate limiter trips, then drains and flushes it as a \`RateLimitTripped\` audit entry on the next successful \`Keep::unlock\` after the audit log is open.

## Changes
- \`keep-core/src/audit.rs\`: new \`AuditEventType::RateLimitTripped = 20\` variant (display: \`rate_limit_tripped\`).
- \`keep-core/src/rate_limit.rs\`:
    - new \`.ratelimit.trips\` file alongside the existing \`.ratelimit\` counter, capped at \`MAX_TRIP_RECORDS = 256\` (~5KB) so disk usage stays bounded when nothing flushes (hidden-vault paths today, see #520).
    - \`record_failure\` queues a \`PendingTrip\` exactly when this call crosses \`MAX_ATTEMPTS\` (prior < MAX, new >= MAX). Successive failures past the threshold do not requeue.
    - \`record_success\` deliberately does NOT touch the trip file so the trip survives long enough to be flushed on the next unlock.
    - \`drain_pending_trips\` reads all HMAC-valid records and removes the file. Tampered/corrupt records are silently skipped (cannot be attributed to a real trip).
    - HMAC key is reused from \`derive_hmac_key(salt)\` (same one that authenticates the rate-limit counter).
- \`keep-core/src/storage.rs\`: new \`Storage::drain_pending_trips\` shim so callers don't reach into the header salt directly.
- \`keep-core/src/lib.rs\`: \`Keep::unlock\` drains pending trips after opening the audit log and emits one \`RateLimitTripped\` entry per trip BEFORE the \`VaultUnlock\` entry, so the chain reads chronologically as lock-out then recovery. The original trip timestamp is preserved on the audit entry (not log-write time). Entries are \`success=false\` with reason \`rate limit threshold reached after N failed attempts\`.

## Hidden-volume paths
\`HiddenStorage::unlock_outer/unlock_hidden/unlock\` call \`record_failure\` too, so trips queue correctly there. The flush half is not wired because \`HiddenStorage\` doesn't open an audit log today (that infrastructure lives on \`Keep\`/\`Storage\`); the trip cap keeps disk usage bounded until #520 wires the hidden-vault audit-log integration.

## Tests
- \`rate_limit::tests::trip_recorded_exactly_once_on_threshold_crossing\`: counter at MAX-1 -> no trip; one more failure -> exactly one trip; drain removes the file.
- \`rate_limit::tests::additional_failures_past_threshold_do_not_requeue\`: piling on past MAX yields one trip total.
- \`rate_limit::tests::success_does_not_clear_trip_file\`: \`record_success\` must not eat the trip.
- \`rate_limit::tests::drain_skips_tampered_records\`: bit-flip in the record fails HMAC; drain silently discards.
- \`rate_limit::tests::trip_file_capped_at_max_records\`: cycling far past \`MAX_TRIP_RECORDS\` doesn't push the file past the cap.
- \`tests::rate_limit_trip_emits_audit_entry_on_next_unlock\`: five wrong-password attempts then a successful unlock surfaces exactly one \`RateLimitTripped\` audit entry with \`success=false\`, a descriptive reason, and chronological ordering before \`VaultUnlock\`. A second unlock cycle does not re-emit the trip.

## Validation
- \`cargo fmt --all\`
- \`cargo clippy --workspace --all-targets -- -D warnings\`
- \`cargo test --workspace\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Rate-limit trip events are now recorded in the audit log. When a vault unlock succeeds following prior failed attempts that triggered rate-limiting, pending rate-limit events are now properly logged in the audit trail, ensuring the complete chronological sequence of lockout and recovery activities is captured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->