### PR TITLE
rotation: audit-log entries for rotate_password / rotate_data_key (closes #566)

### DIFF
--- a/keep-cli/src/commands/audit.rs
+++ b/keep-cli/src/commands/audit.rs
@@ -453,6 +453,10 @@ mod stats_tests {
         stats.record(AuditEventType::RateLimitTripped);
         stats.record(AuditEventType::VaultUnlock);
         stats.record(AuditEventType::VaultLock);
+        stats.record(AuditEventType::PasswordRotate);
+        stats.record(AuditEventType::PasswordRotateFailed);
+        stats.record(AuditEventType::DataKeyRotate);
+        stats.record(AuditEventType::DataKeyRotateFailed);
 
         assert_eq!(stats.key_gen, 1);
         assert_eq!(stats.key_import, 2);
@@ -472,6 +476,10 @@ mod stats_tests {
         assert_eq!(stats.rate_limit_tripped, 1);
         assert_eq!(stats.unlock, 1);
         assert_eq!(stats.lock, 1);
+        assert_eq!(stats.password_rotate_ok, 1);
+        assert_eq!(stats.password_rotate_fail, 1);
+        assert_eq!(stats.data_key_rotate_ok, 1);
+        assert_eq!(stats.data_key_rotate_fail, 1);
     }
 
     /// Closes the #526 gap surfaced by #441's testing pass: each of the

--- a/keep-cli/src/commands/audit.rs
+++ b/keep-cli/src/commands/audit.rs
@@ -307,6 +307,10 @@ struct AuditStats {
     rate_limit_tripped: u32,
     unlock: u32,
     lock: u32,
+    password_rotate_ok: u32,
+    password_rotate_fail: u32,
+    data_key_rotate_ok: u32,
+    data_key_rotate_fail: u32,
 }
 
 impl AuditStats {
@@ -334,6 +338,10 @@ impl AuditStats {
             AuditEventType::RateLimitTripped => self.rate_limit_tripped += 1,
             AuditEventType::VaultUnlock => self.unlock += 1,
             AuditEventType::VaultLock => self.lock += 1,
+            AuditEventType::PasswordRotate => self.password_rotate_ok += 1,
+            AuditEventType::PasswordRotateFailed => self.password_rotate_fail += 1,
+            AuditEventType::DataKeyRotate => self.data_key_rotate_ok += 1,
+            AuditEventType::DataKeyRotateFailed => self.data_key_rotate_fail += 1,
         }
     }
 }
@@ -398,6 +406,14 @@ pub fn cmd_audit_stats(out: &Output, path: &Path, hidden: bool) -> Result<()> {
     out.info(&format!("  Vault locks: {}", stats.lock));
     out.info(&format!("  Auth failures: {}", stats.auth_fail));
     out.info(&format!("  Rate limit trips: {}", stats.rate_limit_tripped));
+    out.info(&format!(
+        "  Password rotations: {} ok / {} failed",
+        stats.password_rotate_ok, stats.password_rotate_fail
+    ));
+    out.info(&format!(
+        "  Data-key rotations: {} ok / {} failed",
+        stats.data_key_rotate_ok, stats.data_key_rotate_fail
+    ));
 
     Ok(())
 }

--- a/keep-core/src/audit.rs
+++ b/keep-core/src/audit.rs
@@ -75,6 +75,18 @@ pub enum AuditEventType {
     /// time on the NEXT successful unlock, since the data key needed to
     /// encrypt audit entries is not available while the vault is locked.
     RateLimitTripped = 20,
+    /// Vault password rotated successfully.
+    PasswordRotate = 21,
+    /// Vault password rotation attempted but rejected (wrong old password,
+    /// invalid new password, or mid-rotation failure). Recorded only when
+    /// the vault was unlocked at attempt time; failed attempts on a locked
+    /// vault cannot be persisted because the audit log needs the data key.
+    PasswordRotateFailed = 22,
+    /// Data encryption key rotated successfully.
+    DataKeyRotate = 23,
+    /// Data-key rotation attempted but rejected (wrong password or mid-
+    /// rotation failure). Same locked-vault caveat as `PasswordRotateFailed`.
+    DataKeyRotateFailed = 24,
 }
 
 impl std::fmt::Display for AuditEventType {
@@ -101,6 +113,10 @@ impl std::fmt::Display for AuditEventType {
             Self::VaultLock => write!(f, "vault_lock"),
             Self::FrostShareRefresh => write!(f, "frost_share_refresh"),
             Self::RateLimitTripped => write!(f, "rate_limit_tripped"),
+            Self::PasswordRotate => write!(f, "password_rotate"),
+            Self::PasswordRotateFailed => write!(f, "password_rotate_failed"),
+            Self::DataKeyRotate => write!(f, "data_key_rotate"),
+            Self::DataKeyRotateFailed => write!(f, "data_key_rotate_failed"),
         }
     }
 }

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -1305,7 +1305,10 @@ impl Keep {
             Err(e) => {
                 // Failed attempts are observable only when the vault was
                 // unlocked before the call (audit log needs the data key).
-                self.audit_event(AuditEventType::PasswordRotateFailed, |e| e);
+                let reason = e.to_string();
+                self.audit_event(AuditEventType::PasswordRotateFailed, |entry| {
+                    entry.with_success(false).with_reason(&reason)
+                });
                 Err(e)
             }
         }
@@ -1315,15 +1318,14 @@ impl Keep {
     ///
     /// Generates a new data encryption key and re-encrypts all stored keys and shares.
     pub fn rotate_data_key(&mut self, password: &str) -> Result<()> {
-        let old_data_key = match self.get_data_key() {
-            Ok(k) => k,
-            Err(e) => {
-                self.audit_event(AuditEventType::DataKeyRotateFailed, |e| e);
-                return Err(e);
-            }
-        };
+        // A locked vault has no data key, so the failure entry cannot be
+        // encrypted/recorded here; `audit_event` no-ops in that case.
+        let old_data_key = self.get_data_key()?;
         if let Err(e) = self.storage.rotate_data_key(password) {
-            self.audit_event(AuditEventType::DataKeyRotateFailed, |e| e);
+            let reason = e.to_string();
+            self.audit_event(AuditEventType::DataKeyRotateFailed, |entry| {
+                entry.with_success(false).with_reason(&reason)
+            });
             return Err(e);
         }
         let new_data_key = self.get_data_key()?;
@@ -2017,11 +2019,17 @@ mod tests {
             after_empty.len() > pre,
             "audit log should grow on empty-new-password rejection"
         );
+        let failure = after_empty
+            .iter()
+            .find(|e| e.event_type == AuditEventType::PasswordRotateFailed)
+            .expect("PasswordRotateFailed entry missing after empty-new-password rejection");
         assert!(
-            after_empty
-                .iter()
-                .any(|e| e.event_type == AuditEventType::PasswordRotateFailed),
-            "PasswordRotateFailed entry missing after empty-new-password rejection"
+            !failure.success,
+            "PasswordRotateFailed entry must be marked success=false"
+        );
+        assert!(
+            failure.reason.is_some(),
+            "PasswordRotateFailed entry must record a failure reason"
         );
 
         // Too-short new password: same rejection.

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -1292,18 +1292,40 @@ impl Keep {
     /// Re-encrypts the data encryption key with a new password-derived key.
     /// The data encryption key itself is unchanged, so stored secrets remain intact.
     pub fn rotate_password(&mut self, old_password: &str, new_password: &str) -> Result<()> {
-        self.storage.rotate_password(old_password, new_password)?;
-        self.keyring.clear();
-        self.load_keys_to_keyring()?;
-        Ok(())
+        match self.storage.rotate_password(old_password, new_password) {
+            Ok(()) => {
+                self.keyring.clear();
+                self.load_keys_to_keyring()?;
+                // Audit AFTER reloading the keyring so the entry binds to the
+                // post-rotation state. Logged through `audit_event`, which
+                // silently no-ops when the vault has no accessible data key.
+                self.audit_event(AuditEventType::PasswordRotate, |e| e);
+                Ok(())
+            }
+            Err(e) => {
+                // Failed attempts are observable only when the vault was
+                // unlocked before the call (audit log needs the data key).
+                self.audit_event(AuditEventType::PasswordRotateFailed, |e| e);
+                Err(e)
+            }
+        }
     }
 
     /// Rotate the data encryption key.
     ///
     /// Generates a new data encryption key and re-encrypts all stored keys and shares.
     pub fn rotate_data_key(&mut self, password: &str) -> Result<()> {
-        let old_data_key = self.get_data_key()?;
-        self.storage.rotate_data_key(password)?;
+        let old_data_key = match self.get_data_key() {
+            Ok(k) => k,
+            Err(e) => {
+                self.audit_event(AuditEventType::DataKeyRotateFailed, |e| e);
+                return Err(e);
+            }
+        };
+        if let Err(e) = self.storage.rotate_data_key(password) {
+            self.audit_event(AuditEventType::DataKeyRotateFailed, |e| e);
+            return Err(e);
+        }
         let new_data_key = self.get_data_key()?;
 
         if let Some(ref mut audit) = self.audit {
@@ -1315,6 +1337,9 @@ impl Keep {
 
         self.keyring.clear();
         self.load_keys_to_keyring()?;
+        // Log AFTER re-encryption: ensures the audit log is now encrypted
+        // under the new data key and the entry sits at the head of the chain.
+        self.audit_event(AuditEventType::DataKeyRotate, |e| e);
         Ok(())
     }
 
@@ -1933,6 +1958,120 @@ mod tests {
             let slot = keep.keyring().get(&pubkey).unwrap();
             assert_eq!(slot.name, "dektest");
         }
+    }
+
+    // === #566: audit-log entries for rotation security operations ===
+
+    /// `Keep::rotate_password` MUST emit a `PasswordRotate` audit entry on
+    /// success. Without this, security-sensitive password rotations leave no
+    /// observable trace for the operator or for post-incident review.
+    #[test]
+    fn rotate_password_emits_success_audit_entry() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("keep");
+        {
+            let mut keep = test_keep(&path);
+            keep.generate_key("audited").unwrap();
+            keep.rotate_password("testpass", "newpass1").unwrap();
+            let entries = keep.audit_read_all().unwrap();
+            assert!(
+                entries
+                    .iter()
+                    .any(|e| e.event_type == AuditEventType::PasswordRotate),
+                "PasswordRotate entry missing from audit log: {:?}",
+                entries.iter().map(|e| e.event_type).collect::<Vec<_>>()
+            );
+        }
+        // Re-open with the NEW password to confirm the audit log survived the
+        // header rotation and still chain-verifies.
+        let mut keep = Keep::open(&path).unwrap();
+        keep.unlock("newpass1").unwrap();
+        keep.audit_verify_chain().unwrap();
+        let entries = keep.audit_read_all().unwrap();
+        assert!(entries
+            .iter()
+            .any(|e| e.event_type == AuditEventType::PasswordRotate));
+    }
+
+    /// `Keep::rotate_password` MUST emit a `PasswordRotateFailed` audit entry
+    /// when the call is rejected, so failed attacker attempts are observable.
+    /// Failed attempts on an already-locked vault cannot be recorded (data
+    /// key unavailable); this test exercises the unlocked path and uses an
+    /// invalid new password as the failure trigger because Storage's
+    /// `rotate_password` short-circuits the wrong-old-password check when
+    /// the vault is already unlocked (which is the path that admits audit
+    /// writes), while `validate_new_password` is enforced unconditionally.
+    #[test]
+    fn rotate_password_emits_failure_audit_entry_when_unlocked() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("keep");
+        let mut keep = test_keep(&path);
+        keep.generate_key("audited").unwrap();
+
+        let pre = keep.audit_read_all().unwrap().len();
+
+        // Empty new password: validate_new_password rejects.
+        assert!(keep.rotate_password("testpass", "").is_err());
+        let after_empty = keep.audit_read_all().unwrap();
+        assert!(
+            after_empty.len() > pre,
+            "audit log should grow on empty-new-password rejection"
+        );
+        assert!(
+            after_empty
+                .iter()
+                .any(|e| e.event_type == AuditEventType::PasswordRotateFailed),
+            "PasswordRotateFailed entry missing after empty-new-password rejection"
+        );
+
+        // Too-short new password: same rejection.
+        let pre2 = keep.audit_read_all().unwrap().len();
+        assert!(keep.rotate_password("testpass", "a").is_err());
+        let entries = keep.audit_read_all().unwrap();
+        assert!(
+            entries.len() > pre2,
+            "audit log should grow on too-short-new-password rejection"
+        );
+        // The original password still unlocks: failure paths don't corrupt
+        // the header. Drop the first handle before reopening so the vault
+        // file lock is released.
+        drop(keep);
+        let mut reopened = Keep::open(&path).unwrap();
+        reopened.unlock("testpass").unwrap();
+    }
+
+    /// `Keep::rotate_data_key` MUST emit a `DataKeyRotate` audit entry on
+    /// success. The entry's payload is encrypted under the NEW data key (the
+    /// log gets re-encrypted as part of rotation); this test confirms the
+    /// entry is readable after rotation and the chain still verifies.
+    #[test]
+    fn rotate_data_key_emits_success_audit_entry() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("keep");
+        {
+            let mut keep = test_keep(&path);
+            keep.generate_key("dek-audit").unwrap();
+            keep.rotate_data_key("testpass").unwrap();
+            let entries = keep.audit_read_all().unwrap();
+            assert!(
+                entries
+                    .iter()
+                    .any(|e| e.event_type == AuditEventType::DataKeyRotate),
+                "DataKeyRotate entry missing from audit log: {:?}",
+                entries.iter().map(|e| e.event_type).collect::<Vec<_>>()
+            );
+            // The audit log was re-encrypted under the new data key during
+            // rotation; the chain over both pre- and post-rotation entries
+            // must remain valid.
+            keep.audit_verify_chain().unwrap();
+        }
+        // Confirm persistence: re-open and the entry is still there.
+        let mut keep = Keep::open(&path).unwrap();
+        keep.unlock("testpass").unwrap();
+        let entries = keep.audit_read_all().unwrap();
+        assert!(entries
+            .iter()
+            .any(|e| e.event_type == AuditEventType::DataKeyRotate));
     }
 
     #[test]


### PR DESCRIPTION
Closes #566. Wires audit-log instrumentation into the security-critical vault mutations that previously emitted no entries.

## State before this PR

- `Keep::frost_refresh` already emitted `AuditEventType::FrostShareRefresh` (event 19).
- `Keep::rotate_password` emitted nothing.
- `Keep::rotate_data_key` emitted nothing.

Per #438's body, the audit-log scope item was deferred from that PR. This PR closes that gap.

## What this PR adds

### New audit event types (`keep-core/src/audit.rs`)

Four new variants on `AuditEventType`:

| Variant | Disc | Display |
|---|---|---|
| `PasswordRotate` | 21 | `password_rotate` |
| `PasswordRotateFailed` | 22 | `password_rotate_failed` |
| `DataKeyRotate` | 23 | `data_key_rotate` |
| `DataKeyRotateFailed` | 24 | `data_key_rotate_failed` |

### Emission sites (`keep-core/src/lib.rs`)

- `Keep::rotate_password`: emits `PasswordRotate` on success (after keyring reload, so the entry binds the post-rotation state) and `PasswordRotateFailed` on the storage rejection path.
- `Keep::rotate_data_key`: emits `DataKeyRotate` on success (after the audit log is re-encrypted under the new data key) and `DataKeyRotateFailed` on the storage rejection path.

Both use the existing `audit_event` helper, which silently no-ops when the vault has no accessible data key. Failed-rotation entries are observable only when the vault was unlocked at attempt time (the audit log cannot be written without the data key, so a wrong-password attempt against a locked vault still cannot be persisted; that's the same constraint as `RateLimitTripped`, which is deferred to the next successful unlock).

### CLI stats (`keep-cli/src/commands/audit.rs`)

`AuditStats` gets four new counters (`password_rotate_ok` / `_fail`, `data_key_rotate_ok` / `_fail`) and the `audit stats` output now reports them in the Security section.

## Tests added (3 inline tests in `keep-core/src/lib.rs::tests`)

- `rotate_password_emits_success_audit_entry`: rotates, asserts `PasswordRotate` lands in the audit log, then re-opens with the NEW password and confirms the entry survives the header rotation and the chain still verifies.
- `rotate_password_emits_failure_audit_entry_when_unlocked`: rejects empty and too-short new passwords, asserts `PasswordRotateFailed` lands in the log, and confirms the original password still unlocks (failure paths don't corrupt the header).
- `rotate_data_key_emits_success_audit_entry`: rotates the DEK, asserts `DataKeyRotate` lands in the log (encrypted under the NEW key), runs `audit_verify_chain` over the re-encrypted log, then re-opens and re-reads to confirm persistence.

## Notes on what's out of scope

- **Wrong-old-password failure auditing**: `Storage::rotate_password` short-circuits the old-password unlock when the vault is already unlocked. The only path that exercises the wrong-old-password gate runs on a locked vault, and a locked vault cannot write audit entries. Recording these would require the same deferred-write machinery as `RateLimitTripped`; left as a follow-up.
- **Mid-rotation crash recovery**: tracked separately under #565.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Audit system now tracks password rotation and data-key rotation events with separate counters for successful and failed operations.
  * `keep audit stats` command displays new password rotation and data-key rotation metrics alongside existing security audit counters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->