### PR TITLE
docs: fix install/env/MCP errors and fill new-user gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,48 @@ Keep runs as a CLI, a desktop app (Linux/macOS/Windows), a mobile library (Andro
 
 ## Quick Start
 
+Install the CLI (Rust 1.89+):
+
 ```bash
+cargo install --git https://github.com/privkeyio/keep keep-cli
+```
+
+Building needs `pkg-config` and `libudev` (Linux); see [`BUILD.md`](BUILD.md) for the full
+per-platform dependency list.
+
+Or build from a clone:
+
+```bash
+git clone https://github.com/privkeyio/keep
+cd keep
 cargo install --path keep-cli
 ```
 
+Then:
+
 ```bash
-keep init                     # Create encrypted vault
+keep init                     # Create encrypted vault (prompts for a password)
 keep generate --name main     # Generate a new Nostr key
 keep serve --relay wss://bucket.coracle.social  # Start remote signer
 ```
 
-Keys are stored encrypted at `~/.keep`. See [`docs/USAGE.md`](docs/USAGE.md) for full CLI reference, FROST setup, Bitcoin commands, and more.
+Keys are stored encrypted at `~/.keep` (override with `KEEP_HOME` or `--path`). Set
+`KEEP_PASSWORD` to skip the interactive unlock prompt in scripts. Back up your vault with
+`keep backup`; see [`docs/USAGE.md`](docs/USAGE.md) for the full CLI reference, FROST
+setup, Bitcoin commands, and more.
+
+## Documentation
+
+| Doc | Covers |
+|-----|--------|
+| [`docs/USAGE.md`](docs/USAGE.md) | CLI reference, FROST, Bitcoin, agents, hidden volumes, troubleshooting |
+| [`keep-web/README.md`](keep-web/README.md) | Self-hosting the headless co-signer (config, auth, API) |
+| [`docs/SECURITY.md`](docs/SECURITY.md) | Cryptography and threat model |
+| [`docs/ENCLAVE.md`](docs/ENCLAVE.md) | AWS Nitro Enclave deployment |
+| [`docs/RELEASE_SIGNING.md`](docs/RELEASE_SIGNING.md) | Threshold-signed releases |
+| [`docs/REPRODUCIBILITY.md`](docs/REPRODUCIBILITY.md) | Reproducible builds |
+| [`BUILD.md`](BUILD.md) | Building from source, system dependencies |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Contributing guidelines |
 
 ## Development
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -5,30 +5,41 @@
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [CLI Reference](#cli-reference)
+- [Backup & Restore](#backup--restore)
 - [Remote Signing (NIP-46)](#remote-signing-nip-46)
 - [Bitcoin](#bitcoin)
 - [Threshold Signatures (FROST)](#threshold-signatures-frost)
+- [Wallet Descriptor Coordination](#wallet-descriptor-coordination)
+- [Audit Log](#audit-log)
 - [Mobile (NIP-55)](#mobile-nip-55)
 - [Agent SDK](#agent-sdk)
 - [AWS Nitro Enclaves](#aws-nitro-enclaves)
 - [Hidden Volumes](#hidden-volumes)
 - [Configuration](#configuration)
+- [Troubleshooting](#troubleshooting)
 
 ---
 
 ## Installation
 
+Requires Rust 1.89+ (MSRV). System dependencies (for the hardware-signer serial support)
+vary by platform: Linux needs `pkg-config` and `libudev` (`build-essential`/`libudev-dev`),
+macOS needs the Xcode Command Line Tools, and Windows needs nothing extra. See
+[`BUILD.md`](../BUILD.md) for the full list.
+
+**Install the CLI directly:**
+
 ```bash
-cargo install --path keep-cli
+cargo install --git https://github.com/privkeyio/keep keep-cli
 ```
 
-Requires Rust 1.89+ (MSRV).
-
-**From source:**
+**From a clone:**
 
 ```bash
 git clone https://github.com/privkeyio/keep
 cd keep
+cargo install --path keep-cli   # installs `keep` to ~/.cargo/bin
+# or, to run without installing:
 cargo build --release
 ./target/release/keep --help
 ```
@@ -54,15 +65,74 @@ Keys are stored encrypted at `~/.keep`.
 
 ## CLI Reference
 
+Run `keep <command> --help` for the full flag list of any command.
+
+**Global flags** (valid on every command):
+
+| Flag | Description |
+|------|-------------|
+| `--path <dir>` | Use a vault at this path instead of `~/.keep` (also `KEEP_HOME`) |
+| `--hidden` | Operate on the hidden volume (see [Hidden Volumes](#hidden-volumes)) |
+| `--no-mlock` | Disable memory locking, accepting degraded security |
+
+**Vault & keys:**
+
 | Command | Description |
 |---------|-------------|
 | `keep init` | Create encrypted vault |
-| `keep generate --name <n>` | Generate new key |
+| `keep generate --name <n>` | Generate new Nostr key |
 | `keep import --name <n>` | Import existing nsec |
 | `keep list` | List all keys |
-| `keep export --name <n>` | Export nsec |
+| `keep export --name <n>` | Print a raw nsec (interactive TTY only, by design) |
 | `keep delete --name <n>` | Delete key |
-| `keep serve` | Start NIP-46 remote signer |
+| `keep rotate-password` | Change the vault unlock password |
+| `keep rotate-data-key` | Rotate the data-encryption key (re-encrypts every secret) |
+| `keep backup [--output <file>]` | Write a passphrase-encrypted vault backup |
+| `keep restore <file> --target <dir>` | Restore a backup into a **new** vault |
+
+**Signing & coordination:**
+
+| Command | Description |
+|---------|-------------|
+| `keep serve` | Start the NIP-46 bunker (and optional FROST co-signer) |
+| `keep frost ...` | FROST threshold operations (see [FROST](#threshold-signatures-frost)) |
+| `keep wallet ...` | Wallet descriptors, proposals, PSBT spend coordination (see [Wallet](#wallet-descriptor-coordination)) |
+| `keep bitcoin ...` | Addresses, descriptors, PSBT signing (see [Bitcoin](#bitcoin)) |
+| `keep nip46 ...` | NIP-46 client app grant management (see [Remote Signing](#remote-signing-nip-46)) |
+| `keep enclave ...` | AWS Nitro Enclave operations (see [Enclaves](#aws-nitro-enclaves)) |
+| `keep agent mcp --key <n>` | Run the MCP signing server (see [Agent SDK](#agent-sdk)) |
+| `keep sign <file> --group <npub>` | Threshold-sign a file (minisign-compatible) |
+| `keep verify <file> <sig> --group <npub>` | Verify a minisign detached signature |
+
+**Maintenance:**
+
+| Command | Description |
+|---------|-------------|
+| `keep audit ...` | Inspect, verify, export, or prune the audit log (see [Audit Log](#audit-log)) |
+| `keep config show \| path \| init` | Inspect or initialize the CLI config file |
+| `keep migrate status` | Inspect on-disk schema migration state |
+
+---
+
+## Backup & Restore
+
+Your vault lives at `~/.keep` (or `KEEP_HOME` / `--path`). Back it up regularly: if you
+lose it and have no backup, the keys are gone.
+
+```bash
+# Write a passphrase-encrypted backup file
+keep backup --output keep-backup.enc
+
+# Restore into a NEW vault (never overwrites the active ~/.keep)
+keep restore keep-backup.enc --target ~/keep-restored
+```
+
+`restore` requires an explicit `--target` and refuses to write over an existing vault, so
+a restore can never clobber your live keys.
+
+For FROST shares specifically, use `keep frost export` / `keep frost import` (per-share,
+passphrase-encrypted) so shares can be moved or backed up independently. See
+[Threshold Signatures](#threshold-signatures-frost).
 
 ---
 
@@ -77,6 +147,34 @@ keep serve --relay wss://bucket.coracle.social
 This displays a bunker URL to paste into your client.
 
 **Controls:** `Y` approve, `N` reject, `Q` quit
+
+### Pre-granting client apps (headless)
+
+Instead of approving each connection interactively, pre-authorize a client app's pubkey so
+`keep serve` accepts it automatically. This is the headless alternative to the interactive
+prompt.
+
+```bash
+# Grant a client app a set of permissions
+keep nip46 grant <client-npub> \
+  --name "my-client" \
+  --permissions get_public_key,sign_event \
+  --auto-approve-kinds 1,7 \
+  --duration forever
+
+# List existing grants
+keep nip46 apps
+
+# Revoke a grant
+keep nip46 revoke <client-npub>
+
+# Globally auto-approve specific event kinds for every client (interactive serving)
+keep nip46 auto-approve --kinds 1,7
+```
+
+Permission names: `get_public_key`, `sign_event`, `nip04_encrypt`, `nip04_decrypt`,
+`nip44_encrypt`, `nip44_decrypt` (or `all`). `--duration` accepts `session`, `forever`, or
+a number of seconds.
 
 ---
 
@@ -237,6 +335,56 @@ All participants must run the command within 5 minutes. On completion, each devi
 
 ---
 
+## Wallet Descriptor Coordination
+
+Turn a FROST group into a Bitcoin wallet with proper external/internal address chains and
+optional time-locked recovery tiers, coordinated across signers over Nostr.
+
+```bash
+# Simple descriptor from a FROST group (no recovery tiers).
+# Single-key FROST descriptors have no BIP-32 derivation, so receive and change
+# collapse to one address; --allow-address-reuse is required to acknowledge that.
+keep wallet descriptor --group npub1... --network mainnet --allow-address-reuse
+
+# Propose a coordinated descriptor with a recovery tier (preferred: distinct chains)
+keep wallet propose --group npub1... --network mainnet \
+  --recovery '2of3@6mo' --relay wss://bucket.coracle.social
+
+# Inspect / export a stored descriptor
+keep wallet show --group npub1...
+keep wallet export --group npub1... --format sparrow
+
+# Announce recovery xpubs to peers, register on a NIP-46 hardware signer
+keep wallet announce-keys --group npub1... --xpub 'xpub.../fingerprint/label'
+keep wallet register --group npub1... --device 'bunker://...'
+
+# Coordinate a recovery-tier (scriptpath) spend via PSBT
+keep wallet spend --group npub1... --recovery-tier 0 --psbt-file unsigned.psbt
+keep wallet approve-psbt --group npub1... --session <id> --signer-bunker 'fp:bunker://...'
+
+# List stored descriptors
+keep wallet list
+```
+
+Recovery tier syntax is `threshold-of-keys@timelock`, e.g. `2of3@6mo` or `3of5@1y`.
+
+---
+
+## Audit Log
+
+Signing and key-lifecycle operations are recorded in a tamper-evident, hash-chained audit
+log inside the vault.
+
+```bash
+keep audit list --limit 50      # Recent entries
+keep audit verify               # Verify hash-chain integrity
+keep audit stats                # Summary statistics
+keep audit export --output audit.json
+keep audit retention --max-days 90 --apply   # Prune old entries
+```
+
+---
+
 ## Mobile (NIP-55)
 
 UniFFI library for Android/iOS apps to hold FROST shares and sign via NIP-55 protocol. See [keep-android](https://github.com/privkeyio/keep-android) for the Android app implementation.
@@ -318,22 +466,28 @@ const info = await session.getSessionInfo();
 
 ### MCP Server (Claude/Cursor)
 
-Add to your MCP configuration:
+`keep agent mcp` runs a stdio MCP signing server bound to one vault key. The server signs
+under a constrained policy, so the model gets signing capability without ever seeing the
+private key.
+
+```bash
+keep agent mcp --key main
+```
+
+Add it to your MCP client configuration:
 
 ```json
 {
   "servers": {
     "keep-signer": {
       "command": "keep",
-      "args": ["mcp-server"],
-      "env": {
-        "KEEP_SESSION_TOKEN": "keep_sess_...",
-        "KEEP_BUNKER_URL": "bunker://npub1.../wss://relay.example.com"
-      }
+      "args": ["agent", "mcp", "--key", "main"]
     }
   }
 }
 ```
+
+Set `KEEP_PASSWORD` in the server's environment so it can unlock the vault non-interactively.
 
 ---
 
@@ -395,8 +549,36 @@ KEEP_PASSWORD="hidden" keep --hidden list
 
 | Variable | Description |
 |----------|-------------|
+| `KEEP_HOME` | Custom vault path (default: `~/.keep`). Must be absolute. Equivalent to `--path` |
 | `KEEP_PASSWORD` | Vault password (avoids interactive prompt) |
-| `KEEP_HIDDEN_PASSWORD` | Hidden volume password (with `--hidden` flag) |
-| `KEEP_PATH` | Custom vault path (default: `~/.keep`) |
-| `WARDEN_TOKEN` | JWT token for Warden API authentication (requires `--features warden`) |
+| `KEEP_HIDDEN_PASSWORD` | Hidden volume password (with `--hidden`) |
+| `KEEP_YES` | Auto-confirm non-destructive prompts in scripts |
+| `WARDEN_TOKEN` | JWT for Warden API authentication (requires `--features warden`) |
+
+> `KEEP_PATH` is **not** used by the CLI; it configures the vault path for the `keep-web`
+> co-signer only. For the CLI, use `KEEP_HOME` or `--path`. See
+> [`keep-web/README.md`](../keep-web/README.md) for the co-signer's variables.
+
+---
+
+## Troubleshooting
+
+**`mlock` warning at startup.** Keep locks secret memory with `mlock(2)`. On systems with a
+low `RLIMIT_MEMLOCK`, locking can fail and Keep logs a warning but continues with degraded
+protection. Raise the limit (`ulimit -l`) or pass `--no-mlock` to silence it deliberately.
+
+**`keep export` refuses to run.** Raw nsec export is interactive-only by design: it requires
+a real TTY on stdin and stderr and refuses when automation variables (`KEEP_YES` /
+`KEEP_PASSWORD`) are set. Run it directly in a terminal.
+
+**Forgot which volume / hidden volume not appearing.** Hidden volumes are unlocked by
+password: pass `--hidden` with the hidden password. There is no way to detect or recover a
+hidden volume without its password. See [Hidden Volumes](#hidden-volumes).
+
+**`KEEP_HOME must be an absolute path`.** `KEEP_HOME` rejects relative paths. Use a full
+path, e.g. `KEEP_HOME=/home/you/.keep-work`.
+
+**Network FROST signers cannot find each other.** All participants must use the same
+`--group` and at least one shared `--relay`, and (for DKG) run within the coordination
+window. Check liveness with `keep frost network peers --group npub1...`.
 

--- a/keep-enclave/README.md
+++ b/keep-enclave/README.md
@@ -1,0 +1,14 @@
+# keep-enclave
+
+AWS Nitro Enclave signer for Keep. Private keys are generated and used inside a
+hardware-isolated enclave and never leave its memory; the host verifies the enclave via
+Nitro attestation (certificate chain to the AWS root, PCR measurement pinning, and a
+nonce challenge) before trusting it.
+
+The crate is split into `host/` (runs on the EC2 parent instance) and `enclave/` (runs
+inside the enclave), with a reproducible enclave build (see `Dockerfile.reproducible` at
+the repo root) so the running image can be independently verified against its PCRs.
+
+For deployment, KMS setup, and attestation details, see
+[`docs/ENCLAVE.md`](../docs/ENCLAVE.md). For the CLI, see
+[`docs/USAGE.md` › AWS Nitro Enclaves](../docs/USAGE.md#aws-nitro-enclaves).

--- a/keep-web/README.md
+++ b/keep-web/README.md
@@ -1,0 +1,81 @@
+# keep-web
+
+Headless co-signer daemon for Keep. It unlocks a vault at boot, optionally joins a FROST
+group as an always-on co-signer, and exposes a small authenticated HTTP API (plus a Svelte
+admin UI) for managing shares, watching the signing log, and approving requests.
+
+This is the process packaged by [keep-startos](https://github.com/start9-community/keep-startos),
+but it runs anywhere you can set a few environment variables (Docker, systemd, a VM).
+
+## Running
+
+```bash
+# Build
+cargo build --release -p keep-web
+
+# Minimum: a vault path, an unlock password, and an API token
+KEEP_PATH=/data \
+KEEP_PASSWORD_FILE=/run/secrets/keep-password \
+KEEP_WEB_AUTH_TOKEN_FILE=/run/secrets/keep-web-token \
+KEEP_WEB_LISTEN=0.0.0.0:8080 \
+./target/release/keep-web
+```
+
+If the vault at `KEEP_PATH` does not exist, it is created with the supplied password on
+first boot. If `KEEP_WEB_AUTH_TOKEN[_FILE]` is unset, a random token is generated and
+logged at startup (pin it in production so the token is stable).
+
+## Configuration
+
+All configuration is via environment variables. Any `*_FILE` variant reads the value from
+the given file path instead (use this for secrets).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KEEP_PATH` | `/data` | Vault directory. Created on first boot if absent |
+| `KEEP_PASSWORD` / `KEEP_PASSWORD_FILE` | (required) | Vault unlock password for headless start |
+| `KEEP_WEB_AUTH_TOKEN` / `_FILE` | random (logged) | Bearer token gating every `/api/*` route |
+| `KEEP_WEB_LISTEN` | `0.0.0.0:8080` | Listen address |
+| `KEEP_WEB_UI_DIR` | `ui/dist` | Path to the built admin UI assets |
+| `KEEP_BUNKER_RELAY` | `KEEP_RELAY` then `wss://bucket.coracle.social` | Relay(s) for the NIP-46 bunker |
+| `KEEP_RELAY` | `wss://bucket.coracle.social` | Fallback relay |
+| `KEEP_FROST_GROUP` | (none) | npub of the FROST group to co-sign for |
+| `KEEP_FROST_RELAY` | (none) | Relay(s) for FROST coordination |
+| `KEEP_FROST_AUTO_APPROVE` | `false` | Auto-approve co-signing requests when `true` |
+| `KEEP_ALLOW_SINGLE_KEY` | `false` | Allow serving a non-threshold single key |
+| `KEEP_SINGLE_KEY_ACK` | (none) | Must be `i-understand` to actually enable single-key serving |
+
+## Authentication
+
+Every `/api/*` route except `/api/health` and the WebSocket upgrade requires a
+`Authorization: Bearer <token>` header matching `KEEP_WEB_AUTH_TOKEN`. The WebSocket gates
+itself on a single-use ticket minted via the authed `/api/ws-ticket`, so the durable token
+never appears in a URL or proxy access log.
+
+## HTTP API
+
+Authenticated (`Bearer` token):
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/bunker` | Bunker connection details |
+| GET | `/api/shares` | List FROST shares |
+| POST | `/api/shares/import` | Import a share |
+| POST | `/api/shares/export` | Export an encrypted share backup |
+| POST | `/api/shares/delete` | Delete a share |
+| POST | `/api/shares/rename` | Rename a share |
+| POST | `/api/active-group` | Switch the active FROST group |
+| GET | `/api/signing-log` | FROST coordination / signing log |
+| GET | `/api/peers` | Live peer status |
+| GET/POST | `/api/killswitch` | Read / toggle the co-signing kill switch |
+| POST | `/api/approvals/{id}` | Resolve a pending approval request |
+| POST | `/api/ws-ticket` | Mint a single-use WebSocket ticket |
+
+Unauthenticated:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/health` | Liveness probe (for StartOS/Docker) |
+| GET | `/api/events` | WebSocket upgrade for real-time events (ticket-gated) |
+
+Requests and responses are JSON; keep-core errors map to standard HTTP status codes.


### PR DESCRIPTION
Strengthens user-facing docs after an audit against the compiled CLI and keep-web source.

## Fixes (factual errors that misled new users)
- **Install**: README/USAGE quick start used `cargo install --path keep-cli` with no clone step, which fails for a fresh user. Now uses `cargo install --git ... keep-cli` plus a from-clone path, with platform-scoped system-dependency notes (Linux libudev/pkg-config, macOS Xcode CLT, Windows nothing extra).
- **Env var**: USAGE documented `KEEP_PATH` as the CLI vault path; the CLI actually reads `KEEP_HOME` (`KEEP_PATH` is keep-web only). Corrected, with a note.
- **MCP server**: USAGE showed `keep mcp-server` with bogus env vars. Actual command is `keep agent mcp --key <name>`. Corrected, including the MCP client JSON.

## Fills (gaps a new user hits)
- Rebuilt the CLI reference: it listed 7 commands; the CLI has ~22. Added global flags and grouped vault/keys, signing, and maintenance commands.
- New **Backup & Restore** section (`keep backup` / `keep restore`).
- New **Wallet Descriptor Coordination**, **Audit Log**, and NIP-46 app-grant sections.
- New **Troubleshooting** section (mlock, interactive export, hidden volumes, KEEP_HOME absolute path, FROST peer discovery).
- New **keep-web/README.md**: self-hosting the headless co-signer (config vars, auth model, full HTTP API) — previously undocumented.
- README: added a Documentation index and a first-run password note.

## Verification
Every documented command and flag was checked against the compiled `keep` binary (`--help` for each subcommand), and the new-user path (`init → generate → list → backup → restore`) was run end to end. keep-web vars/routes/auth taken directly from `keep-web/src/main.rs`.