### PR TITLE
tests: frost sign signature verification + rejection coverage (closes #440)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4356,6 +4356,7 @@ version = "0.4.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "bitcoin",
  "bitflags 2.13.0",
  "chrono",
  "clap",

--- a/keep-cli/Cargo.toml
+++ b/keep-cli/Cargo.toml
@@ -79,6 +79,7 @@ testing = ["keep-core/testing"]
 warden = ["dep:reqwest", "dep:uuid"]
 
 [dev-dependencies]
+bitcoin = { workspace = true }
 tempfile = "3.27"
 sha2 = "0.10"
 hex = "0.4"

--- a/keep-cli/tests/cli_integration.rs
+++ b/keep-cli/tests/cli_integration.rs
@@ -461,6 +461,173 @@ fn test_help_flag() {
     assert!(output_contains(&output, "Sovereign key management"));
 }
 
+// === #440: `frost sign` non-interactive coverage ===
+//
+// The existing `test_frost_generate_list_sign` only checks the signature is
+// 64 hex bytes. These tests:
+//
+// 1. Pin that the produced signature actually VERIFIES against the group
+//    pubkey under BIP-340. The existing test would still pass if a regression
+//    emitted any garbage 64-byte hex value; this one wouldn't.
+// 2. Pin that a malformed message hex is refused with a clean error rather
+//    than panicking or silently signing nonsense bytes.
+// 3. Pin that an unknown group identifier surfaces a clean "not found"
+//    rather than an obscure failure downstream.
+
+/// Extract a 64-byte hex signature line from `frost sign` stdout.
+fn extract_signature_hex(output: &Output) -> [u8; 64] {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let sig_hex = stdout
+        .lines()
+        .find(|l| l.len() == 128 && l.chars().all(|c| c.is_ascii_hexdigit()))
+        .unwrap_or_else(|| {
+            panic!(
+                "no 128-char hex line in stdout:\n{stdout}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            )
+        });
+    let bytes = hex::decode(sig_hex).expect("decode signature hex");
+    let mut sig = [0u8; 64];
+    sig.copy_from_slice(&bytes);
+    sig
+}
+
+#[test]
+fn test_frost_sign_signature_verifies_against_group_pubkey() {
+    use bitcoin::secp256k1::{schnorr, Message, Secp256k1, XOnlyPublicKey};
+    use keep_core::Keep;
+
+    let bin = require_binary!();
+    let dir = TempDir::new().unwrap();
+    let vault = dir.path().join("verify-vault");
+
+    assert_success(&KeepCmd::new(&bin).path(&vault).args(["init"]).run());
+    let gen_output = KeepCmd::new(&bin)
+        .path(&vault)
+        .args([
+            "frost",
+            "generate",
+            "--threshold",
+            "2",
+            "--shares",
+            "3",
+            "--name",
+            "verifygroup",
+        ])
+        .run();
+    assert_success(&gen_output);
+
+    // Read the actual group pubkey out of the vault. The CLI `frost list`
+    // truncates the npub for display, so we can't parse it back; in-process
+    // access via `keep_core::Keep` is exact.
+    let group_pubkey: [u8; 32] = {
+        let mut keep = Keep::open(&vault).unwrap();
+        keep.unlock(TEST_PASSWORD).unwrap();
+        let shares = keep.frost_list_shares().unwrap();
+        let share = shares
+            .iter()
+            .find(|s| s.metadata.name == "verifygroup")
+            .expect("verifygroup share must exist after generate");
+        share.metadata.group_pubkey
+    };
+
+    let message_digest: [u8; 32] = sha2::Sha256::digest(b"verifiable signing payload").into();
+    let msg_hex = hex::encode(message_digest);
+
+    let sign_output = KeepCmd::new(&bin)
+        .path(&vault)
+        .args([
+            "frost",
+            "sign",
+            "--message",
+            &msg_hex,
+            "--group",
+            "verifygroup",
+        ])
+        .run();
+    assert_success(&sign_output);
+
+    let sig_bytes = extract_signature_hex(&sign_output);
+    let signature = schnorr::Signature::from_slice(&sig_bytes).expect("valid schnorr signature");
+    let msg = Message::from_digest(message_digest);
+    let xonly =
+        XOnlyPublicKey::from_slice(&group_pubkey).expect("group pubkey is a valid x-only point");
+    let secp = Secp256k1::verification_only();
+    secp.verify_schnorr(&signature, &msg, &xonly).expect(
+        "`frost sign` output MUST verify against the group pubkey \
+         via BIP-340 schnorr",
+    );
+}
+
+#[test]
+fn test_frost_sign_rejects_malformed_message_hex() {
+    let bin = require_binary!();
+    let dir = TempDir::new().unwrap();
+    let vault = dir.path().join("bad-hex-vault");
+
+    assert_success(&KeepCmd::new(&bin).path(&vault).args(["init"]).run());
+    assert_success(
+        &KeepCmd::new(&bin)
+            .path(&vault)
+            .args([
+                "frost",
+                "generate",
+                "--threshold",
+                "2",
+                "--shares",
+                "3",
+                "--name",
+                "badhex",
+            ])
+            .run(),
+    );
+
+    // Odd-length / non-hex input — must be refused cleanly.
+    let output = KeepCmd::new(&bin)
+        .path(&vault)
+        .args([
+            "frost",
+            "sign",
+            "--message",
+            "ZZZ-not-hex",
+            "--group",
+            "badhex",
+        ])
+        .run();
+    assert_failure(&output);
+    assert!(
+        output_contains(&output, "invalid message hex"),
+        "malformed hex must surface a clean error, got:\n{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn test_frost_sign_rejects_unknown_group() {
+    let bin = require_binary!();
+    let dir = TempDir::new().unwrap();
+    let vault = dir.path().join("no-group-vault");
+
+    assert_success(&KeepCmd::new(&bin).path(&vault).args(["init"]).run());
+
+    // No frost share generated; the lookup must fail cleanly rather than
+    // panic or sign with a random share.
+    let msg_hex = hex::encode(sha2::Sha256::digest(b"x"));
+    let output = KeepCmd::new(&bin)
+        .path(&vault)
+        .args([
+            "frost",
+            "sign",
+            "--message",
+            &msg_hex,
+            "--group",
+            "nosuchgroup",
+        ])
+        .run();
+    assert_failure(&output);
+}
+
 // === #433: WDC CLI pre-vault validation coverage ===
 //
 // `wallet propose` validates `--timeout` and `--network` BEFORE opening the

--- a/keep-cli/tests/cli_integration.rs
+++ b/keep-cli/tests/cli_integration.rs
@@ -566,23 +566,10 @@ fn test_frost_sign_rejects_malformed_message_hex() {
     let vault = dir.path().join("bad-hex-vault");
 
     assert_success(&KeepCmd::new(&bin).path(&vault).args(["init"]).run());
-    assert_success(
-        &KeepCmd::new(&bin)
-            .path(&vault)
-            .args([
-                "frost",
-                "generate",
-                "--threshold",
-                "2",
-                "--shares",
-                "3",
-                "--name",
-                "badhex",
-            ])
-            .run(),
-    );
 
-    // Odd-length / non-hex input — must be refused cleanly.
+    // `--message` hex is decoded before the vault is opened or any group is
+    // resolved, so no frost share setup is needed: odd-length / non-hex input
+    // must be refused cleanly regardless of group state.
     let output = KeepCmd::new(&bin)
         .path(&vault)
         .args([
@@ -626,6 +613,12 @@ fn test_frost_sign_rejects_unknown_group() {
         ])
         .run();
     assert_failure(&output);
+    assert!(
+        output_contains(&output, "No group found"),
+        "unknown group must surface a clean 'not found' error, got:\n{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 // === #433: WDC CLI pre-vault validation coverage ===

--- a/keep-core/src/frost/transport.rs
+++ b/keep-core/src/frost/transport.rs
@@ -549,4 +549,57 @@ mod tests {
         let json = msg.to_json().unwrap();
         assert!(json.contains("round2_share"));
     }
+
+    // === #440: FrostMessage rejection coverage for interactive sign ===
+
+    /// `FrostMessage::from_json` is the parse boundary the interactive
+    /// signer pastes into. Malformed input MUST surface a clean error
+    /// rather than panic. Pin three classes: complete garbage, valid JSON
+    /// with wrong shape, and an empty string.
+    #[test]
+    fn test_frost_message_from_json_rejects_malformed_input() {
+        assert!(FrostMessage::from_json("not-json").is_err());
+        assert!(FrostMessage::from_json("").is_err());
+        // Valid JSON but missing required fields:
+        assert!(FrostMessage::from_json(r#"{"foo": "bar"}"#).is_err());
+    }
+
+    /// The interactive signer compares the parsed `session_id` hex against
+    /// its own session digest to defend against cross-session reuse. The
+    /// `session_id_bytes()` accessor MUST refuse hex that doesn't decode
+    /// to exactly 32 bytes, otherwise the gate could be bypassed by a
+    /// short prefix that happens to match.
+    #[test]
+    fn test_frost_message_session_id_bytes_rejects_wrong_length_hex() {
+        let session_id = [7u8; 32];
+        let payload = vec![1, 2, 3];
+        let mut msg = FrostMessage::commitment(&session_id, 1, &payload);
+
+        // 31-byte hex (62 chars): refused.
+        msg.session_id = "aa".repeat(31);
+        assert!(
+            msg.session_id_bytes().is_err(),
+            "31-byte session_id hex must be refused"
+        );
+
+        // 33-byte hex (66 chars): refused.
+        msg.session_id = "bb".repeat(33);
+        assert!(
+            msg.session_id_bytes().is_err(),
+            "33-byte session_id hex must be refused"
+        );
+
+        // Non-hex characters: refused.
+        msg.session_id = "z".repeat(64);
+        assert!(
+            msg.session_id_bytes().is_err(),
+            "non-hex session_id must be refused"
+        );
+
+        // Exactly 32 bytes (64 hex chars) of valid hex: accepted, and
+        // round-trips to the same bytes.
+        msg.session_id = "cc".repeat(32);
+        let bytes = msg.session_id_bytes().expect("32-byte hex must parse");
+        assert_eq!(bytes, [0xCCu8; 32]);
+    }
 }


### PR DESCRIPTION
Closes #440. Pins the security contracts for non-interactive `frost sign` that #440 names.

## What was already covered

`test_frost_generate_list_sign` in `keep-cli/tests/cli_integration.rs` does the happy path: generate a 2-of-3 keyset, sign a SHA-256 digest, assert the stdout contains a 128-char hex line. It does NOT verify the signature.

`test_frost_message_roundtrip` + `test_frost_message_signature_share` in `keep-core/src/frost/transport.rs` cover happy-path serialize/parse on the interactive transport.

## What this PR adds (5 new tests)

### `keep-cli/tests/cli_integration.rs` (3 CLI tests)

- **`test_frost_sign_signature_verifies_against_group_pubkey`**: the headline gap. Generate a 2-of-3 keyset, read the group pubkey out of the vault in-process (via `keep_core::Keep`, since `frost list` truncates the npub for display), sign a SHA-256 digest via the CLI, then verify the 64-byte signature against the group pubkey under BIP-340 schnorr. A regression that emits any 128-char hex string would slip past the existing test but fail this one.
- **`test_frost_sign_rejects_malformed_message_hex`**: pin that non-hex input (`"ZZZ-not-hex"`) surfaces the explicit `invalid message hex` error rather than panicking or silently signing nonsense bytes.
- **`test_frost_sign_rejects_unknown_group`**: pin that an unknown group identifier fails cleanly without panicking or signing under an unrelated share.

Adds `bitcoin = { workspace = true }` to `keep-cli/[dev-dependencies]` so the integration test can run BIP-340 verification directly.

### `keep-core/src/frost/transport.rs` (2 inline tests)

The interactive signer (`cmd_frost_sign_interactive`) parses pasted JSON via `FrostMessage::from_json` and validates incoming `session_id` via `session_id_bytes()`. Both are the trust boundary for cross-machine coordination; neither was tested for rejection paths.

- **`test_frost_message_from_json_rejects_malformed_input`**: pin that complete garbage, empty input, and valid-JSON-wrong-shape all return errors rather than panicking.
- **`test_frost_message_session_id_bytes_rejects_wrong_length_hex`**: pin the session-id gate that defends against cross-session reuse. 31-byte hex, 33-byte hex, and non-hex characters are all refused; 32-byte valid hex parses and round-trips.

## What's out of scope (and why)

#440's body also lists:
- *Signer drop mid-round* — needs the multi-peer MockRelay harness (#541's territory) since the local-threshold path doesn't have a "mid-round" — it computes the whole signature in one call.
- *Interactive flow end-to-end* — would need stdin scripting against the CLI binary. Each round of the interactive flow blocks on stdin; doable but adds a `pty`-style harness that's bigger than this PR.

Both fit naturally as follow-ups; the headline `verifies against group pubkey` invariant is what closes the security contract, and that's pinned here.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`