### PR TITLE
export: refuse non-TTY stdin (interactive-only by design)

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -56,7 +56,8 @@ pub(crate) enum Commands {
     },
     /// List keys stored in the vault
     List,
-    /// Print a raw nsec for the named key (prompts for confirmation)
+    /// Print a raw nsec for the named key. Interactive-only by design:
+    /// refuses when stdin is not a TTY (see #467 for policy rationale).
     Export {
         #[arg(short, long)]
         name: String,

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -57,7 +57,8 @@ pub(crate) enum Commands {
     /// List keys stored in the vault
     List,
     /// Print a raw nsec for the named key. Interactive-only by design:
-    /// refuses when stdin is not a TTY (see #467 for policy rationale).
+    /// refuses unless stdin and stderr are both a TTY and no automation env
+    /// vars (KEEP_YES / KEEP_PASSWORD) are set (see #467 for policy rationale).
     Export {
         #[arg(short, long)]
         name: String,

--- a/keep-cli/src/commands/mod.rs
+++ b/keep-cli/src/commands/mod.rs
@@ -93,6 +93,29 @@ pub fn get_new_password_with_confirm(prompt: &str, confirm: &str) -> Result<Secr
     Ok(SecretString::from(pw))
 }
 
+/// Refuse to proceed when stdin is not a TTY.
+///
+/// `keep export` reveals raw private key material. Per the #467 decision, raw
+/// private-key export is interactive-only by design: the threat model is
+/// exactly "operator accidentally automates" or "malware scripts the export",
+/// and an env-var or `--yes` gate barely raises the bar against either.
+/// Operators who genuinely need scripted export can wrap in `expect`/`pty`;
+/// the speed bump is intentional. The check fires BEFORE any password prompt
+/// or vault unlock so a missing TTY surfaces immediately on the smallest
+/// possible attack surface.
+pub fn require_interactive_tty(operation: &str) -> Result<()> {
+    use std::io::IsTerminal;
+    if std::io::stdin().is_terminal() {
+        return Ok(());
+    }
+    Err(KeepError::InvalidInput(format!(
+        "{operation} is interactive-only by design: stdin is not a TTY, so this command refuses to run. \
+         Raw private-key export reveals secret material; running it from a script or pipe defeats the operator-in-the-loop \
+         intent. If you genuinely need to automate this, wrap the command in `expect` / a pty harness; see #467 for the \
+         policy rationale."
+    )))
+}
+
 pub fn get_confirm(prompt: &str) -> Result<bool> {
     if std::env::var("KEEP_YES").is_ok() {
         return Ok(true);
@@ -126,4 +149,32 @@ pub fn get_nsec(prompt: &str) -> Result<SecretString> {
 
 pub fn is_hidden_vault(path: &std::path::Path) -> bool {
     path.join("keep.vault").exists()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `require_interactive_tty` must return an `InvalidInput` error whose
+    /// message names the operation and points at #467 when stdin is not a
+    /// TTY. In the test harness stdin is never a TTY, so this is a stable
+    /// negative-path assertion.
+    #[test]
+    fn require_interactive_tty_rejects_non_tty_stdin() {
+        let err = require_interactive_tty("keep export")
+            .expect_err("test harness stdin is not a TTY; require_interactive_tty must refuse");
+        let msg = err.to_string();
+        assert!(
+            matches!(err, KeepError::InvalidInput(_)),
+            "expected InvalidInput, got {err:?}"
+        );
+        assert!(
+            msg.contains("keep export"),
+            "error must name the operation: {msg}"
+        );
+        assert!(
+            msg.contains("interactive-only") && msg.contains("#467"),
+            "error must explain why and point at the policy issue: {msg}"
+        );
+    }
 }

--- a/keep-cli/src/commands/mod.rs
+++ b/keep-cli/src/commands/mod.rs
@@ -93,26 +93,53 @@ pub fn get_new_password_with_confirm(prompt: &str, confirm: &str) -> Result<Secr
     Ok(SecretString::from(pw))
 }
 
-/// Refuse to proceed when stdin is not a TTY.
+/// Refuse to proceed unless the session is genuinely interactive.
 ///
 /// `keep export` reveals raw private key material. Per the #467 decision, raw
 /// private-key export is interactive-only by design: the threat model is
-/// exactly "operator accidentally automates" or "malware scripts the export",
-/// and an env-var or `--yes` gate barely raises the bar against either.
-/// Operators who genuinely need scripted export can wrap in `expect`/`pty`;
-/// the speed bump is intentional. The check fires BEFORE any password prompt
-/// or vault unlock so a missing TTY surfaces immediately on the smallest
-/// possible attack surface.
+/// "operator accidentally automates" or "malware scripts the export". This is
+/// a deliberate speed bump against accidental automation, not a hard control
+/// against a local attacker who can drive a pty.
+///
+/// "Interactive" requires all three to hold:
+///   - stdin is a TTY, so the operator can answer the prompts;
+///   - stderr is a TTY, because the nsec is written to stderr (`Output` uses
+///     `Term::stderr`), so gating only stdin would let `keep export 2>file`
+///     redirect the secret sink while still passing the check; and
+///   - no automation env vars (`KEEP_YES` / `KEEP_PASSWORD`) are set, since
+///     those silently script past the password prompt and the "Display nsec?"
+///     confirmation and would defeat the operator-in-the-loop intent.
+///
+/// The check fires BEFORE any password prompt or vault unlock so a missing TTY
+/// surfaces immediately on the smallest possible attack surface.
 pub fn require_interactive_tty(operation: &str) -> Result<()> {
     use std::io::IsTerminal;
-    if std::io::stdin().is_terminal() {
+    require_interactive(
+        operation,
+        std::io::stdin().is_terminal(),
+        std::io::stderr().is_terminal(),
+        std::env::var_os("KEEP_YES").is_some() || std::env::var_os("KEEP_PASSWORD").is_some(),
+    )
+}
+
+/// Pure policy behind [`require_interactive_tty`], split out so both the accept
+/// and refuse branches are deterministically testable without depending on the
+/// ambient TTY state of the test harness.
+fn require_interactive(
+    operation: &str,
+    stdin_tty: bool,
+    stderr_tty: bool,
+    automation_env: bool,
+) -> Result<()> {
+    if stdin_tty && stderr_tty && !automation_env {
         return Ok(());
     }
     Err(KeepError::InvalidInput(format!(
-        "{operation} is interactive-only by design: stdin is not a TTY, so this command refuses to run. \
-         Raw private-key export reveals secret material; running it from a script or pipe defeats the operator-in-the-loop \
-         intent. If you genuinely need to automate this, wrap the command in `expect` / a pty harness; see #467 for the \
-         policy rationale."
+        "{operation} is interactive-only by design: it refuses to run unless stdin and stderr are both a TTY \
+         and no automation env vars (KEEP_YES / KEEP_PASSWORD) are set. Raw private-key export reveals secret \
+         material; running it from a script, a pipe, or with the secret stream redirected defeats the \
+         operator-in-the-loop intent. If you genuinely need to automate this, wrap the command in `expect` / a \
+         pty harness; see #467 for the policy rationale."
     )))
 }
 
@@ -155,26 +182,49 @@ pub fn is_hidden_vault(path: &std::path::Path) -> bool {
 mod tests {
     use super::*;
 
-    /// `require_interactive_tty` must return an `InvalidInput` error whose
-    /// message names the operation and points at #467 when stdin is not a
-    /// TTY. In the test harness stdin is never a TTY, so this is a stable
-    /// negative-path assertion.
-    #[test]
-    fn require_interactive_tty_rejects_non_tty_stdin() {
-        let err = require_interactive_tty("keep export")
-            .expect_err("test harness stdin is not a TTY; require_interactive_tty must refuse");
+    fn assert_refusal(err: &KeepError, operation: &str) {
         let msg = err.to_string();
         assert!(
             matches!(err, KeepError::InvalidInput(_)),
             "expected InvalidInput, got {err:?}"
         );
         assert!(
-            msg.contains("keep export"),
+            msg.contains(operation),
             "error must name the operation: {msg}"
         );
         assert!(
             msg.contains("interactive-only") && msg.contains("#467"),
             "error must explain why and point at the policy issue: {msg}"
         );
+    }
+
+    /// A genuinely interactive session (TTY in + TTY out, no automation env)
+    /// is the only combination that is allowed through.
+    #[test]
+    fn require_interactive_accepts_full_interactive_session() {
+        require_interactive("keep export", true, true, false)
+            .expect("tty stdin + tty stderr with no automation env must be allowed");
+    }
+
+    #[test]
+    fn require_interactive_refuses_non_tty_stdin() {
+        let err = require_interactive("keep export", false, true, false).unwrap_err();
+        assert_refusal(&err, "keep export");
+    }
+
+    /// The nsec is written to stderr, so redirecting the secret sink
+    /// (`keep export 2>file`) must be refused even when stdin is still a TTY.
+    #[test]
+    fn require_interactive_refuses_non_tty_stderr() {
+        let err = require_interactive("keep export", true, false, false).unwrap_err();
+        assert_refusal(&err, "keep export");
+    }
+
+    /// `KEEP_YES` / `KEEP_PASSWORD` would script past the prompt and confirm,
+    /// so their presence is treated as non-interactive.
+    #[test]
+    fn require_interactive_refuses_automation_env() {
+        let err = require_interactive("keep export", true, true, true).unwrap_err();
+        assert_refusal(&err, "keep export");
     }
 }

--- a/keep-cli/src/commands/vault.rs
+++ b/keep-cli/src/commands/vault.rs
@@ -17,7 +17,7 @@ use crate::output::Output;
 
 use super::{
     get_confirm, get_hidden_password, get_new_password_with_confirm, get_nsec, get_password,
-    get_password_with_confirm, is_hidden_vault,
+    get_password_with_confirm, is_hidden_vault, require_interactive_tty,
 };
 
 #[tracing::instrument(skip(out), fields(path = %path.display()))]
@@ -520,6 +520,13 @@ fn cmd_list_hidden(out: &Output, path: &Path) -> Result<()> {
 
 #[tracing::instrument(skip(out), fields(path = %path.display()))]
 pub fn cmd_export(out: &Output, path: &Path, name: &str, hidden: bool) -> Result<()> {
+    // Fail fast on non-TTY BEFORE prompting for a password or unlocking. Raw
+    // private-key export is interactive-only by design (#467). Surfacing this
+    // before any vault operation keeps the attack surface minimal and avoids
+    // leaving the operator with a half-completed unlock on a non-interactive
+    // session.
+    require_interactive_tty("keep export")?;
+
     if hidden {
         return cmd_export_hidden(out, path, name);
     }
@@ -973,4 +980,51 @@ pub fn cmd_restore(out: &Output, file: &Path, target: &Path) -> Result<()> {
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// End-to-end #467 enforcement: `cmd_export` must refuse before opening
+    /// the vault when stdin is not a TTY. The path it's pointed at does NOT
+    /// exist, so if the TTY check were skipped or moved below `Keep::open`
+    /// the error would be `NotFound` instead of the documented
+    /// `InvalidInput("interactive-only", #467)`. That difference is exactly
+    /// what this test pins.
+    #[test]
+    fn cmd_export_refuses_non_tty_before_touching_vault() {
+        let out = Output::new();
+        let dir = tempdir().unwrap();
+        let nonexistent = dir.path().join("never-created-vault");
+        assert!(!nonexistent.exists());
+
+        let err = cmd_export(&out, &nonexistent, "irrelevant-key", false)
+            .expect_err("non-TTY stdin must short-circuit before vault open");
+        let msg = err.to_string();
+        assert!(
+            matches!(err, KeepError::InvalidInput(_)),
+            "expected InvalidInput from the TTY gate, got {err:?}"
+        );
+        assert!(msg.contains("interactive-only"), "got {msg}");
+        assert!(msg.contains("#467"), "got {msg}");
+    }
+
+    /// The hidden-volume code path (`--hidden`) must enforce the same gate.
+    /// Routing the check to the top of `cmd_export` covers both the regular
+    /// and hidden-vault dispatch arms in one place; this test pins that
+    /// behavior so a future refactor that splits the dispatch can't drop
+    /// the gate on the hidden path.
+    #[test]
+    fn cmd_export_hidden_arg_also_refuses_non_tty_before_touching_vault() {
+        let out = Output::new();
+        let dir = tempdir().unwrap();
+        let nonexistent = dir.path().join("never-created-vault");
+
+        let err = cmd_export(&out, &nonexistent, "irrelevant-key", true)
+            .expect_err("non-TTY stdin must short-circuit before hidden vault open");
+        assert!(matches!(err, KeepError::InvalidInput(_)));
+        assert!(err.to_string().contains("interactive-only"));
+    }
 }

--- a/keep-cli/src/commands/vault.rs
+++ b/keep-cli/src/commands/vault.rs
@@ -520,11 +520,12 @@ fn cmd_list_hidden(out: &Output, path: &Path) -> Result<()> {
 
 #[tracing::instrument(skip(out), fields(path = %path.display()))]
 pub fn cmd_export(out: &Output, path: &Path, name: &str, hidden: bool) -> Result<()> {
-    // Fail fast on non-TTY BEFORE prompting for a password or unlocking. Raw
-    // private-key export is interactive-only by design (#467). Surfacing this
-    // before any vault operation keeps the attack surface minimal and avoids
-    // leaving the operator with a half-completed unlock on a non-interactive
-    // session.
+    // Fail fast BEFORE prompting for a password or unlocking. Raw private-key
+    // export is interactive-only by design (#467): we require stdin and the
+    // stderr secret sink to both be a TTY and no automation env vars to be set.
+    // Surfacing this before any vault operation keeps the attack surface minimal
+    // and avoids leaving the operator with a half-completed unlock on a
+    // non-interactive session.
     require_interactive_tty("keep export")?;
 
     if hidden {
@@ -980,51 +981,4 @@ pub fn cmd_restore(out: &Output, file: &Path, target: &Path) -> Result<()> {
     );
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::tempdir;
-
-    /// End-to-end #467 enforcement: `cmd_export` must refuse before opening
-    /// the vault when stdin is not a TTY. The path it's pointed at does NOT
-    /// exist, so if the TTY check were skipped or moved below `Keep::open`
-    /// the error would be `NotFound` instead of the documented
-    /// `InvalidInput("interactive-only", #467)`. That difference is exactly
-    /// what this test pins.
-    #[test]
-    fn cmd_export_refuses_non_tty_before_touching_vault() {
-        let out = Output::new();
-        let dir = tempdir().unwrap();
-        let nonexistent = dir.path().join("never-created-vault");
-        assert!(!nonexistent.exists());
-
-        let err = cmd_export(&out, &nonexistent, "irrelevant-key", false)
-            .expect_err("non-TTY stdin must short-circuit before vault open");
-        let msg = err.to_string();
-        assert!(
-            matches!(err, KeepError::InvalidInput(_)),
-            "expected InvalidInput from the TTY gate, got {err:?}"
-        );
-        assert!(msg.contains("interactive-only"), "got {msg}");
-        assert!(msg.contains("#467"), "got {msg}");
-    }
-
-    /// The hidden-volume code path (`--hidden`) must enforce the same gate.
-    /// Routing the check to the top of `cmd_export` covers both the regular
-    /// and hidden-vault dispatch arms in one place; this test pins that
-    /// behavior so a future refactor that splits the dispatch can't drop
-    /// the gate on the hidden path.
-    #[test]
-    fn cmd_export_hidden_arg_also_refuses_non_tty_before_touching_vault() {
-        let out = Output::new();
-        let dir = tempdir().unwrap();
-        let nonexistent = dir.path().join("never-created-vault");
-
-        let err = cmd_export(&out, &nonexistent, "irrelevant-key", true)
-            .expect_err("non-TTY stdin must short-circuit before hidden vault open");
-        assert!(matches!(err, KeepError::InvalidInput(_)));
-        assert!(err.to_string().contains("interactive-only"));
-    }
 }

--- a/keep-cli/tests/cli_integration.rs
+++ b/keep-cli/tests/cli_integration.rs
@@ -81,7 +81,15 @@ impl KeepCmd {
     }
 
     fn run(mut self) -> Output {
-        self.cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        // Pin stdin to /dev/null so it is deterministically NOT a TTY rather
+        // than inheriting the parent's (a TTY under interactive `cargo test`).
+        // The export gate also refuses on its automation-env branch because
+        // `KeepCmd::new` always sets KEEP_YES, but pinning stdin keeps the gate
+        // independent of the ambient terminal regardless.
+        self.cmd
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
         let mut child = self.cmd.spawn().expect("failed to spawn");
         let start = Instant::now();
         loop {
@@ -120,6 +128,12 @@ fn output_contains(output: &Output, needle: &str) -> bool {
     stdout.contains(needle) || stderr.contains(needle)
 }
 
+fn assert_interactive_refusal(output: &Output) {
+    assert_failure(output);
+    assert!(output_contains(output, "interactive-only"));
+    assert!(output_contains(output, "#467"));
+}
+
 #[test]
 fn test_init_generate_list_export_workflow() {
     let bin = require_binary!();
@@ -149,9 +163,32 @@ fn test_init_generate_list_export_workflow() {
         .path(&vault)
         .args(["export", "--name", "testkey"])
         .run();
-    assert_failure(&output);
-    assert!(output_contains(&output, "interactive-only"));
-    assert!(output_contains(&output, "#467"));
+    assert_interactive_refusal(&output);
+}
+
+/// The #467 gate must fire BEFORE the vault is opened. Pointed at a vault that
+/// was never created, the command must refuse with the interactive-only policy
+/// error rather than a not-found error, proving the gate short-circuits ahead
+/// of `Keep::open`. Both the regular and `--hidden` dispatch arms share the
+/// single gate at the top of `cmd_export`, so both are pinned here.
+#[test]
+fn test_export_refuses_before_touching_vault() {
+    let bin = require_binary!();
+    let dir = TempDir::new().unwrap();
+    let nonexistent = dir.path().join("never-created-vault");
+
+    let output = KeepCmd::new(&bin)
+        .path(&nonexistent)
+        .args(["export", "--name", "irrelevant"])
+        .run();
+    assert_interactive_refusal(&output);
+
+    let output = KeepCmd::new(&bin)
+        .hidden()
+        .path(&nonexistent)
+        .args(["export", "--name", "irrelevant"])
+        .run();
+    assert_interactive_refusal(&output);
 }
 
 #[test]
@@ -365,20 +402,12 @@ fn test_missing_vault_fails() {
     assert_failure(&KeepCmd::new(&bin).path(&nonexistent).args(["list"]).run());
 }
 
-#[test]
-fn test_export_nonexistent_key_fails() {
-    let bin = require_binary!();
-    let dir = TempDir::new().unwrap();
-    let vault = dir.path().join("nokey-vault");
-
-    assert_success(&KeepCmd::new(&bin).path(&vault).args(["init"]).run());
-    assert_failure(
-        &KeepCmd::new(&bin)
-            .path(&vault)
-            .args(["export", "--name", "nonexistent"])
-            .run(),
-    );
-}
+// Note: there is no `test_export_nonexistent_key_fails` here. `export` is now
+// interactive-only (#467) and this harness is always non-interactive
+// (KEEP_YES set, stdin pinned to null), so the gate refuses before the key
+// lookup is ever reached. The nonexistent-key path is unreachable via the CLI
+// non-interactively; the gate behavior itself is covered by
+// `test_export_refuses_before_touching_vault`.
 
 #[test]
 fn test_delete_nonexistent_key_fails() {

--- a/keep-cli/tests/cli_integration.rs
+++ b/keep-cli/tests/cli_integration.rs
@@ -143,12 +143,15 @@ fn test_init_generate_list_export_workflow() {
     assert!(output_contains(&output, "testkey"));
     assert!(output_contains(&output, "Nostr"));
 
+    // `export` is interactive-only by design (#467): no TTY in this test
+    // harness means the command must refuse rather than print an nsec.
     let output = KeepCmd::new(&bin)
         .path(&vault)
         .args(["export", "--name", "testkey"])
         .run();
-    assert_success(&output);
-    assert!(output_contains(&output, "nsec1"));
+    assert_failure(&output);
+    assert!(output_contains(&output, "interactive-only"));
+    assert!(output_contains(&output, "#467"));
 }
 
 #[test]
@@ -202,48 +205,31 @@ fn test_delete_key() {
     assert!(output_contains(&output, "No keys found"));
 }
 
+/// `export` is interactive-only by design (#467), so the original
+/// generate -> export -> import -> list roundtrip via the CLI is no longer
+/// possible non-interactively. This test now covers the import half against
+/// a fixed test nsec (the export half is asserted to REFUSE in
+/// `test_init_generate_list_export_workflow`).
 #[test]
-fn test_import_export_nsec_roundtrip() {
+fn test_import_nsec_into_fresh_vault() {
     let bin = require_binary!();
     let dir = TempDir::new().unwrap();
-    let vault1 = dir.path().join("vault1");
-    let vault2 = dir.path().join("vault2");
+    let vault = dir.path().join("import-vault");
 
-    assert_success(&KeepCmd::new(&bin).path(&vault1).args(["init"]).run());
-    assert_success(
-        &KeepCmd::new(&bin)
-            .path(&vault1)
-            .args(["generate", "--name", "original"])
-            .run(),
-    );
+    // Deterministic test nsec - never used for anything real. Generated once
+    // and pinned so the test is hermetic.
+    const TEST_NSEC: &str = "nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5";
+
+    assert_success(&KeepCmd::new(&bin).path(&vault).args(["init"]).run());
 
     let output = KeepCmd::new(&bin)
-        .path(&vault1)
-        .args(["export", "--name", "original"])
-        .run();
-    assert_success(&output);
-
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let nsec = combined
-        .lines()
-        .find(|l| l.trim().starts_with("nsec1"))
-        .expect("no nsec found in output")
-        .trim();
-
-    assert_success(&KeepCmd::new(&bin).path(&vault2).args(["init"]).run());
-
-    let output = KeepCmd::new(&bin)
-        .path(&vault2)
-        .env("KEEP_NSEC", nsec)
+        .path(&vault)
+        .env("KEEP_NSEC", TEST_NSEC)
         .args(["import", "--name", "imported"])
         .run();
     assert_success(&output);
 
-    let output = KeepCmd::new(&bin).path(&vault2).args(["list"]).run();
+    let output = KeepCmd::new(&bin).path(&vault).args(["list"]).run();
     assert_success(&output);
     assert!(output_contains(&output, "imported"));
 }


### PR DESCRIPTION
Closes #467.

## Summary
Per the #467 decision, raw private-key export is interactive-only by design. The previous behavior was that the underlying confirmation prompt would error with `read confirmation: IO error: not a terminal`, but `KEEP_YES=1` bypassed the prompt entirely and the rest of `cmd_export` continued through to print the nsec. That's the gap this PR closes.

## Changes
- \`keep-cli/src/commands/mod.rs\`: new \`require_interactive_tty(operation)\` helper. Returns \`KeepError::InvalidInput\` with a message that names the operation, explains the threat model (operator accidentally automates, malware scripts the export), and points at #467 for the policy rationale.
- \`keep-cli/src/commands/vault.rs\`: \`cmd_export\` calls \`require_interactive_tty(\"keep export\")\` BEFORE any password prompt, vault open, or hidden-vault dispatch. The check fires immediately on the smallest possible attack surface; the operator never gets a half-completed unlock on a non-interactive session. Both \`cmd_export_outer\` and \`cmd_export_hidden\` are covered through the dispatch.
- \`keep-cli/src/cli.rs\`: clarify the \`Export\` help text — \"Interactive-only by design: refuses when stdin is not a TTY (see #467 for policy rationale).\"
- \`keep-cli/tests/cli_integration.rs\`:
    - \`test_init_generate_list_export_workflow\`: flipped to assert export NOW refuses with the documented message.
    - \`test_import_export_nsec_roundtrip\` renamed and rewritten as \`test_import_nsec_into_fresh_vault\`. CLI roundtrip via export -> import is no longer possible non-interactively by design; the import half is now exercised against a pinned deterministic test nsec, and the export-side refusal is owned by the test above.

## Tests
- \`commands::tests::require_interactive_tty_rejects_non_tty_stdin\`: unit-level check that the helper returns \`InvalidInput\` naming the operation and pointing at #467 when stdin is not a TTY (which it never is in the test harness).
- \`commands::vault::tests::cmd_export_refuses_non_tty_before_touching_vault\`: points \`cmd_export\` at a nonexistent vault path. If the TTY check were skipped or moved below \`Keep::open\`, the error would be \`NotFound\` instead of \`InvalidInput(\"interactive-only\")\`. Pins that the gate fires BEFORE vault open.
- \`commands::vault::tests::cmd_export_hidden_arg_also_refuses_non_tty_before_touching_vault\`: same guarantee on the \`--hidden\` arm so a future dispatch refactor can't drop the gate on the hidden path.
- The two updated integration tests above.

## Validation
- \`cargo fmt --all\`
- \`cargo clippy --workspace --all-targets -- -D warnings\`
- \`cargo test --workspace\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * The `export` command now requires an interactive terminal and will refuse to execute in non-interactive environments (such as scripts or piped commands), protecting sensitive private keys from exposure in automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->