### PR TITLE
tests: descriptor.rs unit coverage on byte-scan helpers (round-3 of #417)

### DIFF
--- a/keep-core/src/descriptor.rs
+++ b/keep-core/src/descriptor.rs
@@ -182,4 +182,160 @@ mod tests {
             "wsh(sortedmulti(2,xpub1/1/*,xpub2/1/*))"
         );
     }
+
+    // === #417 round 3: targeted unit tests killing the byte-scan mutants ===
+
+    /// `contains_tail` MUST reject the doubled-slash pattern `//{digit}/*)`.
+    /// A regression on the `i == 0 || bytes[i - 1] != b'/'` guard would let a
+    /// descriptor with a bogus `//0/*)` substring drive the rewrite path,
+    /// producing nonsense output. Both the i==0 boundary and the prior-byte
+    /// check are pinned here.
+    #[test]
+    fn contains_tail_rejects_doubled_slash() {
+        assert!(!contains_tail("xpub..//0/*)", '0'));
+        assert!(!contains_tail("xpub..//1/*)", '1'));
+        // ...but a single slash with the same shape DOES match.
+        assert!(contains_tail("xpub../0/*)", '0'));
+    }
+
+    /// The `i == 0` boundary in the prior-byte guard: a descriptor body
+    /// starting with the tail itself MUST match. Mutating the equality flips
+    /// every match through the prior-byte check, which underflows or matches
+    /// the wrong byte when `i == 0`.
+    #[test]
+    fn contains_tail_matches_at_position_zero() {
+        assert!(contains_tail("/0/*)", '0'));
+        assert!(contains_tail("/1/*,", '1'));
+    }
+
+    /// The trailing byte must be `)` or `,`. Any other character (including
+    /// space, end-of-string, or `/`) MUST NOT match, otherwise the rewrite
+    /// fires on arbitrary nested paths and the descriptor becomes malformed.
+    #[test]
+    fn contains_tail_requires_close_paren_or_comma_after_star() {
+        // The five-byte window is /0/*X; X must be ) or , .
+        assert!(!contains_tail("xpub.../0/* ", '0'));
+        assert!(!contains_tail("xpub.../0/*/", '0'));
+        assert!(!contains_tail("xpub.../0/*x", '0'));
+        // Exactly at end-of-string the next byte doesn't exist — loop
+        // condition `i + 4 < bytes.len()` excludes the last 4-byte window,
+        // so a body ending in `/0/*` with no trailing byte cannot match.
+        assert!(!contains_tail("/0/*", '0'));
+    }
+
+    /// `contains_tail` MUST NOT match a wrong digit. Pin `contains_tail("/0/*)", '1')`
+    /// → false and the reverse → true so a regression that ignores the digit
+    /// parameter (e.g. replaces `bytes[i + 1] == digit_byte` with `true`) is
+    /// caught.
+    #[test]
+    fn contains_tail_only_matches_the_requested_digit() {
+        assert!(!contains_tail("xpub.../0/*)", '1'));
+        assert!(!contains_tail("xpub.../1/*)", '0'));
+        // Both digits exist as terminating tails in the body; each call
+        // matches only its own.
+        let mixed = "wsh(sortedmulti(2,xpub1/0/*,xpub2/1/*))";
+        assert!(contains_tail(mixed, '0'));
+        assert!(contains_tail(mixed, '1'));
+    }
+
+    /// `rewrite_trailing_zero_star` MUST be the identity on inputs with no
+    /// terminating `/0/*` tail. A regression that always emits the rewrite
+    /// would corrupt unrelated descriptors and any input containing a `/1/*`
+    /// (the change descriptor) would lose its derivation tail.
+    #[test]
+    fn rewrite_trailing_zero_star_is_identity_when_no_match() {
+        // No /0/* tail at all.
+        assert_eq!(
+            rewrite_trailing_zero_star("tr(xpub.../1/*)"),
+            "tr(xpub.../1/*)"
+        );
+        // Empty body.
+        assert_eq!(rewrite_trailing_zero_star(""), "");
+        // Multipath marker already present.
+        let already = "tr(xpub.../<0;1>/*)";
+        assert_eq!(rewrite_trailing_zero_star(already), already);
+        // Doubled-slash pattern — anchoring rejects.
+        let doubled = "tr(xpub..//0/*)";
+        assert_eq!(rewrite_trailing_zero_star(doubled), doubled);
+    }
+
+    /// `rewrite_trailing_zero_star` preserves content before AND after the
+    /// matched tail. A regression that drops the `out.push_str(&body[run_start..i])`
+    /// would silently truncate the prefix; one that drops the trailing copy
+    /// after the loop would silently truncate the suffix. The input is
+    /// asymmetric on purpose: a distinctive origin-info prefix and a checksum
+    /// suffix flank a single rewrite, so dropping either copy fails uniquely.
+    #[test]
+    fn rewrite_trailing_zero_star_preserves_prefix_and_suffix() {
+        let input = "tr([deadbeef/86'/0'/0']xpub.../0/*)#abcd1234";
+        let out = rewrite_trailing_zero_star(input);
+        assert_eq!(out, "tr([deadbeef/86'/0'/0']xpub.../<0;1>/*)#abcd1234");
+    }
+
+    /// `rewrite_trailing_zero_to_one` is the identity on inputs without a
+    /// terminating `/0/*`. Same anchoring as `rewrite_trailing_zero_star`;
+    /// pin both functions independently in case the implementation diverges.
+    #[test]
+    fn rewrite_trailing_zero_to_one_is_identity_when_no_match() {
+        assert_eq!(
+            rewrite_trailing_zero_to_one("tr(xpub.../1/*)"),
+            "tr(xpub.../1/*)"
+        );
+        assert_eq!(rewrite_trailing_zero_to_one(""), "");
+        let doubled = "tr(xpub..//0/*)";
+        assert_eq!(rewrite_trailing_zero_to_one(doubled), doubled);
+    }
+
+    /// `has_multipath_marker` matches the exact `<0;1>` and `<1;0>` literals,
+    /// NOT partial forms. A regression that checks for `<` alone or just
+    /// `0;1` would let any descriptor with a stray `<` slip past the marker
+    /// gate and reach the rewrite path with a malformed shape.
+    #[test]
+    fn has_multipath_marker_requires_exact_literal() {
+        assert!(has_multipath_marker("tr(xpub.../<0;1>/*)"));
+        assert!(has_multipath_marker("tr(xpub.../<1;0>/*)"));
+
+        // Partial matches must not register.
+        assert!(!has_multipath_marker("tr(xpub.../0;1/*)"));
+        assert!(!has_multipath_marker("tr(xpub.../<0;/*)"));
+        assert!(!has_multipath_marker("tr(xpub.../0;1>/*)"));
+        // Empty body.
+        assert!(!has_multipath_marker(""));
+        // Non-matching substring.
+        assert!(!has_multipath_marker("tr(xpub.../0/*)"));
+    }
+
+    /// `has_single_path_tail` MUST return true if EITHER `/0/*` or `/1/*`
+    /// terminates the body. A regression that drops one of the two
+    /// `contains_tail` checks (e.g. swaps `||` for `&&`) would let one
+    /// digit slip past, defeating the gate's purpose.
+    #[test]
+    fn has_single_path_tail_matches_either_digit() {
+        assert!(has_single_path_tail("tr(xpub.../0/*)"));
+        assert!(has_single_path_tail("tr(xpub.../1/*)"));
+        // Multipath: neither single-path tail matches.
+        assert!(!has_single_path_tail("tr(xpub.../<0;1>/*)"));
+        // Empty body.
+        assert!(!has_single_path_tail(""));
+    }
+
+    /// The inner-window bound `i + 4 < bytes.len()` MUST stay strict. With
+    /// `<=`, an input of length exactly 4 (e.g. `"/0/*"`) would let the if
+    /// chain index `bytes[i + 4]` past the end, panicking the rewrite. Pin
+    /// both rewrite functions with a length-4 input so the mutation is
+    /// caught as a test panic.
+    #[test]
+    fn rewrite_handles_minimum_length_input_without_panicking() {
+        // The body "/0/*" is exactly the 4-byte tail with no trailing
+        // ')' or ',', so neither rewrite function should match. The
+        // `< → <=` mutation on the window bound would push past the
+        // end of the slice during the `matches!(bytes[i + 4], ...)`
+        // check and panic.
+        assert_eq!(rewrite_trailing_zero_star("/0/*"), "/0/*");
+        assert_eq!(rewrite_trailing_zero_to_one("/0/*"), "/0/*");
+        // Length-4 with a non-matching prefix — exercises the same
+        // boundary at i+4 == 4.
+        assert_eq!(rewrite_trailing_zero_star("xyzw"), "xyzw");
+        assert_eq!(rewrite_trailing_zero_to_one("xyzw"), "xyzw");
+    }
 }


### PR DESCRIPTION
Round 3 of #417 (mutation testing on security-critical modules). Rounds 1 (signing.rs, PR #542) and 2 (ecdh modules, PR #544) shipped previously; this is \`keep-core/src/descriptor.rs\` (117 mutants). The two larger \`keep-frost-net\` descriptor-session files (169 + 9 mutants) stay queued for round 3b.

## Baseline mutation run

\`\`\`
cargo mutants -p keep-core --file keep-core/src/descriptor.rs --jobs 2 --timeout-multiplier 2.0
\`\`\`

117 mutants in ~53 min:
- **53 caught** (45%)
- **58 timeouts** (50%) — byte-scan code with mutated index arithmetic causes infinite loops, which cargo-mutants categorizes separately but is effectively "detected"
- **6 missed** (5%)
- **0 unviable**

Effective survival rate after the baseline: 5%.

## Tests added (10 new tests)

Targeting the 6 surviving mutations:

- \`contains_tail_rejects_doubled_slash\`: kills the \`==\` ↔ \`!=\` mutation on the \`i == 0\` boundary guard. Pins that the doubled-slash pattern \`//{digit}/*)\` is rejected — without this guard, a descriptor with a bogus \`//0/*)\` substring would drive the rewrite path.
- \`contains_tail_matches_at_position_zero\`: pins the \`i == 0\` short-circuit so a descriptor body STARTING with the tail itself matches (the prior-byte guard must not underflow).
- \`contains_tail_requires_close_paren_or_comma_after_star\`: locks the 5-byte window's terminal byte requirement.
- \`contains_tail_only_matches_the_requested_digit\`: pins that the \`digit\` parameter actually drives the match (catches a "replace with true" regression on \`bytes[i + 1] == digit_byte\`).
- \`rewrite_trailing_zero_star_is_identity_when_no_match\`: covers empty/no-match/already-multipath/doubled-slash inputs.
- \`rewrite_trailing_zero_star_preserves_prefix_and_suffix\`: kills truncation regressions on the prefix-copy and trailing-suffix paths.
- \`rewrite_trailing_zero_to_one_is_identity_when_no_match\`: same shape, independent function — pinning both in case the implementations diverge.
- \`has_multipath_marker_requires_exact_literal\`: pins both \`<0;1>\` and \`<1;0>\` literals and rejects partial forms (\`0;1\`, \`<0;\`, \`0;1>\`).
- \`has_single_path_tail_matches_either_digit\`: kills the \`||\` ↔ \`&&\` mutation that would drop one of the two digit checks.
- \`rewrite_handles_minimum_length_input_without_panicking\`: kills the \`< → <=\` mutation on the inner window bound (\`i + 4 < bytes.len()\`). With \`<=\`, an input of length 4 (e.g. \`/0/*\`) would let the if chain index \`bytes[i + 4]\` past the end and panic. Pinning both rewrite functions with length-4 inputs catches both site mutations.

## Equivalent mutations NOT chased

The other 5 surviving \`< → <=\` mutations are genuinely equivalent on the observable behavior:

- \`rewrite_trailing_zero_star\` line 45 (\`while i < bytes.len()\`) and the matching line 79 in the sibling function: when \`i == bytes.len()\`, the inner check \`i + 4 < bytes.len()\` short-circuits to false, the if branch doesn't fire, and the next \`i += 1\` makes the loop exit with \`<=\`. One extra iteration with no effect.
- Lines 54 / 64 (\`if run_start < i {\` / \`if run_start < bytes.len() {\`): when the bounds are equal, \`push_str(&body[i..i])\` pushes an empty string. No-op.

Documented in the PR body rather than silently \`#[mutants::skip]\`'d so a future reader can verify the equivalence argument.

## Validation
- \`cargo fmt --all\`
- \`cargo clippy --workspace --all-targets -- -D warnings\`
- \`cargo test --workspace\`

## Up next
- Round 3b: \`keep-frost-net/src/descriptor_session.rs\` (169 mutants) + \`descriptor_session_store.rs\` (9 mutants).
- Round 4: sweep + prevout validation (#414 area).
- Round 5: \`keep-nip46/src/server.rs\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for descriptor tail detection and rewrite functionality. Tests validate correctness, verify safety properties, ensure robust behavior across edge cases and boundary conditions, and confirm proper error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->