### PR TITLE
tests: decode_psbt_for_snapshot non_witness_utxo txid binding (partial #551)

### DIFF
--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -2065,4 +2065,93 @@ mod snapshot_decode_tests {
             "expected a below-threshold error, got {msg}"
         );
     }
+
+    /// `decode_psbt_for_snapshot` binds the `non_witness_utxo` to the input's
+    /// `previous_output.txid` before trusting its value: a mismatched tx
+    /// MUST yield `fee = None`. The `!= → ==` mutation on the txid check
+    /// would silently accept an attacker-supplied unrelated transaction
+    /// whose vout-N output carries an altered value, producing a wrong fee
+    /// in the snapshot. Pin both branches: matching txid → `Some(fee)`,
+    /// mismatched txid → `None`.
+    #[test]
+    fn decode_psbt_for_snapshot_rejects_non_witness_utxo_with_mismatched_txid() {
+        let secp = Secp256k1::new();
+        let keypair = Keypair::from_seckey_slice(&secp, &[1u8; 32]).unwrap();
+        let (x_only_pubkey, _parity) = keypair.x_only_public_key();
+        let tap_script = ScriptBuf::new_p2tr(&secp, x_only_pubkey, None);
+
+        // Build a "previous tx" we claim our input spends from.
+        let real_prev = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_raw_hash(bitcoin::hashes::Hash::all_zeros()),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(60_000),
+                script_pubkey: tap_script.clone(),
+            }],
+        };
+        let real_prev_txid = real_prev.compute_txid();
+
+        // The new tx's input claims to spend from `real_prev_txid:0`.
+        let our_tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: real_prev_txid,
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: tap_script.clone(),
+            }],
+        };
+
+        // Case A: matching txid -> fee = Some(10_000).
+        let mut psbt = Psbt::from_unsigned_tx(our_tx.clone()).unwrap();
+        psbt.inputs[0].non_witness_utxo = Some(real_prev.clone());
+        let bytes = psbt.serialize();
+        let (_hash, _outputs, fee) =
+            decode_psbt_for_snapshot(&bytes).expect("matching txid must decode");
+        assert_eq!(
+            fee,
+            Some(10_000),
+            "matching non_witness_utxo txid must yield the correct fee"
+        );
+
+        // Case B: tamper with the non_witness_utxo so its computed txid no
+        // longer matches `previous_output.txid`. With the `!= → ==`
+        // mutation, the value `999_999_999` would be accepted and fee
+        // would be `Some(999_949_999)`. Original code returns None.
+        let mut tampered_prev = real_prev.clone();
+        tampered_prev.output[0].value = Amount::from_sat(999_999_999);
+        let tampered_txid = tampered_prev.compute_txid();
+        assert_ne!(
+            tampered_txid, real_prev_txid,
+            "control: changing the output value must change the txid"
+        );
+
+        let mut psbt = Psbt::from_unsigned_tx(our_tx).unwrap();
+        psbt.inputs[0].non_witness_utxo = Some(tampered_prev);
+        let bytes = psbt.serialize();
+        let (_hash, _outputs, fee) =
+            decode_psbt_for_snapshot(&bytes).expect("psbt itself is well-formed");
+        assert_eq!(
+            fee, None,
+            "mismatched non_witness_utxo txid MUST yield fee = None; \
+             SECURITY VIOLATION otherwise (proposer-supplied tampered tx accepted)"
+        );
+    }
 }


### PR DESCRIPTION
Partial follow-up to #551. Pins the security-relevant non_witness_utxo binding in `decode_psbt_for_snapshot`.

## Current state on `keep-frost-net/src/node/psbt.rs`

Fresh baseline mutation run after PR #555:
```
147 mutants tested in 27m: 64 missed, 71 caught, 9 unviable, 3 timeouts
```

The 64 surviving mutations are spread across async coordination handlers:

| Function | Surviving |
|---|---|
| `request_descriptor_migration_sweep` | 10 |
| `handle_psbt_finalize` | 10 |
| `handle_psbt_abort` | 8 |
| `handle_psbt_sign` | 3 |
| `finalize_psbt_session` | 3 |
| `verify_descriptor_hash_against_stored` | 2 |
| `validate_migration_sweep_destination` | 2 |
| `aggregate_partial_psbts` | 2 |
| (smaller functions) | 24 |

The subscribe-after-send race that #541 (PR #570) fixed does not exist here: `request_psbt_spend` and `request_descriptor_migration_sweep` are pure setup functions that return the session_id; the caller subscribes externally. No equivalent one-line race fix applies.

## Test added

`decode_psbt_for_snapshot_rejects_non_witness_utxo_with_mismatched_txid` kills the `!= → ==` mutation on the non_witness_utxo txid binding at line 1388. The binding is security-relevant: without it, a malicious proposer could supply a tampered `non_witness_utxo` whose vout-N output carries an inflated value, producing a wrong fee in the snapshot.

The test:
1. Builds a real previous transaction with output value 60_000.
2. Builds a current tx whose input claims to spend from `real_prev_txid:0`.
3. Case A (matching txid): wraps the real prev as `non_witness_utxo`, asserts `fee = Some(10_000)`.
4. Case B (mismatched txid): tampers with the prev's output value (changing its txid), wraps the tampered prev, asserts `fee = None`.

A control assertion `assert_ne!(tampered_txid, real_prev_txid)` confirms the value change actually changed the txid.

## What is not covered

The remaining 63 surviving mutations cluster on async coordination handlers (`handle_psbt_propose`, `handle_psbt_sign`, `handle_psbt_finalize`, `handle_psbt_abort`, `request_descriptor_migration_sweep`). Each handler is exercised by the existing `test_psbt_recovery_spend_end_to_end` happy-path test, but the surviving mutations are boundary-condition / branch-direction mutations that the happy path still completes under.

Killing them requires a sweep-flow integration test in `multinode_test.rs` similar in scale to `test_descriptor_coordination_flow` (~200 lines) and `test_psbt_recovery_spend_end_to_end` (~409 lines). That work remains tracked under #551.

`validate_migration_sweep_destination` and `psbt_session_expected_fingerprints` are methods on `KfpNode` and require the full MockRelay + share + descriptor_lookup setup to test, not a unit-test extension.

## Effect on #551

Survival rate: 64 → 63 missed (44% → 43%). #551 remains open; full closure depends on the sweep-flow integration test.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
