### PR TITLE
tests: NIP-46 dispatch coverage for get_public_key, ping, nip04/nip44 (closes #553)

### DIFF
--- a/keep-nip46/tests/bunker_integration.rs
+++ b/keep-nip46/tests/bunker_integration.rs
@@ -598,12 +598,10 @@ async fn bunker_with_connected_client() -> ConnectedBunker {
     )
     .await
     .expect("connect must respond");
-    assert!(
-        connect_resp
-            .get("error")
-            .map(|v| v.is_null())
-            .unwrap_or(true),
-        "connect must succeed: {connect_resp}"
+    assert_eq!(
+        connect_resp.get("result").and_then(|v| v.as_str()),
+        Some("ack"),
+        "connect must succeed with ack, got: {connect_resp}"
     );
 
     ConnectedBunker {
@@ -700,9 +698,16 @@ async fn test_dispatch_nip44_encrypt_decrypt_roundtrip() {
         .and_then(|v| v.as_str())
         .expect("nip44_encrypt result must be a ciphertext string")
         .to_string();
-    assert!(
-        !ciphertext.is_empty() && ciphertext != plaintext,
-        "ciphertext MUST be non-empty and differ from plaintext"
+    assert!(!ciphertext.is_empty(), "nip44 ciphertext MUST be non-empty");
+    // Independently decrypt with the third party's key against the signer
+    // pubkey. This proves the bunker encrypted to the REQUESTED recipient,
+    // not to a fixed or its own key: a bunker-internal symmetric round-trip
+    // alone can't catch a peer-pubkey-binding regression.
+    let independent = nip44::decrypt(third_party.secret_key(), &cb.signer_pubkey, &ciphertext)
+        .expect("nip44 ciphertext must decrypt for the requested peer");
+    assert_eq!(
+        independent, plaintext,
+        "nip44 ciphertext MUST be addressed to the requested peer pubkey"
     );
 
     let dec = send_and_await(
@@ -744,9 +749,14 @@ async fn test_dispatch_nip04_encrypt_decrypt_roundtrip() {
         .and_then(|v| v.as_str())
         .expect("nip04_encrypt result must be a ciphertext string")
         .to_string();
-    assert!(
-        !ciphertext.is_empty() && ciphertext != plaintext,
-        "ciphertext MUST be non-empty and differ from plaintext"
+    assert!(!ciphertext.is_empty(), "nip04 ciphertext MUST be non-empty");
+    // Independently decrypt with the third party's key against the signer
+    // pubkey to prove the bunker encrypted to the REQUESTED recipient.
+    let independent = nip04::decrypt(third_party.secret_key(), &cb.signer_pubkey, &ciphertext)
+        .expect("nip04 ciphertext must decrypt for the requested peer");
+    assert_eq!(
+        independent, plaintext,
+        "nip04 ciphertext MUST be addressed to the requested peer pubkey"
     );
 
     let dec = send_and_await(

--- a/keep-nip46/tests/bunker_integration.rs
+++ b/keep-nip46/tests/bunker_integration.rs
@@ -505,3 +505,266 @@ async fn test_bunker_e2e_returned_event_signature_verifies() {
     server_handle.abort();
     client.disconnect().await;
 }
+
+// === #553: NIP-46 dispatch_request match-arm coverage ===
+//
+// Each of these tests drives one NIP-46 method through `dispatch_request`
+// over the relay, killing the match-arm-deletion mutation for that
+// method. The existing #435 e2e covers `connect` + `sign_event` only.
+
+/// Holds everything an NIP-46 method test needs after the connect handshake.
+/// `_mock_relay` MUST stay alive for the entire test — dropping it shuts
+/// down the relay and any in-flight method calls hang on the 10s timeout.
+struct ConnectedBunker {
+    client: Client,
+    client_keys: Keys,
+    server_pubkey: PublicKey,
+    signer_pubkey: PublicKey,
+    server_handle: tokio::task::JoinHandle<()>,
+    notifications: tokio::sync::broadcast::Receiver<RelayPoolNotification>,
+    _mock_relay: MockRelay,
+}
+
+async fn bunker_with_connected_client() -> ConnectedBunker {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+
+    let mock_relay = MockRelay::run().await.expect("MockRelay start");
+    let relay_url = mock_relay.url().await.to_string();
+
+    let (keyring, signer_pubkey) = setup_keyring();
+    let mut server = Server::new_with_config(
+        keyring,
+        None,
+        None,
+        std::slice::from_ref(&relay_url),
+        None,
+        ServerConfig {
+            auto_approve: true,
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("server creation");
+
+    let bunker_url = server.bunker_url();
+    let bunker_secret = extract_bunker_secret(&bunker_url).expect("bunker secret");
+    let server_pubkey = server.pubkey();
+    let server_handle = tokio::spawn(async move {
+        let _ = server.run().await;
+    });
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let client_keys = Keys::generate();
+    let client = Client::new(client_keys.clone());
+    client.add_relay(relay_url).await.unwrap();
+    client.connect().await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    client
+        .subscribe(
+            Filter::new()
+                .kind(Kind::NostrConnect)
+                .author(server_pubkey)
+                .pubkey(client_keys.public_key()),
+            None,
+        )
+        .await
+        .expect("subscribe to bunker responses");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let mut notifications = client.notifications();
+
+    let connect_req = serde_json::json!({
+        "id": "req-connect",
+        "method": "connect",
+        "params": [signer_pubkey.to_hex(), bunker_secret],
+    });
+    client
+        .send_event(&build_nip46_request(
+            &client_keys,
+            &server_pubkey,
+            &serde_json::to_string(&connect_req).unwrap(),
+        ))
+        .await
+        .unwrap();
+    let connect_resp = await_nip46_response(
+        &mut notifications,
+        &client_keys,
+        &server_pubkey,
+        "req-connect",
+        Duration::from_secs(10),
+    )
+    .await
+    .expect("connect must respond");
+    assert!(
+        connect_resp
+            .get("error")
+            .map(|v| v.is_null())
+            .unwrap_or(true),
+        "connect must succeed: {connect_resp}"
+    );
+
+    ConnectedBunker {
+        client,
+        client_keys,
+        server_pubkey,
+        signer_pubkey,
+        server_handle,
+        notifications,
+        _mock_relay: mock_relay,
+    }
+}
+
+async fn send_and_await(
+    cb: &mut ConnectedBunker,
+    id: &str,
+    method: &str,
+    params: serde_json::Value,
+) -> serde_json::Value {
+    let req = serde_json::json!({ "id": id, "method": method, "params": params });
+    cb.client
+        .send_event(&build_nip46_request(
+            &cb.client_keys,
+            &cb.server_pubkey,
+            &serde_json::to_string(&req).unwrap(),
+        ))
+        .await
+        .unwrap();
+    await_nip46_response(
+        &mut cb.notifications,
+        &cb.client_keys,
+        &cb.server_pubkey,
+        id,
+        Duration::from_secs(10),
+    )
+    .await
+    .unwrap_or_else(|| panic!("{method} must respond"))
+}
+
+#[tokio::test]
+async fn test_dispatch_get_public_key_returns_signer_pubkey() {
+    let mut cb = bunker_with_connected_client().await;
+
+    let resp = send_and_await(&mut cb, "req-gpk", "get_public_key", serde_json::json!([])).await;
+    let result = resp
+        .get("result")
+        .and_then(|v| v.as_str())
+        .expect("get_public_key result must be a string");
+
+    assert_eq!(
+        result,
+        cb.signer_pubkey.to_hex(),
+        "get_public_key MUST return the bunker's signer pubkey verbatim"
+    );
+
+    cb.server_handle.abort();
+    cb.client.disconnect().await;
+}
+
+#[tokio::test]
+async fn test_dispatch_ping_returns_pong() {
+    let mut cb = bunker_with_connected_client().await;
+
+    let resp = send_and_await(&mut cb, "req-ping", "ping", serde_json::json!([])).await;
+    let result = resp
+        .get("result")
+        .and_then(|v| v.as_str())
+        .expect("ping result must be a string");
+    assert_eq!(
+        result, "pong",
+        "ping MUST return the literal string \"pong\""
+    );
+
+    cb.server_handle.abort();
+    cb.client.disconnect().await;
+}
+
+#[tokio::test]
+async fn test_dispatch_nip44_encrypt_decrypt_roundtrip() {
+    let mut cb = bunker_with_connected_client().await;
+
+    let third_party = Keys::generate();
+    let plaintext = "secret message for #553 nip44 coverage";
+
+    let enc = send_and_await(
+        &mut cb,
+        "req-nip44-enc",
+        "nip44_encrypt",
+        serde_json::json!([third_party.public_key().to_hex(), plaintext]),
+    )
+    .await;
+    let ciphertext = enc
+        .get("result")
+        .and_then(|v| v.as_str())
+        .expect("nip44_encrypt result must be a ciphertext string")
+        .to_string();
+    assert!(
+        !ciphertext.is_empty() && ciphertext != plaintext,
+        "ciphertext MUST be non-empty and differ from plaintext"
+    );
+
+    let dec = send_and_await(
+        &mut cb,
+        "req-nip44-dec",
+        "nip44_decrypt",
+        serde_json::json!([third_party.public_key().to_hex(), ciphertext]),
+    )
+    .await;
+    let decrypted = dec
+        .get("result")
+        .and_then(|v| v.as_str())
+        .expect("nip44_decrypt result must be a plaintext string");
+    assert_eq!(
+        decrypted, plaintext,
+        "nip44 decrypt MUST round-trip to the original plaintext"
+    );
+
+    cb.server_handle.abort();
+    cb.client.disconnect().await;
+}
+
+#[tokio::test]
+async fn test_dispatch_nip04_encrypt_decrypt_roundtrip() {
+    let mut cb = bunker_with_connected_client().await;
+
+    let third_party = Keys::generate();
+    let plaintext = "legacy nip04 coverage for #553";
+
+    let enc = send_and_await(
+        &mut cb,
+        "req-nip04-enc",
+        "nip04_encrypt",
+        serde_json::json!([third_party.public_key().to_hex(), plaintext]),
+    )
+    .await;
+    let ciphertext = enc
+        .get("result")
+        .and_then(|v| v.as_str())
+        .expect("nip04_encrypt result must be a ciphertext string")
+        .to_string();
+    assert!(
+        !ciphertext.is_empty() && ciphertext != plaintext,
+        "ciphertext MUST be non-empty and differ from plaintext"
+    );
+
+    let dec = send_and_await(
+        &mut cb,
+        "req-nip04-dec",
+        "nip04_decrypt",
+        serde_json::json!([third_party.public_key().to_hex(), ciphertext]),
+    )
+    .await;
+    let decrypted = dec
+        .get("result")
+        .and_then(|v| v.as_str())
+        .expect("nip04_decrypt result must be a plaintext string");
+    assert_eq!(
+        decrypted, plaintext,
+        "nip04 decrypt MUST round-trip to the original plaintext"
+    );
+
+    cb.server_handle.abort();
+    cb.client.disconnect().await;
+}


### PR DESCRIPTION
Closes #553 — the NIP-46 dispatch_request match-arm coverage gap from #417 round 5.

## What was already covered

PR #568 (#435) added one end-to-end test driving connect + sign_event over a MockRelay. Existing `keep-nip46/src/server.rs` unit tests cover the synchronous helpers from #417 round 5 (PR #554).

What the existing tests do NOT cover: each individual match arm in `dispatch_request`. Those mutations survived cargo-mutants round 5 because no test calls those methods.

## What this PR adds (4 new tests + shared helpers)

Each test drives one NIP-46 method through `dispatch_request` over the relay, killing its match-arm-deletion mutation:

- **`test_dispatch_get_public_key_returns_signer_pubkey`**: connect + `get_public_key`, assert the result is exactly the bunker's signer pubkey hex. A regression that returns the wrong pubkey, an empty string, or no result at all fails CI.
- **`test_dispatch_ping_returns_pong`**: connect + `ping`, assert the result is literally `"pong"`. Catches the "replace arm with no-op" mutation.
- **`test_dispatch_nip44_encrypt_decrypt_roundtrip`**: connect + `nip44_encrypt` (third-party pubkey + plaintext) → ciphertext, then `nip44_decrypt` (third-party pubkey + ciphertext) → plaintext. Asserts the round-trip matches. Catches mutations on both NIP-44 arms.
- **`test_dispatch_nip04_encrypt_decrypt_roundtrip`**: same shape for NIP-04 legacy.

## Shared helpers extracted

Three helpers added (next to `build_nip46_request` / `await_nip46_response` from #568):

- **`ConnectedBunker`**: holds the connected client, server pubkey, signer pubkey, server task handle, and shared notifications receiver. The `_mock_relay` field keeps the MockRelay alive for the test's lifetime — dropping it shuts down the relay and hangs every subsequent method call on its 10s timeout (the bug I hit during initial implementation).
- **`bunker_with_connected_client()`**: does the MockRelay + Server + nostr-sdk Client setup, drives the connect handshake, waits for the ack, returns a `ConnectedBunker` ready for method calls.
- **`send_and_await(&mut cb, id, method, params)`**: one-shot send-and-wait-for-response helper. Each method test is now ~10 lines.

## Reliability

5 back-to-back runs of all 4 new tests, all pass in 2 seconds each:
```
run 1: 4 passed; 0 failed (2.12s)
run 2: 4 passed; 0 failed (2.12s)
run 3: 4 passed; 0 failed (2.11s)
run 4: 4 passed; 0 failed (2.11s)
run 5: 4 passed; 0 failed (2.11s)
```

## What's NOT in this PR

#553's body also lists:
- `switch_relays` and the `handle_nip46_event` ingestion gates (size cap, kind check, replay window). These need either failure-path test setups (malformed events, oversize JSON, future-skew timestamps) or a different harness. Each is a follow-up extension using the same helpers; not blocking #434.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`