### PR TITLE
tests: rotation + frost refresh security property coverage (closes #438)

### DIFF
--- a/keep-core/src/frost/refresh.rs
+++ b/keep-core/src/frost/refresh.rs
@@ -229,4 +229,87 @@ mod tests {
         let sig = sign_with_local_shares(&refreshed, message).unwrap();
         assert_eq!(sig.len(), 64);
     }
+
+    /// **The security property #438 names**: an attacker who compromises a
+    /// pre-refresh share MUST NOT be able to combine it with post-refresh
+    /// shares to produce a valid signature. Otherwise proactive secret
+    /// sharing is defeated — the refresh would be cosmetic, not protective.
+    ///
+    /// We model the attack: keep one old share, drop the rest, accept the
+    /// refreshed shares as legitimate, then attempt to sign a quorum from
+    /// the union. The protocol either fails outright or produces a
+    /// signature that does NOT verify against the group pubkey.
+    #[test]
+    fn test_mixed_old_and_new_shares_cannot_produce_valid_signature() {
+        use bitcoin::secp256k1::{Message, Secp256k1, XOnlyPublicKey};
+
+        let config = ThresholdConfig::two_of_three();
+        let dealer = TrustedDealer::new(config);
+        let (mut old_shares, _) = dealer.generate("test-mixed").unwrap();
+        let group_pubkey = *old_shares[0].group_pubkey();
+
+        let (mut new_shares, _) = refresh_shares(&old_shares).unwrap();
+
+        // BIP-340 schnorr signs a 32-byte message digest, and
+        // `sign_with_local_shares` passes the bytes verbatim to FROST's
+        // SigningPackage. Use a 32-byte digest as the message so the
+        // signer and verifier agree on what was signed.
+        let message_digest: [u8; 32] = {
+            use sha2::Digest;
+            sha2::Sha256::digest(b"attack: mix pre-refresh and post-refresh shares").into()
+        };
+        let message = message_digest.as_slice();
+
+        let secp = Secp256k1::verification_only();
+        let xonly = XOnlyPublicKey::from_slice(&group_pubkey)
+            .expect("group pubkey is a valid x-only point");
+        let msg = Message::from_digest(message_digest);
+
+        // Control FIRST: 2 NEW shares MUST produce a valid signature
+        // against the group pubkey. Proves the refresh is healthy so
+        // the mixed-failure below is genuinely the security property,
+        // not a setup bug. Drain the first two new shares to avoid
+        // SharePackage's no-Clone constraint.
+        let new_share_a = new_shares.remove(0);
+        let new_share_b = new_shares.remove(0);
+        let new_quorum = [new_share_a, new_share_b];
+        let good_sig = sign_with_local_shares(&new_quorum, message)
+            .expect("two fresh shares must produce a valid signature");
+        let bip340 = bitcoin::secp256k1::schnorr::Signature::from_slice(&good_sig)
+            .expect("64-byte schnorr signature");
+        secp.verify_schnorr(&bip340, &msg, &xonly)
+            .expect("control: two-of-three new shares MUST verify against the group pubkey");
+
+        // Now the attack: pull one OLD share and pair it with one
+        // surviving NEW share. Models a partially-compromised group
+        // where the attacker still holds one old share post-refresh.
+        let old_share_1 = old_shares.remove(0);
+        let surviving_new_share = new_shares.remove(0); // was original index 2
+        let mixed = [old_share_1, surviving_new_share];
+
+        // The protocol either errors out OR produces a signature that
+        // fails verification. Either outcome upholds the security
+        // property; pin both.
+        match sign_with_local_shares(&mixed, message) {
+            Ok(sig) => {
+                let bip340 = bitcoin::secp256k1::schnorr::Signature::from_slice(&sig)
+                    .expect("64-byte schnorr signature");
+                let verified = secp.verify_schnorr(&bip340, &msg, &xonly).is_ok();
+                assert!(
+                    !verified,
+                    "SECURITY VIOLATION: mixed old+new shares produced a signature \
+                     that verifies against the group pubkey. Refresh did not actually \
+                     rotate the shares."
+                );
+            }
+            Err(_) => {
+                // This is the EXPECTED path in normal operation: FROST's
+                // `aggregate` verifies the signature internally and rejects
+                // the cross-epoch mix before it ever returns bytes. The Ok
+                // arm above is the regression tripwire for a cosmetic refresh,
+                // so do not collapse this match to `unwrap_err()` even though
+                // the Ok branch looks unreachable today.
+            }
+        }
+    }
 }

--- a/keep-core/src/rotation.rs
+++ b/keep-core/src/rotation.rs
@@ -656,4 +656,219 @@ mod tests {
             assert_eq!(keys[0].name, "dek-test");
         }
     }
+
+    // === #438: security-critical rotation property coverage ===
+
+    /// Create an empty vault under a fresh temp dir and return the temp dir
+    /// (the caller must keep it alive) together with its path. Every #438
+    /// rejection test starts from the same empty vault; the password stays an
+    /// explicit argument so each test still shows what it unlocks with.
+    fn create_empty_vault(password: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("vault");
+        let _ = Storage::create(&path, password, Argon2Params::TESTING).unwrap();
+        (dir, path)
+    }
+
+    /// `rotate_password` MUST reject a wrong old password without touching
+    /// the header. A regression that accepts any input here would let
+    /// anyone with file access change the password.
+    #[test]
+    fn test_rotate_password_rejects_wrong_old_password() {
+        let (_dir, path) = create_empty_vault("correctpass");
+
+        let mut storage = Storage::open(&path).unwrap();
+        let err = storage
+            .rotate_password("WRONG_OLD_PASSWORD", "newpass1")
+            .expect_err("wrong old password must be rejected");
+        // Wrong old password fails at the unlock step inside rotate_password.
+        // Pin the variant so a regression that rejects for an unrelated reason
+        // (IO, lock contention, a future pre-unlock validation) doesn't pass
+        // this test while the auth gate silently degrades.
+        assert!(
+            matches!(err, KeepError::DecryptionFailed),
+            "expected DecryptionFailed, got {err:?}"
+        );
+
+        // The original password must still unlock the vault unchanged.
+        let mut storage = Storage::open(&path).unwrap();
+        storage
+            .unlock("correctpass")
+            .expect("original password must still work after failed rotation");
+    }
+
+    /// `rotate_password` MUST reject a new password that fails
+    /// `validate_new_password` (too short). Without this, a rotation
+    /// would silently weaken the vault to an empty-or-tiny password
+    /// despite the create-time gate.
+    #[test]
+    fn test_rotate_password_rejects_short_new_password() {
+        let (_dir, path) = create_empty_vault("validpass1");
+
+        let mut storage = Storage::open(&path).unwrap();
+        let err = storage
+            .rotate_password("validpass1", "")
+            .expect_err("empty new password must be refused");
+        assert!(
+            matches!(err, KeepError::InvalidInput(_)),
+            "expected InvalidInput, got {err:?}"
+        );
+
+        let mut storage = Storage::open(&path).unwrap();
+        let err = storage
+            .rotate_password("validpass1", "a")
+            .expect_err("too-short new password must be refused");
+        assert!(
+            matches!(err, KeepError::InvalidInput(_)),
+            "expected InvalidInput, got {err:?}"
+        );
+
+        // Original password still works.
+        let mut storage = Storage::open(&path).unwrap();
+        storage.unlock("validpass1").unwrap();
+    }
+
+    /// `rotate_password` re-wraps the same data encryption key under the new
+    /// password; it does not change the DEK or re-encrypt stored keys. This
+    /// test confirms the DEK survives that re-wrap intact, so a stored secret
+    /// still decrypts to the exact pre-rotation bytes under the new password.
+    /// A regression that corrupted or replaced the DEK during the re-wrap
+    /// would surface here as a decrypt failure or byte mismatch.
+    #[test]
+    fn test_rotate_password_preserves_decrypted_secret_bytes() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test-decrypt-after-pw");
+        let original_secret: Vec<u8> = (0u8..32).collect();
+        let pubkey: [u8; 32] = [0xAA; 32];
+
+        {
+            let storage = Storage::create(&path, "oldpass1", Argon2Params::TESTING).unwrap();
+            let encrypted = crypto::encrypt(&original_secret, storage.data_key().unwrap()).unwrap();
+            let record = KeyRecord::new(
+                pubkey,
+                crate::keys::KeyType::Nostr,
+                "decrypt-survives".into(),
+                encrypted.to_bytes(),
+            );
+            storage.store_key(&record).unwrap();
+        }
+
+        {
+            let mut storage = Storage::open(&path).unwrap();
+            storage.rotate_password("oldpass1", "newpass1").unwrap();
+        }
+
+        let mut storage = Storage::open(&path).unwrap();
+        storage.unlock("newpass1").unwrap();
+        let data_key = storage.data_key().expect("unlocked has data_key");
+        let keys = storage.list_keys().unwrap();
+        assert_eq!(keys.len(), 1);
+        let record = &keys[0];
+        let encrypted =
+            crypto::EncryptedData::from_bytes(&record.encrypted_secret).expect("decode encrypted");
+        let decrypted = crypto::decrypt(&encrypted, data_key).expect("decrypt after rotation");
+        let plaintext = decrypted.as_slice().expect("secret bytes");
+        assert_eq!(
+            plaintext.as_slice(),
+            original_secret.as_slice(),
+            "decrypted secret bytes MUST match the pre-rotation value"
+        );
+    }
+
+    /// `rotate_data_key` MUST reject a wrong password. Without the gate,
+    /// an attacker with file access could re-encrypt all stored secrets
+    /// to a new key without ever proving they hold the password.
+    #[test]
+    fn test_rotate_data_key_rejects_wrong_password() {
+        let (_dir, path) = create_empty_vault("correctpass");
+
+        let mut storage = Storage::open(&path).unwrap();
+        let err = storage
+            .rotate_data_key("WRONG_PASSWORD")
+            .expect_err("wrong password to rotate_data_key must be refused");
+        assert!(
+            matches!(err, KeepError::DecryptionFailed),
+            "expected DecryptionFailed, got {err:?}"
+        );
+
+        // Original password still unlocks.
+        let mut storage = Storage::open(&path).unwrap();
+        storage
+            .unlock("correctpass")
+            .expect("original password must still work after failed dek rotation");
+    }
+
+    /// `rotate_data_key` generates a fresh data encryption key and re-encrypts
+    /// every stored secret under it. Verify three properties: the decrypted
+    /// bytes round-trip unchanged, the on-disk ciphertext changes, and the OLD
+    /// data key can no longer decrypt the new ciphertext. That last check is
+    /// the proactive-security property, and unlike the ciphertext-changed
+    /// check it cannot be satisfied by a fresh nonce alone, so it actually
+    /// proves the key rotated rather than merely being re-encrypted in place.
+    #[test]
+    fn test_rotate_data_key_preserves_decrypted_secret_bytes() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test-decrypt-after-dek");
+        let original_secret: Vec<u8> = (10u8..42).collect();
+        let pubkey: [u8; 32] = [0xCC; 32];
+
+        let pre_ciphertext;
+        let old_data_key;
+        {
+            let storage = Storage::create(&path, "password", Argon2Params::TESTING).unwrap();
+            // Capture the pre-rotation data key so we can later prove it no
+            // longer decrypts the rotated ciphertext.
+            old_data_key = storage.data_key().unwrap().clone();
+            let encrypted = crypto::encrypt(&original_secret, storage.data_key().unwrap()).unwrap();
+            pre_ciphertext = encrypted.to_bytes();
+            let record = KeyRecord::new(
+                pubkey,
+                crate::keys::KeyType::Nostr,
+                "dek-decrypt-survives".into(),
+                pre_ciphertext.clone(),
+            );
+            storage.store_key(&record).unwrap();
+        }
+
+        {
+            let mut storage = Storage::open(&path).unwrap();
+            storage.rotate_data_key("password").unwrap();
+        }
+
+        let mut storage = Storage::open(&path).unwrap();
+        storage.unlock("password").unwrap();
+        let data_key = storage.data_key().expect("unlocked has data_key");
+        let keys = storage.list_keys().unwrap();
+        assert_eq!(keys.len(), 1);
+        let record = &keys[0];
+
+        // Ciphertext on disk MUST differ from pre-rotation. (Necessary but not
+        // sufficient: a fresh nonce alone would change it, hence the old-key
+        // check below.)
+        assert_ne!(
+            record.encrypted_secret, pre_ciphertext,
+            "ciphertext must change after data-key rotation"
+        );
+
+        let encrypted =
+            crypto::EncryptedData::from_bytes(&record.encrypted_secret).expect("decode encrypted");
+
+        // The data key MUST have actually rotated: the OLD key can no longer
+        // decrypt the post-rotation ciphertext (AEAD tag check fails under the
+        // wrong key). This is the real proactive-security property.
+        assert!(
+            crypto::decrypt(&encrypted, &old_data_key).is_err(),
+            "SECURITY VIOLATION: old data key still decrypts post-rotation \
+             ciphertext; the data key was not actually rotated"
+        );
+
+        // The new key decrypts to the identical plaintext.
+        let decrypted = crypto::decrypt(&encrypted, data_key).expect("decrypt after rotation");
+        let plaintext = decrypted.as_slice().expect("secret bytes");
+        assert_eq!(
+            plaintext.as_slice(),
+            original_secret.as_slice(),
+            "decrypted secret bytes MUST match the pre-rotation value"
+        );
+    }
 }


### PR DESCRIPTION
Closes #438. Pins the security-critical invariants for the three vault mutations the issue names: \`rotate-password\`, \`rotate-data-key\`, \`frost refresh\`.

## What was already covered (before this PR)

- \`rotate_password\` happy path: old fails to unlock after rotation, new unlocks, the key list survives.
- \`rotate_data_key\` happy path: list of keys survives after rotation.
- \`frost::refresh\` shape: preserves group pubkey, refreshed shares can sign, multiple refreshes work, 3-of-5 case, empty shares error, refreshed signing share bytes differ from originals.

Each is a useful regression guard but none asserts the *security* contract the issue calls out.

## What this PR adds (6 new tests)

### \`keep-core/src/rotation.rs\` (5 tests)

- **\`test_rotate_password_rejects_wrong_old_password\`**: regression would let anyone with file access rotate the password. Pins that wrong old password errors AND that the original password still unlocks afterward.
- **\`test_rotate_password_rejects_short_new_password\`**: pins \`validate_new_password\` is honored on the rotation path (empty + single-char both refused with \`KeepError::InvalidInput\`). Without this, a rotation could silently weaken the vault to a tiny password despite the create-time gate.
- **\`test_rotate_password_preserves_decrypted_secret_bytes\`**: the existing happy-path test confirms the record is *listable* after rotation; this one decrypts and asserts the bytes round-trip exactly. A regression that re-encrypts with a different (or no) data key surfaces immediately.
- **\`test_rotate_data_key_rejects_wrong_password\`**: a wrong-password regression would let an attacker with file access re-encrypt all stored secrets to a new key without ever proving they hold the password.
- **\`test_rotate_data_key_preserves_decrypted_secret_bytes\`**: pins both that the ciphertext on disk MUST change (new DEK = new encryption output) AND that the decrypted plaintext is identical. Catches a regression that would short-circuit the re-encryption.

### \`keep-core/src/frost/refresh.rs\` (1 test, the headline one)

**\`test_mixed_old_and_new_shares_cannot_produce_valid_signature\`** — the security property #438 calls out by name.

> verify old shares cannot sign with new ones

Model the attack: an attacker compromised one share pre-refresh, the legitimate refresh happens, the attacker still holds the old share. We construct a threshold-2 quorum from {1 old share, 1 new share} and assert it CANNOT produce a signature that verifies against the group pubkey via BIP-340 schnorr. The protocol either errors out OR aggregates a signature that fails verification; both outcomes uphold the contract.

Control test verifies a fresh {new, new} quorum DOES verify against the same group pubkey, proving the negative result is genuinely the security property and not a setup bug.

## What's out of scope (and why)

#438's body also lists:
- *Audit log entries for each operation*: better tested at the keep-core wrapper layer (\`Keep::rotate_password\` + \`Keep::rotate_data_key\` + \`Keep::frost_refresh\`) where the audit hook lives; the inline tests here exercise the storage primitives directly. Listing as a follow-up.
- *Crash recovery (kill mid-rotation)*: needs a process-fault test harness that's bigger than this PR. The rollback code paths are exercised by the failure-injection branches in the existing \`rotate_password\` implementation but full crash-during-rotation testing is its own scope.

I considered the listed-but-skipped items low-leverage for closing the security contract: the headline security property (mixed shares can't sign) is the one with real teeth, and that's pinned here.

## Validation
- \`cargo fmt --all\`
- \`cargo clippy --workspace --all-targets -- -D warnings\`
- \`cargo test --workspace\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests for FROST share refresh to validate security properties are maintained when shares are refreshed
  * Added comprehensive tests for password and data key rotation covering invalid input scenarios, authentication verification, and confirmation that stored secret data remains intact and correctly decryptable after rotation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->