### PR TITLE
vault: rewrite Database-already-open error to name the daemon

### DIFF
--- a/keep-core/src/backend.rs
+++ b/keep-core/src/backend.rs
@@ -397,7 +397,7 @@ pub(crate) fn open_database_with_retry(
 /// so this helper does not swallow real database failures.
 pub(crate) fn map_open_failure(path: &Path, e: redb::DatabaseError) -> KeepError {
     if matches!(&e, redb::DatabaseError::DatabaseAlreadyOpen) {
-        return KeepError::InvalidInput(format!(
+        return KeepError::Database(format!(
             "vault at {} is already opened by another process. \
              A `keep serve` or `keep frost network serve` daemon typically holds the lock; \
              stop it (or wait for it to exit) and retry. \
@@ -630,8 +630,8 @@ mod tests {
         };
         let msg = err.to_string();
         assert!(
-            matches!(err, KeepError::InvalidInput(_)),
-            "expected InvalidInput from map_open_failure, got {err:?}"
+            matches!(err, KeepError::Database(_)),
+            "expected Database from map_open_failure, got {err:?}"
         );
         assert!(
             msg.contains("already opened by another process"),

--- a/keep-core/src/backend.rs
+++ b/keep-core/src/backend.rs
@@ -167,7 +167,7 @@ impl RedbBackend {
             }
         }
         Err(last_err
-            .map(|e| e.into())
+            .map(|e| map_open_failure(path, e))
             .unwrap_or_else(|| StorageError::database("open failed after retries").into()))
     }
 
@@ -357,6 +357,29 @@ impl RedbBackend {
             _ => Err(StorageError::database(format!("unknown table: {name}")).into()),
         }
     }
+}
+
+/// Rewrite the redb `DatabaseAlreadyOpen` failure with a Keep-layer hint that
+/// names the most likely cause (another keep process holding the vault) and
+/// points the operator at how to recover (#422). Without this rewrite, the
+/// operator sees the raw redb message "Database already open. Cannot acquire
+/// lock." with no indication that a running `keep serve` or `keep frost
+/// network serve` daemon is the typical holder, or what to do next.
+///
+/// Non-lock-contention errors fall through to the default `KeepError` mapping
+/// so this helper does not swallow real database failures.
+pub fn map_open_failure(path: &Path, e: redb::DatabaseError) -> KeepError {
+    if matches!(&e, redb::DatabaseError::DatabaseAlreadyOpen) {
+        return KeepError::InvalidInput(format!(
+            "vault at {} is already opened by another process. \
+             A `keep serve` or `keep frost network serve` daemon typically holds the lock; \
+             stop it (or wait for it to exit) and retry. \
+             A separate follow-up will let read-only commands (`list`, `audit list`, etc.) \
+             coexist with a running daemon; see #422 for details.",
+            path.display()
+        ));
+    }
+    e.into()
 }
 
 impl StorageBackend for RedbBackend {
@@ -560,5 +583,38 @@ mod tests {
         let dir = tempdir().unwrap();
         let backend = RedbBackend::create(&dir.path().join("test.db")).unwrap();
         assert!(backend.create_table("unknown").is_err());
+    }
+
+    #[test]
+    fn second_open_surfaces_lock_holder_hint() {
+        // The bare redb message ("Database already open. Cannot acquire lock.")
+        // doesn't tell an operator that a running `keep serve` daemon is the
+        // typical holder, or what to do next. #422 (c) is exactly this rewrite:
+        // when a second open fails on the lock, we surface a Keep-layer hint
+        // that names the daemon and points at the issue for the read-only
+        // follow-up.
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("locked.db");
+        let _first = RedbBackend::create(&db_path).expect("first open holds the lock");
+
+        let err = match RedbBackend::open(&db_path) {
+            Err(e) => e,
+            Ok(_) => panic!("second open while the first is held must fail"),
+        };
+        let msg = err.to_string();
+        assert!(
+            matches!(err, KeepError::InvalidInput(_)),
+            "expected InvalidInput from map_open_failure, got {err:?}"
+        );
+        assert!(
+            msg.contains("already opened by another process"),
+            "got {msg}"
+        );
+        assert!(
+            msg.contains("keep serve") || msg.contains("frost network serve"),
+            "got {msg}"
+        );
+        assert!(msg.contains("#422"), "got {msg}");
+        assert!(msg.contains(&db_path.display().to_string()), "got {msg}");
     }
 }

--- a/keep-core/src/backend.rs
+++ b/keep-core/src/backend.rs
@@ -126,49 +126,27 @@ impl RedbBackend {
     /// Retries on Windows to handle delayed file handle release.
     /// Auto-upgrades from older redb file formats.
     pub fn open(path: &Path) -> Result<Self> {
-        const MAX_RETRIES: u32 = 10;
-        const RETRY_DELAY_MS: u64 = 50;
-
-        let mut last_err = None;
-        for _ in 0..MAX_RETRIES {
-            match Database::open(path) {
-                Ok(db) => {
-                    migration::check_compatibility(&db)?;
-                    let result = migration::run_migrations(&db)?;
-                    if result.migrations_run > 0 {
-                        info!(
-                            count = result.migrations_run,
-                            "vault schema migration completed"
-                        );
-                    }
-                    return Ok(Self { db });
-                }
-                Err(redb::DatabaseError::UpgradeRequired(old_version)) => {
-                    warn!(
-                        old_version,
-                        "redb file format upgrade required, migrating automatically"
+        match open_database_with_retry(path) {
+            Ok(db) => {
+                migration::check_compatibility(&db)?;
+                let result = migration::run_migrations(&db)?;
+                if result.migrations_run > 0 {
+                    info!(
+                        count = result.migrations_run,
+                        "vault schema migration completed"
                     );
-                    return Self::upgrade_file_format(path);
                 }
-                Err(e) => {
-                    let is_retryable = matches!(
-                        &e,
-                        redb::DatabaseError::Storage(redb::StorageError::Io(io_err))
-                            if io_err.kind() == std::io::ErrorKind::PermissionDenied
-                    ) || matches!(&e, redb::DatabaseError::DatabaseAlreadyOpen);
-
-                    if is_retryable {
-                        last_err = Some(e);
-                        std::thread::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS));
-                        continue;
-                    }
-                    return Err(e.into());
-                }
+                Ok(Self { db })
             }
+            Err(OpenWithRetryError::UpgradeRequired(old_version)) => {
+                warn!(
+                    old_version,
+                    "redb file format upgrade required, migrating automatically"
+                );
+                Self::upgrade_file_format(path)
+            }
+            Err(OpenWithRetryError::Other(e)) => Err(map_open_failure(path, e)),
         }
-        Err(last_err
-            .map(|e| map_open_failure(path, e))
-            .unwrap_or_else(|| StorageError::database("open failed after retries").into()))
     }
 
     /// Upgrade from an older redb file format by copying all data.
@@ -359,6 +337,55 @@ impl RedbBackend {
     }
 }
 
+/// Outcome of [`open_database_with_retry`] when retries are exhausted or a
+/// non-retryable failure is observed. `UpgradeRequired` is split out because
+/// callers route it to a format upgrade path, not to error mapping.
+pub(crate) enum OpenWithRetryError {
+    UpgradeRequired(u8),
+    Other(redb::DatabaseError),
+}
+
+/// Open a redb database with the same bounded retry policy used everywhere in
+/// keep-core: handles transient `DatabaseAlreadyOpen` (Windows handle release,
+/// brief contention windows) and `PermissionDenied` failures. After
+/// `MAX_RETRIES` attempts the most recent error is returned so callers can
+/// surface a Keep-layer message via [`map_open_failure`].
+pub(crate) fn open_database_with_retry(
+    path: &Path,
+) -> std::result::Result<Database, OpenWithRetryError> {
+    const MAX_RETRIES: u32 = 10;
+    const RETRY_DELAY_MS: u64 = 50;
+
+    let mut last_err = None;
+    for _ in 0..MAX_RETRIES {
+        match Database::open(path) {
+            Ok(db) => return Ok(db),
+            Err(redb::DatabaseError::UpgradeRequired(old_version)) => {
+                return Err(OpenWithRetryError::UpgradeRequired(old_version));
+            }
+            Err(e) => {
+                let is_retryable = matches!(
+                    &e,
+                    redb::DatabaseError::Storage(redb::StorageError::Io(io_err))
+                        if io_err.kind() == std::io::ErrorKind::PermissionDenied
+                ) || matches!(&e, redb::DatabaseError::DatabaseAlreadyOpen);
+
+                if is_retryable {
+                    last_err = Some(e);
+                    std::thread::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS));
+                    continue;
+                }
+                return Err(OpenWithRetryError::Other(e));
+            }
+        }
+    }
+    Err(OpenWithRetryError::Other(last_err.unwrap_or_else(|| {
+        redb::DatabaseError::Storage(redb::StorageError::Io(std::io::Error::other(
+            "open failed after retries",
+        )))
+    })))
+}
+
 /// Rewrite the redb `DatabaseAlreadyOpen` failure with a Keep-layer hint that
 /// names the most likely cause (another keep process holding the vault) and
 /// points the operator at how to recover (#422). Without this rewrite, the
@@ -368,7 +395,7 @@ impl RedbBackend {
 ///
 /// Non-lock-contention errors fall through to the default `KeepError` mapping
 /// so this helper does not swallow real database failures.
-pub fn map_open_failure(path: &Path, e: redb::DatabaseError) -> KeepError {
+pub(crate) fn map_open_failure(path: &Path, e: redb::DatabaseError) -> KeepError {
     if matches!(&e, redb::DatabaseError::DatabaseAlreadyOpen) {
         return KeepError::InvalidInput(format!(
             "vault at {} is already opened by another process. \

--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -1346,8 +1346,8 @@ mod tests {
         };
         let msg = err.to_string();
         assert!(
-            matches!(err, KeepError::InvalidInput(_)),
-            "expected InvalidInput from map_open_failure, got {err:?}"
+            matches!(err, KeepError::Database(_)),
+            "expected Database from map_open_failure, got {err:?}"
         );
         assert!(
             msg.contains("already opened by another process"),

--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -293,7 +293,8 @@ impl HiddenStorage {
         self.outer_key = Some(SecretKey::from_slice(&decrypted_slice)?);
 
         let db_path = self.path.join("keep.db");
-        let db = Database::open(&db_path)?;
+        let db =
+            Database::open(&db_path).map_err(|e| crate::backend::map_open_failure(&db_path, e))?;
 
         self.outer_db = Some(db);
         self.active_volume = Some(VolumeType::Outer);

--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -293,8 +293,22 @@ impl HiddenStorage {
         self.outer_key = Some(SecretKey::from_slice(&decrypted_slice)?);
 
         let db_path = self.path.join("keep.db");
-        let db =
-            Database::open(&db_path).map_err(|e| crate::backend::map_open_failure(&db_path, e))?;
+        let db = match crate::backend::open_database_with_retry(&db_path) {
+            Ok(db) => db,
+            // Hidden vaults don't auto-upgrade the redb file format here; the
+            // outer-volume schema is owned by `RedbBackend::open`. Surface the
+            // upgrade requirement as a generic database error rather than
+            // silently half-migrating a hidden-init vault.
+            Err(crate::backend::OpenWithRetryError::UpgradeRequired(v)) => {
+                return Err(StorageError::database(format!(
+                    "hidden-vault outer redb requires file format upgrade from v{v}; not yet supported"
+                ))
+                .into());
+            }
+            Err(crate::backend::OpenWithRetryError::Other(e)) => {
+                return Err(crate::backend::map_open_failure(&db_path, e));
+            }
+        };
 
         self.outer_db = Some(db);
         self.active_volume = Some(VolumeType::Outer);
@@ -1300,5 +1314,45 @@ mod tests {
                 .unwrap();
             assert_eq!(loaded.auto_approve_kinds, vec![1, 2, 3]);
         }
+    }
+
+    /// Pin that hidden-vault outer unlock surfaces the #422 lock-holder hint
+    /// when the outer redb is already held (mirrors
+    /// `backend::tests::second_open_surfaces_lock_holder_hint` for the
+    /// HiddenStorage code path, which has its own retry+map_open_failure
+    /// chain).
+    #[test]
+    fn hidden_outer_unlock_surfaces_lock_holder_hint() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test-locked-hidden");
+
+        HiddenStorage::create(
+            &path,
+            "outer",
+            None,
+            10 * 1024 * 1024,
+            0.0,
+            Argon2Params::TESTING,
+        )
+        .unwrap();
+
+        let mut first = HiddenStorage::open(&path).unwrap();
+        first.unlock_outer("outer").unwrap();
+
+        let mut second = HiddenStorage::open(&path).unwrap();
+        let err = match second.unlock_outer("outer") {
+            Err(e) => e,
+            Ok(_) => panic!("second outer unlock while first is held must fail"),
+        };
+        let msg = err.to_string();
+        assert!(
+            matches!(err, KeepError::InvalidInput(_)),
+            "expected InvalidInput from map_open_failure, got {err:?}"
+        );
+        assert!(
+            msg.contains("already opened by another process"),
+            "got {msg}"
+        );
+        assert!(msg.contains("#422"), "got {msg}");
     }
 }


### PR DESCRIPTION
Closes #422 part (c). Part (b) (read-only opens for inspect/list commands) tracked as #533.

## Summary
\`Database error: Database already open. Cannot acquire lock.\` doesn't tell an operator that a running \`keep serve\` or \`keep frost network serve\` daemon is the typical lock holder, or what to do next. Per the #422 decision plan (c-now + b-follow-up + a-long-term), this PR rewrites the failure with a Keep-layer hint that names the daemon, the affected vault path, and points at #422 for the read-only follow-up that will let inspect/list commands coexist.

## Changes
- \`keep-core/src/backend.rs\`:
    - New free function \`map_open_failure(path, redb::DatabaseError) -> KeepError\`. On \`DatabaseAlreadyOpen\` returns a \`KeepError::InvalidInput\` whose message names the path, identifies \`keep serve\` / \`keep frost network serve\` as the typical holder, and points operators at #422. Non-lock failures fall through to the default \`KeepError\` mapping, so the helper does not swallow real database errors.
    - \`RedbBackend::open\`'s exhausted-retry branch now routes through \`map_open_failure\` so the lock-contention path picks up the new message.
- \`keep-core/src/hidden/volume.rs\`: \`unlock_outer\`'s \`Database::open\` call routes through \`map_open_failure\` too, so a hidden-init vault with a running daemon gets the same hint.

## Tests
- \`backend::tests::second_open_surfaces_lock_holder_hint\`: open a \`RedbBackend\` to hold the lock, then attempt a second open and assert the resulting error is a \`KeepError::InvalidInput\` whose message contains the vault path, names \`keep serve\` (or \`frost network serve\`), and references #422. The retry loop (10 * 50ms) makes this test ~500ms but it's stable.

## Out of scope
- \`Keep::open\` read-only path so inspect/list commands can coexist with a running writer: tracked as #533.
- Local IPC daemon (\`a\` in the original options): tracked as long-term architecture follow-up; this PR doesn't claim to fix that.

## Validation
- \`cargo fmt --all\`
- \`cargo clippy --workspace --all-targets -- -D warnings\`
- \`cargo test --workspace\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Significantly improved error messages when the database is already in use by another process. Users now receive detailed information about which running services may hold the lock, actionable recovery guidance, and the affected database path.

* **Tests**
  * Added comprehensive test coverage for database lock scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->