### PR TITLE
tests: sweep boundary + PSBT signer coverage (round-4a of #417)

### DIFF
--- a/keep-bitcoin/src/psbt.rs
+++ b/keep-bitcoin/src/psbt.rs
@@ -247,6 +247,7 @@ pub fn serialize_psbt_base64(psbt: &Psbt) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bitcoin::hashes::Hash;
 
     #[test]
     fn test_psbt_signer_creation() {
@@ -255,5 +256,164 @@ mod tests {
 
         let pubkey = signer.x_only_public_key();
         assert_eq!(pubkey.serialize().len(), 32);
+    }
+
+    // === #417 round 4a: targeted unit tests killing the surviving mutations ===
+
+    /// `parse_psbt(serialize_psbt(p)) == p`. The `serialize_psbt → vec![]`
+    /// and `vec![0]` / `vec![1]` regressions all produce non-PSBT bytes
+    /// that `parse_psbt` rejects, so this roundtrip catches every constant-
+    /// return mutation on `serialize_psbt`. A `serialize_psbt_base64` →
+    /// `"xyzzy"` regression is caught the same way through `parse_psbt_base64`.
+    #[test]
+    fn psbt_serialization_roundtrip() {
+        use bitcoin::{
+            absolute::LockTime, transaction::Version, OutPoint, Sequence, Transaction, TxIn, TxOut,
+            Witness,
+        };
+        let tx = Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: bitcoin::Txid::all_zeros(),
+                    vout: 0,
+                },
+                script_sig: bitcoin::ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: bitcoin::Amount::from_sat(50_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+        let psbt = Psbt::from_unsigned_tx(tx).unwrap();
+
+        // Binary roundtrip.
+        let bytes = serialize_psbt(&psbt);
+        assert!(!bytes.is_empty(), "serialize_psbt must not return empty");
+        let parsed = parse_psbt(&bytes).expect("must roundtrip through binary");
+        assert_eq!(parsed.unsigned_tx, psbt.unsigned_tx);
+
+        // Base64 roundtrip.
+        let b64 = serialize_psbt_base64(&psbt);
+        assert!(
+            !b64.is_empty(),
+            "serialize_psbt_base64 must not return empty"
+        );
+        let parsed = parse_psbt_base64(&b64).expect("must roundtrip through base64");
+        assert_eq!(parsed.unsigned_tx, psbt.unsigned_tx);
+    }
+
+    /// `should_sign_input` returns true iff any of the three conditions
+    /// match (internal_key, tap_key_origins, or script_pubkey of our
+    /// address). A constant `Ok(true)` regression would make this signer
+    /// sign EVERY input it sees, including ones not actually addressed to
+    /// it. A constant `Ok(false)` would refuse to sign anything.
+    #[test]
+    fn should_sign_input_returns_false_for_unrelated_input() {
+        use bitcoin::{
+            absolute::LockTime, transaction::Version, OutPoint, Sequence, Transaction, TxIn, TxOut,
+            Witness,
+        };
+        let mut our_secret = [1u8; 32];
+        let signer = PsbtSigner::new(&mut our_secret, Network::Testnet).unwrap();
+
+        // Build a PSBT whose witness_utxo's script_pubkey points to a
+        // DIFFERENT taproot key (we use [2; 32] as the other party's
+        // secret-derived xonly proxy).
+        let mut other_secret = [2u8; 32];
+        let other_signer = PsbtSigner::new(&mut other_secret, Network::Testnet).unwrap();
+        let other_addr = Address::p2tr(
+            &Secp256k1::new(),
+            other_signer.x_only_public_key(),
+            None,
+            Network::Testnet,
+        );
+
+        let tx = Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: bitcoin::Txid::all_zeros(),
+                    vout: 0,
+                },
+                script_sig: bitcoin::ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: bitcoin::Amount::from_sat(50_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: bitcoin::Amount::from_sat(60_000),
+            script_pubkey: other_addr.script_pubkey(),
+        });
+
+        // Our signer is unrelated to this input; should_sign_input must
+        // return false. A `Ok(true)` regression here would have us
+        // sign an input whose UTXO we don't control.
+        assert!(!signer.should_sign_input(&psbt, 0).unwrap());
+    }
+
+    /// `sign` returns the count of inputs the signer actually signed. A
+    /// `Ok(0)` / `Ok(1)` constant-return regression would silently report
+    /// the wrong success state to the caller, who routes the signed PSBT
+    /// based on this count.
+    #[test]
+    fn sign_returns_zero_when_no_inputs_match_our_key() {
+        use bitcoin::{
+            absolute::LockTime, transaction::Version, OutPoint, Sequence, Transaction, TxIn, TxOut,
+            Witness,
+        };
+        let mut our_secret = [1u8; 32];
+        let signer = PsbtSigner::new(&mut our_secret, Network::Testnet).unwrap();
+
+        // Same setup as above: a PSBT whose only input is addressed to
+        // someone else. `sign` should iterate and skip every input,
+        // returning 0.
+        let mut other_secret = [2u8; 32];
+        let other_signer = PsbtSigner::new(&mut other_secret, Network::Testnet).unwrap();
+        let other_addr = Address::p2tr(
+            &Secp256k1::new(),
+            other_signer.x_only_public_key(),
+            None,
+            Network::Testnet,
+        );
+
+        let tx = Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: bitcoin::Txid::all_zeros(),
+                    vout: 0,
+                },
+                script_sig: bitcoin::ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: bitcoin::Amount::from_sat(50_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: bitcoin::Amount::from_sat(60_000),
+            script_pubkey: other_addr.script_pubkey(),
+        });
+
+        let signed = signer.sign(&mut psbt).unwrap();
+        assert_eq!(signed, 0, "sign must report zero when no inputs match");
+        assert!(
+            psbt.inputs[0].tap_key_sig.is_none(),
+            "no signature should be written for an unrelated input"
+        );
     }
 }

--- a/keep-bitcoin/src/psbt.rs
+++ b/keep-bitcoin/src/psbt.rs
@@ -260,13 +260,7 @@ mod tests {
 
     // === #417 round 4a: targeted unit tests killing the surviving mutations ===
 
-    /// `parse_psbt(serialize_psbt(p)) == p`. The `serialize_psbt → vec![]`
-    /// and `vec![0]` / `vec![1]` regressions all produce non-PSBT bytes
-    /// that `parse_psbt` rejects, so this roundtrip catches every constant-
-    /// return mutation on `serialize_psbt`. A `serialize_psbt_base64` →
-    /// `"xyzzy"` regression is caught the same way through `parse_psbt_base64`.
-    #[test]
-    fn psbt_serialization_roundtrip() {
+    fn fixture_psbt_to(spk: bitcoin::ScriptBuf, value: u64) -> Psbt {
         use bitcoin::{
             absolute::LockTime, transaction::Version, OutPoint, Sequence, Transaction, TxIn, TxOut,
             Witness,
@@ -288,7 +282,35 @@ mod tests {
                 script_pubkey: bitcoin::ScriptBuf::new(),
             }],
         };
-        let psbt = Psbt::from_unsigned_tx(tx).unwrap();
+        let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: bitcoin::Amount::from_sat(value),
+            script_pubkey: spk,
+        });
+        psbt
+    }
+
+    fn own_address(signer: &PsbtSigner) -> Address {
+        Address::p2tr(
+            &Secp256k1::new(),
+            signer.x_only_public_key(),
+            None,
+            Network::Testnet,
+        )
+    }
+
+    fn other_address(secret: &mut [u8; 32]) -> Address {
+        own_address(&PsbtSigner::new(secret, Network::Testnet).unwrap())
+    }
+
+    /// `parse_psbt(serialize_psbt(p)) == p`. The `serialize_psbt → vec![]`
+    /// and `vec![0]` / `vec![1]` regressions all produce non-PSBT bytes
+    /// that `parse_psbt` rejects, so this roundtrip catches every constant-
+    /// return mutation on `serialize_psbt`. A `serialize_psbt_base64` →
+    /// `"xyzzy"` regression is caught the same way through `parse_psbt_base64`.
+    #[test]
+    fn psbt_serialization_roundtrip() {
+        let psbt = fixture_psbt_to(bitcoin::ScriptBuf::new(), 60_000);
 
         // Binary roundtrip.
         let bytes = serialize_psbt(&psbt);
@@ -306,114 +328,71 @@ mod tests {
         assert_eq!(parsed.unsigned_tx, psbt.unsigned_tx);
     }
 
-    /// `should_sign_input` returns true iff any of the three conditions
-    /// match (internal_key, tap_key_origins, or script_pubkey of our
-    /// address). A constant `Ok(true)` regression would make this signer
-    /// sign EVERY input it sees, including ones not actually addressed to
-    /// it. A constant `Ok(false)` would refuse to sign anything.
+    /// `should_sign_input` returns false for an input whose witness_utxo
+    /// belongs to a different taproot key. A constant `Ok(true)`
+    /// regression would have us sign an input whose UTXO we don't control.
     #[test]
     fn should_sign_input_returns_false_for_unrelated_input() {
-        use bitcoin::{
-            absolute::LockTime, transaction::Version, OutPoint, Sequence, Transaction, TxIn, TxOut,
-            Witness,
-        };
         let mut our_secret = [1u8; 32];
         let signer = PsbtSigner::new(&mut our_secret, Network::Testnet).unwrap();
 
-        // Build a PSBT whose witness_utxo's script_pubkey points to a
-        // DIFFERENT taproot key (we use [2; 32] as the other party's
-        // secret-derived xonly proxy).
         let mut other_secret = [2u8; 32];
-        let other_signer = PsbtSigner::new(&mut other_secret, Network::Testnet).unwrap();
-        let other_addr = Address::p2tr(
-            &Secp256k1::new(),
-            other_signer.x_only_public_key(),
-            None,
-            Network::Testnet,
-        );
+        let other_addr = other_address(&mut other_secret);
+        let psbt = fixture_psbt_to(other_addr.script_pubkey(), 60_000);
 
-        let tx = Transaction {
-            version: Version(2),
-            lock_time: LockTime::ZERO,
-            input: vec![TxIn {
-                previous_output: OutPoint {
-                    txid: bitcoin::Txid::all_zeros(),
-                    vout: 0,
-                },
-                script_sig: bitcoin::ScriptBuf::new(),
-                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-                witness: Witness::default(),
-            }],
-            output: vec![TxOut {
-                value: bitcoin::Amount::from_sat(50_000),
-                script_pubkey: bitcoin::ScriptBuf::new(),
-            }],
-        };
-        let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
-        psbt.inputs[0].witness_utxo = Some(TxOut {
-            value: bitcoin::Amount::from_sat(60_000),
-            script_pubkey: other_addr.script_pubkey(),
-        });
-
-        // Our signer is unrelated to this input; should_sign_input must
-        // return false. A `Ok(true)` regression here would have us
-        // sign an input whose UTXO we don't control.
         assert!(!signer.should_sign_input(&psbt, 0).unwrap());
     }
 
-    /// `sign` returns the count of inputs the signer actually signed. A
-    /// `Ok(0)` / `Ok(1)` constant-return regression would silently report
-    /// the wrong success state to the caller, who routes the signed PSBT
-    /// based on this count.
+    /// `should_sign_input` returns true when the input's witness_utxo
+    /// script_pubkey is the signer's own p2tr address (the script_pubkey
+    /// match arm). A constant `Ok(false)` regression would refuse to sign
+    /// an input we actually control.
+    #[test]
+    fn should_sign_input_returns_true_for_our_own_p2tr_input() {
+        let mut our_secret = [1u8; 32];
+        let signer = PsbtSigner::new(&mut our_secret, Network::Testnet).unwrap();
+        let our_addr = own_address(&signer);
+        let psbt = fixture_psbt_to(our_addr.script_pubkey(), 60_000);
+
+        assert!(signer.should_sign_input(&psbt, 0).unwrap());
+    }
+
+    /// `sign` returns 0 when no input matches our key and writes no
+    /// signature. A constant `Ok(1)` regression would report a phantom
+    /// signed input.
     #[test]
     fn sign_returns_zero_when_no_inputs_match_our_key() {
-        use bitcoin::{
-            absolute::LockTime, transaction::Version, OutPoint, Sequence, Transaction, TxIn, TxOut,
-            Witness,
-        };
         let mut our_secret = [1u8; 32];
         let signer = PsbtSigner::new(&mut our_secret, Network::Testnet).unwrap();
 
-        // Same setup as above: a PSBT whose only input is addressed to
-        // someone else. `sign` should iterate and skip every input,
-        // returning 0.
         let mut other_secret = [2u8; 32];
-        let other_signer = PsbtSigner::new(&mut other_secret, Network::Testnet).unwrap();
-        let other_addr = Address::p2tr(
-            &Secp256k1::new(),
-            other_signer.x_only_public_key(),
-            None,
-            Network::Testnet,
-        );
-
-        let tx = Transaction {
-            version: Version(2),
-            lock_time: LockTime::ZERO,
-            input: vec![TxIn {
-                previous_output: OutPoint {
-                    txid: bitcoin::Txid::all_zeros(),
-                    vout: 0,
-                },
-                script_sig: bitcoin::ScriptBuf::new(),
-                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-                witness: Witness::default(),
-            }],
-            output: vec![TxOut {
-                value: bitcoin::Amount::from_sat(50_000),
-                script_pubkey: bitcoin::ScriptBuf::new(),
-            }],
-        };
-        let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
-        psbt.inputs[0].witness_utxo = Some(TxOut {
-            value: bitcoin::Amount::from_sat(60_000),
-            script_pubkey: other_addr.script_pubkey(),
-        });
+        let other_addr = other_address(&mut other_secret);
+        let mut psbt = fixture_psbt_to(other_addr.script_pubkey(), 60_000);
 
         let signed = signer.sign(&mut psbt).unwrap();
         assert_eq!(signed, 0, "sign must report zero when no inputs match");
         assert!(
             psbt.inputs[0].tap_key_sig.is_none(),
             "no signature should be written for an unrelated input"
+        );
+    }
+
+    /// `sign` signs an input addressed to our own key, writes the taproot
+    /// key-spend signature, and reports the count. This drives
+    /// `sign_taproot_keypath`; a constant `Ok(0)` regression would leave
+    /// `tap_key_sig` unset while reporting nothing signed.
+    #[test]
+    fn sign_signs_our_own_input_and_reports_count() {
+        let mut our_secret = [1u8; 32];
+        let signer = PsbtSigner::new(&mut our_secret, Network::Testnet).unwrap();
+        let our_addr = own_address(&signer);
+        let mut psbt = fixture_psbt_to(our_addr.script_pubkey(), 60_000);
+
+        let signed = signer.sign(&mut psbt).unwrap();
+        assert_eq!(signed, 1, "sign must report one signed input");
+        assert!(
+            psbt.inputs[0].tap_key_sig.is_some(),
+            "a signature must be written for our own input"
         );
     }
 }

--- a/keep-bitcoin/src/recovery_tx.rs
+++ b/keep-bitcoin/src/recovery_tx.rs
@@ -1059,12 +1059,10 @@ mod tests {
         assert!(err.to_string().contains("dust threshold"));
     }
 
-    /// `verify_script_spend_input_binding` rejects when the witness_utxo
-    /// is missing, when the script_pubkey doesn't match, or when the
-    /// tap_scripts entry doesn't match the expected leaf. Several `delete
-    /// !` mutations would silently accept an attacker-supplied PSBT with
-    /// wrong bindings. Cover the missing-witness_utxo case since it's
-    /// the cheapest to construct without a full PSBT fixture.
+    /// Pins only the `MissingWitnessUtxo` early return: a PSBT with the
+    /// witness_utxo stripped is rejected before any of the three binding
+    /// checks run. The checks themselves are pinned by the dedicated
+    /// success and negative tests below.
     #[test]
     fn verify_script_spend_input_binding_refuses_psbt_with_no_witness_utxo() {
         let builder = fixture_builder();
@@ -1083,6 +1081,100 @@ mod tests {
             result.is_err(),
             "missing witness_utxo must surface a binding error"
         );
+    }
+
+    /// Success path: a PSBT built by the real builder passes all three
+    /// security checks (P2TR witness_utxo, control block commits to the
+    /// output key, leaf script references the local x-only key) and
+    /// returns the verified sighash bundle. This drives every `!`-negated
+    /// guard through its accept branch, so a `delete !` mutation on any of
+    /// them flips this success into a failure.
+    #[test]
+    fn verify_script_spend_input_binding_accepts_valid_psbt() {
+        let builder = fixture_builder();
+        let utxo = fixture_outpoint();
+        let dest = fixture_dest();
+        let (_, local_pk) = test_keypair_full(2);
+
+        let psbt = builder
+            .build_recovery_psbt(0, utxo, 100_000, &dest, 1_000)
+            .unwrap();
+
+        let bundle = verify_script_spend_input_binding(&psbt, 0, &local_pk).unwrap();
+        assert_eq!(bundle.input_index, 0);
+    }
+
+    /// Trips the P2TR check: a witness_utxo whose script_pubkey is not a
+    /// 34-byte P2TR output is rejected. A `delete !` on the `!is_p2tr()`
+    /// guard would accept a non-P2TR output.
+    #[test]
+    fn verify_script_spend_input_binding_rejects_non_p2tr_witness_utxo() {
+        let builder = fixture_builder();
+        let utxo = fixture_outpoint();
+        let dest = fixture_dest();
+        let (_, local_pk) = test_keypair_full(2);
+
+        let mut psbt = builder
+            .build_recovery_psbt(0, utxo, 100_000, &dest, 1_000)
+            .unwrap();
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey: ScriptBuf::new(),
+        });
+
+        let err = verify_script_spend_input_binding(&psbt, 0, &local_pk).unwrap_err();
+        assert!(err.to_string().contains("not a P2TR output"));
+    }
+
+    /// Trips the taproot-commitment check: a valid P2TR witness_utxo whose
+    /// output key differs from the one the tap_scripts control block
+    /// commits to is rejected. A `delete !` on
+    /// `!verify_taproot_commitment(...)` would accept a leaf that isn't
+    /// part of the spent output's taproot tree.
+    #[test]
+    fn verify_script_spend_input_binding_rejects_uncommitted_control_block() {
+        let builder = fixture_builder();
+        let utxo = fixture_outpoint();
+        let dest = fixture_dest();
+        let (_, local_pk) = test_keypair_full(2);
+
+        let mut psbt = builder
+            .build_recovery_psbt(0, utxo, 100_000, &dest, 1_000)
+            .unwrap();
+        // Swap in a valid but unrelated P2TR output key; the control
+        // block no longer commits to it.
+        let (_, other_pk) = test_keypair_full(9);
+        let other_xonly = XOnlyPublicKey::from_slice(&other_pk).unwrap();
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey: ScriptBuf::new_p2tr(&Secp256k1::new(), other_xonly, None),
+        });
+
+        let err = verify_script_spend_input_binding(&psbt, 0, &local_pk).unwrap_err();
+        assert!(err.to_string().contains("does not commit"));
+    }
+
+    /// Trips the leaf-key check: even with a valid P2TR witness_utxo and a
+    /// committing control block, a local x-only key absent from the leaf
+    /// script is rejected. A `delete !` on `!script_contains_xonly(...)`
+    /// would let a malicious proposer bind the responder to an unrelated
+    /// leaf.
+    #[test]
+    fn verify_script_spend_input_binding_rejects_local_key_absent_from_leaf() {
+        let builder = fixture_builder();
+        let utxo = fixture_outpoint();
+        let dest = fixture_dest();
+        // Key 9 participates in no tier built by fixture_builder.
+        let (_, absent_pk) = test_keypair_full(9);
+
+        let psbt = builder
+            .build_recovery_psbt(0, utxo, 100_000, &dest, 1_000)
+            .unwrap();
+
+        let err = verify_script_spend_input_binding(&psbt, 0, &absent_pk).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("does not reference the local responder"));
     }
 
     /// `script_contains_xonly` is a small but security-critical helper:

--- a/keep-bitcoin/src/recovery_tx.rs
+++ b/keep-bitcoin/src/recovery_tx.rs
@@ -880,4 +880,230 @@ mod tests {
             .count();
         assert_eq!(sig_count, 2);
     }
+
+    // === #417 round 4a: targeted unit tests killing the surviving mutations ===
+    //
+    // The boundary checks below are #414/#502's exact security boundary:
+    // - `fee_sats > MAX_FEE_SATS` (defends against runaway fees)
+    // - `utxo_value <= fee_sats` (insufficient funds)
+    // - `output_value < TAPROOT_DUST_LIMIT_SATS` (dust)
+    //
+    // `>` ↔ `==` / `>=` and `<` ↔ `==` / `<=` mutations on these checks
+    // would let through "exactly at the cap" inputs or skip the gate
+    // entirely on a malicious proposer-supplied amount, exactly the
+    // attack surface #414 describes.
+
+    fn fixture_builder() -> RecoveryTxBuilder {
+        let (_, pk1) = test_keypair_full(1);
+        let (_, pk2) = test_keypair_full(2);
+        let config = RecoveryConfig {
+            primary: SpendingTier {
+                keys: vec![pk1],
+                threshold: 1,
+            },
+            recovery_tiers: vec![RecoveryTier {
+                keys: vec![pk2],
+                threshold: 1,
+                timelock_months: 6,
+            }],
+            network: Network::Testnet,
+        };
+        let output = config.build().unwrap();
+        RecoveryTxBuilder::new(output)
+    }
+
+    fn fixture_outpoint() -> OutPoint {
+        OutPoint {
+            txid: bitcoin::Txid::all_zeros(),
+            vout: 0,
+        }
+    }
+
+    fn fixture_dest() -> ScriptBuf {
+        let (_, pk) = test_keypair_full(7);
+        let xonly = XOnlyPublicKey::from_slice(&pk).unwrap();
+        ScriptBuf::new_p2tr(&Secp256k1::new(), xonly, None)
+    }
+
+    /// Fee strictly equal to MAX_FEE_SATS is REJECTED only if `>` is
+    /// strict; a `>=` mutation would refuse exactly-at-cap fees,
+    /// while a `==` mutation would let above-cap fees slip past for
+    /// any non-equality. Both are corrupt; pin the exact boundary.
+    #[test]
+    fn build_recovery_psbt_rejects_fee_above_max_only() {
+        let builder = fixture_builder();
+        let utxo = fixture_outpoint();
+        let dest = fixture_dest();
+
+        // Exactly MAX_FEE_SATS is allowed (the `>` check is strict).
+        // Use a large enough utxo to leave output above dust.
+        assert!(
+            builder
+                .build_recovery_psbt(0, utxo, MAX_FEE_SATS + 1_000, &dest, MAX_FEE_SATS)
+                .is_ok(),
+            "fee exactly at the MAX_FEE_SATS cap must be allowed"
+        );
+
+        // One sat above the cap is refused.
+        let err = builder
+            .build_recovery_psbt(0, utxo, MAX_FEE_SATS + 2_000, &dest, MAX_FEE_SATS + 1)
+            .unwrap_err();
+        assert!(err.to_string().contains("exceeds maximum"));
+    }
+
+    /// `utxo_value <= fee_sats` means we have no output value left after
+    /// paying the fee. The `<` ↔ `==` or `<=` mutation would either
+    /// silently accept a zero-output transaction (which is non-standard)
+    /// or refuse the legitimate one-sat-above-fee case.
+    #[test]
+    fn build_recovery_psbt_rejects_when_fee_equals_or_exceeds_utxo_value() {
+        let builder = fixture_builder();
+        let utxo = fixture_outpoint();
+        let dest = fixture_dest();
+
+        // fee == utxo_value: output value is zero, refused.
+        let err = builder
+            .build_recovery_psbt(0, utxo, 1_000, &dest, 1_000)
+            .unwrap_err();
+        assert!(err.to_string().contains("insufficient funds"));
+
+        // fee > utxo_value: also refused.
+        let err = builder
+            .build_recovery_psbt(0, utxo, 1_000, &dest, 1_001)
+            .unwrap_err();
+        assert!(err.to_string().contains("insufficient funds"));
+    }
+
+    /// The dust threshold check is strict: an output of EXACTLY
+    /// TAPROOT_DUST_LIMIT_SATS is allowed; one below is refused. A `<` ↔
+    /// `==` or `<=` mutation would either refuse the legal exactly-dust
+    /// boundary (defeating recovery on tight budgets) or accept a
+    /// 1-sat-below-dust output (producing a non-standard tx that
+    /// mempool would reject anyway, but the call still succeeds).
+    #[test]
+    fn build_recovery_psbt_dust_boundary_is_strict() {
+        let builder = fixture_builder();
+        let utxo = fixture_outpoint();
+        let dest = fixture_dest();
+
+        // output == dust limit: allowed.
+        let utxo_value = TAPROOT_DUST_LIMIT_SATS + 100;
+        let fee = 100;
+        assert!(
+            builder
+                .build_recovery_psbt(0, utxo, utxo_value, &dest, fee)
+                .is_ok(),
+            "output exactly at dust limit must be allowed"
+        );
+
+        // output == dust limit - 1: refused.
+        let utxo_value = TAPROOT_DUST_LIMIT_SATS + 100;
+        let fee = 101;
+        let err = builder
+            .build_recovery_psbt(0, utxo, utxo_value, &dest, fee)
+            .unwrap_err();
+        assert!(err.to_string().contains("dust threshold"));
+    }
+
+    /// Same three boundary invariants for `build_sweep_psbt`: fee cap,
+    /// insufficient funds, dust. The sweep path has its own surviving
+    /// mutations on each, and an authorized proposer attacks the sweep
+    /// path the same way as the single-input recovery path.
+    #[test]
+    fn build_sweep_psbt_rejects_fee_above_max_only() {
+        let builder = fixture_builder();
+        let dest = fixture_dest();
+        let utxos = vec![SweepUtxo {
+            outpoint: fixture_outpoint(),
+            value_sats: MAX_FEE_SATS + 1_000,
+        }];
+
+        // Exactly at the cap: allowed.
+        assert!(builder
+            .build_sweep_psbt(0, &utxos, &dest, MAX_FEE_SATS)
+            .is_ok());
+
+        // One above: refused.
+        let err = builder
+            .build_sweep_psbt(0, &utxos, &dest, MAX_FEE_SATS + 1)
+            .unwrap_err();
+        assert!(err.to_string().contains("exceeds maximum"));
+    }
+
+    /// `build_sweep_psbt` insufficient-funds boundary: pin `<= fee` is
+    /// rejected and `> fee` accepted (when above dust).
+    #[test]
+    fn build_sweep_psbt_rejects_when_total_inputs_equal_or_below_fee() {
+        let builder = fixture_builder();
+        let dest = fixture_dest();
+
+        // total == fee: refused.
+        let utxos = vec![SweepUtxo {
+            outpoint: fixture_outpoint(),
+            value_sats: 1_000,
+        }];
+        let err = builder
+            .build_sweep_psbt(0, &utxos, &dest, 1_000)
+            .unwrap_err();
+        assert!(err.to_string().contains("insufficient funds"));
+
+        // total > fee but output below dust: surfaces the dust error
+        // (not the insufficient-funds error). Pin both for clarity.
+        let utxos = vec![SweepUtxo {
+            outpoint: fixture_outpoint(),
+            value_sats: 1_000,
+        }];
+        let err = builder
+            .build_sweep_psbt(0, &utxos, &dest, 1_000 - (TAPROOT_DUST_LIMIT_SATS - 1))
+            .unwrap_err();
+        assert!(err.to_string().contains("dust threshold"));
+    }
+
+    /// `verify_script_spend_input_binding` rejects when the witness_utxo
+    /// is missing, when the script_pubkey doesn't match, or when the
+    /// tap_scripts entry doesn't match the expected leaf. Several `delete
+    /// !` mutations would silently accept an attacker-supplied PSBT with
+    /// wrong bindings. Cover the missing-witness_utxo case since it's
+    /// the cheapest to construct without a full PSBT fixture.
+    #[test]
+    fn verify_script_spend_input_binding_refuses_psbt_with_no_witness_utxo() {
+        let builder = fixture_builder();
+        let utxo = fixture_outpoint();
+        let dest = fixture_dest();
+        let (_, local_pk) = test_keypair_full(2);
+
+        // Build a valid recovery PSBT, then strip the witness_utxo.
+        let mut psbt = builder
+            .build_recovery_psbt(0, utxo, 100_000, &dest, 1_000)
+            .unwrap();
+        psbt.inputs[0].witness_utxo = None;
+
+        let result = verify_script_spend_input_binding(&psbt, 0, &local_pk);
+        assert!(
+            result.is_err(),
+            "missing witness_utxo must surface a binding error"
+        );
+    }
+
+    /// `script_contains_xonly` is a small but security-critical helper:
+    /// it scans a tap-script's pushdata for a 32-byte x-only key. A
+    /// `true`/`false`-return regression silently accepts any key as
+    /// present (or none); an `==` ↔ `!=` regression would match every
+    /// non-matching key.
+    #[test]
+    fn script_contains_xonly_only_matches_exact_32_byte_pushdata() {
+        let key_a = [0xAAu8; 32];
+        let key_b = [0xBBu8; 32];
+
+        // Script containing key_a as a pushdata.
+        let script_a = bitcoin::ScriptBuf::builder()
+            .push_slice(key_a)
+            .into_script();
+        assert!(script_contains_xonly(&script_a, &key_a));
+        assert!(!script_contains_xonly(&script_a, &key_b));
+
+        // Empty script never matches.
+        let empty = bitcoin::ScriptBuf::new();
+        assert!(!script_contains_xonly(&empty, &key_a));
+    }
 }


### PR DESCRIPTION
Round 4a of #417 (mutation testing on security-critical modules). Rounds 1 (signing.rs, PR #542), 2 (ecdh modules, PR #544), 3a (\`keep-core/src/descriptor.rs\`, PR #545), and 3b (\`keep-frost-net/src/descriptor_session.rs\`, PR #550) shipped previously. This is the \`keep-bitcoin\` half of the sweep/prevout validation paths (#414 / #502 area).

The much larger \`keep-frost-net/src/node/psbt.rs\` (147 mutants, 0 inline tests) is filed as round 4b under #551 — that file is mostly async coordination handlers and needs multi-peer integration test infrastructure (same shape as #541, #543, #549).

## Baseline mutation run

\`\`\`
cargo mutants -p keep-bitcoin \
  --file keep-bitcoin/src/recovery_tx.rs \
  --file keep-bitcoin/src/psbt.rs \
  --jobs 2 --timeout-multiplier 2.0
\`\`\`

86 mutants in ~2 min:
- **30 caught** (35%)
- **42 missed** (49%)
- **14 unviable** (16%)
- **0 timeouts**

## Tests added (10 new tests)

### \`keep-bitcoin/src/recovery_tx.rs\` (7 tests)

These pin the exact security boundary checks #414 and #502 care about. A \`>\` ↔ \`==\` / \`>=\` mutation on the fee cap, or a \`<\` ↔ \`==\` / \`<=\` mutation on the insufficient-funds / dust gates, would let a malicious authorized proposer slip an attacker-supplied amount past:

- \`build_recovery_psbt_rejects_fee_above_max_only\`: \`fee = MAX_FEE_SATS\` exactly is allowed; \`MAX_FEE_SATS + 1\` is refused. Pins the strict \`>\` boundary.
- \`build_recovery_psbt_rejects_when_fee_equals_or_exceeds_utxo_value\`: \`fee == utxo_value\` AND \`fee > utxo_value\` both refused with \"insufficient funds\".
- \`build_recovery_psbt_dust_boundary_is_strict\`: \`output == TAPROOT_DUST_LIMIT_SATS\` allowed; \`output == limit - 1\` refused.
- \`build_sweep_psbt_rejects_fee_above_max_only\`: same boundary, sweep path.
- \`build_sweep_psbt_rejects_when_total_inputs_equal_or_below_fee\`: insufficient-funds AND dust gates, sweep path.
- \`verify_script_spend_input_binding_refuses_psbt_with_no_witness_utxo\`: kills \"delete !\" regressions on the witness_utxo presence check — without this gate a malicious PSBT bypasses script-spend binding verification entirely.
- \`script_contains_xonly_only_matches_exact_32_byte_pushdata\`: kills the \`true\` / \`false\` constant-return regressions on a small but security-critical helper.

### \`keep-bitcoin/src/psbt.rs\` (3 tests)

- \`psbt_serialization_roundtrip\`: \`parse_psbt(serialize_psbt(p))\` and the base64 variant. Constant-return regressions on \`serialize_psbt\` (\`vec![]\`, \`vec![0]\`, \`vec![1]\`) and \`serialize_psbt_base64\` (\`String::new()\`, \`\"xyzzy\"\`) all produce non-PSBT bytes that \`parse_psbt\` rejects, so the roundtrip catches each.
- \`should_sign_input_returns_false_for_unrelated_input\`: builds a PSBT whose witness_utxo's \`script_pubkey\` points to someone else's taproot key; the signer must return false. \`Ok(true)\` regression would have the signer sign every input it sees (including ones not addressed to it).
- \`sign_returns_zero_when_no_inputs_match_our_key\`: the same setup as above, but checks \`sign\`'s return count. \`Ok(0)\` / \`Ok(1)\` constant-return regressions would silently report wrong success state to the caller, which routes signed PSBTs based on this count.

## Remaining survivors

Most of the surviving mutations in \`recovery_tx.rs\` and \`psbt.rs\` are on \`finalize_recovery\`, \`script_spend_sighashes\`, \`merge_tap_script_sig\`, \`sign_taproot_keypath\`, and \`is_change_output\` — these need full PSBT fixtures with real schnorr signatures, multi-input tap-script setups, or change-output tap_key_origins maps. Doable but each requires substantial fixture construction; better targeted by integration tests once the \`node/psbt.rs\` coordination work in round 4b (#551) lands.

## Validation
- \`cargo fmt --all\`
- \`cargo clippy --workspace --all-targets -- -D warnings\`
- \`cargo test --workspace\`

## Up next
- Round 4b (#551): \`keep-frost-net/src/node/psbt.rs\` — multi-peer integration tests covering the actual sweep/spend coordination.
- Round 5: \`keep-nip46/src/server.rs\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded PSBT roundtrip and format-conversion tests to ensure serialization/deserialization preserve unsigned transactions and signer behavior.
  * Added signer behavior tests confirming when inputs are/aren't signed and signature presence.
  * Added extensive boundary and security tests for recovery and sweep transaction construction: fee caps, insufficient-funds, dust thresholds, and script-spend binding/validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->