### PR TITLE
hidden-vault: audit log on outer + RateLimitTripped flush

### DIFF
--- a/keep-cli/src/commands/audit.rs
+++ b/keep-cli/src/commands/audit.rs
@@ -3,11 +3,12 @@ use std::path::{Path, PathBuf};
 use chrono::{TimeZone, Utc};
 use secrecy::ExposeSecret;
 
-use keep_core::audit::{AuditEventType, RetentionPolicy};
+use keep_core::audit::{AuditEntry, AuditEventType, RetentionPolicy};
 use keep_core::error::{KeepError, Result};
+use keep_core::hidden::HiddenStorage;
 use keep_core::Keep;
 
-use crate::commands::get_password;
+use crate::commands::{get_password, is_hidden_vault};
 use crate::output::Output;
 
 fn resolve_path(path: &Path, hidden: bool) -> PathBuf {
@@ -15,6 +16,68 @@ fn resolve_path(path: &Path, hidden: bool) -> PathBuf {
         path.join("inner")
     } else {
         path.to_path_buf()
+    }
+}
+
+/// Dispatch the audit surface across the two vault layouts. Hidden-init
+/// vaults (`keep.vault` present) route through `HiddenStorage`'s outer
+/// volume so `keep audit list/verify/stats/retention` work consistently
+/// after #520. Regular vaults (`keep.hdr` / the legacy `inner` layout) go
+/// through `Keep` as before.
+enum AuditVault {
+    Keep(Box<Keep>),
+    HiddenOuter(Box<HiddenStorage>),
+}
+
+impl AuditVault {
+    fn open_unlock(path: &Path, hidden_flag: bool, password: &str) -> Result<Self> {
+        let target = resolve_path(path, hidden_flag);
+        if is_hidden_vault(&target) {
+            let mut storage = HiddenStorage::open(&target)?;
+            storage.unlock_outer(password)?;
+            Ok(Self::HiddenOuter(Box::new(storage)))
+        } else {
+            let mut keep = Keep::open(&target)?;
+            keep.unlock(password)?;
+            Ok(Self::Keep(Box::new(keep)))
+        }
+    }
+
+    fn read_all(&self) -> Result<Vec<AuditEntry>> {
+        match self {
+            Self::Keep(k) => k.audit_read_all(),
+            Self::HiddenOuter(s) => s.audit_read_all(),
+        }
+    }
+
+    fn verify_chain(&self) -> Result<bool> {
+        match self {
+            Self::Keep(k) => k.audit_verify_chain(),
+            Self::HiddenOuter(s) => s.audit_verify_chain(),
+        }
+    }
+
+    fn export(&self) -> Result<String> {
+        match self {
+            Self::Keep(k) => k.audit_export(),
+            Self::HiddenOuter(_) => Err(KeepError::Other(
+                "audit export is not yet wired for hidden-init vaults; see #520 follow-up".into(),
+            )),
+        }
+    }
+
+    fn set_retention(&mut self, policy: RetentionPolicy) {
+        match self {
+            Self::Keep(k) => k.audit_set_retention(policy),
+            Self::HiddenOuter(s) => s.audit_set_retention(policy),
+        }
+    }
+
+    fn apply_retention(&mut self) -> Result<usize> {
+        match self {
+            Self::Keep(k) => k.audit_apply_retention(),
+            Self::HiddenOuter(s) => s.audit_apply_retention(),
+        }
     }
 }
 
@@ -26,11 +89,10 @@ fn format_timestamp(timestamp: i64) -> String {
 }
 
 pub fn cmd_audit_list(out: &Output, path: &Path, limit: Option<usize>, hidden: bool) -> Result<()> {
-    let mut keep = Keep::open(&resolve_path(path, hidden))?;
     let password = get_password("Password")?;
-    keep.unlock(password.expose_secret())?;
+    let vault = AuditVault::open_unlock(path, hidden, password.expose_secret())?;
 
-    let entries = keep.audit_read_all()?;
+    let entries = vault.read_all()?;
     let display_entries: Vec<_> = if let Some(n) = limit {
         entries.iter().rev().take(n).collect()
     } else {
@@ -114,11 +176,10 @@ pub fn cmd_audit_export(
     output_path: Option<&str>,
     hidden: bool,
 ) -> Result<()> {
-    let mut keep = Keep::open(&resolve_path(path, hidden))?;
     let password = get_password("Password")?;
-    keep.unlock(password.expose_secret())?;
+    let vault = AuditVault::open_unlock(path, hidden, password.expose_secret())?;
 
-    let json = keep.audit_export()?;
+    let json = vault.export()?;
 
     match output_path {
         Some(out_path) => {
@@ -133,11 +194,10 @@ pub fn cmd_audit_export(
 }
 
 pub fn cmd_audit_verify(out: &Output, path: &Path, hidden: bool) -> Result<()> {
-    let mut keep = Keep::open(&resolve_path(path, hidden))?;
     let password = get_password("Password")?;
-    keep.unlock(password.expose_secret())?;
+    let vault = AuditVault::open_unlock(path, hidden, password.expose_secret())?;
 
-    let valid = keep.audit_verify_chain().map_err(map_verify_error)?;
+    let valid = vault.verify_chain().map_err(map_verify_error)?;
 
     if valid {
         out.success("Audit log integrity verified - hash chain is valid");
@@ -176,16 +236,15 @@ pub fn cmd_audit_retention(
     apply: bool,
     hidden: bool,
 ) -> Result<()> {
-    let mut keep = Keep::open(&resolve_path(path, hidden))?;
     let password = get_password("Password")?;
-    keep.unlock(password.expose_secret())?;
+    let mut vault = AuditVault::open_unlock(path, hidden, password.expose_secret())?;
 
     let policy = RetentionPolicy {
         max_entries,
         max_age_days: max_days,
     };
 
-    keep.audit_set_retention(policy);
+    vault.set_retention(policy);
 
     let has_policy_args = max_entries.is_some() || max_days.is_some();
 
@@ -195,7 +254,7 @@ pub fn cmd_audit_retention(
                 "audit retention --apply needs at least one of --max-entries or --max-days; pass a policy bound and try again".into(),
             ));
         }
-        let removed = keep.audit_apply_retention()?;
+        let removed = vault.apply_retention()?;
         if removed > 0 {
             out.success(&format!("Removed {removed} old audit entries"));
         } else {
@@ -266,11 +325,10 @@ impl AuditStats {
 }
 
 pub fn cmd_audit_stats(out: &Output, path: &Path, hidden: bool) -> Result<()> {
-    let mut keep = Keep::open(&resolve_path(path, hidden))?;
     let password = get_password("Password")?;
-    keep.unlock(password.expose_secret())?;
+    let vault = AuditVault::open_unlock(path, hidden, password.expose_secret())?;
 
-    let entries = keep.audit_read_all()?;
+    let entries = vault.read_all()?;
 
     if entries.is_empty() {
         out.info("No audit entries found");

--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -354,11 +354,16 @@ impl HiddenStorage {
     }
 
     /// Open the outer-volume audit log and drain pending trip events. Called
-    /// from `unlock_outer` after the data key is in hand. Errors on the audit
-    /// log are non-fatal to the unlock itself; we log and continue so a
-    /// corrupted audit log can't make the whole vault inaccessible.
+    /// from `unlock_outer` and the `unlock()` dispatcher after the data key is
+    /// in hand. Errors on the audit log are non-fatal to the unlock itself; we
+    /// log and continue so a corrupted audit log can't make the whole vault
+    /// inaccessible. Idempotent: a no-op once the log is already attached.
     fn attach_outer_audit(&mut self, hmac_key: &[u8; 32]) -> Result<()> {
         use crate::audit::{AuditEntry, AuditEventType};
+
+        if self.outer_audit.is_some() {
+            return Ok(());
+        }
 
         let data_key = self.outer_key.as_ref().ok_or(KeepError::Locked)?;
         let mut audit = match crate::audit::AuditLog::open(&self.path, data_key) {
@@ -371,7 +376,7 @@ impl HiddenStorage {
 
         let trips = rate_limit::drain_pending_trips(&self.path, hmac_key);
         for trip in trips {
-            let trip_ts = trip.timestamp as i64;
+            let trip_ts = i64::try_from(trip.timestamp).unwrap_or(i64::MAX);
             let reason = format!(
                 "rate limit threshold reached after {} failed attempts",
                 trip.failed_attempts
@@ -486,6 +491,10 @@ impl HiddenStorage {
             (Ok(()), _) => {
                 self.active_volume = Some(VolumeType::Outer);
                 rate_limit::record_success(&self.path);
+                // #520: the auto-detect path must flush trips and attach the
+                // outer audit log too, otherwise `audit_*` accessors see an
+                // unlocked vault with `outer_audit == None`. Mirror `unlock_outer`.
+                self.attach_outer_audit(&hmac_key)?;
                 Ok(VolumeType::Outer)
             }
             (Err(_), Ok(())) => {
@@ -1561,5 +1570,47 @@ mod tests {
         assert!(storage.audit_read_all().unwrap().is_empty());
         assert!(storage.audit_verify_chain().unwrap());
         assert!(storage.audit_apply_retention().is_err());
+    }
+
+    /// #520 on the auto-detect `unlock()` path: tripping the limiter then
+    /// unlocking via the dispatcher (not `unlock_outer`) must still flush the
+    /// `RateLimitTripped` entry and attach the outer audit log. Pins the fix
+    /// for the dispatcher arm that previously skipped `attach_outer_audit`.
+    #[test]
+    fn hidden_dispatch_unlock_flushes_rate_limit_trips_to_audit() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("vault-dispatch-trip-audit");
+
+        HiddenStorage::create(
+            &path,
+            "outer-password",
+            None,
+            10 * 1024 * 1024,
+            0.0,
+            Argon2Params::TESTING,
+        )
+        .unwrap();
+
+        for _ in 0..5 {
+            let mut storage = HiddenStorage::open(&path).unwrap();
+            let _ = storage.unlock_outer("wrong-password");
+        }
+
+        crate::rate_limit::record_success(&path);
+
+        let mut storage = HiddenStorage::open(&path).unwrap();
+        assert_eq!(storage.unlock("outer-password").unwrap(), VolumeType::Outer);
+
+        let entries = storage.audit_read_all().unwrap();
+        let trips: Vec<_> = entries
+            .iter()
+            .filter(|e| matches!(e.event_type, crate::audit::AuditEventType::RateLimitTripped))
+            .collect();
+        assert_eq!(
+            trips.len(),
+            1,
+            "dispatcher unlock must flush exactly one trip entry; got {trips:#?}"
+        );
+        assert!(storage.audit_verify_chain().unwrap());
     }
 }

--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -96,6 +96,11 @@ pub struct HiddenStorage {
     hidden_key: Option<SecretKey>,
     active_volume: Option<VolumeType>,
     outer_db: Option<Database>,
+    /// Audit log attached on outer unlock so the `keep audit list/verify/...`
+    /// surface works on hidden-init vaults and `drain_pending_trips` can
+    /// flush rate-limit trip events queued by failed unlocks (#520).
+    /// Outer-volume scope only, paralleling the #507 relay-config decision.
+    outer_audit: Option<crate::audit::AuditLog>,
 }
 
 impl HiddenStorage {
@@ -243,6 +248,7 @@ impl HiddenStorage {
             hidden_key: hidden_data_key,
             active_volume: Some(VolumeType::Outer),
             outer_db: Some(db),
+            outer_audit: None,
         })
     }
 
@@ -267,6 +273,7 @@ impl HiddenStorage {
             hidden_key: None,
             active_volume: None,
             outer_db: None,
+            outer_audit: None,
         })
     }
 
@@ -330,6 +337,11 @@ impl HiddenStorage {
         match self.try_unlock_outer(password) {
             Ok(()) => {
                 rate_limit::record_success(&self.path);
+                // #520: open the audit log under the outer data key and flush
+                // any queued rate-limit trip events. Mirrors `Keep::unlock` so
+                // hidden-init vaults get the same `RateLimitTripped` audit
+                // surfacing that regular vaults do.
+                self.attach_outer_audit(&hmac_key)?;
                 Ok(())
             }
             Err(e) => {
@@ -339,6 +351,48 @@ impl HiddenStorage {
                 Err(e)
             }
         }
+    }
+
+    /// Open the outer-volume audit log and drain pending trip events. Called
+    /// from `unlock_outer` after the data key is in hand. Errors on the audit
+    /// log are non-fatal to the unlock itself; we log and continue so a
+    /// corrupted audit log can't make the whole vault inaccessible.
+    fn attach_outer_audit(&mut self, hmac_key: &[u8; 32]) -> Result<()> {
+        use crate::audit::{AuditEntry, AuditEventType};
+
+        let data_key = self.outer_key.as_ref().ok_or(KeepError::Locked)?;
+        let mut audit = match crate::audit::AuditLog::open(&self.path, data_key) {
+            Ok(log) => log,
+            Err(e) => {
+                tracing::warn!(error = %e, "could not open audit log on hidden vault outer unlock; trips will not flush this cycle");
+                return Ok(());
+            }
+        };
+
+        let trips = rate_limit::drain_pending_trips(&self.path, hmac_key);
+        for trip in trips {
+            let trip_ts = trip.timestamp as i64;
+            let reason = format!(
+                "rate limit threshold reached after {} failed attempts",
+                trip.failed_attempts
+            );
+            let mut entry = AuditEntry::new(AuditEventType::RateLimitTripped, audit.last_hash())
+                .with_success(false)
+                .with_reason(&reason);
+            entry.timestamp = trip_ts;
+            if let Err(e) = audit.log(entry, data_key) {
+                tracing::warn!(error = %e, "failed to flush RateLimitTripped audit entry on hidden vault");
+            }
+        }
+
+        // Emit VaultUnlock to mirror `Keep::unlock`.
+        let unlock_entry = AuditEntry::new(AuditEventType::VaultUnlock, audit.last_hash());
+        if let Err(e) = audit.log(unlock_entry, data_key) {
+            tracing::warn!(error = %e, "failed to log VaultUnlock audit entry on hidden vault");
+        }
+
+        self.outer_audit = Some(audit);
+        Ok(())
     }
 
     fn try_unlock_hidden(&mut self, password: &str) -> Result<()> {
@@ -464,6 +518,7 @@ impl HiddenStorage {
         self.hidden_header = None;
         self.active_volume = None;
         self.outer_db = None;
+        self.outer_audit = None;
     }
 
     /// Returns true if any volume is unlocked.
@@ -769,6 +824,63 @@ impl HiddenStorage {
     /// The vault directory path.
     pub fn path(&self) -> &Path {
         &self.path
+    }
+
+    /// Read every audit entry stored under the outer data key. Hidden-vault
+    /// scope is deliberately limited to the outer volume (#520, paralleling
+    /// the #507 relay-config decision); a hidden-active session has no
+    /// audit log of its own and returns `Ok(vec![])` rather than reading
+    /// the outer log's contents.
+    pub fn audit_read_all(&self) -> Result<Vec<crate::audit::AuditEntry>> {
+        match self.active_volume {
+            Some(VolumeType::Outer) => {}
+            Some(VolumeType::Hidden) => return Ok(Vec::new()),
+            None => return Err(KeepError::Locked),
+        }
+        let data_key = self.outer_key.as_ref().ok_or(KeepError::Locked)?;
+        let audit = self.outer_audit.as_ref().ok_or(KeepError::Locked)?;
+        audit.read_all(data_key)
+    }
+
+    /// Verify the outer-volume audit log's hash chain. Hidden-active sessions
+    /// have no log of their own and return `Ok(true)` (vacuously valid).
+    pub fn audit_verify_chain(&self) -> Result<bool> {
+        match self.active_volume {
+            Some(VolumeType::Outer) => {}
+            Some(VolumeType::Hidden) => return Ok(true),
+            None => return Err(KeepError::Locked),
+        }
+        let data_key = self.outer_key.as_ref().ok_or(KeepError::Locked)?;
+        let audit = self.outer_audit.as_ref().ok_or(KeepError::Locked)?;
+        audit.verify_chain(data_key)
+    }
+
+    /// Set the retention policy on the outer-volume audit log. No-op when
+    /// the active volume is hidden.
+    pub fn audit_set_retention(&mut self, policy: crate::audit::RetentionPolicy) {
+        if !matches!(self.active_volume, Some(VolumeType::Outer)) {
+            return;
+        }
+        if let Some(audit) = self.outer_audit.as_mut() {
+            audit.set_retention(policy);
+        }
+    }
+
+    /// Apply the retention policy on the outer-volume audit log. Errors on
+    /// hidden-active sessions since no audit log exists there.
+    pub fn audit_apply_retention(&mut self) -> Result<usize> {
+        match self.active_volume {
+            Some(VolumeType::Outer) => {}
+            Some(VolumeType::Hidden) => {
+                return Err(KeepError::Other(
+                    "audit retention is not yet supported on the hidden volume".into(),
+                ));
+            }
+            None => return Err(KeepError::Locked),
+        }
+        let data_key = self.outer_key.as_ref().ok_or(KeepError::Locked)?;
+        let audit = self.outer_audit.as_mut().ok_or(KeepError::Locked)?;
+        audit.apply_retention(data_key)
     }
 }
 
@@ -1354,5 +1466,100 @@ mod tests {
             "got {msg}"
         );
         assert!(msg.contains("#422"), "got {msg}");
+    }
+
+    /// #520 end-to-end on the hidden-vault outer path: trip the rate limiter
+    /// with failed unlocks, then successfully unlock and observe the
+    /// `RateLimitTripped` entry in the outer audit log. Mirrors the
+    /// `rate_limit_trip_emits_audit_entry_on_next_unlock` test that proves
+    /// this works on regular vaults.
+    #[test]
+    fn hidden_outer_unlock_flushes_rate_limit_trips_to_audit() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("vault-trip-audit");
+
+        HiddenStorage::create(
+            &path,
+            "outer-password",
+            None,
+            10 * 1024 * 1024,
+            0.0,
+            Argon2Params::TESTING,
+        )
+        .unwrap();
+
+        // Five failed attempts trip the limiter.
+        for _ in 0..5 {
+            let mut storage = HiddenStorage::open(&path).unwrap();
+            let _ = storage.unlock_outer("wrong-password");
+        }
+
+        // Clear the rate-limit counter so the next attempt isn't gated by the
+        // active back-off. The trip queue lives in a separate file the rate
+        // limiter deliberately does NOT clear on success.
+        crate::rate_limit::record_success(&path);
+
+        let mut storage = HiddenStorage::open(&path).unwrap();
+        storage.unlock_outer("outer-password").unwrap();
+
+        let entries = storage.audit_read_all().unwrap();
+        let trips: Vec<_> = entries
+            .iter()
+            .filter(|e| matches!(e.event_type, crate::audit::AuditEventType::RateLimitTripped))
+            .collect();
+        assert_eq!(
+            trips.len(),
+            1,
+            "exactly one trip entry must surface after hidden-outer unlock; got {trips:#?}"
+        );
+        assert!(!trips[0].success, "trip entry must record success=false");
+        assert!(
+            trips[0]
+                .reason
+                .as_deref()
+                .is_some_and(|r| r.contains("rate limit")),
+            "trip entry must carry a descriptive reason"
+        );
+
+        let trip_idx = entries
+            .iter()
+            .position(|e| matches!(e.event_type, crate::audit::AuditEventType::RateLimitTripped))
+            .unwrap();
+        let unlock_idx = entries
+            .iter()
+            .rposition(|e| matches!(e.event_type, crate::audit::AuditEventType::VaultUnlock))
+            .unwrap();
+        assert!(
+            trip_idx < unlock_idx,
+            "trip must precede the unlock it was observed by"
+        );
+
+        assert!(storage.audit_verify_chain().unwrap());
+    }
+
+    /// A hidden-active session must NOT surface the outer audit log's
+    /// contents. Pin so a future refactor doesn't accidentally leak outer
+    /// activity through the hidden-active read paths.
+    #[test]
+    fn hidden_active_audit_returns_empty() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("vault-hidden-audit-empty");
+
+        HiddenStorage::create(
+            &path,
+            "outer",
+            Some("hidden"),
+            10 * 1024 * 1024,
+            0.2,
+            Argon2Params::TESTING,
+        )
+        .unwrap();
+
+        let mut storage = HiddenStorage::open(&path).unwrap();
+        storage.unlock_hidden("hidden").unwrap();
+
+        assert!(storage.audit_read_all().unwrap().is_empty());
+        assert!(storage.audit_verify_chain().unwrap());
+        assert!(storage.audit_apply_retention().is_err());
     }
 }


### PR DESCRIPTION
Closes #520.

## Summary
`HiddenStorage` had no `AuditLog`, so `RateLimitTripped` events queued by failed unlocks on a hidden-init vault piled up in `.ratelimit.trips` until they hit the cap and got dropped silently. Same for `audit list/verify/stats/retention` — those commands errored on hidden-init vaults because they routed through `Keep::open` which expects a `keep.hdr` layout, not `keep.vault`.

Per the #520 decision (option 1: hoist `AuditLog` onto `HiddenStorage`, outer-volume scope, paralleling #507's relay-config decision), this PR closes both gaps.

## Changes
- `keep-core/src/hidden/volume.rs`:
    - New `outer_audit: Option<AuditLog>` field; cleared by `lock()` and the two `Self {...}` constructors.
    - `unlock_outer` calls `attach_outer_audit` after the rate limiter records success. The helper opens an `AuditLog` under the outer data key, drains pending trip events via `rate_limit::drain_pending_trips`, emits one `RateLimitTripped` audit entry per trip (with the original trip timestamp preserved on `entry.timestamp`, `success=false`, and a descriptive reason), then emits a `VaultUnlock` entry, mirroring `Keep::unlock`. Audit failures are logged at WARN but non-fatal so a corrupted audit log can't make the vault inaccessible.
    - New public methods on `HiddenStorage`: `audit_read_all`, `audit_verify_chain`, `audit_set_retention`, `audit_apply_retention`. All dispatch on `active_volume`: outer routes to the new `outer_audit`; hidden returns `Ok(vec![])` / `Ok(true)` / no-op / `Err` so a hidden-active session can never accidentally leak outer activity through these read paths.
- `keep-cli/src/commands/audit.rs`:
    - New `AuditVault` dispatch enum (paralleling `NipVault` from PR #514). On open, it picks `Keep` for regular vaults and `HiddenStorage`'s outer volume for `keep.vault` layouts via the existing `is_hidden_vault` autodetect.
    - All five audit commands (`list`, `export`, `verify`, `retention`, `stats`) route through it. The legacy `hidden: bool` flag is preserved so existing `keep audit --hidden` invocations keep working; new hidden-init vaults are picked up automatically.
    - `cmd_audit_export` on hidden-init vaults returns a clear "not yet wired" error rather than silently failing — the JSON export path exists on `Keep` but isn't yet shimmed through HiddenStorage; tracked as next-pass work.

## Tests
- `hidden::volume::tests::hidden_outer_unlock_flushes_rate_limit_trips_to_audit`: e2e replica of `rate_limit_trip_emits_audit_entry_on_next_unlock` for the hidden-vault outer path. Trip the limiter with five wrong-password unlocks, clear the active back-off so the next attempt isn't gated, successfully unlock, observe exactly one `RateLimitTripped` entry with `success=false` and a descriptive reason. Also pin chronological order (trip precedes the `VaultUnlock` that observed it) and audit-chain validity after the flush.
- `hidden::volume::tests::hidden_active_audit_returns_empty`: pin that a hidden-active session surfaces an empty audit, a vacuously-valid chain, and refuses retention. Without this, a future refactor could accidentally leak outer audit contents to a hidden-active read path — the exact deniability boundary #520 was about.

## Out of scope (future follow-ups)
- `cmd_audit_export` on hidden-init vaults — needs a thin `HiddenStorage::audit_export` shim. Trivial but not in this PR.
- Hidden-active audit log (a separate log inside the hidden blob) — same deniability constraint as relay-config storage; tracked under the broader hidden-volume work (#513 / #438 umbrella).
- Read-only inspect commands while a daemon holds the writer: the original #533 framing assumed redb supports concurrent reads alongside a writer, which is incorrect. #533's body is updated to reflect the corrected architecture options (IPC vs snapshot).

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit commands now fully support hidden vaults
  * Audit logs record vault unlock events and rate-limit incidents for enhanced security tracking
  * Added audit log retention policy management with configurable enforcement

* **Changes**
  * Export functionality behavior adjusted for hidden vaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->