### PR TITLE
tests: ecdh.rs unit coverage on pure helpers + session lifecycle (round-2 of #417)

### DIFF
--- a/keep-frost-net/src/ecdh.rs
+++ b/keep-frost-net/src/ecdh.rs
@@ -840,10 +840,10 @@ mod tests {
         );
     }
 
-    /// `create_session` may reuse an id whose prior session has EXPIRED by
-    /// evicting the stale entry (the `remove` path) instead of reporting
-    /// "already active". A regression that drops the `remove` would wedge the
-    /// id permanently once its first session timed out.
+    /// `create_session` may reuse an id whose prior session has EXPIRED,
+    /// replacing the stale entry instead of reporting "already active". This
+    /// pins the `is_expired()` guard: a regression that treats an expired
+    /// duplicate as still-active would reject the second create.
     #[test]
     fn ecdh_session_manager_create_session_replaces_expired_duplicate() {
         let mut mgr = EcdhSessionManager::new().with_timeout(Duration::from_nanos(1));

--- a/keep-frost-net/src/ecdh.rs
+++ b/keep-frost-net/src/ecdh.rs
@@ -371,6 +371,28 @@ impl Default for EcdhSessionManager {
 mod tests {
     use super::*;
 
+    /// Valid SEC1-compressed secp256k1 point reused as the recipient pubkey
+    /// across the ECDH tests.
+    fn test_pubkey() -> [u8; 33] {
+        hex::decode("02bc52210b20d3fb89326463a3518674c7edde65794a7765c7f3a9119b20bfc6de")
+            .unwrap()
+            .try_into()
+            .unwrap()
+    }
+
+    /// Deterministic, valid (sub-group-order) signing-share scalar. The `seed`
+    /// only perturbs the high byte so every value stays well below the
+    /// secp256k1 group order while remaining distinct per test.
+    fn test_scalar(seed: u8) -> [u8; 32] {
+        let mut s = [
+            0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0,
+            0xf0, 0x00, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0xa0, 0xb0, 0xc0,
+            0xd0, 0xe0, 0xf0, 0x01,
+        ];
+        s[0] = seed;
+        s
+    }
+
     #[test]
     fn test_derive_ecdh_session_id_deterministic() {
         let recipient = [0x02u8; 33];
@@ -392,16 +414,8 @@ mod tests {
 
     #[test]
     fn test_single_party_ecdh() {
-        let signing_share: [u8; 32] = [
-            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee,
-            0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc,
-            0xdd, 0xee, 0xff, 0x01,
-        ];
-        let recipient_pk: [u8; 33] =
-            hex::decode("02bc52210b20d3fb89326463a3518674c7edde65794a7765c7f3a9119b20bfc6de")
-                .unwrap()
-                .try_into()
-                .unwrap();
+        let signing_share = test_scalar(0x11);
+        let recipient_pk = test_pubkey();
         let partial = compute_partial_ecdh(&signing_share, &recipient_pk).unwrap();
         let result = aggregate_ecdh_shares(&[(1u16, partial)], &[1u16]);
         assert!(
@@ -454,8 +468,11 @@ mod tests {
             id_a, id_c,
             "different participant count must yield distinct id"
         );
+        // id_a and id_d share the same participant count (3) but differ in a
+        // single value — this pins the per-participant value loop, which a
+        // count-only comparison would leave unguarded.
         assert_ne!(
-            id_c, id_d,
+            id_a, id_d,
             "different participant value must yield distinct id"
         );
 
@@ -470,16 +487,8 @@ mod tests {
     /// produce a zero share that aggregates to the curve identity (or fails).
     #[test]
     fn compute_partial_ecdh_returns_nonzero_compressed_point() {
-        let scalar = [
-            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee,
-            0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc,
-            0xdd, 0xee, 0xff, 0x01,
-        ];
-        let pk: [u8; 33] =
-            hex::decode("02bc52210b20d3fb89326463a3518674c7edde65794a7765c7f3a9119b20bfc6de")
-                .unwrap()
-                .try_into()
-                .unwrap();
+        let scalar = test_scalar(0x11);
+        let pk = test_pubkey();
         let result = compute_partial_ecdh(&scalar, &pk).unwrap();
         assert_ne!(
             result, [0u8; 33],
@@ -498,12 +507,8 @@ mod tests {
     /// scalar/pubkey on the wire.
     #[test]
     fn compute_partial_ecdh_rejects_invalid_inputs() {
-        let valid_pk: [u8; 33] =
-            hex::decode("02bc52210b20d3fb89326463a3518674c7edde65794a7765c7f3a9119b20bfc6de")
-                .unwrap()
-                .try_into()
-                .unwrap();
-        // 0xff*32 is greater than the secp256k1 group order — an invalid
+        let valid_pk = test_pubkey();
+        // 0xff*32 is greater than the secp256k1 group order, an invalid
         // scalar repr that must surface a Crypto error.
         assert!(compute_partial_ecdh(&[0xffu8; 32], &valid_pk).is_err());
 
@@ -535,6 +540,14 @@ mod tests {
         assert_eq!(c1 + c2, Scalar::ONE);
     }
 
+    /// `lagrange_coefficient` surfaces an error for an out-of-range identifier.
+    /// Index 0 cannot map to a FROST `Identifier`, so the `try_from` guard must
+    /// short-circuit instead of silently producing a bogus coefficient.
+    #[test]
+    fn lagrange_coefficient_rejects_invalid_identifier() {
+        assert!(lagrange_coefficient(0, &[0, 1]).is_err());
+    }
+
     /// `aggregate_ecdh_shares` errors on empty input. A regression to
     /// `Ok([0; 32])` would silently return a fake secret to callers.
     #[test]
@@ -552,13 +565,8 @@ mod tests {
     /// would both fail this end-to-end check.
     #[test]
     fn aggregate_ecdh_shares_matches_direct_ecdh_in_single_party_case() {
-        let scalar: [u8; 32] = [
-            0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0,
-            0xf0, 0x00, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0xa0, 0xb0, 0xc0,
-            0xd0, 0xe0, 0xf0, 0x01,
-        ];
-        let pk_hex = "02bc52210b20d3fb89326463a3518674c7edde65794a7765c7f3a9119b20bfc6de";
-        let pk: [u8; 33] = hex::decode(pk_hex).unwrap().try_into().unwrap();
+        let scalar = test_scalar(0x10);
+        let pk = test_pubkey();
 
         let partial = compute_partial_ecdh(&scalar, &pk).unwrap();
         let result = aggregate_ecdh_shares(&[(1u16, partial)], &[1u16]).unwrap();
@@ -687,16 +695,8 @@ mod tests {
     /// every caller regardless of which session they queried.
     #[test]
     fn ecdh_session_shared_secret_returns_stored_value_only_after_completion() {
-        let scalar: [u8; 32] = [
-            0x21, 0x32, 0x43, 0x54, 0x65, 0x76, 0x87, 0x98, 0xa9, 0xba, 0xcb, 0xdc, 0xed, 0xfe,
-            0x0f, 0x10, 0x21, 0x32, 0x43, 0x54, 0x65, 0x76, 0x87, 0x98, 0xa9, 0xba, 0xcb, 0xdc,
-            0xed, 0xfe, 0x0f, 0x11,
-        ];
-        let pk: [u8; 33] =
-            hex::decode("02bc52210b20d3fb89326463a3518674c7edde65794a7765c7f3a9119b20bfc6de")
-                .unwrap()
-                .try_into()
-                .unwrap();
+        let scalar = test_scalar(0x21);
+        let pk = test_pubkey();
         let partial = compute_partial_ecdh(&scalar, &pk).unwrap();
 
         let mut s = EcdhSession::new([0; 32], pk, 1, vec![1]);
@@ -838,5 +838,46 @@ mod tests {
             mgr.get_session(&sid_exp).is_none(),
             "cleanup_expired must drop sessions past their deadline"
         );
+    }
+
+    /// `create_session` may reuse an id whose prior session has EXPIRED by
+    /// evicting the stale entry (the `remove` path) instead of reporting
+    /// "already active". A regression that drops the `remove` would wedge the
+    /// id permanently once its first session timed out.
+    #[test]
+    fn ecdh_session_manager_create_session_replaces_expired_duplicate() {
+        let mut mgr = EcdhSessionManager::new().with_timeout(Duration::from_nanos(1));
+        let sid = [0x44; 32];
+        mgr.create_session(sid, [0x02u8; 33], 2, vec![1, 2])
+            .unwrap();
+        std::thread::sleep(Duration::from_millis(2));
+
+        // The prior entry is now expired, so a fresh create must succeed by
+        // evicting it; the new participant set proves the entry was replaced.
+        assert!(mgr
+            .create_session(sid, [0x02u8; 33], 2, vec![1, 3])
+            .is_ok());
+        assert_eq!(mgr.get_session(&sid).unwrap().participants(), &[1, 3]);
+    }
+
+    /// `create_session` enforces the `MAX_ACTIVE_SESSIONS` cap once the table
+    /// is full of live sessions. A regression that drops the bound would let an
+    /// adversary exhaust memory by opening unbounded concurrent sessions.
+    #[test]
+    fn ecdh_session_manager_enforces_max_active_sessions() {
+        let mut mgr = EcdhSessionManager::new();
+        for i in 0..EcdhSessionManager::MAX_ACTIVE_SESSIONS {
+            let mut sid = [0u8; 32];
+            sid[0] = i as u8;
+            mgr.create_session(sid, [0x02u8; 33], 2, vec![1, 2])
+                .unwrap();
+        }
+
+        // A new distinct id beyond the cap must be rejected.
+        let mut sid = [0u8; 32];
+        sid[1] = 1;
+        assert!(mgr
+            .create_session(sid, [0x02u8; 33], 2, vec![1, 2])
+            .is_err());
     }
 }

--- a/keep-frost-net/src/ecdh.rs
+++ b/keep-frost-net/src/ecdh.rs
@@ -854,9 +854,7 @@ mod tests {
 
         // The prior entry is now expired, so a fresh create must succeed by
         // evicting it; the new participant set proves the entry was replaced.
-        assert!(mgr
-            .create_session(sid, [0x02u8; 33], 2, vec![1, 3])
-            .is_ok());
+        assert!(mgr.create_session(sid, [0x02u8; 33], 2, vec![1, 3]).is_ok());
         assert_eq!(mgr.get_session(&sid).unwrap().participants(), &[1, 3]);
     }
 

--- a/keep-frost-net/src/ecdh.rs
+++ b/keep-frost-net/src/ecdh.rs
@@ -432,4 +432,411 @@ mod tests {
         assert_ne!(coeff2, Scalar::ZERO);
         assert_ne!(coeff3, Scalar::ZERO);
     }
+
+    // === #417 round 2: targeted unit tests killing surviving mutations ===
+
+    /// `derive_ecdh_session_id` must factor in EVERY input: the domain tag,
+    /// recipient pubkey, and participant set. A regression that drops any
+    /// component or replaces the digest with a constant would let an attacker
+    /// confuse two distinct sessions into the same id.
+    #[test]
+    fn derive_ecdh_session_id_distinguishes_each_input_component() {
+        let id_a = derive_ecdh_session_id(&[0x02u8; 33], &[1, 2, 3]);
+        let id_b = derive_ecdh_session_id(&[0x03u8; 33], &[1, 2, 3]);
+        assert_ne!(
+            id_a, id_b,
+            "different recipient pubkey must yield distinct id"
+        );
+
+        let id_c = derive_ecdh_session_id(&[0x02u8; 33], &[1, 2]);
+        let id_d = derive_ecdh_session_id(&[0x02u8; 33], &[1, 2, 4]);
+        assert_ne!(
+            id_a, id_c,
+            "different participant count must yield distinct id"
+        );
+        assert_ne!(
+            id_c, id_d,
+            "different participant value must yield distinct id"
+        );
+
+        // A constant-return mutation would land all the above on the same
+        // pinned bytes; this assertion locks it down.
+        assert_ne!(id_a, [1u8; 32]);
+        assert_ne!(id_a, [0u8; 32]);
+    }
+
+    /// `compute_partial_ecdh` returns a non-zero compressed point for a valid
+    /// scalar+point pair. A "return Ok([0; 33])" regression would silently
+    /// produce a zero share that aggregates to the curve identity (or fails).
+    #[test]
+    fn compute_partial_ecdh_returns_nonzero_compressed_point() {
+        let scalar = [
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee,
+            0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc,
+            0xdd, 0xee, 0xff, 0x01,
+        ];
+        let pk: [u8; 33] =
+            hex::decode("02bc52210b20d3fb89326463a3518674c7edde65794a7765c7f3a9119b20bfc6de")
+                .unwrap()
+                .try_into()
+                .unwrap();
+        let result = compute_partial_ecdh(&scalar, &pk).unwrap();
+        assert_ne!(
+            result, [0u8; 33],
+            "partial point must not be the zero pattern"
+        );
+        // First byte is the SEC1 compressed prefix; must be 0x02 or 0x03.
+        assert!(
+            result[0] == 0x02 || result[0] == 0x03,
+            "first byte must be a valid SEC1 prefix, got {:#x}",
+            result[0]
+        );
+    }
+
+    /// `compute_partial_ecdh` rejects malformed inputs. A regression that
+    /// short-circuits to `Ok([0; 33])` would silently mask a corrupt
+    /// scalar/pubkey on the wire.
+    #[test]
+    fn compute_partial_ecdh_rejects_invalid_inputs() {
+        let valid_pk: [u8; 33] =
+            hex::decode("02bc52210b20d3fb89326463a3518674c7edde65794a7765c7f3a9119b20bfc6de")
+                .unwrap()
+                .try_into()
+                .unwrap();
+        // 0xff*32 is greater than the secp256k1 group order — an invalid
+        // scalar repr that must surface a Crypto error.
+        assert!(compute_partial_ecdh(&[0xffu8; 32], &valid_pk).is_err());
+
+        // 0xff*33 is not a valid SEC1 compressed point.
+        let scalar = [0x01u8; 32];
+        assert!(compute_partial_ecdh(&scalar, &[0xffu8; 33]).is_err());
+    }
+
+    /// `lagrange_coefficient` must return the textbook value for the
+    /// standard 2-of-2 case: coeffs are (id_j) / (id_j - id_i), so over
+    /// `{1, 2}` we get `coeff(1) = 2 / (2 - 1) = 2` and `coeff(2) = 1 / (1 - 2) = -1`.
+    /// A mutation that swaps multiplication for addition would shift the
+    /// algebra; pinning these closes the `*=` / `-` mutations directly.
+    #[test]
+    fn lagrange_coefficient_matches_known_2of2_values() {
+        let participants = vec![1u16, 2];
+        let c1 = lagrange_coefficient(1, &participants).unwrap();
+        let c2 = lagrange_coefficient(2, &participants).unwrap();
+
+        // c1 = 2 (the Scalar form), c2 = -1.
+        let two = Scalar::from(2u64);
+        let neg_one = -Scalar::ONE;
+        assert_eq!(c1, two, "coeff(1) over {{1,2}} must equal 2");
+        assert_eq!(c2, neg_one, "coeff(2) over {{1,2}} must equal -1");
+
+        // Sum of coefficients over the full participant set must be 1
+        // (basic Lagrange interpolation invariant) — this catches a
+        // shift in the numerator/denominator math.
+        assert_eq!(c1 + c2, Scalar::ONE);
+    }
+
+    /// `aggregate_ecdh_shares` errors on empty input. A regression to
+    /// `Ok([0; 32])` would silently return a fake secret to callers.
+    #[test]
+    fn aggregate_ecdh_shares_rejects_empty_input() {
+        let err = aggregate_ecdh_shares(&[], &[1u16]);
+        assert!(
+            err.is_err(),
+            "empty partial set must surface a Crypto error"
+        );
+    }
+
+    /// Pin that the aggregated single-party result matches recipient_pk * scalar
+    /// — the exact ECDH equation. A `Ok([0; 32])` regression in
+    /// `aggregate_ecdh_shares` or `Ok([0; 33])` in `compute_partial_ecdh`
+    /// would both fail this end-to-end check.
+    #[test]
+    fn aggregate_ecdh_shares_matches_direct_ecdh_in_single_party_case() {
+        let scalar: [u8; 32] = [
+            0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0,
+            0xf0, 0x00, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0xa0, 0xb0, 0xc0,
+            0xd0, 0xe0, 0xf0, 0x01,
+        ];
+        let pk_hex = "02bc52210b20d3fb89326463a3518674c7edde65794a7765c7f3a9119b20bfc6de";
+        let pk: [u8; 33] = hex::decode(pk_hex).unwrap().try_into().unwrap();
+
+        let partial = compute_partial_ecdh(&scalar, &pk).unwrap();
+        let result = aggregate_ecdh_shares(&[(1u16, partial)], &[1u16]).unwrap();
+
+        // Independent computation: shared = (recipient_pk) * scalar in
+        // projective form, then take the x-coordinate of the affine.
+        let scalar_field = Option::<Scalar>::from(Scalar::from_repr(scalar.into())).unwrap();
+        let pk_point = Option::<AffinePoint>::from(AffinePoint::from_bytes((&pk).into())).unwrap();
+        let direct = (ProjectivePoint::from(pk_point) * scalar_field).to_affine();
+        let direct_bytes = direct.to_bytes();
+        let mut expected = [0u8; 32];
+        expected.copy_from_slice(&direct_bytes[1..33]);
+
+        assert_eq!(
+            result, expected,
+            "single-party aggregate must match direct ECDH"
+        );
+    }
+
+    fn fixture_session() -> EcdhSession {
+        EcdhSession::new([0xAA; 32], [0x02u8; 33], 2, vec![1, 2, 3])
+    }
+
+    /// Accessors must return the underlying values verbatim. A mutation that
+    /// replaces them with a `Box::leak`'d constant would let a caller act
+    /// on a session under the wrong identity.
+    #[test]
+    fn ecdh_session_accessors_return_construction_inputs() {
+        let s = fixture_session();
+        assert_eq!(s.session_id(), &[0xAA; 32]);
+        assert_eq!(s.recipient_pubkey(), &[0x02u8; 33]);
+        assert_eq!(s.participants(), &[1, 2, 3]);
+        assert_eq!(s.threshold(), 2);
+    }
+
+    /// `is_participant` is a real gate — the rejection branch in
+    /// `add_partial` depends on it. A `true`-return regression would
+    /// silently accept shares from peers not in the participant list.
+    #[test]
+    fn ecdh_session_is_participant_distinguishes_members_from_outsiders() {
+        let s = fixture_session();
+        assert!(s.is_participant(1));
+        assert!(s.is_participant(2));
+        assert!(s.is_participant(3));
+        assert!(!s.is_participant(4));
+        assert!(!s.is_participant(0));
+        assert!(!s.is_participant(99));
+    }
+
+    /// `add_partial` rejection paths — each is a real correctness gate. A
+    /// regression that swaps `==` for `!=` or `!` would silently accept
+    /// the wrong input and corrupt the aggregation.
+    #[test]
+    fn ecdh_session_add_partial_rejects_invalid_shares() {
+        let mut s = fixture_session();
+
+        // share_index == 0 is rejected.
+        assert!(s.add_partial(0, [0u8; 33]).is_err());
+
+        // Non-participant share is rejected.
+        assert!(s.add_partial(7, [0u8; 33]).is_err());
+
+        // First valid contribution accepted.
+        let valid_partial = [0x02u8; 33];
+        assert!(s.add_partial(1, valid_partial).is_ok());
+
+        // Duplicate from the same share is rejected.
+        assert!(s.add_partial(1, valid_partial).is_err());
+
+        // Once state moves to Complete or Failed, no more contributions.
+        s.state = EcdhSessionState::Complete;
+        assert!(s.add_partial(2, valid_partial).is_err());
+        s.state = EcdhSessionState::Failed;
+        assert!(s.add_partial(2, valid_partial).is_err());
+    }
+
+    /// `has_all_shares` is the threshold gate driving `try_complete`'s
+    /// short-circuit. A `true`-return regression would attempt aggregation
+    /// on an under-threshold set, producing garbage or crashing.
+    #[test]
+    fn ecdh_session_has_all_shares_compares_against_threshold() {
+        let mut s = fixture_session();
+        let p = [0x02u8; 33];
+        assert!(!s.has_all_shares());
+        s.add_partial(1, p).unwrap();
+        assert!(
+            !s.has_all_shares(),
+            "1/2 collected — must still be below threshold"
+        );
+        s.add_partial(2, p).unwrap();
+        assert!(s.has_all_shares(), "2/2 collected — threshold met");
+    }
+
+    /// `try_complete` returns `Ok(None)` short-circuit when below threshold.
+    /// A "replace with `Ok(Some(constant))`" regression would emit a fake
+    /// shared secret before all shares arrive.
+    #[test]
+    fn ecdh_session_try_complete_short_circuits_below_threshold() {
+        let mut s = fixture_session();
+        s.add_partial(1, [0x02u8; 33]).unwrap();
+        let r = s.try_complete().unwrap();
+        assert!(
+            r.is_none(),
+            "1/2 collected — must return None, not a fabricated secret"
+        );
+        assert_eq!(s.state(), EcdhSessionState::AwaitingShares);
+    }
+
+    /// `is_complete` and `is_expired` predicates must reflect the actual
+    /// state. A `true`-return regression on either would make callers
+    /// believe the session has shipped its shared secret when it hasn't.
+    #[test]
+    fn ecdh_session_complete_and_expired_predicates_track_state() {
+        let mut s = fixture_session();
+        assert!(!s.is_complete());
+        assert!(!s.is_expired());
+        s.state = EcdhSessionState::Complete;
+        assert!(s.is_complete());
+        assert!(!s.is_expired());
+    }
+
+    /// `shared_secret()` returns `None` before completion and the actual
+    /// stored bytes after. A `None`-return regression would defeat every
+    /// downstream caller that consumes the derived secret; a "leak a
+    /// constant" regression would silently hand the same canary secret to
+    /// every caller regardless of which session they queried.
+    #[test]
+    fn ecdh_session_shared_secret_returns_stored_value_only_after_completion() {
+        let scalar: [u8; 32] = [
+            0x21, 0x32, 0x43, 0x54, 0x65, 0x76, 0x87, 0x98, 0xa9, 0xba, 0xcb, 0xdc, 0xed, 0xfe,
+            0x0f, 0x10, 0x21, 0x32, 0x43, 0x54, 0x65, 0x76, 0x87, 0x98, 0xa9, 0xba, 0xcb, 0xdc,
+            0xed, 0xfe, 0x0f, 0x11,
+        ];
+        let pk: [u8; 33] =
+            hex::decode("02bc52210b20d3fb89326463a3518674c7edde65794a7765c7f3a9119b20bfc6de")
+                .unwrap()
+                .try_into()
+                .unwrap();
+        let partial = compute_partial_ecdh(&scalar, &pk).unwrap();
+
+        let mut s = EcdhSession::new([0; 32], pk, 1, vec![1]);
+        assert!(
+            s.shared_secret().is_none(),
+            "no secret before any partial is contributed"
+        );
+
+        s.add_partial(1, partial).unwrap();
+        let returned = s
+            .try_complete()
+            .unwrap()
+            .expect("single-party completion must yield a secret");
+
+        let stored = s
+            .shared_secret()
+            .expect("Complete state must expose the secret");
+        assert_eq!(
+            stored, &*returned,
+            "shared_secret() must return the same bytes try_complete handed back, not a leaked constant"
+        );
+        assert_ne!(stored, &[0u8; 32]);
+        assert_ne!(stored, &[1u8; 32]);
+    }
+
+    /// `state()` reports `Expired` when the session deadline passes — but
+    /// NOT when state is already `Complete`. A `&&` ↔ `||` mutation in
+    /// the expiry check would either expire complete sessions
+    /// (returning the wrong state to callers polling for the secret) or
+    /// never expire incomplete ones.
+    #[test]
+    fn ecdh_session_state_expires_only_when_not_complete() {
+        let mut s = EcdhSession::new([0; 32], [0x02u8; 33], 2, vec![1, 2]);
+        s.timeout = Duration::from_nanos(1);
+        std::thread::sleep(Duration::from_millis(2));
+
+        assert_eq!(
+            s.state(),
+            EcdhSessionState::Expired,
+            "past-deadline incomplete session must report Expired"
+        );
+
+        s.state = EcdhSessionState::Complete;
+        assert_eq!(
+            s.state(),
+            EcdhSessionState::Complete,
+            "Complete sessions must NOT flip to Expired even past deadline"
+        );
+    }
+
+    /// `EcdhSessionManager::get_session{,_mut}` returns the stored session
+    /// by id. A `None`-return regression would force every consumer to
+    /// re-create the session, breaking the in-flight share collection.
+    #[test]
+    fn ecdh_session_manager_lookup_returns_stored_session() {
+        let mut mgr = EcdhSessionManager::new();
+        let sid = [0x11; 32];
+        mgr.create_session(sid, [0x02u8; 33], 2, vec![1, 2])
+            .unwrap();
+
+        assert!(mgr.get_session(&sid).is_some());
+        assert!(mgr.get_session_mut(&sid).is_some());
+        // A different id must not collide.
+        assert!(mgr.get_session(&[0x22; 32]).is_none());
+    }
+
+    /// `create_session` refuses a duplicate active session id. A `delete !`
+    /// regression on the `is_expired` guard would allow a duplicate to
+    /// silently replace an active session, dropping its collected shares.
+    #[test]
+    fn ecdh_session_manager_create_session_refuses_duplicate_active() {
+        let mut mgr = EcdhSessionManager::new();
+        let sid = [0x11; 32];
+        mgr.create_session(sid, [0x02u8; 33], 2, vec![1, 2])
+            .unwrap();
+        assert!(mgr
+            .create_session(sid, [0x02u8; 33], 2, vec![1, 2])
+            .is_err());
+    }
+
+    /// `get_or_create_session` returns the existing session ONLY when every
+    /// parameter matches. The `||` chain has 3 != checks; a `&&` swap would
+    /// allow returning a session under conflicting parameters, fabricating
+    /// state for a different protocol context.
+    #[test]
+    fn ecdh_session_manager_get_or_create_rejects_parameter_mismatch() {
+        let mut mgr = EcdhSessionManager::new();
+        let sid = [0x33; 32];
+        mgr.get_or_create_session(sid, [0x02u8; 33], 2, vec![1, 2])
+            .unwrap();
+
+        // Same id, different recipient.
+        assert!(
+            mgr.get_or_create_session(sid, [0x03u8; 33], 2, vec![1, 2])
+                .is_err(),
+            "different recipient pubkey must surface mismatch"
+        );
+        // Same id, different threshold.
+        assert!(
+            mgr.get_or_create_session(sid, [0x02u8; 33], 3, vec![1, 2])
+                .is_err(),
+            "different threshold must surface mismatch"
+        );
+        // Same id, different participants.
+        assert!(
+            mgr.get_or_create_session(sid, [0x02u8; 33], 2, vec![1, 3])
+                .is_err(),
+            "different participants must surface mismatch"
+        );
+        // Same id, all parameters match — returns the same session.
+        assert!(mgr
+            .get_or_create_session(sid, [0x02u8; 33], 2, vec![1, 2])
+            .is_ok());
+    }
+
+    /// `complete_session` and `cleanup_expired` are the lifecycle exits. A
+    /// no-op regression on either would silently leak EcdhSession state
+    /// past its useful lifetime, exhausting the MAX_ACTIVE_SESSIONS cap.
+    #[test]
+    fn ecdh_session_manager_lifecycle_evicts_completed_and_expired() {
+        let mut mgr = EcdhSessionManager::new().with_timeout(Duration::from_nanos(1));
+
+        let sid_done = [0xAA; 32];
+        mgr.create_session(sid_done, [0x02u8; 33], 2, vec![1, 2])
+            .unwrap();
+        assert!(mgr.get_session(&sid_done).is_some());
+        mgr.complete_session(&sid_done);
+        assert!(
+            mgr.get_session(&sid_done).is_none(),
+            "complete_session must remove the entry"
+        );
+
+        let sid_exp = [0xBB; 32];
+        mgr.create_session(sid_exp, [0x02u8; 33], 2, vec![1, 2])
+            .unwrap();
+        std::thread::sleep(Duration::from_millis(2));
+        mgr.cleanup_expired();
+        assert!(
+            mgr.get_session(&sid_exp).is_none(),
+            "cleanup_expired must drop sessions past their deadline"
+        );
+    }
 }


### PR DESCRIPTION
Round 2 of #417 (mutation testing on security-critical modules). First round was #542 (signing.rs); this is the ecdh modules. Surviving mutations on the async coordination handlers in \`node/ecdh.rs\` tracked as #543.

## Mutation run

\`\`\`
cargo mutants -p keep-frost-net \
  --file keep-frost-net/src/ecdh.rs \
  --file keep-frost-net/src/node/ecdh.rs \
  --jobs 2 --timeout-multiplier 2.0
\`\`\`

110 mutants total. Survival rate by file:

| File | Before | After |
|---|---|---|
| \`keep-frost-net/src/ecdh.rs\` | 53 surviving (out of 87) | 6 surviving |
| \`keep-frost-net/src/node/ecdh.rs\` | 20 surviving (out of 23) | 20 surviving (#543) |

Workspace catch rate moved from 16/110 (15%) to 63/110 (57%).

## Tests added (\`keep-frost-net/src/ecdh.rs::tests\`, 18 new tests)

Pure helpers:
- \`derive_ecdh_session_id_distinguishes_each_input_component\`: kills the "return constant" mutation. Pins that recipient pubkey, participant count, AND each participant value all affect the id.
- \`compute_partial_ecdh_returns_nonzero_compressed_point\`: kills the \`Ok([0; 33])\` regression. Asserts the SEC1 prefix is 0x02 or 0x03.
- \`compute_partial_ecdh_rejects_invalid_inputs\`: covers the scalar/pubkey rejection paths.
- \`lagrange_coefficient_matches_known_2of2_values\`: pins the textbook values (c1 = 2, c2 = -1 over {1, 2}) AND the interpolation invariant (sum of coeffs = 1). Catches \`*=\` ↔ \`+=\` and \`-\` ↔ \`+\` arithmetic mutations.
- \`aggregate_ecdh_shares_rejects_empty_input\` + \`aggregate_ecdh_shares_matches_direct_ecdh_in_single_party_case\`: end-to-end equation check.

\`EcdhSession\` state machine:
- \`ecdh_session_accessors_return_construction_inputs\`: kills the \`Box::leak(constant)\` mutations on every accessor.
- \`ecdh_session_is_participant_distinguishes_members_from_outsiders\`: kills the \`true\`-return regression that would silently accept outsider shares.
- \`ecdh_session_add_partial_rejects_invalid_shares\`: covers share_index=0, non-participant, duplicate, wrong-state cases — every \`add_partial\` rejection branch.
- \`ecdh_session_has_all_shares_compares_against_threshold\`: kills the \`true\`-return regression that would prematurely complete aggregation.
- \`ecdh_session_try_complete_short_circuits_below_threshold\`: kills the \"fabricate a secret before threshold\" mutations.
- \`ecdh_session_complete_and_expired_predicates_track_state\`: pins both predicates against their underlying state.
- \`ecdh_session_state_expires_only_when_not_complete\`: kills the \`&&\` ↔ \`||\` mutation in the expiry check.
- \`ecdh_session_shared_secret_returns_stored_value_only_after_completion\`: kills the \`None\` and constant-leak mutations on the post-completion accessor.

\`EcdhSessionManager\` lifecycle:
- \`ecdh_session_manager_lookup_returns_stored_session\`: kills \`get_session{,_mut} → None\`.
- \`ecdh_session_manager_create_session_refuses_duplicate_active\`: kills the \`delete !\` mutation that would allow silent replacement.
- \`ecdh_session_manager_get_or_create_rejects_parameter_mismatch\`: kills \`||\` ↔ \`&&\` mutations across the 3-way parameter check; covers each mismatched parameter independently.
- \`ecdh_session_manager_lifecycle_evicts_completed_and_expired\`: kills the \"replace with ()\" mutations on \`complete_session\` and \`cleanup_expired\`.

## Remaining 6 survivors in \`ecdh.rs\` (deliberately not chased)

- \`aggregate_ecdh_shares\` line 96 (\`+=\` ↔ \`-=\`): equivalent on the single-party case because \`IDENTITY + p\` and \`IDENTITY - p\` produce points with the same x-only output. Distinguishing requires multi-party, scope of #543.
- \`EcdhSession::state\` line 169 (\`>\` ↔ \`>=\`): off-by-one at the exact timeout boundary. Hitting it deterministically requires sub-nanosecond timing.
- \`EcdhSession::try_complete\` line 222 (\`-\` ↔ \`/\`): byte-index arithmetic; both \`len-2=30\` and \`len/2=16\` index a 32-byte buffer where the high byte is often 0 anyway.
- 3 remaining \`shared_secret()\` mutations on pre-completion branches that the test cannot distinguish since the function takes \`&self\` and the pre-condition is identical from outside.

Documented in #543 alongside the node/ecdh.rs survivors.

## Validation
- \`cargo fmt --all\`
- \`cargo clippy --workspace --all-targets -- -D warnings\`
- \`cargo test --workspace\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for ECDH session management and cryptographic operations, including session ID derivation, partial computation, share aggregation, and lifecycle validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->