### PR TITLE
Fix NIP-46 bunker auto-approval and persist transport keys

### DIFF
--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -430,6 +430,7 @@ pub struct KeepMobile {
     pre_approved_hashes: PreApprovedHashes,
     session_store_path: Arc<std::sync::Mutex<Option<String>>>,
     descriptor_write_lock: Arc<std::sync::Mutex<()>>,
+    pub(crate) bunker_config_lock: Arc<std::sync::Mutex<()>>,
 }
 
 struct PendingRequest {
@@ -569,6 +570,7 @@ impl KeepMobile {
             pre_approved_hashes: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             session_store_path: Arc::new(std::sync::Mutex::new(None)),
             descriptor_write_lock: Arc::new(std::sync::Mutex::new(())),
+            bunker_config_lock: Arc::new(std::sync::Mutex::new(())),
         })
     }
 
@@ -1758,7 +1760,16 @@ impl KeepMobile {
     pub fn save_bunker_config(&self, config: BunkerConfigInfo) -> Result<(), KeepMobileError> {
         // Preserve the persisted transport key + connect secret so toggling the
         // bunker off/on (or any other config save) does not rotate the bunker://
-        // URL out from under already-paired clients.
+        // URL out from under already-paired clients. The whole read-modify-write
+        // runs under bunker_config_lock so a save that loaded a stale snapshot
+        // (transport_secret: None) cannot clobber keys freshly generated and
+        // persisted by a concurrent load_or_create_bunker_keys.
+        let _guard = self
+            .bunker_config_lock
+            .lock()
+            .map_err(|_| KeepMobileError::StorageError {
+                msg: "bunker config lock poisoned".into(),
+            })?;
         let existing = persistence::load_bunker_config(&self.storage, BUNKER_CONFIG_STORAGE_KEY)?
             .unwrap_or_default();
         let stored = persistence::StoredBunkerConfig {

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1756,9 +1756,16 @@ impl KeepMobile {
     }
 
     pub fn save_bunker_config(&self, config: BunkerConfigInfo) -> Result<(), KeepMobileError> {
+        // Preserve the persisted transport key + connect secret so toggling the
+        // bunker off/on (or any other config save) does not rotate the bunker://
+        // URL out from under already-paired clients.
+        let existing = persistence::load_bunker_config(&self.storage, BUNKER_CONFIG_STORAGE_KEY)?
+            .unwrap_or_default();
         let stored = persistence::StoredBunkerConfig {
             enabled: config.enabled,
             authorized_clients: config.authorized_clients,
+            transport_secret: existing.transport_secret,
+            connect_secret: existing.connect_secret,
         };
         persistence::persist_bunker_config(&self.storage, BUNKER_CONFIG_STORAGE_KEY, &stored)
     }

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -8,6 +8,7 @@ use keep_nip46::{NetworkFrostSigner, Permission, RateLimitConfig, Server, Server
 use nostr_sdk::Kind;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
+use zeroize::{Zeroize, Zeroizing};
 
 const STATUS_STOPPED: u8 = 0;
 const STATUS_STARTING: u8 = 1;
@@ -182,12 +183,31 @@ impl BunkerHandler {
 /// required by web clients such as nostr-tools' `BunkerSigner`, which sign a
 /// fresh auth event for *every* API call and time out (~60s) if the signer
 /// prompts per request. Kind 7 (reactions) matches the engine default.
+///
+/// TRUST MODEL: auto-approving kind 27235 makes the bunker URL + connect secret
+/// an HTTP-auth bearer credential. Any client that completes the connect
+/// handshake can silently mint NIP-98 auth tokens for *any* URL and method with
+/// no per-request prompt, exactly like handing out an HTTP `Authorization`
+/// header. Amber behaves the same way. Unlike Amber, this is currently GLOBAL:
+/// one shared connect secret and one global `auto_approve_kinds` set, not
+/// per-app scoped, so every connected client shares the same blanket grant.
+/// Per-app scoping is tracked as follow-up work; treat the bunker URL as a
+/// secret of equivalent power to the signing key for HTTP-auth purposes.
 fn bunker_auto_approve_kinds() -> std::collections::HashSet<Kind> {
     std::collections::HashSet::from([Kind::Reaction, keep_nip46::NIP98_HTTP_AUTH])
 }
 
-fn decode_transport_secret(hex_str: &str) -> Option<[u8; 32]> {
-    hex::decode(hex_str).ok()?.try_into().ok()
+/// Decodes a persisted transport secret, returning `None` when the stored value
+/// is malformed, the wrong length, or not a valid secp256k1 scalar (zero or
+/// `>=` the curve order). The value is persisted and reused on every start, so a
+/// corrupt-but-32-byte hex string would otherwise be cached forever and brick
+/// the bunker permanently; rejecting it here lets `load_or_create_bunker_keys`
+/// regenerate and self-heal. The decoded buffer is zeroized on drop.
+fn decode_transport_secret(hex_str: &str) -> Option<Zeroizing<[u8; 32]>> {
+    let decoded = Zeroizing::new(hex::decode(hex_str).ok()?);
+    let bytes: Zeroizing<[u8; 32]> = Zeroizing::new(decoded.as_slice().try_into().ok()?);
+    nostr_sdk::secp256k1::SecretKey::from_slice(bytes.as_slice()).ok()?;
+    Some(bytes)
 }
 
 /// Loads the persisted bunker transport key + connect secret, generating and
@@ -198,8 +218,22 @@ fn decode_transport_secret(hex_str: &str) -> Option<[u8; 32]> {
 /// receiving responses after a reboot or off/on toggle. The secrets live in the
 /// same SQLCipher-backed SecureStorage as the FROST share material.
 fn load_or_create_bunker_keys(
-    storage: &Arc<dyn crate::SecureStorage>,
-) -> Result<([u8; 32], String), KeepMobileError> {
+    mobile: &KeepMobile,
+) -> Result<(Zeroizing<[u8; 32]>, Zeroizing<String>), KeepMobileError> {
+    let storage = &mobile.storage;
+
+    // Serialize the whole load-modify-store against `save_bunker_config`, which
+    // performs the same read-modify-write on this record. Without the lock a
+    // config save that read a stale snapshot (transport_secret: None) could
+    // overwrite the keys we generate and persist here, rotating the bunker URL
+    // and breaking already-paired clients — the failure this code prevents.
+    let _guard = mobile
+        .bunker_config_lock
+        .lock()
+        .map_err(|_| KeepMobileError::StorageError {
+            msg: "bunker config lock poisoned".into(),
+        })?;
+
     let mut stored =
         crate::persistence::load_bunker_config(storage, crate::BUNKER_CONFIG_STORAGE_KEY)?
             .unwrap_or_default();
@@ -213,18 +247,18 @@ fn load_or_create_bunker_keys(
     {
         Some(bytes) => bytes,
         None => {
-            let bytes = keep_core::crypto::random_bytes::<32>();
-            stored.transport_secret = Some(hex::encode(bytes));
+            let bytes = Zeroizing::new(keep_core::crypto::random_bytes::<32>());
+            stored.transport_secret = Some(hex::encode(&bytes[..]));
             dirty = true;
             bytes
         }
     };
 
-    let connect_secret = match stored.connect_secret.take() {
-        Some(secret) if !secret.is_empty() => secret,
+    let connect_secret = match stored.connect_secret.as_deref() {
+        Some(secret) if !secret.is_empty() => Zeroizing::new(secret.to_owned()),
         _ => {
-            let secret = hex::encode(keep_core::crypto::random_bytes::<16>());
-            stored.connect_secret = Some(secret.clone());
+            let secret = Zeroizing::new(hex::encode(keep_core::crypto::random_bytes::<16>()));
+            stored.connect_secret = Some(secret.as_str().to_owned());
             dirty = true;
             secret
         }
@@ -236,6 +270,16 @@ fn load_or_create_bunker_keys(
             crate::BUNKER_CONFIG_STORAGE_KEY,
             &stored,
         )?;
+    }
+
+    // `stored` still holds a plaintext hex copy of the transport and connect
+    // secrets; clear them before drop so the decrypted key material does not
+    // linger in memory.
+    if let Some(s) = stored.transport_secret.as_mut() {
+        s.zeroize();
+    }
+    if let Some(s) = stored.connect_secret.as_mut() {
+        s.zeroize();
     }
 
     Ok((transport_secret, connect_secret))
@@ -294,17 +338,23 @@ impl BunkerHandler {
             let network_signer =
                 NetworkFrostSigner::with_shared_node(group_pubkey_bytes, Arc::clone(node));
 
-            let (transport_secret, connect_secret) =
-                load_or_create_bunker_keys(&self.mobile.storage)?;
+            let (transport_secret, connect_secret) = load_or_create_bunker_keys(&self.mobile)?;
 
             let config = ServerConfig {
                 rate_limit: Some(RateLimitConfig::default()),
-                expected_secret: Some(connect_secret),
+                expected_secret: Some(connect_secret.as_str().to_owned()),
                 // Approving the bunker connection (the secret in the bunker URL
                 // is the grant) must let the client sign, mirroring the
                 // always-on bunker in keep-web. Without this the client only
                 // gets get_public_key and every sign_event is denied — the
                 // client logs in but its signed-request calls all fail.
+                //
+                // TRUST MODEL: this connect grant plus the global
+                // auto_approve_kinds (see `bunker_auto_approve_kinds`) means a
+                // single shared connect secret authorizes signing and silent
+                // NIP-98 (kind 27235) token minting for every connected client.
+                // The connect secret is a bearer credential, not yet per-app
+                // scoped; per-app grants are tracked as follow-up work.
                 connect_grant: Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT,
                 auto_approve_kinds: bunker_auto_approve_kinds(),
                 ..ServerConfig::default()
@@ -312,7 +362,7 @@ impl BunkerHandler {
 
             let server = Server::new_network_frost_with_proxy(
                 network_signer,
-                transport_secret,
+                *transport_secret,
                 &relays,
                 Some(Arc::new(CallbackBridge { callbacks }) as Arc<dyn ServerCallbacks>),
                 config,
@@ -449,7 +499,8 @@ mod tests {
             .unwrap()
             .is_none());
 
-        let (transport, secret) = load_or_create_bunker_keys(&storage).unwrap();
+        let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
+        let (transport, secret) = load_or_create_bunker_keys(&mobile).unwrap();
         assert!(!secret.is_empty());
 
         let stored = load_bunker_config(&storage, BUNKER_CONFIG_STORAGE_KEY)
@@ -459,8 +510,9 @@ mod tests {
             stored
                 .transport_secret
                 .as_deref()
-                .and_then(decode_transport_secret),
-            Some(transport)
+                .and_then(decode_transport_secret)
+                .map(|t| *t),
+            Some(*transport)
         );
         assert_eq!(stored.connect_secret.as_deref(), Some(secret.as_str()));
     }
@@ -471,11 +523,12 @@ mod tests {
     fn restart_reuses_persisted_keys() {
         let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
 
-        let (transport1, secret1) = load_or_create_bunker_keys(&storage).unwrap();
-        let (transport2, secret2) = load_or_create_bunker_keys(&storage).unwrap();
+        let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
+        let (transport1, secret1) = load_or_create_bunker_keys(&mobile).unwrap();
+        let (transport2, secret2) = load_or_create_bunker_keys(&mobile).unwrap();
 
-        assert_eq!(transport1, transport2);
-        assert_eq!(secret1, secret2);
+        assert_eq!(*transport1, *transport2);
+        assert_eq!(*secret1, *secret2);
     }
 
     // Corrupt (invalid-hex transport) or empty (blank connect secret) persisted
@@ -492,9 +545,10 @@ mod tests {
         };
         persist_bunker_config(&storage, BUNKER_CONFIG_STORAGE_KEY, &stored).unwrap();
 
-        let (transport, secret) = load_or_create_bunker_keys(&storage).unwrap();
+        let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
+        let (transport, secret) = load_or_create_bunker_keys(&mobile).unwrap();
         assert!(!secret.is_empty());
-        assert_ne!(secret, "");
+        assert_ne!(secret.as_str(), "");
         assert_eq!(transport.len(), 32);
 
         let reloaded = load_bunker_config(&storage, BUNKER_CONFIG_STORAGE_KEY)
@@ -504,14 +558,45 @@ mod tests {
             reloaded
                 .transport_secret
                 .as_deref()
-                .and_then(decode_transport_secret),
-            Some(transport)
+                .and_then(decode_transport_secret)
+                .map(|t| *t),
+            Some(*transport)
         );
         assert_eq!(reloaded.connect_secret.as_deref(), Some(secret.as_str()));
 
-        let (transport2, secret2) = load_or_create_bunker_keys(&storage).unwrap();
-        assert_eq!(transport, transport2);
-        assert_eq!(secret, secret2);
+        let (transport2, secret2) = load_or_create_bunker_keys(&mobile).unwrap();
+        assert_eq!(*transport, *transport2);
+        assert_eq!(*secret, *secret2);
+    }
+
+    // A persisted transport secret that is valid 32-byte hex but not a valid
+    // secp256k1 scalar (here all-zero) must be rejected and regenerated, so a
+    // corrupt key cannot brick the bunker permanently.
+    #[test]
+    fn invalid_scalar_transport_secret_regenerates() {
+        assert!(decode_transport_secret(&"00".repeat(32)).is_none());
+
+        let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
+        let stored = StoredBunkerConfig {
+            transport_secret: Some("00".repeat(32)),
+            connect_secret: Some("preserved-secret".into()),
+            ..StoredBunkerConfig::default()
+        };
+        persist_bunker_config(&storage, BUNKER_CONFIG_STORAGE_KEY, &stored).unwrap();
+
+        let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
+        let (transport, secret) = load_or_create_bunker_keys(&mobile).unwrap();
+        assert_ne!(*transport, [0u8; 32]);
+        assert!(nostr_sdk::secp256k1::SecretKey::from_slice(&transport[..]).is_ok());
+        // Regenerating the corrupt transport key must not rotate the still-valid
+        // connect secret, or the bunker URL would change on next restart.
+        assert_eq!(*secret, "preserved-secret");
+        let reloaded = load_bunker_config(&storage, BUNKER_CONFIG_STORAGE_KEY)
+            .unwrap()
+            .expect("config persisted");
+        assert_eq!(reloaded.connect_secret.as_deref(), Some("preserved-secret"));
+        let (_, secret2) = load_or_create_bunker_keys(&mobile).unwrap();
+        assert_eq!(*secret2, "preserved-secret");
     }
 
     // Drive the real `KeepMobile::save_bunker_config`: persisted transport key +
@@ -520,9 +605,9 @@ mod tests {
     fn save_bunker_config_preserves_secrets() {
         let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
 
-        let (transport, secret) = load_or_create_bunker_keys(&storage).unwrap();
-
         let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
+        let (transport, secret) = load_or_create_bunker_keys(&mobile).unwrap();
+
         mobile
             .save_bunker_config(crate::BunkerConfigInfo {
                 enabled: false,
@@ -539,8 +624,9 @@ mod tests {
             reloaded
                 .transport_secret
                 .as_deref()
-                .and_then(decode_transport_secret),
-            Some(transport)
+                .and_then(decode_transport_secret)
+                .map(|t| *t),
+            Some(*transport)
         );
         assert_eq!(reloaded.connect_secret.as_deref(), Some(secret.as_str()));
     }
@@ -550,7 +636,8 @@ mod tests {
     fn rewriting_config_preserves_keys() {
         let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
 
-        let (transport1, secret1) = load_or_create_bunker_keys(&storage).unwrap();
+        let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
+        let (transport1, secret1) = load_or_create_bunker_keys(&mobile).unwrap();
 
         let mut stored = load_bunker_config(&storage, BUNKER_CONFIG_STORAGE_KEY)
             .unwrap()
@@ -559,8 +646,8 @@ mod tests {
         stored.authorized_clients.push("client".into());
         persist_bunker_config(&storage, BUNKER_CONFIG_STORAGE_KEY, &stored).unwrap();
 
-        let (transport2, secret2) = load_or_create_bunker_keys(&storage).unwrap();
-        assert_eq!(transport1, transport2);
-        assert_eq!(secret1, secret2);
+        let (transport2, secret2) = load_or_create_bunker_keys(&mobile).unwrap();
+        assert_eq!(*transport1, *transport2);
+        assert_eq!(*secret1, *secret2);
     }
 }

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -4,7 +4,8 @@
 use crate::network::validate_relay_url;
 use crate::{KeepMobile, KeepMobileError};
 use keep_nip46::types::{ApprovalRequest, LogEvent, ServerCallbacks};
-use keep_nip46::{NetworkFrostSigner, RateLimitConfig, Server, ServerConfig};
+use keep_nip46::{NetworkFrostSigner, Permission, RateLimitConfig, Server, ServerConfig};
+use nostr_sdk::Kind;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 
@@ -176,6 +177,70 @@ impl BunkerHandler {
     }
 }
 
+/// NIP-46 event kinds the bunker signs without a per-request approval prompt,
+/// once the connection itself is authorized. Kind 27235 (NIP-98 HTTP auth) is
+/// required by web clients such as nostr-tools' `BunkerSigner`, which sign a
+/// fresh auth event for *every* API call and time out (~60s) if the signer
+/// prompts per request. Kind 7 (reactions) matches the engine default.
+fn bunker_auto_approve_kinds() -> std::collections::HashSet<Kind> {
+    std::collections::HashSet::from([Kind::Reaction, keep_nip46::NIP98_HTTP_AUTH])
+}
+
+fn decode_transport_secret(hex_str: &str) -> Option<[u8; 32]> {
+    hex::decode(hex_str).ok()?.try_into().ok()
+}
+
+/// Loads the persisted bunker transport key + connect secret, generating and
+/// persisting fresh values on first start (or when absent/corrupt). The
+/// bunker:// pubkey is derived from the transport key and the URL embeds the
+/// connect secret, so reusing the persisted values keeps the bunker URL stable
+/// across service restarts — saved client sessions (readstr and the like) keep
+/// receiving responses after a reboot or off/on toggle. The secrets live in the
+/// same SQLCipher-backed SecureStorage as the FROST share material.
+fn load_or_create_bunker_keys(
+    storage: &Arc<dyn crate::SecureStorage>,
+) -> Result<([u8; 32], String), KeepMobileError> {
+    let mut stored =
+        crate::persistence::load_bunker_config(storage, crate::BUNKER_CONFIG_STORAGE_KEY)?
+            .unwrap_or_default();
+
+    let mut dirty = false;
+
+    let transport_secret = match stored
+        .transport_secret
+        .as_deref()
+        .and_then(decode_transport_secret)
+    {
+        Some(bytes) => bytes,
+        None => {
+            let bytes = keep_core::crypto::random_bytes::<32>();
+            stored.transport_secret = Some(hex::encode(bytes));
+            dirty = true;
+            bytes
+        }
+    };
+
+    let connect_secret = match stored.connect_secret.take() {
+        Some(secret) if !secret.is_empty() => secret,
+        _ => {
+            let secret = hex::encode(keep_core::crypto::random_bytes::<16>());
+            stored.connect_secret = Some(secret.clone());
+            dirty = true;
+            secret
+        }
+    };
+
+    if dirty {
+        crate::persistence::persist_bunker_config(
+            storage,
+            crate::BUNKER_CONFIG_STORAGE_KEY,
+            &stored,
+        )?;
+    }
+
+    Ok((transport_secret, connect_secret))
+}
+
 impl BunkerHandler {
     fn do_start_bunker(
         &self,
@@ -229,11 +294,19 @@ impl BunkerHandler {
             let network_signer =
                 NetworkFrostSigner::with_shared_node(group_pubkey_bytes, Arc::clone(node));
 
-            let transport_secret = keep_core::crypto::random_bytes::<32>();
+            let (transport_secret, connect_secret) =
+                load_or_create_bunker_keys(&self.mobile.storage)?;
 
             let config = ServerConfig {
                 rate_limit: Some(RateLimitConfig::default()),
-                expected_secret: Some(hex::encode(keep_core::crypto::random_bytes::<16>())),
+                expected_secret: Some(connect_secret),
+                // Approving the bunker connection (the secret in the bunker URL
+                // is the grant) must let the client sign, mirroring the
+                // always-on bunker in keep-web. Without this the client only
+                // gets get_public_key and every sign_event is denied — the
+                // client logs in but its signed-request calls all fail.
+                connect_grant: Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT,
+                auto_approve_kinds: bunker_auto_approve_kinds(),
                 ..ServerConfig::default()
             };
 
@@ -285,5 +358,209 @@ async fn run_server(
             server.stop().await;
             status.store(STATUS_STOPPED, Ordering::Release);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persistence::{load_bunker_config, persist_bunker_config, StoredBunkerConfig};
+    use crate::storage::{SecureStorage, ShareMetadataInfo};
+    use crate::KeepMobileError;
+    use crate::BUNKER_CONFIG_STORAGE_KEY;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct MemStorage {
+        data: Mutex<HashMap<String, Vec<u8>>>,
+    }
+
+    impl SecureStorage for MemStorage {
+        fn store_share(
+            &self,
+            _data: Vec<u8>,
+            _metadata: ShareMetadataInfo,
+        ) -> Result<(), KeepMobileError> {
+            unimplemented!()
+        }
+        fn load_share(&self) -> Result<Vec<u8>, KeepMobileError> {
+            unimplemented!()
+        }
+        fn has_share(&self) -> bool {
+            false
+        }
+        fn get_share_metadata(&self) -> Option<ShareMetadataInfo> {
+            None
+        }
+        fn delete_share(&self) -> Result<(), KeepMobileError> {
+            unimplemented!()
+        }
+        fn store_share_by_key(
+            &self,
+            key: String,
+            data: Vec<u8>,
+            _metadata: ShareMetadataInfo,
+        ) -> Result<(), KeepMobileError> {
+            self.data.lock().unwrap().insert(key, data);
+            Ok(())
+        }
+        fn load_share_by_key(&self, key: String) -> Result<Vec<u8>, KeepMobileError> {
+            self.data
+                .lock()
+                .unwrap()
+                .get(&key)
+                .cloned()
+                .ok_or(KeepMobileError::StorageNotFound)
+        }
+        fn list_all_shares(&self) -> Vec<ShareMetadataInfo> {
+            Vec::new()
+        }
+        fn delete_share_by_key(&self, key: String) -> Result<(), KeepMobileError> {
+            self.data.lock().unwrap().remove(&key);
+            Ok(())
+        }
+        fn get_active_share_key(&self) -> Option<String> {
+            None
+        }
+        fn set_active_share_key(&self, _key: Option<String>) -> Result<(), KeepMobileError> {
+            Ok(())
+        }
+    }
+
+    // (a) Configs serialized before the transport_secret/connect_secret fields
+    // existed must still deserialize, leaving the new fields as None.
+    #[test]
+    fn old_bunker_config_deserializes() {
+        let legacy = br#"{"enabled":true,"authorized_clients":["abc"]}"#;
+        let config: StoredBunkerConfig = serde_json::from_slice(legacy).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.authorized_clients, vec!["abc".to_string()]);
+        assert!(config.transport_secret.is_none());
+        assert!(config.connect_secret.is_none());
+    }
+
+    // (c) A fresh storage generates and persists new transport key + secret.
+    #[test]
+    fn fresh_storage_generates_and_persists() {
+        let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
+
+        assert!(load_bunker_config(&storage, BUNKER_CONFIG_STORAGE_KEY)
+            .unwrap()
+            .is_none());
+
+        let (transport, secret) = load_or_create_bunker_keys(&storage).unwrap();
+        assert!(!secret.is_empty());
+
+        let stored = load_bunker_config(&storage, BUNKER_CONFIG_STORAGE_KEY)
+            .unwrap()
+            .expect("config persisted on first start");
+        assert_eq!(
+            stored
+                .transport_secret
+                .as_deref()
+                .and_then(decode_transport_secret),
+            Some(transport)
+        );
+        assert_eq!(stored.connect_secret.as_deref(), Some(secret.as_str()));
+    }
+
+    // (b) Starting the bunker twice against the same storage reuses the same
+    // transport key + connect secret, so the derived bunker:// URI is stable.
+    #[test]
+    fn restart_reuses_persisted_keys() {
+        let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
+
+        let (transport1, secret1) = load_or_create_bunker_keys(&storage).unwrap();
+        let (transport2, secret2) = load_or_create_bunker_keys(&storage).unwrap();
+
+        assert_eq!(transport1, transport2);
+        assert_eq!(secret1, secret2);
+    }
+
+    // Corrupt (invalid-hex transport) or empty (blank connect secret) persisted
+    // values must be treated as absent: regenerated to valid material, persisted,
+    // and stable across the next load — the junk is never propagated.
+    #[test]
+    fn corrupt_or_empty_keys_regenerate_and_persist() {
+        let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
+
+        let stored = StoredBunkerConfig {
+            transport_secret: Some("zzz".into()),
+            connect_secret: Some(String::new()),
+            ..StoredBunkerConfig::default()
+        };
+        persist_bunker_config(&storage, BUNKER_CONFIG_STORAGE_KEY, &stored).unwrap();
+
+        let (transport, secret) = load_or_create_bunker_keys(&storage).unwrap();
+        assert!(!secret.is_empty());
+        assert_ne!(secret, "");
+        assert_eq!(transport.len(), 32);
+
+        let reloaded = load_bunker_config(&storage, BUNKER_CONFIG_STORAGE_KEY)
+            .unwrap()
+            .expect("regenerated config persisted");
+        assert_eq!(
+            reloaded
+                .transport_secret
+                .as_deref()
+                .and_then(decode_transport_secret),
+            Some(transport)
+        );
+        assert_eq!(reloaded.connect_secret.as_deref(), Some(secret.as_str()));
+
+        let (transport2, secret2) = load_or_create_bunker_keys(&storage).unwrap();
+        assert_eq!(transport, transport2);
+        assert_eq!(secret, secret2);
+    }
+
+    // Drive the real `KeepMobile::save_bunker_config`: persisted transport key +
+    // connect secret survive an unrelated config save (disable + add a client).
+    #[test]
+    fn save_bunker_config_preserves_secrets() {
+        let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
+
+        let (transport, secret) = load_or_create_bunker_keys(&storage).unwrap();
+
+        let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
+        mobile
+            .save_bunker_config(crate::BunkerConfigInfo {
+                enabled: false,
+                authorized_clients: vec!["c".into()],
+            })
+            .unwrap();
+
+        let reloaded = load_bunker_config(&storage, BUNKER_CONFIG_STORAGE_KEY)
+            .unwrap()
+            .expect("config persisted");
+        assert!(!reloaded.enabled);
+        assert_eq!(reloaded.authorized_clients, vec!["c".to_string()]);
+        assert_eq!(
+            reloaded
+                .transport_secret
+                .as_deref()
+                .and_then(decode_transport_secret),
+            Some(transport)
+        );
+        assert_eq!(reloaded.connect_secret.as_deref(), Some(secret.as_str()));
+    }
+
+    // Saving unrelated config (e.g. toggling enabled) must not rotate the keys.
+    #[test]
+    fn rewriting_config_preserves_keys() {
+        let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
+
+        let (transport1, secret1) = load_or_create_bunker_keys(&storage).unwrap();
+
+        let mut stored = load_bunker_config(&storage, BUNKER_CONFIG_STORAGE_KEY)
+            .unwrap()
+            .unwrap();
+        stored.enabled = false;
+        stored.authorized_clients.push("client".into());
+        persist_bunker_config(&storage, BUNKER_CONFIG_STORAGE_KEY, &stored).unwrap();
+
+        let (transport2, secret2) = load_or_create_bunker_keys(&storage).unwrap();
+        assert_eq!(transport1, transport2);
+        assert_eq!(secret1, secret2);
     }
 }

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -178,23 +178,31 @@ impl BunkerHandler {
     }
 }
 
-/// NIP-46 event kinds the bunker signs without a per-request approval prompt,
-/// once the connection itself is authorized. Kind 27235 (NIP-98 HTTP auth) is
-/// required by web clients such as nostr-tools' `BunkerSigner`, which sign a
-/// fresh auth event for *every* API call and time out (~60s) if the signer
-/// prompts per request. Kind 7 (reactions) matches the engine default.
+/// Global event kinds the bunker signs without a per-request prompt for any
+/// client. Kept to the safe engine default (kind 7 reactions) only. NIP-98 is
+/// NOT global; see `bunker_connect_auto_approve_kinds`.
+fn bunker_auto_approve_kinds() -> std::collections::HashSet<Kind> {
+    std::collections::HashSet::from([Kind::Reaction])
+}
+
+/// Event kinds auto-approved per-app for each client that completes the connect
+/// handshake, scoped to that client's pubkey instead of granted globally. Kind
+/// 27235 (NIP-98 HTTP auth) is required by web clients such as nostr-tools'
+/// `BunkerSigner`, which sign a fresh auth event for *every* API call and time
+/// out (~60s) if the signer prompts per request.
 ///
 /// TRUST MODEL: auto-approving kind 27235 makes the bunker URL + connect secret
 /// an HTTP-auth bearer credential. Any client that completes the connect
 /// handshake can silently mint NIP-98 auth tokens for *any* URL and method with
 /// no per-request prompt, exactly like handing out an HTTP `Authorization`
-/// header. Amber behaves the same way. Unlike Amber, this is currently GLOBAL:
-/// one shared connect secret and one global `auto_approve_kinds` set, not
-/// per-app scoped, so every connected client shares the same blanket grant.
-/// Per-app scoping is tracked as follow-up work; treat the bunker URL as a
-/// secret of equivalent power to the signing key for HTTP-auth purposes.
-fn bunker_auto_approve_kinds() -> std::collections::HashSet<Kind> {
-    std::collections::HashSet::from([Kind::Reaction, keep_nip46::NIP98_HTTP_AUTH])
+/// header. Amber behaves the same way. The grant is now scoped to each
+/// connected app's pubkey (revocable and auditable per app) rather than a
+/// blanket global rule, but the connect secret is still shared across clients,
+/// so treat the bunker URL as a secret of equivalent power to the signing key
+/// for HTTP-auth purposes. A per-app/URL-method allowlist is tracked as
+/// follow-up work.
+fn bunker_connect_auto_approve_kinds() -> std::collections::HashSet<Kind> {
+    std::collections::HashSet::from([keep_nip46::NIP98_HTTP_AUTH])
 }
 
 /// Decodes a persisted transport secret, returning `None` when the stored value
@@ -349,14 +357,17 @@ impl BunkerHandler {
                 // gets get_public_key and every sign_event is denied — the
                 // client logs in but its signed-request calls all fail.
                 //
-                // TRUST MODEL: this connect grant plus the global
-                // auto_approve_kinds (see `bunker_auto_approve_kinds`) means a
-                // single shared connect secret authorizes signing and silent
-                // NIP-98 (kind 27235) token minting for every connected client.
-                // The connect secret is a bearer credential, not yet per-app
-                // scoped; per-app grants are tracked as follow-up work.
+                // TRUST MODEL: this connect grant plus the per-app
+                // connect_auto_approve_kinds (see
+                // `bunker_connect_auto_approve_kinds`) means a single shared
+                // connect secret authorizes signing and silent NIP-98 (kind
+                // 27235) token minting for every connected client. NIP-98 is
+                // granted per connected app pubkey (revocable/auditable), not
+                // globally. The connect secret is still a shared bearer
+                // credential; a per-app/URL-method allowlist is follow-up work.
                 connect_grant: Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT,
                 auto_approve_kinds: bunker_auto_approve_kinds(),
+                connect_auto_approve_kinds: bunker_connect_auto_approve_kinds(),
                 ..ServerConfig::default()
             };
 

--- a/keep-mobile/src/persistence.rs
+++ b/keep-mobile/src/persistence.rs
@@ -653,6 +653,17 @@ pub(crate) struct StoredBunkerConfig {
     pub(crate) enabled: bool,
     #[serde(default)]
     pub(crate) authorized_clients: Vec<String>,
+    /// Hex-encoded 32-byte transport secret key. The bunker:// pubkey is derived
+    /// from this key, so persisting it keeps the bunker URL stable across service
+    /// restarts. Stored in the same SQLCipher-backed SecureStorage as the FROST
+    /// share material. `Option` + `serde(default)` keeps pre-existing configs
+    /// (written before this field existed) deserializable.
+    #[serde(default)]
+    pub(crate) transport_secret: Option<String>,
+    /// Connect secret embedded in the bunker:// URL. Persisted alongside the
+    /// transport key so saved client sessions keep authenticating after a restart.
+    #[serde(default)]
+    pub(crate) connect_secret: Option<String>,
 }
 
 pub(crate) fn load_bunker_config(

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -104,6 +104,12 @@ pub struct SignerHandler {
     /// act of approving the connection is the grant. Defaults to the
     /// least-privilege `Permission::DEFAULT`.
     connect_grant: Permission,
+    /// Event kinds auto-approved per-app for every client that completes the
+    /// connect handshake, granted to that specific app pubkey (revocable,
+    /// auditable) rather than via the blanket `global_auto_approve` set. The
+    /// mobile bunker uses this to auto-approve NIP-98 (kind 27235) for connected
+    /// web clients without making it a global rule for unconnected apps.
+    connect_auto_approve_kinds: HashSet<Kind>,
     relay_urls: Vec<String>,
     kill_switch: Arc<AtomicBool>,
     /// The transport (bunker URL) pubkey clients connect to. For a remote
@@ -134,6 +140,7 @@ impl SignerHandler {
             expected_secret: None,
             auto_approve: false,
             connect_grant: Permission::DEFAULT,
+            connect_auto_approve_kinds: HashSet::new(),
             relay_urls: Vec::new(),
             kill_switch: Arc::new(AtomicBool::new(false)),
             transport_pubkey: None,
@@ -152,6 +159,11 @@ impl SignerHandler {
 
     pub fn with_connect_grant(mut self, grant: Permission) -> Self {
         self.connect_grant = grant;
+        self
+    }
+
+    pub fn with_connect_auto_approve_kinds(mut self, kinds: HashSet<Kind>) -> Self {
+        self.connect_auto_approve_kinds = kinds;
         self
     }
 
@@ -343,10 +355,11 @@ impl SignerHandler {
             }
         }
 
-        let (mut requested_perms, auto_kinds) = permissions
+        let (mut requested_perms, mut auto_kinds) = permissions
             .as_deref()
             .map(parse_permission_string)
             .unwrap_or((self.connect_grant, HashSet::new()));
+        auto_kinds.extend(self.connect_auto_approve_kinds.iter().copied());
 
         if self.auto_approve {
             requested_perms = Permission::ALL;
@@ -626,9 +639,10 @@ impl SignerHandler {
     ) -> Result<()> {
         self.check_rate_limit(&app_pubkey).await?;
 
-        let (requested_perms, auto_kinds) = permissions_str
+        let (requested_perms, mut auto_kinds) = permissions_str
             .map(parse_permission_string)
             .unwrap_or((self.connect_grant, HashSet::new()));
+        auto_kinds.extend(self.connect_auto_approve_kinds.iter().copied());
 
         let mut pm = self.permissions.lock().await;
         if !pm.connect_with_permissions(app_pubkey, name.clone(), requested_perms, auto_kinds) {
@@ -847,6 +861,38 @@ mod tests {
         assert!(
             !methods.iter().any(|m| m == "sign_event"),
             "kind 27235 must not trigger a per-request approval prompt, saw: {methods:?}"
+        );
+    }
+
+    // App-scoped grant: `connect_auto_approve_kinds` auto-approves kind 27235
+    // only for clients that completed the connect handshake (scoped to their
+    // pubkey), and does NOT leak to apps that never connected — unlike the
+    // global `auto_approve_kinds` set.
+    #[tokio::test]
+    async fn connect_auto_approve_kinds_are_per_app_not_global() {
+        let keyring = setup_keyring();
+        let permissions = Arc::new(Mutex::new(PermissionManager::new()));
+        let audit = Arc::new(Mutex::new(AuditLog::new(100)));
+        let handler = SignerHandler::new(keyring, Arc::clone(&permissions), audit, None)
+            .with_expected_secret("connect-secret".into())
+            .with_connect_grant(Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT)
+            .with_connect_auto_approve_kinds(HashSet::from([NIP98_HTTP_AUTH]));
+
+        let connected = Keys::generate().public_key();
+        handler
+            .handle_connect(connected, None, Some("connect-secret".into()), None)
+            .await
+            .unwrap();
+
+        let never_connected = Keys::generate().public_key();
+        let pm = permissions.lock().await;
+        assert!(
+            !pm.needs_approval(&connected, NIP98_HTTP_AUTH),
+            "connected app must have NIP-98 auto-approved per-app"
+        );
+        assert!(
+            pm.needs_approval(&never_connected, NIP98_HTTP_AUTH),
+            "NIP-98 must NOT be globally auto-approved for unconnected apps"
         );
     }
 

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -742,6 +742,7 @@ mod tests {
     use super::*;
     use crate::audit::AuditLog;
     use crate::permissions::PermissionManager;
+    use crate::NIP98_HTTP_AUTH;
     use keep_core::keyring::Keyring;
     use keep_core::keys::{KeyType, NostrKeypair};
 
@@ -764,6 +765,132 @@ mod tests {
         let permissions = Arc::new(Mutex::new(PermissionManager::new()));
         let audit = Arc::new(Mutex::new(AuditLog::new(100)));
         SignerHandler::new(keyring, permissions, audit, None).with_auto_approve(true)
+    }
+
+    /// Records every `request_approval` invocation (by method) so a test can
+    /// assert which operations triggered an interactive prompt. Approves all.
+    struct RecordingCallbacks {
+        methods: std::sync::Mutex<Vec<String>>,
+    }
+    impl crate::types::ServerCallbacks for RecordingCallbacks {
+        fn on_log(&self, _event: crate::types::LogEvent) {}
+        fn request_approval(&self, request: ApprovalRequest) -> bool {
+            self.methods.lock().unwrap().push(request.method);
+            true
+        }
+        fn on_connect(&self, _pubkey: &str, _name: &str) {}
+    }
+
+    // Reproduces the readstr / nostr-tools failure: a client that connects
+    // WITHOUT requesting permissions only receives the least-privilege
+    // `connect_grant` default (get_public_key), so signing a kind-27235
+    // (NIP-98) event is denied — the client logs in but its signed requests
+    // all fail. The mobile/web bunkers must override `connect_grant`.
+    #[tokio::test]
+    async fn default_connect_grant_denies_sign_event() {
+        let keyring = setup_keyring();
+        let permissions = Arc::new(Mutex::new(PermissionManager::new()));
+        let audit = Arc::new(Mutex::new(AuditLog::new(100)));
+        let cb = Arc::new(RecordingCallbacks {
+            methods: std::sync::Mutex::new(Vec::new()),
+        });
+        // Default connect_grant == Permission::DEFAULT (get_public_key only).
+        let handler = SignerHandler::new(keyring, permissions, audit, Some(cb));
+
+        let app = Keys::generate().public_key();
+        handler.handle_connect(app, None, None, None).await.unwrap();
+
+        let signer_pk = handler.our_pubkey().await.unwrap();
+        let unsigned = UnsignedEvent::new(signer_pk, Timestamp::now(), NIP98_HTTP_AUTH, vec![], "");
+        let result = handler.handle_sign_event(app, unsigned).await;
+        assert!(
+            result.is_err(),
+            "default connect_grant must not permit sign_event"
+        );
+    }
+
+    // The fix: with `connect_grant` including SIGN_EVENT and kind 27235 in the
+    // global auto-approve set, a client that connected without requesting
+    // permissions can sign a NIP-98 event immediately, and NO per-request
+    // approval prompt fires (only the connection itself is gated).
+    #[tokio::test]
+    async fn http_auth_signed_without_per_request_prompt() {
+        let keyring = setup_keyring();
+        let permissions = Arc::new(Mutex::new(PermissionManager::new()));
+        permissions
+            .lock()
+            .await
+            .set_auto_approve_kinds(HashSet::from([NIP98_HTTP_AUTH]));
+        let audit = Arc::new(Mutex::new(AuditLog::new(100)));
+        let cb = Arc::new(RecordingCallbacks {
+            methods: std::sync::Mutex::new(Vec::new()),
+        });
+        let handler = SignerHandler::new(keyring, permissions, audit, Some(cb.clone()))
+            .with_connect_grant(Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT);
+
+        let app = Keys::generate().public_key();
+        handler.handle_connect(app, None, None, None).await.unwrap();
+
+        let signer_pk = handler.our_pubkey().await.unwrap();
+        let tags = vec![
+            Tag::parse(["u", "https://readstr.example/api/feed"]).unwrap(),
+            Tag::parse(["method", "GET"]).unwrap(),
+        ];
+        let unsigned = UnsignedEvent::new(signer_pk, Timestamp::now(), NIP98_HTTP_AUTH, tags, "");
+        let signed = handler
+            .handle_sign_event(app, unsigned)
+            .await
+            .expect("kind 27235 must auto-sign for an authorized client");
+        assert_eq!(signed.kind, NIP98_HTTP_AUTH);
+
+        let methods = cb.methods.lock().unwrap().clone();
+        assert!(
+            !methods.iter().any(|m| m == "sign_event"),
+            "kind 27235 must not trigger a per-request approval prompt, saw: {methods:?}"
+        );
+    }
+
+    // Requirement 3: the signer must sign the event EXACTLY as received —
+    // created_at is not rewritten and tags (including the NIP-98 `payload`
+    // tag) are preserved verbatim and in order.
+    #[tokio::test]
+    async fn sign_event_preserves_created_at_and_tags() {
+        let keyring = setup_keyring();
+        let permissions = Arc::new(Mutex::new(PermissionManager::new()));
+        permissions
+            .lock()
+            .await
+            .set_auto_approve_kinds(HashSet::from([NIP98_HTTP_AUTH]));
+        let audit = Arc::new(Mutex::new(AuditLog::new(100)));
+        let handler = SignerHandler::new(keyring, permissions, audit, None).with_auto_approve(true);
+
+        let app = Keys::generate().public_key();
+        handler.handle_connect(app, None, None, None).await.unwrap();
+        let signer_pk = handler.our_pubkey().await.unwrap();
+
+        let created_at = Timestamp::from(1_700_000_000);
+        let tags = vec![
+            Tag::parse(["u", "https://readstr.example/api/feed"]).unwrap(),
+            Tag::parse(["method", "POST"]).unwrap(),
+            Tag::parse([
+                "payload",
+                "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+            ])
+            .unwrap(),
+        ];
+        let unsigned = UnsignedEvent::new(signer_pk, created_at, NIP98_HTTP_AUTH, tags.clone(), "");
+        let signed = handler.handle_sign_event(app, unsigned).await.unwrap();
+
+        assert_eq!(
+            signed.created_at, created_at,
+            "created_at must not be rewritten"
+        );
+        assert!(signed.verify().is_ok(), "signed event must verify");
+        assert_eq!(
+            signed.tags.to_vec(),
+            tags,
+            "tags must be preserved verbatim and in order"
+        );
     }
 
     #[tokio::test]

--- a/keep-nip46/src/lib.rs
+++ b/keep-nip46/src/lib.rs
@@ -34,4 +34,4 @@ pub use local_server::{LocalServer, LocalServerConfig};
 pub use permissions::{AppPermission, Permission, PermissionDuration, PermissionManager};
 pub use rate_limit::{RateLimitConfig, RateLimiter};
 pub use server::{PreGrantedApp, Server, ServerConfig};
-pub use types::{ApprovalRequest, LogEvent, ServerCallbacks};
+pub use types::{ApprovalRequest, LogEvent, ServerCallbacks, NIP98_HTTP_AUTH};

--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -43,6 +43,12 @@ pub struct ServerConfig {
     /// `keep nip46 auto-approve`. Only meaningful for interactive serving;
     /// in headless mode every request is auto-approved regardless.
     pub auto_approve_kinds: std::collections::HashSet<nostr_sdk::Kind>,
+    /// Event kinds auto-approved per-app for each client that completes the
+    /// connect handshake, scoped to that app's pubkey instead of the global
+    /// `auto_approve_kinds`. The mobile bunker grants NIP-98 (kind 27235) this
+    /// way so connected web clients sign without per-request prompts while
+    /// unconnected apps get no blanket grant.
+    pub connect_auto_approve_kinds: std::collections::HashSet<nostr_sdk::Kind>,
 }
 
 /// A NIP-46 client app whose permissions are loaded into the
@@ -120,6 +126,7 @@ impl Default for ServerConfig {
             connect_grant: Permission::DEFAULT,
             pre_grants: Vec::new(),
             auto_approve_kinds: std::collections::HashSet::from([nostr_sdk::Kind::Reaction]),
+            connect_auto_approve_kinds: std::collections::HashSet::new(),
         }
     }
 }
@@ -342,6 +349,7 @@ impl Server {
         let mut handler = SignerHandler::new(keyring, permissions, audit, callbacks.clone())
             .with_auto_approve(config.auto_approve)
             .with_connect_grant(config.connect_grant)
+            .with_connect_auto_approve_kinds(config.connect_auto_approve_kinds.clone())
             .with_transport_pubkey(keys.public_key());
         if let Some(frost) = frost_signer {
             handler = handler.with_frost_signer(frost);
@@ -446,6 +454,7 @@ impl Server {
             .with_network_frost_signer(network_signer)
             .with_auto_approve(config.auto_approve)
             .with_connect_grant(config.connect_grant)
+            .with_connect_auto_approve_kinds(config.connect_auto_approve_kinds.clone())
             .with_transport_pubkey(keys.public_key());
         let (handler, bunker_secret) = finalize_handler(handler, &config, relay_urls);
 

--- a/keep-nip46/src/types.rs
+++ b/keep-nip46/src/types.rs
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: MIT
 use nostr_sdk::prelude::*;
 
+/// NIP-98 HTTP Auth event kind (27235). Web clients such as nostr-tools'
+/// `BunkerSigner` sign a fresh auth event for every API call, so the bunkers
+/// auto-approve this kind to avoid a per-request prompt that would time out.
+pub const NIP98_HTTP_AUTH: Kind = Kind::Custom(27235);
+
 #[derive(Debug, Clone)]
 pub struct LogEvent {
     pub app: String,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bunker connection URLs now remain stable across app restarts by persisting connection secrets.
  * NIP-98 HTTP Auth events are automatically approved without manual per-request prompts.

* **Bug Fixes**
  * Bunker settings are now properly preserved, protecting transport and connection secrets from being overwritten.

* **Tests**
  * Added comprehensive test coverage for bunker configuration persistence and HTTP Auth signing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->