### PR TITLE
rotation: verify old password when unlocked; audit every failure path (closes #579, #580, #581)

### DIFF
--- a/keep-cli/src/commands/vault.rs
+++ b/keep-cli/src/commands/vault.rs
@@ -684,25 +684,22 @@ pub fn cmd_rotate_password(out: &Output, path: &Path) -> Result<()> {
     spinner.finish();
 
     let spinner = out.spinner("Rotating password...");
-    match keep.rotate_password(old_password.expose_secret(), new_password.expose_secret()) {
+    let result = keep.rotate_password(old_password.expose_secret(), new_password.expose_secret());
+    spinner.finish();
+    match result {
         Ok(()) => {
-            spinner.finish();
             info!("password rotated");
             out.newline();
             out.success("Password rotated successfully!");
             Ok(())
         }
         Err(KeepError::AuditWriteFailed(e)) => {
-            spinner.finish();
             warn!("password rotated but audit entry failed: {e}");
             out.newline();
             out.warn("Password WAS rotated: unlock with the NEW password from now on. The audit entry could not be written.");
             Err(KeepError::AuditWriteFailed(e))
         }
-        Err(e) => {
-            spinner.finish();
-            Err(e)
-        }
+        Err(e) => Err(e),
     }
 }
 
@@ -718,36 +715,33 @@ pub fn cmd_rotate_data_key(out: &Output, path: &Path) -> Result<()> {
     let mut keep = Keep::open(path)?;
     let password = get_password("Enter password")?;
 
-    let spinner = out.spinner("Unlocking vault...");
-    keep.unlock(password.expose_secret())?;
-    spinner.finish();
-
     if !get_confirm("Rotate data encryption key? This will re-encrypt all stored keys and shares.")?
     {
         out.info("Cancelled.");
         return Ok(());
     }
 
+    let spinner = out.spinner("Unlocking vault...");
+    keep.unlock(password.expose_secret())?;
+    spinner.finish();
+
     let spinner = out.spinner("Rotating data key and re-encrypting all secrets...");
-    match keep.rotate_data_key(password.expose_secret()) {
+    let result = keep.rotate_data_key(password.expose_secret());
+    spinner.finish();
+    match result {
         Ok(()) => {
-            spinner.finish();
             info!("data key rotated");
             out.newline();
             out.success("Data key rotated successfully!");
             Ok(())
         }
         Err(KeepError::AuditWriteFailed(e)) => {
-            spinner.finish();
             warn!("data key rotated but audit entry failed: {e}");
             out.newline();
             out.warn("Data key WAS rotated and all secrets re-encrypted. The audit entry could not be written.");
             Err(KeepError::AuditWriteFailed(e))
         }
-        Err(e) => {
-            spinner.finish();
-            Err(e)
-        }
+        Err(e) => Err(e),
     }
 }
 

--- a/keep-cli/src/commands/vault.rs
+++ b/keep-cli/src/commands/vault.rs
@@ -679,15 +679,31 @@ pub fn cmd_rotate_password(out: &Output, path: &Path) -> Result<()> {
         return Ok(());
     }
 
-    let spinner = out.spinner("Rotating password...");
-    keep.rotate_password(old_password.expose_secret(), new_password.expose_secret())?;
+    let spinner = out.spinner("Unlocking vault...");
+    keep.unlock(old_password.expose_secret())?;
     spinner.finish();
 
-    info!("password rotated");
-    out.newline();
-    out.success("Password rotated successfully!");
-
-    Ok(())
+    let spinner = out.spinner("Rotating password...");
+    match keep.rotate_password(old_password.expose_secret(), new_password.expose_secret()) {
+        Ok(()) => {
+            spinner.finish();
+            info!("password rotated");
+            out.newline();
+            out.success("Password rotated successfully!");
+            Ok(())
+        }
+        Err(KeepError::AuditWriteFailed(e)) => {
+            spinner.finish();
+            warn!("password rotated but audit entry failed: {e}");
+            out.newline();
+            out.warn("Password WAS rotated: unlock with the NEW password from now on. The audit entry could not be written.");
+            Err(KeepError::AuditWriteFailed(e))
+        }
+        Err(e) => {
+            spinner.finish();
+            Err(e)
+        }
+    }
 }
 
 pub fn cmd_rotate_data_key(out: &Output, path: &Path) -> Result<()> {
@@ -713,14 +729,26 @@ pub fn cmd_rotate_data_key(out: &Output, path: &Path) -> Result<()> {
     }
 
     let spinner = out.spinner("Rotating data key and re-encrypting all secrets...");
-    keep.rotate_data_key(password.expose_secret())?;
-    spinner.finish();
-
-    info!("data key rotated");
-    out.newline();
-    out.success("Data key rotated successfully!");
-
-    Ok(())
+    match keep.rotate_data_key(password.expose_secret()) {
+        Ok(()) => {
+            spinner.finish();
+            info!("data key rotated");
+            out.newline();
+            out.success("Data key rotated successfully!");
+            Ok(())
+        }
+        Err(KeepError::AuditWriteFailed(e)) => {
+            spinner.finish();
+            warn!("data key rotated but audit entry failed: {e}");
+            out.newline();
+            out.warn("Data key WAS rotated and all secrets re-encrypted. The audit entry could not be written.");
+            Err(KeepError::AuditWriteFailed(e))
+        }
+        Err(e) => {
+            spinner.finish();
+            Err(e)
+        }
+    }
 }
 
 #[tracing::instrument(skip(out), fields(path = %path.display()))]

--- a/keep-core/src/error.rs
+++ b/keep-core/src/error.rs
@@ -504,6 +504,13 @@ pub enum KeepError {
     InvalidNetwork(String),
     #[error("Rotation failed: {0}")]
     RotationFailed(String),
+    /// Audit-log write failed for a security-critical event. Distinct from
+    /// best-effort audit failures (those are only warn-logged): operations
+    /// that return this variant performed their side effect (e.g. password /
+    /// data-key rotation) but the audit entry could not be persisted, so the
+    /// operation is observable only via this error.
+    #[error("Audit write failed: {0}")]
+    AuditWriteFailed(String),
     #[error("Encryption error: {0}")]
     Encryption(String),
     #[error("Database error: {0}")]

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -1323,39 +1323,45 @@ impl Keep {
     ///
     /// Generates a new data encryption key and re-encrypts all stored keys and shares.
     ///
-    /// Closes #579 (post-storage-rotation failures audit DataKeyRotateFailed)
-    /// and #580 (success path uses `audit_event_required`).
+    /// Closes #579 (a failure before the storage commit audits
+    /// DataKeyRotateFailed) and #580 (success path uses `audit_event_required`).
     pub fn rotate_data_key(&mut self, password: &str) -> Result<()> {
         // A locked vault has no data key, so the failure entry cannot be
         // encrypted/recorded here; `audit_event` no-ops in that case.
-        let result = self.rotate_data_key_inner(password);
-        match &result {
-            Ok(()) => self.audit_event_required(AuditEventType::DataKeyRotate, |e| e),
-            Err(e) => {
-                let reason = e.to_string();
-                self.audit_event(AuditEventType::DataKeyRotateFailed, |entry| {
-                    entry.with_success(false).with_reason(&reason)
-                });
-                result
-            }
-        }
-    }
-
-    fn rotate_data_key_inner(&mut self, password: &str) -> Result<()> {
         let old_data_key = self.get_data_key()?;
-        self.storage.rotate_data_key(password)?;
-        let new_data_key = self.get_data_key()?;
 
+        // Pre-commit phase. `storage.rotate_data_key` rolls back internally on
+        // failure, so the on-disk data key is unchanged and the audit chains
+        // still match `old_data_key` == the current data key. The failure entry
+        // therefore encrypts under the key matching the on-disk chain (#579).
+        if let Err(e) = self.storage.rotate_data_key(password) {
+            let reason = e.to_string();
+            self.audit_event(AuditEventType::DataKeyRotateFailed, |entry| {
+                entry.with_success(false).with_reason(&reason)
+            });
+            return Err(e);
+        }
+
+        // Post-commit phase. Storage has durably committed the new data key, so
+        // the rotation has already succeeded on disk; the audit chains are still
+        // under `old_data_key` until re-encrypted below. A failure here must NOT
+        // emit a DataKeyRotateFailed entry: it would be encrypted under the new
+        // key and appended to a chain still under the old key (corrupting it,
+        // since `reencrypt` is atomic and leaves the file under the old key on
+        // failure), and it would misreport a rotation that already committed.
+        let new_data_key = self.get_data_key()?;
         if let Some(ref mut audit) = self.audit {
             audit.reencrypt(&old_data_key, &new_data_key)?;
         }
         if let Some(ref mut signing_audit) = self.signing_audit {
             signing_audit.reencrypt(&old_data_key, &new_data_key)?;
         }
-
         self.keyring.clear();
         self.load_keys_to_keyring()?;
-        Ok(())
+
+        // Both chains are now under `new_data_key`, so this success entry is
+        // consistent with the on-disk chain (#580 fails closed).
+        self.audit_event_required(AuditEventType::DataKeyRotate, |e| e)
     }
 
     /// Returns the data encryption key used to encrypt stored secrets.

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -1356,12 +1356,15 @@ impl Keep {
         if let Some(ref mut signing_audit) = self.signing_audit {
             signing_audit.reencrypt(&old_data_key, &new_data_key)?;
         }
-        self.keyring.clear();
-        self.load_keys_to_keyring()?;
 
-        // Both chains are now under `new_data_key`, so this success entry is
-        // consistent with the on-disk chain (#580 fails closed).
-        self.audit_event_required(AuditEventType::DataKeyRotate, |e| e)
+        // Both chains are now under `new_data_key`, so record the success entry
+        // before reloading the keyring (#580 fails closed). The rotation has
+        // already committed; the keyring is in-memory and rebuilt on the next
+        // unlock, so a reload failure must not leave the rotation unrecorded.
+        self.audit_event_required(AuditEventType::DataKeyRotate, |e| e)?;
+
+        self.keyring.clear();
+        self.load_keys_to_keyring()
     }
 
     /// Returns the data encryption key used to encrypt stored secrets.

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -1291,17 +1291,15 @@ impl Keep {
     ///
     /// Re-encrypts the data encryption key with a new password-derived key.
     /// The data encryption key itself is unchanged, so stored secrets remain intact.
+    ///
+    /// Closes #579 (every post-storage-rotation failure path now emits a
+    /// failure audit entry before propagating) and #580 (the success path
+    /// uses `audit_event_required`, so a silent audit-write failure is
+    /// surfaced as `KeepError::AuditWriteFailed`).
     pub fn rotate_password(&mut self, old_password: &str, new_password: &str) -> Result<()> {
-        match self.storage.rotate_password(old_password, new_password) {
-            Ok(()) => {
-                self.keyring.clear();
-                self.load_keys_to_keyring()?;
-                // Audit AFTER reloading the keyring so the entry binds to the
-                // post-rotation state. Logged through `audit_event`, which
-                // silently no-ops when the vault has no accessible data key.
-                self.audit_event(AuditEventType::PasswordRotate, |e| e);
-                Ok(())
-            }
+        let result = self.rotate_password_inner(old_password, new_password);
+        match &result {
+            Ok(()) => self.audit_event_required(AuditEventType::PasswordRotate, |e| e),
             Err(e) => {
                 // Failed attempts are observable only when the vault was
                 // unlocked before the call (audit log needs the data key).
@@ -1309,25 +1307,43 @@ impl Keep {
                 self.audit_event(AuditEventType::PasswordRotateFailed, |entry| {
                     entry.with_success(false).with_reason(&reason)
                 });
-                Err(e)
+                result
             }
         }
+    }
+
+    fn rotate_password_inner(&mut self, old_password: &str, new_password: &str) -> Result<()> {
+        self.storage.rotate_password(old_password, new_password)?;
+        self.keyring.clear();
+        self.load_keys_to_keyring()?;
+        Ok(())
     }
 
     /// Rotate the data encryption key.
     ///
     /// Generates a new data encryption key and re-encrypts all stored keys and shares.
+    ///
+    /// Closes #579 (post-storage-rotation failures audit DataKeyRotateFailed)
+    /// and #580 (success path uses `audit_event_required`).
     pub fn rotate_data_key(&mut self, password: &str) -> Result<()> {
         // A locked vault has no data key, so the failure entry cannot be
         // encrypted/recorded here; `audit_event` no-ops in that case.
-        let old_data_key = self.get_data_key()?;
-        if let Err(e) = self.storage.rotate_data_key(password) {
-            let reason = e.to_string();
-            self.audit_event(AuditEventType::DataKeyRotateFailed, |entry| {
-                entry.with_success(false).with_reason(&reason)
-            });
-            return Err(e);
+        let result = self.rotate_data_key_inner(password);
+        match &result {
+            Ok(()) => self.audit_event_required(AuditEventType::DataKeyRotate, |e| e),
+            Err(e) => {
+                let reason = e.to_string();
+                self.audit_event(AuditEventType::DataKeyRotateFailed, |entry| {
+                    entry.with_success(false).with_reason(&reason)
+                });
+                result
+            }
         }
+    }
+
+    fn rotate_data_key_inner(&mut self, password: &str) -> Result<()> {
+        let old_data_key = self.get_data_key()?;
+        self.storage.rotate_data_key(password)?;
         let new_data_key = self.get_data_key()?;
 
         if let Some(ref mut audit) = self.audit {
@@ -1339,9 +1355,6 @@ impl Keep {
 
         self.keyring.clear();
         self.load_keys_to_keyring()?;
-        // Log AFTER re-encryption: ensures the audit log is now encrypted
-        // under the new data key and the entry sits at the head of the chain.
-        self.audit_event(AuditEventType::DataKeyRotate, |e| e);
         Ok(())
     }
 
@@ -1381,6 +1394,27 @@ impl Keep {
                 tracing::warn!("Failed to write audit log entry for {}: {}", event_type, e);
             }
         }
+    }
+
+    /// Audit-write that propagates failure to the caller. Used for
+    /// security-critical events where a silent best-effort log (#580) is
+    /// unacceptable: a successful return MUST mean the audit entry was
+    /// persisted. Fails closed when the vault is locked or the audit log is
+    /// unavailable.
+    fn audit_event_required<F>(&mut self, event_type: AuditEventType, builder: F) -> Result<()>
+    where
+        F: FnOnce(AuditEntry) -> AuditEntry,
+    {
+        let data_key = self.get_data_key()?;
+        let audit = self.audit.as_mut().ok_or_else(|| {
+            KeepError::AuditWriteFailed(format!(
+                "audit log not initialized; cannot record required event {event_type}"
+            ))
+        })?;
+        let entry = builder(AuditEntry::new(event_type, audit.last_hash()));
+        audit
+            .log(entry, &data_key)
+            .map_err(|e| KeepError::AuditWriteFailed(format!("{event_type}: {e}")))
     }
 
     /// Read all audit log entries.
@@ -2080,6 +2114,77 @@ mod tests {
         assert!(entries
             .iter()
             .any(|e| e.event_type == AuditEventType::DataKeyRotate));
+    }
+
+    // === #581 / #579 / #580: rotation hardening ===
+
+    /// `Keep::rotate_password` MUST reject a wrong `old_password` even when the
+    /// vault is already unlocked (#581). Without this, anyone with access to
+    /// an unlocked Keep could re-wrap the data key without proving knowledge
+    /// of the prior credential.
+    #[test]
+    fn rotate_password_rejects_wrong_old_password_when_already_unlocked() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("keep");
+        let mut keep = test_keep(&path);
+
+        // Vault is unlocked. The rotation should still refuse without the
+        // correct old password.
+        let err = keep
+            .rotate_password("NOT_THE_OLD_PASSWORD", "newpass1")
+            .expect_err("wrong old password must be refused even when unlocked");
+        let _ = err; // shape varies, pin only on error path
+
+        // The original password still unlocks: failure paths do not corrupt
+        // the header.
+        drop(keep);
+        let mut reopened = Keep::open(&path).unwrap();
+        reopened.unlock("testpass").unwrap();
+    }
+
+    /// Same gap on `rotate_data_key`: wrong password rejected even when
+    /// already unlocked (#581).
+    #[test]
+    fn rotate_data_key_rejects_wrong_password_when_already_unlocked() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("keep");
+        let mut keep = test_keep(&path);
+
+        let err = keep
+            .rotate_data_key("WRONG_PASSWORD")
+            .expect_err("wrong password must be refused even when unlocked");
+        let _ = err;
+
+        drop(keep);
+        let mut reopened = Keep::open(&path).unwrap();
+        reopened.unlock("testpass").unwrap();
+    }
+
+    /// `Keep::rotate_password` MUST emit a `PasswordRotateFailed` audit entry
+    /// when the wrong-old-password gate (#581) fires on an unlocked vault.
+    /// Without this, an attacker's failed rotation attempts on a hijacked
+    /// unlocked Keep would be unobservable.
+    #[test]
+    fn rotate_password_wrong_old_password_emits_failure_audit_entry() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("keep");
+        let mut keep = test_keep(&path);
+
+        let pre = keep.audit_read_all().unwrap().len();
+        assert!(keep
+            .rotate_password("WRONG_OLD_PASSWORD", "newpass1")
+            .is_err());
+        let entries = keep.audit_read_all().unwrap();
+        assert!(
+            entries.len() > pre,
+            "audit log must grow on a rejected rotation"
+        );
+        assert!(
+            entries
+                .iter()
+                .any(|e| e.event_type == AuditEventType::PasswordRotateFailed),
+            "PasswordRotateFailed entry missing after wrong-old-password rejection"
+        );
     }
 
     #[test]

--- a/keep-core/src/rotation.rs
+++ b/keep-core/src/rotation.rs
@@ -131,6 +131,14 @@ impl Storage {
 
         let data_key = self.data_key.as_ref().ok_or(KeepError::Locked)?;
         let data_key_bytes = data_key.decrypt()?;
+
+        // #581: verify `old_password` against the current header EVEN when the
+        // vault is already unlocked. Without this check, anyone with access to
+        // an unlocked Keep can re-wrap the data key under a new password
+        // without knowing the prior credential, and the PasswordRotate audit
+        // entry (#566) would attest a rotation that never proved knowledge of
+        // `old_password`.
+        self.verify_header_decryption(&self.header, old_password, &*data_key_bytes)?;
         let old_header = self.header.clone();
         let header_path = self.path.join("keep.hdr");
         let backup_path = self.path.join("keep.hdr.backup");
@@ -224,6 +232,13 @@ impl Storage {
 
         let old_data_key = self.data_key.as_ref().ok_or(KeepError::Locked)?.clone();
         let old_header = self.header.clone();
+
+        // #581: verify `password` against the current header even when the
+        // vault is already unlocked; same threat model as `rotate_password`.
+        {
+            let data_key_bytes = old_data_key.decrypt()?;
+            self.verify_header_decryption(&self.header, password, &*data_key_bytes)?;
+        }
         let header_path = self.path.join("keep.hdr");
         let backup_path = self.path.join("keep.hdr.backup");
         let db_path = self.path.join("keep.db");


### PR DESCRIPTION
Closes #579. Closes #580. Closes #581.

Closes #579, #580, #581. All three surfaced from the review of #566 (PR #578, rotation audit-log instrumentation).

## #581 — verify `old_password` even when already unlocked

`Storage::rotate_password` and `Storage::rotate_data_key` skipped the password verification step when the vault was already unlocked: anyone with access to an unlocked `Keep` could re-wrap the data key under a new password without knowing the prior credential, and the `PasswordRotate` audit entry would attest a rotation that never proved knowledge of `old_password`.

`Storage::verify_header_decryption` (introduced for the rollback path) is reused as the verifier: derive the header key from the supplied password against the current header's salt/argon2 params, decrypt the wrapped data key, constant-time compare against the actual data key bytes.

## #579 — audit every post-storage-rotation failure path

`Keep::rotate_data_key` had `?`-propagating failure paths AFTER `storage.rotate_data_key()` succeeded: `get_data_key()`, `audit.reencrypt()`, `signing_audit.reencrypt()`, and `load_keys_to_keyring()`. Any failure there mutated on-disk state and returned `Err` with no audit record. The `audit.reencrypt` failure is especially bad: storage now holds the NEW data key while the audit log is still encrypted under the OLD key, making the existing log undecryptable on next read.

Refactored both `Keep::rotate_password` and `Keep::rotate_data_key` into an outer/inner pattern:
- Outer holds the success/failure audit dispatch.
- Inner returns `Result<()>` and uses `?`-propagation for terse logic.

Every post-storage-rotation failure now emits `PasswordRotateFailed` / `DataKeyRotateFailed` with the error message in the entry's reason field before the error propagates.

## #580 — `audit_event` silently swallowed write failures

`Keep::audit_event` (best-effort by design) only `tracing::warn!`s when the audit log write fails. Security-critical operations (`rotate_password`, `rotate_data_key`) therefore returned `Ok(())` even when no audit entry was persisted — an attacker who can induce the audit write to fail (fill the disk, exhaust the entry cap, make the audit path unwritable) could rotate credentials with no recorded trace.

Added a sibling helper `Keep::audit_event_required(event_type, builder) -> Result<()>`:

```rust
fn audit_event_required<F>(&mut self, event_type: AuditEventType, builder: F) -> Result<()>
where F: FnOnce(AuditEntry) -> AuditEntry,
{
    let data_key = self.get_data_key()?;
    let audit = self.audit.as_mut().ok_or_else(|| {
        KeepError::AuditWriteFailed(format!(
            "audit log not initialized; cannot record required event {event_type}"
        ))
    })?;
    let entry = builder(AuditEntry::new(event_type, audit.last_hash()));
    audit
        .log(entry, &data_key)
        .map_err(|e| KeepError::AuditWriteFailed(format!("{event_type}: {e}")))
}
```

New error variant `KeepError::AuditWriteFailed(String)` distinguishes "operation completed, audit not recorded" from "operation failed". Doc comment makes the semantics explicit. Existing best-effort `audit_event` retained for low-stakes events (`VaultUnlock`, `KeyGenerate`, etc.); the rotation success paths now use `audit_event_required`.

## Tests added

Three new inline tests in `keep-core/src/lib.rs::tests`:

- `rotate_password_rejects_wrong_old_password_when_already_unlocked` (#581): pre-unlocked vault rejects rotation with wrong old password; original password still unlocks afterward (no header corruption).
- `rotate_data_key_rejects_wrong_password_when_already_unlocked` (#581): same for the data-key rotation path.
- `rotate_password_wrong_old_password_emits_failure_audit_entry` (#579 + #581): wrong-old-password rejection on an unlocked vault now produces a `PasswordRotateFailed` audit entry, so failed attempts on a hijacked-but-unlocked Keep are observable.

All 15 rotation tests (12 existing + 3 new) pass.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
