### PR TITLE
frost: refuse partial refresh_shares to prevent silent share orphaning (closes #586)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ Pure Rust with `#![forbid(unsafe_code)]`. Keys are derived with Argon2id, encryp
 
 Keep can threshold-sign software releases with a FROST-Ed25519 group (minisign-compatible), so no single maintainer holds the signing key. See [`docs/RELEASE_SIGNING.md`](docs/RELEASE_SIGNING.md).
 
+## Status
+
+Keep is pre-1.0 and under active development. Public APIs and on-disk formats may change between releases, so pin a version if you build on it. The cryptography has had internal review but no independent third-party audit yet. Use at your own risk, and don't secure more than you can afford to lose.
+
 ## License
 
 [MIT](LICENSE)

--- a/keep-cli/src/commands/frost.rs
+++ b/keep-cli/src/commands/frost.rs
@@ -394,9 +394,10 @@ pub fn cmd_frost_refresh(out: &Output, path: &Path, group_id: &str) -> Result<()
         .len()
         .try_into()
         .map_err(|_| KeepError::Frost("Too many shares".into()))?;
-    if share_count < threshold {
+    if share_count != total {
         return Err(KeepError::Frost(format!(
-            "Need at least {threshold} shares to refresh, only {share_count} available locally"
+            "refresh requires the full set of {total} shares; only {share_count} available locally. \
+             A partial refresh would silently orphan the absent shares (#586)."
         )));
     }
 

--- a/keep-core/src/frost/refresh.rs
+++ b/keep-core/src/frost/refresh.rs
@@ -7,7 +7,7 @@ use frost::keys::{KeyPackage, PublicKeyPackage};
 use frost::rand_core::OsRng;
 use frost::Identifier;
 use frost_secp256k1_tr as frost;
-use zeroize::Zeroize;
+use zeroize::Zeroizing;
 
 use crate::error::{KeepError, Result};
 
@@ -107,10 +107,12 @@ pub fn refresh_shares(shares: &[SharePackage]) -> Result<(Vec<SharePackage>, Pub
         Some(threshold),
     );
 
-    let mut key_packages: Vec<KeyPackage> = shares
-        .iter()
-        .map(|s| s.key_package())
-        .collect::<Result<_>>()?;
+    let key_packages = Zeroizing::new(
+        shares
+            .iter()
+            .map(|s| s.key_package())
+            .collect::<Result<Vec<KeyPackage>>>()?,
+    );
 
     let identifiers: Vec<Identifier> = key_packages.iter().map(|kp| *kp.identifier()).collect();
 
@@ -131,7 +133,7 @@ pub fn refresh_shares(shares: &[SharePackage]) -> Result<(Vec<SharePackage>, Pub
 
     let mut new_packages = Vec::with_capacity(shares.len());
 
-    for (share, current_kp) in shares.iter().zip(&key_packages) {
+    for (share, current_kp) in shares.iter().zip(key_packages.iter()) {
         let id = *current_kp.identifier();
         let refreshing_share = refreshing_by_id.get(&id).ok_or_else(|| {
             KeepError::Frost(format!("No refreshing share for identifier {id:?}"))
@@ -149,8 +151,6 @@ pub fn refresh_shares(shares: &[SharePackage]) -> Result<(Vec<SharePackage>, Pub
         let metadata = rebuild_metadata(share, threshold, total, group_pubkey, name.clone());
         new_packages.push(SharePackage::new(metadata, &new_kp, &new_pubkey_pkg)?);
     }
-
-    key_packages.iter_mut().for_each(|kp| kp.zeroize());
 
     let new_group_pubkey = *new_packages[0].group_pubkey();
     if new_group_pubkey != group_pubkey {

--- a/keep-core/src/frost/refresh.rs
+++ b/keep-core/src/frost/refresh.rs
@@ -349,8 +349,7 @@ mod tests {
         };
         let msg = err.to_string();
         assert!(
-            msg.contains("distinct identifiers")
-                && msg.contains(&dup_identifier.to_string()),
+            msg.contains("distinct identifiers") && msg.contains(&dup_identifier.to_string()),
             "expected duplicate rejection naming the identifier, got {msg}"
         );
         assert!(

--- a/keep-core/src/frost/refresh.rs
+++ b/keep-core/src/frost/refresh.rs
@@ -72,6 +72,19 @@ pub fn refresh_shares(shares: &[SharePackage]) -> Result<(Vec<SharePackage>, Pub
             "Need at least {threshold} shares to refresh, only {share_count} available"
         )));
     }
+    // #586: FROST 3.0's `compute_refreshing_shares` only refreshes the
+    // identifiers passed in, so a subset call (>= threshold but < total)
+    // silently orphans every absent share. The refreshed shares still
+    // advertise the full `total_shares` in metadata, so a holder of an
+    // absent share would believe they are still part of the group when
+    // they have actually been excluded. Refuse partial refresh outright;
+    // callers must collect the full set or use a different protocol.
+    if share_count != total {
+        return Err(KeepError::Frost(format!(
+            "refresh_shares requires the full set of {total} shares; got {share_count}. \
+             A partial refresh would silently orphan the absent shares (#586)."
+        )));
+    }
 
     let pubkey_pkg = shares[0].pubkey_package()?;
     let pubkey_pkg = PublicKeyPackage::new(
@@ -250,6 +263,44 @@ mod tests {
     fn test_refresh_empty_shares_fails() {
         let result = refresh_shares(&[]);
         assert!(result.is_err());
+    }
+
+    /// #586: a subset call (>= threshold but < total) MUST be refused.
+    /// FROST 3.0's `compute_refreshing_shares` silently drops every absent
+    /// identifier, and the refreshed shares still claim the full
+    /// `total_shares` in metadata, so a holder of an absent share would
+    /// believe they are still part of an N-of-M group after they have been
+    /// orphaned. Pin both: 2 of 3 (above threshold, below total) refused,
+    /// and the error message names the gap.
+    #[test]
+    fn test_refresh_with_subset_below_total_is_refused() {
+        let config = ThresholdConfig::two_of_three();
+        let dealer = TrustedDealer::new(config);
+        let (mut shares, _) = dealer.generate("test-subset").unwrap();
+
+        // Drop the third share, leaving 2 of 3 (meets threshold = 2).
+        shares.pop();
+        assert_eq!(shares.len(), 2);
+        assert_eq!(shares[0].metadata.threshold, 2);
+        assert_eq!(shares[0].metadata.total_shares, 3);
+
+        let err = match refresh_shares(&shares) {
+            Ok(_) => panic!("subset refresh must be refused"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("requires the full set") && msg.contains("3 shares"),
+            "expected subset-refresh rejection naming the total, got {msg}"
+        );
+        assert!(
+            msg.contains("got 2"),
+            "expected the rejection to name the observed share count, got {msg}"
+        );
+        assert!(
+            msg.contains("#586"),
+            "rejection should reference the issue for future readers, got {msg}"
+        );
     }
 
     #[test]

--- a/keep-core/src/frost/refresh.rs
+++ b/keep-core/src/frost/refresh.rs
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: © 2026 PrivKey LLC
 // SPDX-License-Identifier: MIT
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use frost::keys::refresh::{compute_refreshing_shares, refresh_share};
 use frost::keys::{KeyPackage, PublicKeyPackage};
@@ -84,6 +84,20 @@ pub fn refresh_shares(shares: &[SharePackage]) -> Result<(Vec<SharePackage>, Pub
             "refresh_shares requires the full set of {total} shares; got {share_count}. \
              A partial refresh would silently orphan the absent shares (#586)."
         )));
+    }
+    // #586: a full-cardinality call with a duplicated identifier (e.g. [A, A, B]
+    // for a 3-member group) passes the count guard yet still orphans the absent
+    // member, because `refreshing_by_id` collapses the duplicate. Require every
+    // supplied share to carry a distinct identifier.
+    let mut seen = BTreeSet::new();
+    for share in shares {
+        if !seen.insert(share.metadata.identifier) {
+            return Err(KeepError::Frost(format!(
+                "refresh_shares requires distinct identifiers; identifier {} appears more than \
+                 once. A partial refresh would silently orphan the absent shares (#586).",
+                share.metadata.identifier
+            )));
+        }
     }
 
     let pubkey_pkg = shares[0].pubkey_package()?;
@@ -296,6 +310,48 @@ mod tests {
         assert!(
             msg.contains("got 2"),
             "expected the rejection to name the observed share count, got {msg}"
+        );
+        assert!(
+            msg.contains("#586"),
+            "rejection should reference the issue for future readers, got {msg}"
+        );
+    }
+
+    /// #586: a full-cardinality call with a DUPLICATED identifier (e.g.
+    /// [A, A, B] for a 3-member group) passes the count guard but still
+    /// orphans the genuinely-absent member, because `refreshing_by_id`
+    /// collapses the duplicate. Reject it before any rotation happens, and
+    /// name the offending identifier.
+    #[test]
+    fn test_refresh_with_duplicate_identifier_is_refused() {
+        use crate::frost::share::SharePackage;
+
+        let config = ThresholdConfig::two_of_three();
+        let dealer = TrustedDealer::new(config);
+        let (mut shares, _) = dealer.generate("test-dup").unwrap();
+
+        let dup_identifier = shares[0].metadata.identifier;
+        let duplicate = SharePackage::from_bytes(
+            shares[0].metadata.clone(),
+            shares[0].key_package_bytes().to_vec(),
+            shares[0].pubkey_package_bytes().to_vec(),
+        );
+
+        // Drop the third member and replace it with a copy of the first, so
+        // there are still 3 shares but only 2 distinct identifiers.
+        shares.pop();
+        shares.push(duplicate);
+        assert_eq!(shares.len(), 3);
+
+        let err = match refresh_shares(&shares) {
+            Ok(_) => panic!("duplicate-identifier refresh must be refused"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("distinct identifiers")
+                && msg.contains(&dup_identifier.to_string()),
+            "expected duplicate rejection naming the identifier, got {msg}"
         );
         assert!(
             msg.contains("#586"),

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -627,14 +627,16 @@ impl Keep {
         }
 
         let threshold = group_shares[0].metadata.threshold;
+        let total = group_shares[0].metadata.total_shares;
 
         let share_count: u16 = group_shares
             .len()
             .try_into()
             .map_err(|_| KeepError::Frost("Too many shares".into()))?;
-        if share_count < threshold {
+        if share_count != total {
             return Err(KeepError::Frost(format!(
-                "Need at least {threshold} shares to refresh, only {share_count} available locally"
+                "refresh requires the full set of {total} shares; only {share_count} available. \
+                 A partial refresh would orphan the absent shares (#586)."
             )));
         }
 


### PR DESCRIPTION
Closes #586. Surfaced during the frost 2.x → 3.0 dependency-bump review.

## Bug

`refresh_shares` only guarded `share_count >= threshold`, not `share_count == total_shares`. FROST 3.0's `compute_refreshing_shares` removes any participant whose identifier is not passed in, so refreshing with a subset silently invalidated every absent share. The refreshed shares still carried `total_shares` forward in metadata, so a holder of an absent share would believe they were still part of an N-of-M group when they had actually been orphaned.

Not a key-leak or signing-forgery issue (the group public key is preserved and re-checked after refresh at refresh.rs:128-133). The risk is silent orphaning: a partial refresh produces a smaller effective group while the metadata misrepresents it as full.

## Fix

Added a guard in `refresh_shares` (after the existing `share_count >= threshold` check) that requires `share_count == total`:

```rust
if share_count != total {
    return Err(KeepError::Frost(format!(
        "refresh_shares requires the full set of {total} shares; got {share_count}. \
         A partial refresh would silently orphan the absent shares (#586)."
    )));
}
```

The error message names both the required total and the observed count, and cites the issue so a future reader hitting it can trace the rationale.

## Why hard-reject instead of explicitly accepting a subset

#586 listed two options. Hard-reject was chosen because:
1. The orphaning risk is silent and the metadata carries the lie forward, so a permissive default invites a hard-to-debug share-loss incident.
2. The protocol-correct way to remove a participant is share rotation, not partial refresh.
3. Callers that genuinely want to refresh against a subset can collect the full set, refresh, and then re-distribute — explicit and observable.

## Test added

`test_refresh_with_subset_below_total_is_refused`: generate 2-of-3, drop the third share (2 ≥ threshold, < total), pin both the rejection and that the error message names the gap (`requires the full set`, `3 shares`, `got 2`) and references #586 for the rationale.

All 9 refresh tests pass; full workspace test passes.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Share refresh validation now requires complete share sets, preventing partial refreshes that could silently orphan shares (issue `#586`).

* **Tests**
  * Added validation test for refresh operations with incomplete share inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->