### PR TITLE
Set bunker expected_secret so NIP-46 URL includes secret param

### DIFF
--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -90,7 +90,8 @@ impl ServerCallbacks for CallbackBridge {
     }
 
     fn on_connect(&self, pubkey: &str, name: &str) {
-        self.callbacks.on_connect(pubkey.to_string(), name.to_string());
+        self.callbacks
+            .on_connect(pubkey.to_string(), name.to_string());
     }
 }
 

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -61,6 +61,7 @@ pub fn parse_bunker_url(url: &str) -> Result<ParsedBunkerUrl, KeepMobileError> {
 pub trait BunkerCallbacks: Send + Sync {
     fn on_log(&self, event: BunkerLogEvent);
     fn request_approval(&self, request: BunkerApprovalRequest) -> bool;
+    fn on_connect(&self, pubkey: String, name: String);
 }
 
 struct CallbackBridge {
@@ -86,6 +87,10 @@ impl ServerCallbacks for CallbackBridge {
             event_content: request.event_content,
             requested_permissions: request.requested_permissions,
         })
+    }
+
+    fn on_connect(&self, pubkey: &str, name: &str) {
+        self.callbacks.on_connect(pubkey.to_string(), name.to_string());
     }
 }
 

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -61,6 +61,9 @@ pub fn parse_bunker_url(url: &str) -> Result<ParsedBunkerUrl, KeepMobileError> {
 pub trait BunkerCallbacks: Send + Sync {
     fn on_log(&self, event: BunkerLogEvent);
     fn request_approval(&self, request: BunkerApprovalRequest) -> bool;
+    /// Fired when an app completes the NIP-46 connect handshake. `pubkey` and
+    /// `name` are untrusted, remote-derived values: render them as inert text,
+    /// never as markup.
     fn on_connect(&self, pubkey: String, name: String);
 }
 

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -224,6 +224,7 @@ impl BunkerHandler {
 
             let config = ServerConfig {
                 rate_limit: Some(RateLimitConfig::default()),
+                expected_secret: Some(hex::encode(keep_core::crypto::random_bytes::<16>())),
                 ..ServerConfig::default()
             };
 


### PR DESCRIPTION
Mobile bunker URLs were missing the `&secret=...` parameter, so pasting a keep bunker address into NIP-46 client apps did not connect.

`do_start_bunker` built `ServerConfig` with `expected_secret = None`, so `finalize_handler` left `bunker_secret = None` and `generate_bunker_url` omitted the secret. This sets a freshly generated random `expected_secret` (same style already used for headless auto-approve), which both surfaces the secret in the URL and enforces it on connect — matching Amber.

Verified end-to-end on a Pixel 9a: the generated bunker URL now ends with `&secret=<32 hex chars>`.

Closes #558. App-side: privkeyio/keep-android#288.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added connection event callbacks that deliver peer identification (public key and name) when peers connect, enabling richer integration and responsive UI/notifications.

* **Security Improvements**
  * Bunker startup now generates a random secret value for each run, strengthening connection validation and reducing replay/guessing risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->