### PR TITLE
tests: WDC CLI parser + propose validation coverage (closes #433, #418)

### DIFF
--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -2448,4 +2448,52 @@ mod tests {
         assert!(msg.contains("version 3"), "got {msg}");
         assert!(msg.contains("#426"), "got {msg}");
     }
+
+    // === #433: recovery-spec parser rejection coverage ===
+    //
+    // Pin the specific malformed inputs the WDC CLI smoke (#418) tested
+    // manually so any future parser regression surfaces in CI rather than
+    // in the next round of manual smoke. Each input exercises a distinct
+    // rejection branch:
+    //
+    // - `xof3@1mo`           — non-numeric threshold
+    // - `3of2@1mo`           — threshold > N
+    // - `0of3@1mo`           — threshold zero
+    // - `2of3@0mo`           — zero-month timelock
+    // - `2of3`               — no `@<timelock>` separator
+    //
+    // All five MUST produce a clean error, not a panic or silent accept.
+
+    #[test]
+    fn test_parse_recovery_tier_rejects_non_numeric_threshold() {
+        let err = parse_recovery_tier("xof3@1mo", 3)
+            .expect_err("non-numeric threshold must be refused");
+        assert!(matches!(err, KeepError::InvalidInput(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn test_parse_recovery_tier_rejects_threshold_greater_than_n() {
+        let err = parse_recovery_tier("3of2@1mo", 5).expect_err("threshold > N must be refused");
+        assert!(matches!(err, KeepError::InvalidInput(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn test_parse_recovery_tier_rejects_zero_threshold() {
+        let err = parse_recovery_tier("0of3@1mo", 5).expect_err("threshold of 0 must be refused");
+        assert!(matches!(err, KeepError::InvalidInput(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn test_parse_recovery_tier_rejects_zero_month_timelock() {
+        let err =
+            parse_recovery_tier("2of3@0mo", 5).expect_err("zero-month timelock must be refused");
+        assert!(matches!(err, KeepError::InvalidInput(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn test_parse_recovery_tier_rejects_missing_timelock_separator() {
+        let err = parse_recovery_tier("2of3", 5)
+            .expect_err("recovery-tier spec without `@<timelock>` must be refused");
+        assert!(matches!(err, KeepError::InvalidInput(_)), "got {err:?}");
+    }
 }

--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -2466,8 +2466,8 @@ mod tests {
 
     #[test]
     fn test_parse_recovery_tier_rejects_non_numeric_threshold() {
-        let err = parse_recovery_tier("xof3@1mo", 3)
-            .expect_err("non-numeric threshold must be refused");
+        let err =
+            parse_recovery_tier("xof3@1mo", 3).expect_err("non-numeric threshold must be refused");
         assert!(matches!(err, KeepError::InvalidInput(_)), "got {err:?}");
     }
 

--- a/keep-cli/tests/cli_integration.rs
+++ b/keep-cli/tests/cli_integration.rs
@@ -460,3 +460,104 @@ fn test_help_flag() {
     assert_success(&output);
     assert!(output_contains(&output, "Sovereign key management"));
 }
+
+// === #433: WDC CLI pre-vault validation coverage ===
+//
+// `wallet propose` validates `--timeout` and `--network` BEFORE opening the
+// vault, so these tests don't need a real frost share to pin the gates.
+// They use a temp path that does NOT have a vault, plus any-string args for
+// the other required parameters: the validation fires before any of those
+// are dereferenced.
+//
+// Each input is one of the boundary cases documented in #418's smoke notes;
+// pinning them here makes a future regression on the rejection error
+// surface fail in CI instead of in the next round of manual testing.
+
+fn propose_cmd(bin: &Path, path: &Path) -> KeepCmd {
+    KeepCmd::new(bin).path(path).args([
+        "wallet",
+        "propose",
+        "--group",
+        // any-string: validation fires before group_pubkey decoding.
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "--relay",
+        "wss://relay.example.com",
+        "--recovery",
+        "2of3@6mo",
+    ])
+}
+
+#[test]
+fn test_wallet_propose_rejects_zero_timeout() {
+    let bin = require_binary!();
+    let dir = TempDir::new().unwrap();
+    let vault = dir.path().join("vault");
+
+    let output = propose_cmd(&bin, &vault)
+        .args(["--network", "signet", "--timeout", "0"])
+        .run();
+    assert_failure(&output);
+    assert!(
+        output_contains(&output, "timeout must be between"),
+        "expected timeout boundary error, got: {}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn test_wallet_propose_rejects_oversize_timeout() {
+    let bin = require_binary!();
+    let dir = TempDir::new().unwrap();
+    let vault = dir.path().join("vault");
+
+    let output = propose_cmd(&bin, &vault)
+        .args(["--network", "signet", "--timeout", "86401"])
+        .run();
+    assert_failure(&output);
+    assert!(
+        output_contains(&output, "timeout must be between"),
+        "expected timeout boundary error"
+    );
+}
+
+#[test]
+fn test_wallet_propose_rejects_unknown_network() {
+    let bin = require_binary!();
+    let dir = TempDir::new().unwrap();
+    let vault = dir.path().join("vault");
+
+    let output = propose_cmd(&bin, &vault)
+        .args(["--network", "fakenet"])
+        .run();
+    assert_failure(&output);
+    assert!(
+        output_contains(&output, "Invalid network"),
+        "expected unknown-network rejection, got: {}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn test_wallet_propose_accepts_every_canonical_network() {
+    // Mirror of `parse_network`'s positive cases (#428) so the wallet-propose
+    // surface gates them the same way as the bitcoin subcommands. We expect
+    // the network check to PASS and the command to fail later on vault open,
+    // proving the early `Invalid network` gate let the input through.
+    let bin = require_binary!();
+
+    for network in ["bitcoin", "testnet", "signet", "regtest"] {
+        let dir = TempDir::new().unwrap();
+        let vault = dir.path().join("vault");
+
+        let output = propose_cmd(&bin, &vault).args(["--network", network]).run();
+        assert_failure(&output); // vault doesn't exist
+                                 // The failure MUST NOT be on the network check; it must surface from
+                                 // a later step (vault open / missing file).
+        assert!(
+            !output_contains(&output, "Invalid network"),
+            "network {network:?} must pass the early validation gate"
+        );
+    }
+}


### PR DESCRIPTION
Closes #433. Closes #418.

#433 is #418's last remaining open child, so this also closes #418 (WDC CLI findings batch from manual testing).

## What's pinned

Maps to the test set described in #433:

### Recovery-tier parser rejection coverage (5 inline tests in `commands/wallet.rs`)

Each of the malformed inputs the manual WDC smoke (#418) ran by hand:

| Input | Class | Test |
|---|---|---|
| `xof3@1mo` | non-numeric threshold | `test_parse_recovery_tier_rejects_non_numeric_threshold` |
| `3of2@1mo` | threshold > N | `test_parse_recovery_tier_rejects_threshold_greater_than_n` |
| `0of3@1mo` | threshold zero | `test_parse_recovery_tier_rejects_zero_threshold` |
| `2of3@0mo` | zero-month timelock | `test_parse_recovery_tier_rejects_zero_month_timelock` |
| `2of3` | no `@<timelock>` separator | `test_parse_recovery_tier_rejects_missing_timelock_separator` |

Each pins `KeepError::InvalidInput(_)` so a future regression that panics, silently accepts, or downgrades the error variant fails CI immediately.

### `wallet propose` pre-vault validation (4 CLI tests in `tests/cli_integration.rs`)

These pin the boundary checks that fire BEFORE the vault is opened (so no frost-share setup is needed):

- `test_wallet_propose_rejects_zero_timeout`: `--timeout 0` rejected with "timeout must be between".
- `test_wallet_propose_rejects_oversize_timeout`: `--timeout 86401` (one above `DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS`) rejected.
- `test_wallet_propose_rejects_unknown_network`: `--network fakenet` rejected with "Invalid network".
- `test_wallet_propose_accepts_every_canonical_network`: `bitcoin`, `testnet`, `signet`, `regtest` all pass the early network gate. Confirms the propose surface gates them the same way as `parse_network` does for the `bitcoin` subcommands (the #428 alias work).

## What's NOT in this PR

#433 also asked for happy-path descriptor goldens (exact taproot descriptor string from `2of3@1mo` etc.), peer-discovery window check, and bounded pre-approval cache. Those need either a MockRelay-orchestrated subprocess (the CLI binary connecting to a Rust-level MockRelay) or extending `multinode_test.rs` with named-flow tests that mirror what the CLI would produce.

Out of scope for the closing-#418 milestone; the remaining items are a non-blocking enhancement that fits naturally with #541/#551 multi-peer harness work.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (passes; 5 new parser unit tests + 4 new CLI integration tests)
