### PR TITLE
release: v0.4.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4306,7 +4306,7 @@ dependencies = [
 
 [[package]]
 name = "keep-agent"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "chrono",
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "keep-bitcoin"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "bitcoin",
  "getrandom 0.4.2",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "keep-cli"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4393,7 +4393,7 @@ dependencies = [
 
 [[package]]
 name = "keep-core"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "aes 0.9.1",
  "argon2",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "keep-desktop"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4471,14 +4471,14 @@ dependencies = [
 
 [[package]]
 name = "keep-enclave"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "keep-enclave-host",
 ]
 
 [[package]]
 name = "keep-enclave-host"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "keep-frost-net"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4547,7 +4547,7 @@ dependencies = [
 
 [[package]]
 name = "keep-mobile"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4577,7 +4577,7 @@ dependencies = [
 
 [[package]]
 name = "keep-nip46"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "bitflags 2.13.0",
  "chrono",
@@ -4603,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "keep-web"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "axum",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"


### PR DESCRIPTION
Bumps the workspace version 0.4.7 → 0.4.8.

## Highlights

### Testing campaign (#417 closed)
Mutation-testing rounds 1-5 shipped across the security-critical modules, plus the integration follow-ups they identified. Coverage now lands at the unit + protocol level for: FROST signing helpers (#542), ECDH (#544), descriptor session machinery (#545, #550), node/PSBT helpers (#552, #555), and NIP-46 server (#554). The integration follow-ups added end-to-end MockRelay-backed coverage for ECDH (#560), NIP-46 signature round-trip (#568) + dispatch (#569), PSBT migration sweep (#573), descriptor session persistence (#556), and broader CLI flows (#563, #567).

### Production fixes surfaced by the testing campaign
- **#562** — ECDH subscribe-before-send race fix. `request_ecdh` subscribed AFTER publishing events; a fast cosigner could trigger `EcdhComplete` before anyone was listening, stalling the requester until the 30s timeout. The integration test for #543 surfaced this; the fix made it reliable.
- **#570** — Same race shape in `request_signature`. Closed #541 and un-`#[ignore]`d 7 previously-flaky multinode signing tests.

### Persistent NIP-46 grants
- **#506** — `keep nip46 apps` / `grant` / `revoke` CLI; `keep serve` loads persisted grants at startup.
- **#514** — Hidden-vault grant CLI; serve loads pre-grants from the outer scope.
- **#574** — Bunker auto-approval + transport-key persistence fix.

### WDC fixes
- **#532** — Allow xpub reuse across recovery tiers.
- **#535** — `wallet propose` refuses to overwrite an existing finalized descriptor unless `--force --replacing-version` matches.
- **#534** — Database-already-open error rewritten to name the daemon process holding the lock.

### Audit log
- **#521** — `RateLimitTripped` recorded on next successful unlock (deferred write, since locked-vault attempts can't access the data key).
- **#528** — `audit stats` surfaces RateLimitTripped + locks + FROST share lifecycle counters.
- **#538** — Hidden-vault audit-log on outer + RateLimitTripped flush.
- **#540** — Audit export shim on outer volume for hidden-vault.
- **#578** — Rotation audit entries (`PasswordRotate` / `PasswordRotateFailed` / `DataKeyRotate` / `DataKeyRotateFailed`).

### FROST coordination
- **#505** — Fast failover: auto-retry signing round on co-signer timeout.
- **#523** — `frost-network sign-event` end-to-end software path.
- **#530** — Opt-in `RefuseRawSignatureHooks` + `message_type` in `SessionInfo`.

### Other
- **#531** — `export` refuses non-TTY stdin (interactive-only by design).
- **#539** — `KfpNode` graceful shutdown via RAII guard.
- **#585** — frost crate bumped 2.2.0 → 3.0.
- **#548** — `signature` crate bumped 2.2.0 → 3.0.
- **#582-#584** — Docs portal foundations (mdBook config for docs.privkey.io, agent SDK install corrections, MCP fixes).

## After merge
- Tag `v0.4.8` on the merged main commit so Release CI publishes the 9 binaries.
- keep-android: re-pin `keep.version` to the merged SHA, cut a release.
- keep-startos PR #1: bump submodule to v0.4.8, add `startos/versions/v0.4.8_0.ts`, set `current`.