### PR TITLE
hidden-vault: wire audit_export shim on outer volume

### DIFF
--- a/keep-cli/src/commands/audit.rs
+++ b/keep-cli/src/commands/audit.rs
@@ -194,10 +194,7 @@ pub fn cmd_audit_export(
                 // `.mode()` only applies when the file is newly created; force
                 // 0o600 so re-exporting over a pre-existing, looser-permission
                 // file does not leak the audit history group/world-readable.
-                std::fs::set_permissions(
-                    &canonical,
-                    std::fs::Permissions::from_mode(0o600),
-                )?;
+                std::fs::set_permissions(&canonical, std::fs::Permissions::from_mode(0o600))?;
                 std::io::Write::write_all(&mut file, json.as_bytes())?;
             }
             #[cfg(not(unix))]

--- a/keep-cli/src/commands/audit.rs
+++ b/keep-cli/src/commands/audit.rs
@@ -60,9 +60,7 @@ impl AuditVault {
     fn export(&self) -> Result<String> {
         match self {
             Self::Keep(k) => k.audit_export(),
-            Self::HiddenOuter(_) => Err(KeepError::Other(
-                "audit export is not yet wired for hidden-init vaults; see #520 follow-up".into(),
-            )),
+            Self::HiddenOuter(s) => s.audit_export(),
         }
     }
 

--- a/keep-cli/src/commands/audit.rs
+++ b/keep-cli/src/commands/audit.rs
@@ -182,6 +182,25 @@ pub fn cmd_audit_export(
     match output_path {
         Some(out_path) => {
             let canonical = resolve_output_path(out_path)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+                let mut file = std::fs::OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .mode(0o600)
+                    .open(&canonical)?;
+                // `.mode()` only applies when the file is newly created; force
+                // 0o600 so re-exporting over a pre-existing, looser-permission
+                // file does not leak the audit history group/world-readable.
+                std::fs::set_permissions(
+                    &canonical,
+                    std::fs::Permissions::from_mode(0o600),
+                )?;
+                std::io::Write::write_all(&mut file, json.as_bytes())?;
+            }
+            #[cfg(not(unix))]
             std::fs::write(&canonical, &json)?;
             out.success(&format!("Audit log exported to {}", canonical.display()));
         }

--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -851,6 +851,20 @@ impl HiddenStorage {
         audit.read_all(data_key)
     }
 
+    /// Export the outer-volume audit log as JSON. Hidden-active sessions
+    /// return an empty array rather than the outer log's contents, matching
+    /// the deniability boundary `audit_read_all` enforces.
+    pub fn audit_export(&self) -> Result<String> {
+        match self.active_volume {
+            Some(VolumeType::Outer) => {}
+            Some(VolumeType::Hidden) => return Ok("[]".to_string()),
+            None => return Err(KeepError::Locked),
+        }
+        let data_key = self.outer_key.as_ref().ok_or(KeepError::Locked)?;
+        let audit = self.outer_audit.as_ref().ok_or(KeepError::Locked)?;
+        audit.export(data_key)
+    }
+
     /// Verify the outer-volume audit log's hash chain. Hidden-active sessions
     /// have no log of their own and return `Ok(true)` (vacuously valid).
     pub fn audit_verify_chain(&self) -> Result<bool> {
@@ -1570,6 +1584,40 @@ mod tests {
         assert!(storage.audit_read_all().unwrap().is_empty());
         assert!(storage.audit_verify_chain().unwrap());
         assert!(storage.audit_apply_retention().is_err());
+        // Export must also surface the same deniability boundary — the outer
+        // log's JSON must not appear under a hidden-active session.
+        assert_eq!(storage.audit_export().unwrap(), "[]");
+    }
+
+    /// `audit_export` on the outer-volume path must serialise the outer log
+    /// as JSON. Pin so `keep audit export` against a hidden-init vault stops
+    /// erroring (the explicit gap left open by PR #538 / closed here).
+    #[test]
+    fn hidden_outer_audit_export_returns_valid_json() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("vault-outer-audit-export");
+
+        HiddenStorage::create(
+            &path,
+            "outer",
+            None,
+            10 * 1024 * 1024,
+            0.0,
+            Argon2Params::TESTING,
+        )
+        .unwrap();
+
+        let mut storage = HiddenStorage::open(&path).unwrap();
+        storage.unlock_outer("outer").unwrap();
+
+        let json = storage.audit_export().unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).expect("audit_export output must be valid JSON");
+        let arr = parsed.as_array().expect("export root must be a JSON array");
+
+        // Unlock emits at least the VaultUnlock entry; the JSON array must
+        // surface it.
+        assert!(!arr.is_empty(), "expected at least the VaultUnlock entry");
     }
 
     /// #520 on the auto-detect `unlock()` path: tripping the limiter then

--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -1620,6 +1620,37 @@ mod tests {
         assert!(!arr.is_empty(), "expected at least the VaultUnlock entry");
     }
 
+    /// Deniability boundary must hold even when the outer log is populated.
+    /// Unlocking outer first fills `outer_key`/`outer_audit`; switching to the
+    /// hidden volume must still yield "[]" from `audit_export`. Pins that the
+    /// hidden-active guard, not a `None` outer key, enforces the boundary.
+    #[test]
+    fn hidden_active_audit_export_empty_with_populated_outer() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("vault-outer-populated-then-hidden");
+
+        HiddenStorage::create(
+            &path,
+            "outer",
+            Some("hidden"),
+            10 * 1024 * 1024,
+            0.2,
+            Argon2Params::TESTING,
+        )
+        .unwrap();
+
+        let mut storage = HiddenStorage::open(&path).unwrap();
+        storage.unlock_outer("outer").unwrap();
+        // Outer export is non-empty here (VaultUnlock entry present).
+        let outer_json = storage.audit_export().unwrap();
+        let outer_parsed: serde_json::Value = serde_json::from_str(&outer_json).unwrap();
+        assert!(!outer_parsed.as_array().unwrap().is_empty());
+
+        storage.unlock_hidden("hidden").unwrap();
+        assert_eq!(storage.active_volume(), Some(VolumeType::Hidden));
+        assert_eq!(storage.audit_export().unwrap(), "[]");
+    }
+
     /// #520 on the auto-detect `unlock()` path: tripping the limiter then
     /// unlocking via the dispatcher (not `unlock_outer`) must still flush the
     /// `RateLimitTripped` entry and attach the outer audit log. Pins the fix

--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -846,8 +846,7 @@ impl HiddenStorage {
             Some(VolumeType::Hidden) => return Ok(Vec::new()),
             None => return Err(KeepError::Locked),
         }
-        let data_key = self.outer_key.as_ref().ok_or(KeepError::Locked)?;
-        let audit = self.outer_audit.as_ref().ok_or(KeepError::Locked)?;
+        let (data_key, audit) = self.outer_audit_handles()?;
         audit.read_all(data_key)
     }
 
@@ -860,8 +859,7 @@ impl HiddenStorage {
             Some(VolumeType::Hidden) => return Ok("[]".to_string()),
             None => return Err(KeepError::Locked),
         }
-        let data_key = self.outer_key.as_ref().ok_or(KeepError::Locked)?;
-        let audit = self.outer_audit.as_ref().ok_or(KeepError::Locked)?;
+        let (data_key, audit) = self.outer_audit_handles()?;
         audit.export(data_key)
     }
 
@@ -873,9 +871,24 @@ impl HiddenStorage {
             Some(VolumeType::Hidden) => return Ok(true),
             None => return Err(KeepError::Locked),
         }
-        let data_key = self.outer_key.as_ref().ok_or(KeepError::Locked)?;
-        let audit = self.outer_audit.as_ref().ok_or(KeepError::Locked)?;
+        let (data_key, audit) = self.outer_audit_handles()?;
         audit.verify_chain(data_key)
+    }
+
+    /// Resolve the outer data key and audit log for an outer-active session.
+    /// A `None` `outer_audit` despite an unlocked outer volume means
+    /// `attach_outer_audit` failed to open the on-disk audit log earlier and
+    /// logged the underlying error. Surface a descriptive error rather than
+    /// the misleading `Locked` so callers can distinguish "not unlocked yet"
+    /// from "unlocked but audit log unavailable" (see PR #540 review).
+    fn outer_audit_handles(&self) -> Result<(&SecretKey, &crate::audit::AuditLog)> {
+        let data_key = self.outer_key.as_ref().ok_or(KeepError::Locked)?;
+        let audit = self.outer_audit.as_ref().ok_or_else(|| {
+            KeepError::Other(
+                "outer-volume audit log is unavailable; check earlier logs for the underlying open failure (the unlock succeeded but `attach_outer_audit` did not attach an audit log)".into(),
+            )
+        })?;
+        Ok((data_key, audit))
     }
 
     /// Set the retention policy on the outer-volume audit log. No-op when
@@ -902,7 +915,11 @@ impl HiddenStorage {
             None => return Err(KeepError::Locked),
         }
         let data_key = self.outer_key.as_ref().ok_or(KeepError::Locked)?;
-        let audit = self.outer_audit.as_mut().ok_or(KeepError::Locked)?;
+        let audit = self.outer_audit.as_mut().ok_or_else(|| {
+            KeepError::Other(
+                "outer-volume audit log is unavailable; check earlier logs for the underlying open failure (the unlock succeeded but `attach_outer_audit` did not attach an audit log)".into(),
+            )
+        })?;
         audit.apply_retention(data_key)
     }
 }
@@ -1615,9 +1632,21 @@ mod tests {
             serde_json::from_str(&json).expect("audit_export output must be valid JSON");
         let arr = parsed.as_array().expect("export root must be a JSON array");
 
-        // Unlock emits at least the VaultUnlock entry; the JSON array must
-        // surface it.
-        assert!(!arr.is_empty(), "expected at least the VaultUnlock entry");
+        // `AuditEventType` derives `Serialize` without a tag attribute, so a
+        // `VaultUnlock` entry serializes as `{"event_type":"VaultUnlock", ...}`.
+        // Pin the actual invariant — unlock emitted at least one such entry —
+        // instead of a loose `!arr.is_empty()` check which would also pass on
+        // a stray `RateLimitTripped` from an earlier session.
+        let has_unlock = arr.iter().any(|entry| {
+            entry
+                .get("event_type")
+                .and_then(|v| v.as_str())
+                .is_some_and(|s| s == "VaultUnlock")
+        });
+        assert!(
+            has_unlock,
+            "expected exported audit to contain a VaultUnlock entry; got {arr:#?}"
+        );
     }
 
     /// Deniability boundary must hold even when the outer log is populated.


### PR DESCRIPTION
Finishes the hidden-vault audit story #520 / PR #538 explicitly left open. \`AuditVault::export\` on a hidden-init vault no longer returns the "not yet wired" error — it routes to a new \`HiddenStorage::audit_export\` that surfaces the outer-volume audit log as JSON. Hidden-active sessions return \`[]\` so the deniability boundary the other \`audit_*\` methods enforce holds for export too.

## Changes
- \`keep-core/src/hidden/volume.rs\`: new \`HiddenStorage::audit_export\` paralleling \`audit_read_all\` / \`audit_verify_chain\`. Outer-active routes to the outer audit log; hidden-active returns \`"[]"\`; locked returns \`Locked\`.
- \`keep-cli/src/commands/audit.rs\`: \`AuditVault::export\` for the \`HiddenOuter\` arm now delegates to \`HiddenStorage::audit_export\` instead of returning the stub error.

## Tests
- \`hidden_outer_audit_export_returns_valid_json\`: outer-unlock emits a \`VaultUnlock\` entry; \`audit_export\` must return parseable JSON whose root array contains it. Without this the export path could silently produce malformed JSON or empty output and ship past the existing tests.
- \`hidden_active_audit_returns_empty\` extended: the existing pin for \`audit_read_all\`/\`audit_verify_chain\`/\`audit_apply_retention\` on a hidden-active session now also asserts \`audit_export()\` returns \`"[]"\`, so a future refactor that leaks the outer log through export gets caught at the same point as the other deniability boundaries.

## Out of scope
- Hidden-active audit log (a separate log inside the hidden blob) — same deniability constraint as relay-config storage; still tracked under the broader hidden-volume work (#513 / #438).

## Validation
- \`cargo fmt --all\`
- \`cargo clippy --workspace --all-targets -- -D warnings\`
- \`cargo test --workspace\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audit export support for hidden-init vaults, enabling users to export audit logs that were previously unavailable.

* **Bug Fixes**
  * Improved security on Unix systems: audit export files now created with restricted file permissions (0o600).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->