### PR TITLE
docs: add mdBook config for the docs.privkey.io portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ cdk.context.json
 *.tar.gz
 dist/
 dist-verify/
+book/

--- a/book.toml
+++ b/book.toml
@@ -6,11 +6,10 @@ src = "docs"
 language = "en"
 
 [output.html]
-site-url = "/"
 git-repository-url = "https://github.com/privkeyio/keep"
 edit-url-template = "https://github.com/privkeyio/keep/edit/main/docs/{path}"
-default-theme = "navy"
-preferred-dark-theme = "navy"
+# Theme (default-theme, site-url) is enforced by the docs.privkey.io aggregator
+# at build time; see github.com/privkeyio/docs.
 
 [output.html.fold]
 enable = true

--- a/book.toml
+++ b/book.toml
@@ -1,0 +1,20 @@
+[book]
+title = "Keep Documentation"
+authors = ["PrivKey LLC"]
+description = "Self-custodial key management for Nostr and Bitcoin"
+src = "docs"
+language = "en"
+
+[output.html]
+site-url = "/"
+git-repository-url = "https://github.com/privkeyio/keep"
+edit-url-template = "https://github.com/privkeyio/keep/edit/main/docs/{path}"
+default-theme = "navy"
+preferred-dark-theme = "navy"
+
+[output.html.fold]
+enable = true
+level = 1
+
+[output.html.search]
+enable = true

--- a/docs/ENCLAVE.md
+++ b/docs/ENCLAVE.md
@@ -39,7 +39,7 @@ Keys live only in enclave memory. KMS decrypts only if PCRs match.
 - AWS account with EC2, KMS, IAM permissions
 - AWS CLI configured
 - Docker installed
-- Nitro SDK binaries, see [keep-enclave/build/README.md](../keep-enclave/build/README.md)
+- Nitro SDK binaries, see [keep-enclave/build/README.md](https://github.com/privkeyio/keep/blob/main/keep-enclave/build/README.md)
 
 ## Deployment Options
 
@@ -153,7 +153,7 @@ exit  # Re-login to apply groups
 
 ## Build Enclave
 
-See [keep-enclave/build/README.md](../keep-enclave/build/README.md). Produces `keep-enclave.eif` and `pcrs.json`.
+See [keep-enclave/build/README.md](https://github.com/privkeyio/keep/blob/main/keep-enclave/build/README.md). Produces `keep-enclave.eif` and `pcrs.json`.
 
 PCRs (Platform Configuration Registers) are hashes of the enclave code. They change on rebuild. KMS uses them to restrict decryption to your exact code.
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,9 @@
+# Summary
+
+[Introduction](./introduction.md)
+
+- [Usage](./USAGE.md)
+- [Security](./SECURITY.md)
+- [AWS Nitro Enclaves](./ENCLAVE.md)
+- [Release Signing](./RELEASE_SIGNING.md)
+- [Reproducible Builds](./REPRODUCIBILITY.md)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -25,7 +25,7 @@
 Requires Rust 1.89+ (MSRV). System dependencies (for the hardware-signer serial support)
 vary by platform: Linux needs `pkg-config` and `libudev` (`build-essential`/`libudev-dev`),
 macOS needs the Xcode Command Line Tools, and Windows needs nothing extra. See
-[`BUILD.md`](../BUILD.md) for the full list.
+[`BUILD.md`](https://github.com/privkeyio/keep/blob/main/BUILD.md) for the full list.
 
 **Install the CLI directly:**
 
@@ -557,7 +557,7 @@ KEEP_PASSWORD="hidden" keep --hidden list
 
 > `KEEP_PATH` is **not** used by the CLI; it configures the vault path for the `keep-web`
 > co-signer only. For the CLI, use `KEEP_HOME` or `--path`. See
-> [`keep-web/README.md`](../keep-web/README.md) for the co-signer's variables.
+> [`keep-web/README.md`](https://github.com/privkeyio/keep/blob/main/keep-web/README.md) for the co-signer's variables.
 
 ---
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,27 @@
+# Keep
+
+*Self-custodial key management for Nostr and Bitcoin.*
+
+Keep is an encrypted vault for Nostr and Bitcoin keys. It stores keys locally with strong
+encryption, signs remotely via NIP-46 without exposing private keys, and supports FROST
+threshold signatures so no single device ever holds enough to spend.
+
+Keep runs as a CLI, a desktop app (Linux/macOS/Windows), a mobile library (Android/iOS via
+UniFFI), a StartOS service for always-on FROST co-signing, or inside AWS Nitro Enclaves for
+hardware-isolated signing.
+
+## Where to start
+
+- **[Usage](./USAGE.md)** — install the CLI, create a vault, generate keys, remote
+  signing, Bitcoin, FROST, agents, and troubleshooting.
+- **[Security](./SECURITY.md)** — cryptography and threat model.
+- **[AWS Nitro Enclaves](./ENCLAVE.md)** — hardware-isolated signing deployment.
+- **[Release Signing](./RELEASE_SIGNING.md)** — how Keep threshold-signs its own releases.
+- **[Reproducible Builds](./REPRODUCIBILITY.md)** — verifying builds bit-for-bit.
+
+## Project links
+
+- Source: <https://github.com/privkeyio/keep>
+- License: [MIT](https://github.com/privkeyio/keep/blob/main/LICENSE)
+- Self-hosting the headless co-signer:
+  [keep-web/README.md](https://github.com/privkeyio/keep/blob/main/keep-web/README.md)


### PR DESCRIPTION
Adds the mdBook configuration so this repo's `docs/` builds as the **keep** section of the [docs.privkey.io](https://docs.privkey.io) documentation portal.

## How it fits together

The `privkeyio/docs` repo is a portal aggregator: it clones each public project, builds its mdBook, applies the shared PrivKey theme, and deploys to GitHub Pages (`docs.privkey.io/keep/`, `/relay/`, ...). **Theming and deployment live entirely in that repo** — this PR is just the source config, with no theme files, no deploy workflow, and nothing repo-specific to maintain here.

## Contents

- **`book.toml`** — mdBook config: `src = docs`, section folding and search enabled, repo/edit links. Theme and mount path (`default-theme`, `site-url`) are intentionally **not** set here; the aggregator enforces them at build time so every project is styled consistently.
- **`docs/SUMMARY.md`** — table of contents: Introduction, Usage, Security, AWS Nitro Enclaves, Release Signing, Reproducible Builds.
- **`docs/introduction.md`** — landing page for the keep section.
- **`docs/USAGE.md`, `docs/ENCLAVE.md`** — link fixes only: 4 cross-tree relative links (`../BUILD.md`, `../keep-web/README.md`, `../keep-enclave/build/README.md`) now use absolute GitHub URLs so they resolve both in-repo and in the rendered book.
- **`.gitignore`** — ignore the `book/` build output.

## Notes

- Builds clean with `mdbook v0.5.3`. A standalone `mdbook build` here renders with mdBook's default theme; the PrivKey brand is applied only in the portal build.
- After this merges, the aggregator's `projects.json` ref for keep flips from `docs/mdbook-site` to `main`.
- Docs-only change; CI green (build, lint, deny, msrv, fuzz).
