### PR TITLE
frost-net: graceful KfpNode shutdown via RAII guard

### DIFF
--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -378,14 +378,14 @@ pub fn cmd_frost_network_peers(
             .await
             .map_err(|e| KeepError::Frost(e.to_string()))?;
 
-        let node_handle = tokio::spawn({
+        let _run_guard = NodeRunGuard::aborting(tokio::spawn({
             let node = node.clone();
             async move {
                 if let Err(e) = node.run().await {
                     tracing::error!(error = %e, "FROST node error");
                 }
             }
-        });
+        }));
 
         // Peers announce every 20s. A bare 3s sleep was missing most announces.
         // Poll for up to 25s, exit early as soon as we see anyone.
@@ -399,7 +399,6 @@ pub fn cmd_frost_network_peers(
             tokio::time::sleep(PEER_POLL_INTERVAL).await;
         }
         spinner.finish();
-        node_handle.abort();
 
         let status = node.peer_status();
 
@@ -650,6 +649,18 @@ struct NodeRunGuard {
     shutdown: Option<tokio::sync::mpsc::Sender<()>>,
 }
 
+impl NodeRunGuard {
+    /// Aborts `handle` on drop with no cooperative channel. For short-lived
+    /// probes (peer discovery, health check) that just need the `run()` task
+    /// torn down on every exit path, including early `?` returns and panics.
+    fn aborting(handle: tokio::task::JoinHandle<()>) -> Self {
+        Self {
+            handle,
+            shutdown: None,
+        }
+    }
+}
+
 impl Drop for NodeRunGuard {
     fn drop(&mut self) {
         match self.shutdown.take() {
@@ -819,14 +830,14 @@ pub fn cmd_frost_network_health_check(
             .await
             .map_err(|e| KeepError::Frost(e.to_string()))?;
 
-        let node_handle = tokio::spawn({
+        let _run_guard = NodeRunGuard::aborting(tokio::spawn({
             let node = node.clone();
             async move {
                 if let Err(e) = node.run().await {
                     tracing::error!(error = %e, "FROST node error");
                 }
             }
-        });
+        }));
 
         let spinner = out.spinner("Discovering peers...");
         tokio::time::sleep(std::time::Duration::from_secs(3)).await;
@@ -836,7 +847,6 @@ pub fn cmd_frost_network_health_check(
         out.info(&format!("{online} peer(s) discovered"));
 
         if online == 0 {
-            node_handle.abort();
             out.newline();
             out.warn("No peers discovered. Run 'keep frost network serve' on other devices first.");
             return Ok::<_, KeepError>(());
@@ -848,7 +858,6 @@ pub fn cmd_frost_network_health_check(
             .await
             .map_err(|e| KeepError::Frost(e.to_string()))?;
         spinner.finish();
-        node_handle.abort();
 
         out.newline();
         out.header("Results");

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -580,7 +580,7 @@ async fn frost_network_sign_round(
     message_bytes: Vec<u8>,
     message_type: &str,
 ) -> Result<[u8; 64]> {
-    let node = keep_frost_net::KfpNode::new(share, vec![relay.to_string()])
+    let mut node = keep_frost_net::KfpNode::new(share, vec![relay.to_string()])
         .await
         .map_err(|e| KeepError::Frost(e.to_string()))?;
 
@@ -592,14 +592,20 @@ async fn frost_network_sign_round(
     );
     out.newline();
 
+    // Take the cooperative shutdown sender before sharing the node behind an
+    // Arc; the guard uses it to ask run() to break at its next loop iteration.
+    let shutdown_tx = node.take_shutdown_handle();
     let node = std::sync::Arc::new(node);
     let node_clone = node.clone();
-    // RAII guard so the background run() task is aborted on every exit path
+    // RAII guard so the background run() task is wound down on every exit path
     // (Ok return, the `?` from `request_signature`, or a panic), not silently
     // detached until the surrounding tokio runtime tears down. See #525.
-    let _run_guard = NodeRunGuard(tokio::spawn(async move {
-        let _ = node_clone.run().await;
-    }));
+    let _run_guard = NodeRunGuard {
+        handle: tokio::spawn(async move {
+            let _ = node_clone.run().await;
+        }),
+        shutdown: shutdown_tx,
+    };
 
     out.info("Discovering peers...");
     for i in 0..12 {
@@ -631,15 +637,27 @@ async fn frost_network_sign_round(
     Ok(signature)
 }
 
-/// Aborts the background `KfpNode::run()` task on drop so a signing helper's
-/// every exit path (Ok return, `?` error, panic) tears down relay
-/// subscriptions promptly instead of relying on the surrounding tokio
-/// runtime's drop to cancel a detached task at its next await point.
-struct NodeRunGuard(tokio::task::JoinHandle<()>);
+/// Winds down the background `KfpNode::run()` task on drop so a signing
+/// helper's every exit path (Ok return, `?` error, panic) stops the relay
+/// loop instead of leaving a detached task for the surrounding tokio runtime
+/// to cancel much later (#525). Signals the node's cooperative shutdown
+/// channel so an in-flight `handle_event` finishes and the loop breaks at its
+/// next iteration, dropping the task's `Arc<KfpNode>` and its relay
+/// subscriptions. If no shutdown channel was captured, falls back to aborting
+/// the task so it can never leak.
+struct NodeRunGuard {
+    handle: tokio::task::JoinHandle<()>,
+    shutdown: Option<tokio::sync::mpsc::Sender<()>>,
+}
 
 impl Drop for NodeRunGuard {
     fn drop(&mut self) {
-        self.0.abort();
+        match self.shutdown.take() {
+            Some(tx) => {
+                let _ = tx.try_send(());
+            }
+            None => self.handle.abort(),
+        }
     }
 }
 
@@ -993,45 +1011,63 @@ mod tests {
             .expect("assembled event must verify under the group key");
     }
 
-    /// `NodeRunGuard` must abort its inner `JoinHandle` on drop so a signing
-    /// helper that returns early via `?` doesn't leak a detached `run()`
-    /// task. Without the guard, the only cleanup signal is the surrounding
-    /// tokio runtime tearing down on shutdown, which arrives much later than
-    /// the operator's view of the command exiting (#525).
+    /// Dropping `NodeRunGuard` signals the node's cooperative shutdown channel
+    /// so a signing helper that returns early via `?` lets the background
+    /// `run()` loop break on its own instead of leaking a detached task until
+    /// the surrounding tokio runtime tears down (#525).
     #[tokio::test]
-    async fn node_run_guard_aborts_on_drop() {
-        // A long-running task simulates `KfpNode::run()`'s relay subscription
-        // loop. Without the guard's Drop impl, this future would keep
-        // running past the helper's exit.
-        let handle = tokio::spawn(async {
-            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+    async fn node_run_guard_signals_graceful_shutdown() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<()>(1);
+
+        // Stand in for `KfpNode::run()`'s select! loop: runs until it observes
+        // the cooperative shutdown signal, then returns on its own.
+        let run_loop = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = rx.recv() => break,
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(3600)) => {}
+                }
+            }
         });
 
-        {
-            let _guard = NodeRunGuard(handle);
-            // Guard goes out of scope here; Drop fires.
-        }
+        let guard = NodeRunGuard {
+            handle: tokio::spawn(async {}),
+            shutdown: Some(tx),
+        };
+        assert!(
+            !run_loop.is_finished(),
+            "run loop must still be running before guard drop"
+        );
 
-        // The previous handle was consumed, so spawn another task that
-        // observes whether tokio knows the prior was aborted. We re-create
-        // the guarded handle to make a clean assertion: a fresh JoinHandle's
-        // is_finished() should flip to true shortly after we abort.
-        let handle = tokio::spawn(async {
-            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
-        });
+        // Dropping the guard sends `()` on the shutdown channel; the loop
+        // breaks and the task completes deterministically (no abort).
+        drop(guard);
+        run_loop
+            .await
+            .expect("run loop should complete after graceful shutdown signal");
+    }
+
+    /// With no shutdown channel captured, the guard must abort its task on drop
+    /// so it can never leak.
+    #[tokio::test]
+    async fn node_run_guard_aborts_when_no_shutdown_channel() {
+        let handle = tokio::spawn(std::future::pending::<()>());
         let abort_handle = handle.abort_handle();
-        let guard = NodeRunGuard(handle);
+
+        let guard = NodeRunGuard {
+            handle,
+            shutdown: None,
+        };
         assert!(
             !abort_handle.is_finished(),
             "task must still be running before guard drop"
         );
         drop(guard);
 
-        // Yield once so the abort signal is observed by the runtime.
-        tokio::task::yield_now().await;
-        assert!(
-            abort_handle.is_finished(),
-            "guard's Drop impl must have aborted the inner JoinHandle"
-        );
+        // The guard aborted the task; spin until the runtime observes the
+        // cancellation (terminates as soon as the abort is processed).
+        while !abort_handle.is_finished() {
+            tokio::task::yield_now().await;
+        }
     }
 }

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -594,9 +594,12 @@ async fn frost_network_sign_round(
 
     let node = std::sync::Arc::new(node);
     let node_clone = node.clone();
-    let _handle = tokio::spawn(async move {
+    // RAII guard so the background run() task is aborted on every exit path
+    // (Ok return, the `?` from `request_signature`, or a panic), not silently
+    // detached until the surrounding tokio runtime tears down. See #525.
+    let _run_guard = NodeRunGuard(tokio::spawn(async move {
         let _ = node_clone.run().await;
-    });
+    }));
 
     out.info("Discovering peers...");
     for i in 0..12 {
@@ -626,6 +629,18 @@ async fn frost_network_sign_round(
         .map_err(|e| KeepError::Frost(e.to_string()))?;
     spinner.finish();
     Ok(signature)
+}
+
+/// Aborts the background `KfpNode::run()` task on drop so a signing helper's
+/// every exit path (Ok return, `?` error, panic) tears down relay
+/// subscriptions promptly instead of relying on the surrounding tokio
+/// runtime's drop to cancel a detached task at its next await point.
+struct NodeRunGuard(tokio::task::JoinHandle<()>);
+
+impl Drop for NodeRunGuard {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
 }
 
 #[tracing::instrument(skip(out, content), fields(path = %path.display()))]
@@ -976,5 +991,47 @@ mod tests {
         signed
             .verify()
             .expect("assembled event must verify under the group key");
+    }
+
+    /// `NodeRunGuard` must abort its inner `JoinHandle` on drop so a signing
+    /// helper that returns early via `?` doesn't leak a detached `run()`
+    /// task. Without the guard, the only cleanup signal is the surrounding
+    /// tokio runtime tearing down on shutdown, which arrives much later than
+    /// the operator's view of the command exiting (#525).
+    #[tokio::test]
+    async fn node_run_guard_aborts_on_drop() {
+        // A long-running task simulates `KfpNode::run()`'s relay subscription
+        // loop. Without the guard's Drop impl, this future would keep
+        // running past the helper's exit.
+        let handle = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+        });
+
+        {
+            let _guard = NodeRunGuard(handle);
+            // Guard goes out of scope here; Drop fires.
+        }
+
+        // The previous handle was consumed, so spawn another task that
+        // observes whether tokio knows the prior was aborted. We re-create
+        // the guarded handle to make a clean assertion: a fresh JoinHandle's
+        // is_finished() should flip to true shortly after we abort.
+        let handle = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+        });
+        let abort_handle = handle.abort_handle();
+        let guard = NodeRunGuard(handle);
+        assert!(
+            !abort_handle.is_finished(),
+            "task must still be running before guard drop"
+        );
+        drop(guard);
+
+        // Yield once so the abort signal is observed by the runtime.
+        tokio::task::yield_now().await;
+        assert!(
+            abort_handle.is_finished(),
+            "guard's Drop impl must have aborted the inner JoinHandle"
+        );
     }
 }


### PR DESCRIPTION
Closes #525.

## Summary
`frost_network_sign_round` spawned `node.run()` and dropped the `JoinHandle`, so the only cleanup signal was the surrounding tokio runtime tearing down on shutdown — which aborts the task at its next await point rather than at the operator's view of the command exiting. Both `cmd_frost_network_sign` and `cmd_frost_network_sign_event` were affected (the helper is shared).

This PR replaces the dropped handle with a `NodeRunGuard` RAII wrapper whose `Drop` impl calls `abort()`. Every exit path (Ok return, `?` from `request_signature`, panic) tears down the background relay-subscription loop promptly.

## Changes
- `keep-cli/src/commands/frost_network/mod.rs`:
    - New `NodeRunGuard(tokio::task::JoinHandle<()>)` with a `Drop` impl that calls `abort()`.
    - `frost_network_sign_round` binds the spawned `node.run()` task to `_run_guard: NodeRunGuard` instead of `_handle: JoinHandle<()>`. The variable name + binding ensures the guard lives for the whole function body and runs at scope exit.

## Tests
- `commands::frost_network::tests::node_run_guard_aborts_on_drop`: tokio test that spawns a 3600s-sleeping task, wraps its `JoinHandle` in a `NodeRunGuard`, observes the task is still running, drops the guard, yields once, then asserts the task's `AbortHandle::is_finished()` flipped to true. Pins both that `Drop` fires AND that the abort signal actually cancels the inner task — without that proof, a future no-op `Drop` impl could regress silently.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background task cleanup in frost network signing operations to properly handle all termination paths, including error conditions.

* **Tests**
  * Added test coverage for background task termination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->