### PR TITLE
tests: audit verify tamper-detection + stats coverage gaps

### DIFF
--- a/keep-cli/src/commands/audit.rs
+++ b/keep-cli/src/commands/audit.rs
@@ -304,3 +304,76 @@ pub fn cmd_audit_stats(out: &Output, path: &Path, hidden: bool) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod stats_tests {
+    use super::*;
+
+    /// Documents the AuditEventType variants `audit stats` currently rolls up
+    /// into counters. Any variant not exercised here is silently dropped by
+    /// the `_ => {}` arm and will not surface in the operator's stats view;
+    /// see #526 for the gap (RateLimitTripped, VaultLock, FrostSessionStart,
+    /// FrostShare*, FrostShareRefresh).
+    #[test]
+    fn audit_stats_counts_recognised_event_types() {
+        let mut stats = AuditStats::default();
+        stats.record(AuditEventType::KeyGenerate);
+        stats.record(AuditEventType::KeyImport);
+        stats.record(AuditEventType::KeyImport);
+        stats.record(AuditEventType::KeyExport);
+        stats.record(AuditEventType::KeyDelete);
+        stats.record(AuditEventType::Sign);
+        stats.record(AuditEventType::Sign);
+        stats.record(AuditEventType::SignFailed);
+        stats.record(AuditEventType::FrostGenerate);
+        stats.record(AuditEventType::FrostSplit);
+        stats.record(AuditEventType::FrostSign);
+        stats.record(AuditEventType::FrostSessionComplete);
+        stats.record(AuditEventType::FrostSignFailed);
+        stats.record(AuditEventType::FrostSessionFailed);
+        stats.record(AuditEventType::AuthFailed);
+        stats.record(AuditEventType::VaultUnlock);
+
+        assert_eq!(stats.key_gen, 1);
+        assert_eq!(stats.key_import, 2);
+        assert_eq!(stats.key_export, 1);
+        assert_eq!(stats.key_delete, 1);
+        assert_eq!(stats.sign_ok, 2);
+        assert_eq!(stats.sign_fail, 1);
+        assert_eq!(stats.frost_gen, 2);
+        assert_eq!(stats.frost_sign_ok, 2);
+        assert_eq!(stats.frost_sign_fail, 2);
+        assert_eq!(stats.auth_fail, 1);
+        assert_eq!(stats.unlock, 1);
+    }
+
+    /// Regression guard: AuditEventType variants NOT exercised by
+    /// `AuditStats::record` are silently dropped today. This test pins the
+    /// gap so a future fix that wires them up flips the counters from 0 to
+    /// non-zero and the assertions below need updating.
+    #[test]
+    fn audit_stats_silently_drops_security_relevant_variants() {
+        let mut stats = AuditStats::default();
+        stats.record(AuditEventType::RateLimitTripped);
+        stats.record(AuditEventType::VaultLock);
+        stats.record(AuditEventType::FrostSessionStart);
+        stats.record(AuditEventType::FrostShareImport);
+        stats.record(AuditEventType::FrostShareExport);
+        stats.record(AuditEventType::FrostShareDelete);
+        stats.record(AuditEventType::FrostShareRefresh);
+
+        // The current AuditStats has no fields for any of these, so every
+        // counter remains at its default.
+        assert_eq!(stats.key_gen, 0);
+        assert_eq!(stats.key_import, 0);
+        assert_eq!(stats.key_export, 0);
+        assert_eq!(stats.key_delete, 0);
+        assert_eq!(stats.sign_ok, 0);
+        assert_eq!(stats.sign_fail, 0);
+        assert_eq!(stats.frost_gen, 0);
+        assert_eq!(stats.frost_sign_ok, 0);
+        assert_eq!(stats.frost_sign_fail, 0);
+        assert_eq!(stats.auth_fail, 0);
+        assert_eq!(stats.unlock, 0);
+    }
+}

--- a/keep-core/src/audit.rs
+++ b/keep-core/src/audit.rs
@@ -1041,6 +1041,92 @@ mod tests {
     }
 
     #[test]
+    fn verify_chain_returns_true_when_log_absent() {
+        // A vault that has never recorded an entry has no audit.log on disk.
+        // `verify_chain` must not error or return false in that case, or every
+        // freshly-created vault would look "tampered" to `keep audit verify`.
+        let dir = tempdir().unwrap();
+        let key = test_key();
+        let log = AuditLog::open(dir.path(), &key).unwrap();
+        assert!(log.verify_chain(&key).unwrap());
+        assert!(log.read_all(&key).unwrap().is_empty());
+    }
+
+    #[test]
+    fn verify_chain_detects_ciphertext_tamper() {
+        // The audit log's primary integrity guarantee: a byte flip in a
+        // persisted entry must NOT pass verify_chain. The line-level
+        // ciphertext check is what `keep audit verify` relies on to detect
+        // post-hoc edits of the audit log.
+        let dir = tempdir().unwrap();
+        let key = test_key();
+        let mut log = AuditLog::open(dir.path(), &key).unwrap();
+
+        for i in 0..3 {
+            let entry =
+                AuditEntry::new(AuditEventType::Sign, log.last_hash()).with_pubkey(&[i as u8; 32]);
+            log.log(entry, &key).unwrap();
+        }
+        assert!(log.verify_chain(&key).unwrap());
+
+        // Flip a byte in the middle of the first persisted entry.
+        let audit_path = dir.path().join("audit.log");
+        let mut content = std::fs::read(&audit_path).unwrap();
+        let first_newline = content.iter().position(|b| *b == b'\n').unwrap();
+        // Pick a base64 alphabet character inside the first line so the byte
+        // remains decode-valid but the underlying ciphertext is altered.
+        let target = first_newline / 2;
+        content[target] = if content[target] == b'A' { b'B' } else { b'A' };
+        std::fs::write(&audit_path, &content).unwrap();
+
+        // The tampered line must NOT verify cleanly. Either Ok(false) for a
+        // hash-chain mismatch, or Err(Corrupted/InvalidFormat) for a failed
+        // decrypt: both are acceptable failure modes that `keep audit verify`
+        // surfaces to the operator as a tamper warning.
+        match log.verify_chain(&key) {
+            Ok(false) => {}
+            Err(_) => {}
+            Ok(true) => panic!("verify_chain accepted a tampered entry as valid"),
+        }
+    }
+
+    #[test]
+    fn apply_retention_by_age_drops_old_entries() {
+        // The age-based retention path is what `keep audit retention --max-days`
+        // exercises; nothing tested it end-to-end before.
+        let dir = tempdir().unwrap();
+        let key = test_key();
+        let mut log = AuditLog::open(dir.path(), &key).unwrap();
+
+        let now = chrono::Utc::now().timestamp();
+        let old_ts = now - 60 * 86400; // 60 days ago.
+        let recent_ts = now - 86400; // 1 day ago.
+
+        let mut old_entry = AuditEntry::new(AuditEventType::Sign, log.last_hash());
+        old_entry.timestamp = old_ts;
+        log.log(old_entry, &key).unwrap();
+
+        let mut recent_entry = AuditEntry::new(AuditEventType::Sign, log.last_hash());
+        recent_entry.timestamp = recent_ts;
+        log.log(recent_entry, &key).unwrap();
+
+        log.set_retention(RetentionPolicy {
+            max_entries: None,
+            max_age_days: Some(30),
+        });
+        let removed = log.apply_retention(&key).unwrap();
+        assert_eq!(removed, 1, "the 60-day-old entry must be pruned");
+
+        let remaining = log.read_all(&key).unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].timestamp, recent_ts);
+        assert!(
+            log.verify_chain(&key).unwrap(),
+            "retention rewrite must preserve a valid hash chain"
+        );
+    }
+
+    #[test]
     fn test_signing_audit_hash_chain() {
         let genesis = [0u8; 32];
         let entry1 = SigningAuditEntry::new(


### PR DESCRIPTION
Closes #441. Spawned follow-up #526.

## Summary
\`audit list\` is incidentally exercised by WDC testing, but \`audit verify\`, \`audit retention\`, and \`audit stats\` had no direct coverage. This PR adds tests against the underlying \`AuditLog\` API and the CLI's \`AuditStats\` roll-up, plus surfaces one real finding as a follow-up issue.

## Tests added (keep-core/src/audit.rs)
- \`verify_chain_returns_true_when_log_absent\`: a freshly-created vault has no \`audit.log\` on disk; \`verify_chain\` must return \`Ok(true)\` rather than error. Without this, \`keep audit verify\` would falsely report every new vault as \"tampered\".
- \`verify_chain_detects_ciphertext_tamper\`: log three entries, byte-flip inside the first persisted line, confirm \`verify_chain\` no longer accepts it (either \`Ok(false)\` for a hash-chain mismatch or \`Err\` for a decrypt failure, both of which \`map_verify_error\` surfaces as a tamper warning).
- \`apply_retention_by_age_drops_old_entries\`: \`keep audit retention --max-days\` had no e2e coverage. Logs a 60-day-old entry and a 1-day-old entry, applies a 30-day policy, asserts the old one is pruned, the recent one stays, and the chain remains valid after the rewrite.

## Tests added (keep-cli/src/commands/audit.rs)
- \`audit_stats_counts_recognised_event_types\`: pins the current \`AuditStats::record\` matrix so a future refactor (or a removed match arm) flips a counter and the test fails.
- \`audit_stats_silently_drops_security_relevant_variants\`: documents that \`RateLimitTripped\`, \`VaultLock\`, \`FrostSessionStart\`, \`FrostShareImport\`/\`Export\`/\`Delete\`, and \`FrostShareRefresh\` are silently dropped by the \`_ => {}\` arm today. A future fix that wires them up flips these zeros to non-zero and the assertions need updating. The doc comment points to #526.

## Finding filed
- #526: \`audit stats\` doesn't surface \`RateLimitTripped\` (added by PR #521 / #495) or several FROST-share lifecycle events. An operator reviewing a vault after a suspected attack sees no count of lockouts today, defeating the point of #495.

## Validation
- \`cargo fmt --all\`
- \`cargo clippy --workspace --all-targets -- -D warnings\`
- \`cargo test --workspace\`