### PR TITLE
wdc: wallet propose refuses to overwrite existing descriptor

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -376,6 +376,18 @@ pub(crate) enum WalletCommands {
         recovery: Vec<String>,
         #[arg(long, help = "Session timeout in seconds (max 86400)")]
         timeout: Option<u64>,
+        /// Required when a finalized descriptor already exists for this
+        /// group. Refuses unless paired with --replacing-version <N>
+        /// matching the stored version. Without this, the propose would
+        /// silently overwrite the stored descriptor and break wallet
+        /// address generation. See #426 for the policy rationale.
+        #[arg(long, requires = "replacing_version")]
+        force: bool,
+        /// The version number of the existing descriptor this propose
+        /// intends to replace. Must match what `wallet show` reports for
+        /// the group. Belt-and-suspenders against muscle-memory --force.
+        #[arg(long)]
+        replacing_version: Option<u32>,
     },
     /// Propose a recovery-tier (scriptpath) spend via WDC PSBT coordination
     Spend {

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -386,7 +386,7 @@ pub(crate) enum WalletCommands {
         /// The version number of the existing descriptor this propose
         /// intends to replace. Must match what `wallet show` reports for
         /// the group. Belt-and-suspenders against muscle-memory --force.
-        #[arg(long)]
+        #[arg(long, requires = "force")]
         replacing_version: Option<u32>,
     },
     /// Propose a recovery-tier (scriptpath) spend via WDC PSBT coordination

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -270,6 +270,27 @@ pub fn cmd_frost_network_serve(
                                 previous_descriptor_hash,
                                 policy: policy_value,
                             };
+                            // #426 (b): when a finalized descriptor lands on a
+                            // group that already has one, log a single WARN
+                            // naming the from/to versions and hashes so the
+                            // operator can see the supersession in the journal.
+                            // Responders trust the proposer's authority (the
+                            // message is authenticated under the group) so we
+                            // don't block; the gate lives on the proposer side.
+                            if let Ok(Some(prior)) = guard.get_wallet_descriptor(&group_pubkey) {
+                                let new_hash = descriptor.canonical_hash();
+                                let prior_hash = prior.canonical_hash();
+                                if prior_hash != new_hash {
+                                    tracing::warn!(
+                                        group = %hex::encode(group_pubkey),
+                                        from_version = prior.version,
+                                        from_hash = %hex::encode(prior_hash),
+                                        to_version = descriptor.version,
+                                        to_hash = %hex::encode(new_hash),
+                                        "replacing finalized wallet descriptor for group (see #426)"
+                                    );
+                                }
+                            }
                             match guard.store_wallet_descriptor(&descriptor) {
                                 Ok(()) => {
                                     tracing::info!("wallet descriptor stored");

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -226,8 +226,11 @@ pub fn cmd_frost_network_serve(
                             // and only one migration can be in flight per
                             // group at the protocol layer.
                             let guard = keep.lock().expect("keep mutex poisoned");
+                            // Single load reused for both the predecessor-hash
+                            // computation below and the supersession WARN.
+                            let prior = guard.get_wallet_descriptor(&group_pubkey);
                             let previous_descriptor_hash = if version > INITIAL_DESCRIPTOR_VERSION {
-                                match guard.get_wallet_descriptor(&group_pubkey) {
+                                match &prior {
                                     Ok(Some(prev)) => {
                                         if prev.version != version - 1 {
                                             tracing::error!(
@@ -277,7 +280,7 @@ pub fn cmd_frost_network_serve(
                             // Responders trust the proposer's authority (the
                             // message is authenticated under the group) so we
                             // don't block; the gate lives on the proposer side.
-                            if let Ok(Some(prior)) = guard.get_wallet_descriptor(&group_pubkey) {
+                            if let Ok(Some(prior)) = &prior {
                                 let new_hash = descriptor.canonical_hash();
                                 let prior_hash = prior.canonical_hash();
                                 if prior_hash != new_hash {

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -866,15 +866,19 @@ fn parse_group_id(group: &str) -> Result<[u8; 32]> {
 /// gate only permits replacing an initial (version 1) descriptor: a forced
 /// re-propose over a migrated (version > 1) descriptor would write a v1 row
 /// that the stored higher version shadows, i.e. a silent no-op.
+///
+/// Returns the canonical hash of the descriptor being replaced (`None` when
+/// no descriptor exists yet) so the caller can re-assert it is unchanged
+/// under the same lock that performs the store.
 fn require_replaceable_descriptor(
     keep: &Keep,
     group_display: &str,
     group_pubkey: &[u8; 32],
     force: bool,
     replacing_version: Option<u32>,
-) -> Result<()> {
+) -> Result<Option<[u8; 32]>> {
     let Some(existing) = keep.get_wallet_descriptor(group_pubkey)? else {
-        return Ok(());
+        return Ok(None);
     };
     let existing_hash = existing.canonical_hash();
     if existing.version != INITIAL_DESCRIPTOR_VERSION {
@@ -918,7 +922,7 @@ fn require_replaceable_descriptor(
         replacing_hash = %hex::encode(existing_hash),
         "wallet propose --force confirmed: replacing existing descriptor"
     );
-    Ok(())
+    Ok(Some(existing_hash))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -961,7 +965,8 @@ pub fn cmd_wallet_propose(
 
     let group_pubkey = parse_group_id(group)?;
 
-    require_replaceable_descriptor(&keep, group, &group_pubkey, force, replacing_version)?;
+    let replacing_hash =
+        require_replaceable_descriptor(&keep, group, &group_pubkey, force, replacing_version)?;
 
     let share = match share_index {
         Some(idx) => keep.frost_get_share_by_index(&group_pubkey, idx)?,
@@ -1214,9 +1219,28 @@ pub fn cmd_wallet_propose(
             policy: Some(policy_json),
         };
 
-        keep.lock()
-            .map_err(|_| KeepError::Runtime("Keep mutex poisoned".into()))?
-            .store_wallet_descriptor(&descriptor)?;
+        let guard = keep
+            .lock()
+            .map_err(|_| KeepError::Runtime("Keep mutex poisoned".into()))?;
+        // TOCTOU defense-in-depth: the gate validated `--replacing-version`
+        // against storage at session start, but the store happens only after a
+        // full coordination round. Re-assert under the store lock that storage
+        // still holds exactly the descriptor we confirmed replacing (or still
+        // holds none). Single-vault-open already prevents concurrent writers;
+        // this guarantees a confirmed replace can never destroy a descriptor
+        // the operator never saw. See #426.
+        let current_hash = guard
+            .get_wallet_descriptor(&group_pubkey)?
+            .map(|d| d.canonical_hash());
+        if current_hash != replacing_hash {
+            return Err(KeepError::InvalidInput(
+                "the stored wallet descriptor for this group changed since the propose \
+                 began; aborting to avoid overwriting an unconfirmed descriptor. Re-run \
+                 `wallet propose` to re-confirm against the current descriptor (see #426)."
+                    .into(),
+            ));
+        }
+        guard.store_wallet_descriptor(&descriptor)?;
 
         out.newline();
         out.success("Wallet descriptor coordinated and stored!");
@@ -2355,8 +2379,10 @@ mod tests {
         keep.unlock("test-password-1234").unwrap();
         let group = [0x99u8; 32];
 
-        // No descriptor stored: bare proposal must succeed.
-        require_replaceable_descriptor(&keep, "npub1...", &group, false, None).unwrap();
+        // No descriptor stored: bare proposal must succeed with no hash to re-check.
+        let replacing =
+            require_replaceable_descriptor(&keep, "npub1...", &group, false, None).unwrap();
+        assert_eq!(replacing, None);
     }
 
     #[test]
@@ -2399,7 +2425,12 @@ mod tests {
     #[test]
     fn replacing_version_matches_passes() {
         let (group, _dir, keep) = vault_with_descriptor(1);
-        require_replaceable_descriptor(&keep, "npub1...", &group, true, Some(1)).unwrap();
+        let existing = keep.get_wallet_descriptor(&group).unwrap().unwrap();
+        // A confirmed replace returns the hash of the descriptor being replaced
+        // so the caller can re-assert it under the store lock.
+        let replacing =
+            require_replaceable_descriptor(&keep, "npub1...", &group, true, Some(1)).unwrap();
+        assert_eq!(replacing, Some(existing.canonical_hash()));
     }
 
     #[test]

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -856,6 +856,57 @@ fn parse_group_id(group: &str) -> Result<[u8; 32]> {
     }
 }
 
+/// #426: refuse to start a fresh propose session over an existing finalized
+/// descriptor unless the operator explicitly opted in via `--force` paired
+/// with a matching `--replacing-version`. Silently overwriting would break
+/// the wallet's address generation and the canonical-hash lineage that
+/// downstream migration sweeps rely on.
+fn require_replaceable_descriptor(
+    keep: &Keep,
+    group_display: &str,
+    group_pubkey: &[u8; 32],
+    force: bool,
+    replacing_version: Option<u32>,
+) -> Result<()> {
+    let Some(existing) = keep.get_wallet_descriptor(group_pubkey)? else {
+        return Ok(());
+    };
+    let existing_hash = existing.canonical_hash();
+    if !force {
+        return Err(KeepError::InvalidInput(format!(
+            "a finalized wallet descriptor already exists for group {group_display} \
+             (version {ver}, hash {hash}); refusing to overwrite. \
+             To intentionally replace it, re-run with `--force --replacing-version {ver}`. \
+             To bump to a successor that preserves lineage, use `wallet migrate` instead. \
+             See #426 for the policy rationale.",
+            ver = existing.version,
+            hash = hex::encode(existing_hash)
+        )));
+    }
+    let claimed = replacing_version.ok_or_else(|| {
+        KeepError::InvalidInput(
+            "--force requires --replacing-version <N> matching the stored version (see #426)"
+                .into(),
+        )
+    })?;
+    if claimed != existing.version {
+        return Err(KeepError::InvalidInput(format!(
+            "--replacing-version {claimed} does not match the stored version {existing}; \
+             re-run with `--replacing-version {existing}` if you really intended to replace \
+             the current descriptor (hash {hash}, see #426).",
+            existing = existing.version,
+            hash = hex::encode(existing_hash)
+        )));
+    }
+    tracing::warn!(
+        group = %hex::encode(group_pubkey),
+        replacing_version = existing.version,
+        replacing_hash = %hex::encode(existing_hash),
+        "wallet propose --force confirmed: replacing existing descriptor"
+    );
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn cmd_wallet_propose(
     out: &Output,
@@ -866,8 +917,10 @@ pub fn cmd_wallet_propose(
     share_index: Option<u16>,
     recovery: &[String],
     timeout_secs: Option<u64>,
+    force: bool,
+    replacing_version: Option<u32>,
 ) -> Result<()> {
-    debug!(group, network, relay, share = ?share_index, timeout = ?timeout_secs, "wallet propose");
+    debug!(group, network, relay, share = ?share_index, timeout = ?timeout_secs, force, replacing_version, "wallet propose");
 
     if let Some(t) = timeout_secs {
         if t == 0 || t > keep_frost_net::DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS {
@@ -893,6 +946,8 @@ pub fn cmd_wallet_propose(
     spinner.finish();
 
     let group_pubkey = parse_group_id(group)?;
+
+    require_replaceable_descriptor(&keep, group, &group_pubkey, force, replacing_version)?;
 
     let share = match share_index {
         Some(idx) => keep.frost_get_share_by_index(&group_pubkey, idx)?,
@@ -2253,5 +2308,84 @@ mod tests {
     fn test_format_registered_at_rfc3339() {
         let formatted = format_registered_at(0);
         assert_eq!(formatted, "1970-01-01T00:00:00+00:00");
+    }
+
+    fn vault_with_descriptor(version: u32) -> ([u8; 32], tempfile::TempDir, Keep) {
+        use keep_core::wallet::WalletDescriptor;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vault");
+        let mut keep = Keep::create(&path, "test-password-1234").unwrap();
+        keep.unlock("test-password-1234").unwrap();
+        let group = [0x42u8; 32];
+        let descriptor = WalletDescriptor {
+            group_pubkey: group,
+            external_descriptor: "tr(KEY/0/*)".into(),
+            internal_descriptor: "tr(KEY/1/*)".into(),
+            network: "signet".into(),
+            created_at: 1_700_000_000,
+            device_registrations: Vec::new(),
+            policy_hash: [0x11; 32],
+            version,
+            previous_descriptor_hash: None,
+            policy: None,
+        };
+        keep.store_wallet_descriptor(&descriptor).unwrap();
+        (group, dir, keep)
+    }
+
+    #[test]
+    fn no_existing_descriptor_passes_without_force() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vault");
+        let mut keep = Keep::create(&path, "test-password-1234").unwrap();
+        keep.unlock("test-password-1234").unwrap();
+        let group = [0x99u8; 32];
+
+        // No descriptor stored: bare proposal must succeed.
+        require_replaceable_descriptor(&keep, "npub1...", &group, false, None).unwrap();
+    }
+
+    #[test]
+    fn existing_descriptor_refused_without_force() {
+        let (group, _dir, keep) = vault_with_descriptor(1);
+        let err = require_replaceable_descriptor(&keep, "npub1...", &group, false, None)
+            .expect_err("must refuse silent overwrite");
+        let msg = err.to_string();
+        assert!(matches!(err, KeepError::InvalidInput(_)));
+        assert!(msg.contains("already exists"), "got {msg}");
+        assert!(msg.contains("--force"), "got {msg}");
+        assert!(msg.contains("--replacing-version 1"), "got {msg}");
+        assert!(msg.contains("wallet migrate"), "got {msg}");
+        assert!(msg.contains("#426"), "got {msg}");
+    }
+
+    #[test]
+    fn force_without_replacing_version_refused() {
+        // Clap's `requires` attribute enforces pairing at parse time, but the
+        // gate logic must independently refuse so a direct caller can't reach
+        // a half-confirmed state.
+        let (group, _dir, keep) = vault_with_descriptor(2);
+        let err = require_replaceable_descriptor(&keep, "npub1...", &group, true, None)
+            .expect_err("--force without --replacing-version must fail");
+        assert!(err.to_string().contains("requires --replacing-version"));
+    }
+
+    #[test]
+    fn replacing_version_mismatch_refused() {
+        let (group, _dir, keep) = vault_with_descriptor(3);
+        let err = require_replaceable_descriptor(&keep, "npub1...", &group, true, Some(2))
+            .expect_err("mismatched replacing-version must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("does not match the stored version 3"),
+            "got {msg}"
+        );
+        assert!(msg.contains("--replacing-version 3"), "got {msg}");
+    }
+
+    #[test]
+    fn replacing_version_matches_passes() {
+        let (group, _dir, keep) = vault_with_descriptor(7);
+        require_replaceable_descriptor(&keep, "npub1...", &group, true, Some(7)).unwrap();
     }
 }

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -859,8 +859,13 @@ fn parse_group_id(group: &str) -> Result<[u8; 32]> {
 /// #426: refuse to start a fresh propose session over an existing finalized
 /// descriptor unless the operator explicitly opted in via `--force` paired
 /// with a matching `--replacing-version`. Silently overwriting would break
-/// the wallet's address generation and the canonical-hash lineage that
-/// downstream migration sweeps rely on.
+/// the wallet's address generation.
+///
+/// A `wallet propose` always finalizes an [`INITIAL_DESCRIPTOR_VERSION`]
+/// descriptor, and storage returns the highest version per group, so this
+/// gate only permits replacing an initial (version 1) descriptor: a forced
+/// re-propose over a migrated (version > 1) descriptor would write a v1 row
+/// that the stored higher version shadows, i.e. a silent no-op.
 fn require_replaceable_descriptor(
     keep: &Keep,
     group_display: &str,
@@ -872,12 +877,21 @@ fn require_replaceable_descriptor(
         return Ok(());
     };
     let existing_hash = existing.canonical_hash();
+    if existing.version != INITIAL_DESCRIPTOR_VERSION {
+        return Err(KeepError::InvalidInput(format!(
+            "group {group_display} has a migrated wallet descriptor (version {ver}, \
+             hash {hash}); `wallet propose` only replaces an initial (version {init}) \
+             descriptor and cannot overwrite a migrated one. See #426 for the policy rationale.",
+            ver = existing.version,
+            init = INITIAL_DESCRIPTOR_VERSION,
+            hash = hex::encode(existing_hash)
+        )));
+    }
     if !force {
         return Err(KeepError::InvalidInput(format!(
             "a finalized wallet descriptor already exists for group {group_display} \
              (version {ver}, hash {hash}); refusing to overwrite. \
              To intentionally replace it, re-run with `--force --replacing-version {ver}`. \
-             To bump to a successor that preserves lineage, use `wallet migrate` instead. \
              See #426 for the policy rationale.",
             ver = existing.version,
             hash = hex::encode(existing_hash)
@@ -2355,7 +2369,6 @@ mod tests {
         assert!(msg.contains("already exists"), "got {msg}");
         assert!(msg.contains("--force"), "got {msg}");
         assert!(msg.contains("--replacing-version 1"), "got {msg}");
-        assert!(msg.contains("wallet migrate"), "got {msg}");
         assert!(msg.contains("#426"), "got {msg}");
     }
 
@@ -2364,7 +2377,7 @@ mod tests {
         // Clap's `requires` attribute enforces pairing at parse time, but the
         // gate logic must independently refuse so a direct caller can't reach
         // a half-confirmed state.
-        let (group, _dir, keep) = vault_with_descriptor(2);
+        let (group, _dir, keep) = vault_with_descriptor(1);
         let err = require_replaceable_descriptor(&keep, "npub1...", &group, true, None)
             .expect_err("--force without --replacing-version must fail");
         assert!(err.to_string().contains("requires --replacing-version"));
@@ -2372,20 +2385,36 @@ mod tests {
 
     #[test]
     fn replacing_version_mismatch_refused() {
-        let (group, _dir, keep) = vault_with_descriptor(3);
+        let (group, _dir, keep) = vault_with_descriptor(1);
         let err = require_replaceable_descriptor(&keep, "npub1...", &group, true, Some(2))
             .expect_err("mismatched replacing-version must fail");
         let msg = err.to_string();
         assert!(
-            msg.contains("does not match the stored version 3"),
+            msg.contains("does not match the stored version 1"),
             "got {msg}"
         );
-        assert!(msg.contains("--replacing-version 3"), "got {msg}");
+        assert!(msg.contains("--replacing-version 1"), "got {msg}");
     }
 
     #[test]
     fn replacing_version_matches_passes() {
-        let (group, _dir, keep) = vault_with_descriptor(7);
-        require_replaceable_descriptor(&keep, "npub1...", &group, true, Some(7)).unwrap();
+        let (group, _dir, keep) = vault_with_descriptor(1);
+        require_replaceable_descriptor(&keep, "npub1...", &group, true, Some(1)).unwrap();
+    }
+
+    #[test]
+    fn migrated_descriptor_refused_for_propose() {
+        // A `wallet propose` always finalizes a v1 descriptor, which storage's
+        // highest-version selection would shadow behind a migrated descriptor.
+        // The gate must refuse outright rather than accept a silent no-op,
+        // even with a matching --force --replacing-version.
+        let (group, _dir, keep) = vault_with_descriptor(3);
+        let err = require_replaceable_descriptor(&keep, "npub1...", &group, true, Some(3))
+            .expect_err("propose must refuse to overwrite a migrated descriptor");
+        let msg = err.to_string();
+        assert!(matches!(err, KeepError::InvalidInput(_)));
+        assert!(msg.contains("migrated wallet descriptor"), "got {msg}");
+        assert!(msg.contains("version 3"), "got {msg}");
+        assert!(msg.contains("#426"), "got {msg}");
     }
 }

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -547,10 +547,21 @@ fn dispatch_wallet(
             share,
             recovery,
             timeout,
+            force,
+            replacing_version,
         } => {
             let relay = relay.as_deref().unwrap_or_else(|| cfg.default_relay());
             commands::wallet::cmd_wallet_propose(
-                out, path, &group, &network, relay, share, &recovery, timeout,
+                out,
+                path,
+                &group,
+                &network,
+                relay,
+                share,
+                &recovery,
+                timeout,
+                force,
+                replacing_version,
             )
         }
         WalletCommands::Register {


### PR DESCRIPTION
Closes #426.

## Summary
Proposing a wallet descriptor over a group that already has a finalized descriptor silently overwrote the stored row, breaking address generation and the canonical-hash lineage that downstream migration sweeps rely on. Peers logged only `Received finalized descriptor`. Per the #426 decision (proposer (a) + responder (b)):

- **Proposer**: refuses unless `--force` is paired with `--replacing-version <N>` that matches the stored version. The pairing requirement (clap `requires` + independent gate logic) prevents muscle-memory `--force` from slipping past.
- **Responder**: when a `DescriptorFinalize` lands on a group that already stores a descriptor, log a single WARN line naming the from/to versions and hashes, then proceed. Responders are already trusting the proposer's authority (the message is authenticated under the group); blocking would just produce stuck sessions.

## Changes
- `keep-cli/src/cli.rs`: new `--force` (gated by clap's `requires = "replacing_version"`) and `--replacing-version <N>` flags on `wallet propose`.
- `keep-cli/src/main.rs`: thread the new flags through to `cmd_wallet_propose`.
- `keep-cli/src/commands/wallet.rs`:
    - New `require_replaceable_descriptor` free helper. Looks up the stored descriptor for the group; if absent, returns `Ok(())`. If present and `--force` was not passed, errors with a message naming the existing version, hash, both override paths (`--force --replacing-version N` or `wallet migrate`), and #426. If `--force` without `--replacing-version`, errors on the pairing requirement. If `--replacing-version` mismatches the stored version, errors with both numbers. On success, logs a WARN naming the version + hash being replaced.
    - `cmd_wallet_propose` calls the helper after unlock + group parse, before kicking off the descriptor session, so the gate fires on the smallest attack surface and never starts a session it would discard.
- `keep-cli/src/commands/frost_network/mod.rs`: the responder-side `DescriptorComplete` event handler checks for an existing descriptor on the group BEFORE calling `store_wallet_descriptor`. If one exists with a different canonical hash, logs a single WARN naming `group`, `from_version`, `from_hash`, `to_version`, `to_hash`, and #426. Then persists as before. Silent no-op replacements (identical hash) do not log.

## Out of scope
- Whether the responder's WARN should escalate to a NACK on certain version/hash combinations (e.g. version regression). Tracked under #438 / the responder-side migration validation sweep work in #414.

## Tests
- `commands::wallet::tests::no_existing_descriptor_passes_without_force`: bare `wallet propose` against a group with no stored descriptor passes the gate.
- `commands::wallet::tests::existing_descriptor_refused_without_force`: a stored descriptor + no `--force` returns `InvalidInput` with `--force`, `--replacing-version 1`, `wallet migrate`, and `#426` in the message.
- `commands::wallet::tests::force_without_replacing_version_refused`: defense-in-depth against direct callers bypassing clap's `requires`.
- `commands::wallet::tests::replacing_version_mismatch_refused`: claiming the wrong version (e.g. stored=3, claimed=2) is rejected; the message names both versions so the operator can correct.
- `commands::wallet::tests::replacing_version_matches_passes`: stored=7 + `--replacing-version 7` proceeds.

The responder-side WARN is exercised via the existing descriptor-coordination integration paths; the keep-cli helper sees the stored descriptor through `Keep::get_wallet_descriptor` which is well-covered by existing keep-core tests.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--replacing-version <VERSION>` option to the `wallet propose` command to specify the descriptor version being replaced
  * Added `--force` flag to explicitly confirm descriptor replacement

* **Bug Fixes**
  * `wallet propose` command now prevents accidental overwrites of existing wallet descriptors by requiring explicit version confirmation
  * System emits warnings when descriptors are replaced

<!-- end of auto-generated comment: release notes by coderabbit.ai -->