### PR TITLE
docs: correct agent SDK install instructions (not yet published)

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -411,8 +411,11 @@ Secure signing for AI agents with constrained sessions.
 
 ### Python
 
+Not yet published to PyPI. Install from a repo clone (the build backend is
+[maturin](https://www.maturin.rs/)):
+
 ```bash
-pip install keep-agent
+pip install ./keep-agent-py
 ```
 
 ```python
@@ -453,8 +456,10 @@ tools = create_keep_tools(session)
 
 ### TypeScript
 
+Not yet published to npm. Build from a repo clone:
+
 ```bash
-npm install @keep/agent
+cd keep-agent-ts && npm install && npm run build
 ```
 
 ```typescript

--- a/keep-agent-py/README.md
+++ b/keep-agent-py/README.md
@@ -4,8 +4,11 @@ Python SDK for Keep - secure signing for AI agents.
 
 ## Installation
 
+Not yet published to PyPI. Install from a clone of the [keep](https://github.com/privkeyio/keep)
+repo (built with [maturin](https://www.maturin.rs/)):
+
 ```bash
-pip install keep-agent
+pip install ./keep-agent-py
 ```
 
 ## Quick Start

--- a/keep-agent-ts/README.md
+++ b/keep-agent-ts/README.md
@@ -4,8 +4,11 @@ TypeScript SDK for Keep - secure signing for AI agents.
 
 ## Installation
 
+Not yet published to npm. Build from a clone of the
+[keep](https://github.com/privkeyio/keep) repo:
+
 ```bash
-npm install @keep/agent
+cd keep-agent-ts && npm install && npm run build
 ```
 
 ## Quick Start


### PR DESCRIPTION
Follow-up to #582. The Agent SDK install instructions told users `pip install keep-agent` and `npm install @keep/agent`, but neither package is published yet:

- PyPI `keep-agent` → 404
- npm `@keep/agent` → 404
- No publish step exists in any workflow; both are at `0.1.0`.

So those commands fail for a new user, same class of broken-install issue #582 fixed for the CLI. This corrects them to build-from-source instructions:

- **Python** (maturin backend): `pip install ./keep-agent-py`
- **TypeScript** (napi-rs): `cd keep-agent-ts && npm install && npm run build`

Updated in `docs/USAGE.md`, `keep-agent-py/README.md`, and `keep-agent-ts/README.md`. When these are actually published, revert to the registry install commands.