### PR TITLE
enclave: fail-closed PCR matching; require ExpectedPcrs by construction (closes #577)

### DIFF
--- a/keep-agent/src/attestation.rs
+++ b/keep-agent/src/attestation.rs
@@ -25,8 +25,16 @@ impl ExpectedPcrs {
                 .try_into()
                 .map_err(|_| AgentError::Attestation("PCR must be 48 bytes".into()))
         };
+        let pcr0 = parse(pcr0)?;
+        if pcr0.iter().all(|&b| b == 0) {
+            return Err(AgentError::Attestation(
+                "PCR0 is all zeros, which indicates a debug-mode enclave; refusing to pin it. \
+                 Use the insecure no-PCR path if you genuinely intend to verify a debug enclave."
+                    .into(),
+            ));
+        }
         Ok(Self {
-            pcr0: parse(pcr0)?,
+            pcr0,
             pcr1: parse(pcr1)?,
             pcr2: parse(pcr2)?,
         })
@@ -289,13 +297,21 @@ mod tests {
 
     #[test]
     fn test_expected_pcrs_from_hex() {
-        let pcr0 = "0".repeat(96);
+        let pcr0 = "9".repeat(96);
         let pcr1 = "1".repeat(96);
         let pcr2 = "2".repeat(96);
         let pcrs = ExpectedPcrs::from_hex(&pcr0, &pcr1, &pcr2).unwrap();
-        assert_eq!(pcrs.pcr0[0], 0x00);
+        assert_eq!(pcrs.pcr0[0], 0x99);
         assert_eq!(pcrs.pcr1[0], 0x11);
         assert_eq!(pcrs.pcr2[0], 0x22);
+    }
+
+    #[test]
+    fn test_expected_pcrs_from_hex_rejects_all_zero_pcr0() {
+        let pcr0 = "0".repeat(96);
+        let pcr1 = "1".repeat(96);
+        let pcr2 = "2".repeat(96);
+        assert!(ExpectedPcrs::from_hex(&pcr0, &pcr1, &pcr2).is_err());
     }
 
     #[test]

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -846,6 +846,12 @@ pub(crate) enum EnclaveCommands {
         pcr2: Option<String>,
         #[arg(long, help = "Use mock enclave for local testing")]
         local: bool,
+        #[arg(
+            long,
+            help = "INSECURE: skip PCR matching (cert-chain + nonce still verified). \
+                    Dev/testing only; does NOT bind the attestation to a known image (#577)."
+        )]
+        insecure_no_pcrs: bool,
     },
     GenerateKey {
         #[arg(short, long)]

--- a/keep-cli/src/commands/enclave.rs
+++ b/keep-cli/src/commands/enclave.rs
@@ -183,7 +183,6 @@ pub fn cmd_enclave_verify(
             }
             Err(e) => {
                 spinner.finish();
-                out.error(&format!("Verification failed: {e}"));
                 return Err(KeepError::Runtime(format!(
                     "attestation verification failed: {e}"
                 )));
@@ -193,7 +192,7 @@ pub fn cmd_enclave_verify(
 
     #[cfg(not(target_os = "linux"))]
     {
-        let _ = (pcr0, pcr1, pcr2);
+        let _ = (pcr0, pcr1, pcr2, insecure_no_pcrs);
         out.warn("Enclave operations only available on Linux with Nitro");
     }
 

--- a/keep-cli/src/commands/enclave.rs
+++ b/keep-cli/src/commands/enclave.rs
@@ -89,6 +89,7 @@ pub fn cmd_enclave_verify(
     pcr1: Option<&str>,
     pcr2: Option<&str>,
     local: bool,
+    insecure_no_pcrs: bool,
 ) -> Result<()> {
     out.newline();
     out.header("Enclave Attestation Verification");
@@ -133,16 +134,33 @@ pub fn cmd_enclave_verify(
         })?;
         spinner.finish();
 
-        let expected_pcrs = if let (Some(p0), Some(p1), Some(p2)) = (pcr0, pcr1, pcr2) {
-            Some(
-                keep_enclave_host::ExpectedPcrs::from_hex(p0, p1, p2)
-                    .map_err(|e| KeepError::InvalidInput(format!("invalid PCR hex: {e}")))?,
-            )
-        } else {
-            None
+        // #577: PCR matching is the only thing that binds an AWS-signed
+        // attestation to a specific reproducible-build enclave image. Fail
+        // closed when PCRs are absent unless the operator explicitly opted
+        // in to the insecure path via `--insecure-no-pcrs`.
+        let verifier = match (pcr0, pcr1, pcr2) {
+            (Some(p0), Some(p1), Some(p2)) => {
+                let pcrs = keep_enclave_host::ExpectedPcrs::from_hex(p0, p1, p2)
+                    .map_err(|e| KeepError::InvalidInput(format!("invalid PCR hex: {e}")))?;
+                keep_enclave_host::AttestationVerifier::new(pcrs)
+            }
+            _ if insecure_no_pcrs => {
+                out.warn(
+                    "INSECURE: --insecure-no-pcrs set; the attestation will be cert-chain and \
+                     nonce verified but NOT bound to a specific enclave image. Any AWS-signed \
+                     enclave document will pass. Do not use in production.",
+                );
+                keep_enclave_host::AttestationVerifier::insecure_without_pcrs()
+            }
+            _ => {
+                return Err(KeepError::InvalidInput(
+                    "expected PCRs are required (--pcr0 --pcr1 --pcr2). Without them, the \
+                     attestation cannot be bound to a known enclave image (#577). To skip PCR \
+                     matching for dev/testing, pass --insecure-no-pcrs explicitly."
+                        .into(),
+                ));
+            }
         };
-
-        let verifier = keep_enclave_host::AttestationVerifier::new(expected_pcrs);
 
         let spinner = out.spinner("Verifying attestation...");
         match verifier.verify(&attestation_doc, &nonce) {

--- a/keep-cli/src/commands/enclave.rs
+++ b/keep-cli/src/commands/enclave.rs
@@ -144,13 +144,21 @@ pub fn cmd_enclave_verify(
                     .map_err(|e| KeepError::InvalidInput(format!("invalid PCR hex: {e}")))?;
                 keep_enclave_host::AttestationVerifier::new(pcrs)
             }
-            _ if insecure_no_pcrs => {
+            (None, None, None) if insecure_no_pcrs => {
                 out.warn(
                     "INSECURE: --insecure-no-pcrs set; the attestation will be cert-chain and \
                      nonce verified but NOT bound to a specific enclave image. Any AWS-signed \
                      enclave document will pass. Do not use in production.",
                 );
                 keep_enclave_host::AttestationVerifier::insecure_without_pcrs()
+            }
+            _ if insecure_no_pcrs => {
+                return Err(KeepError::InvalidInput(
+                    "--insecure-no-pcrs cannot be combined with a partial set of PCRs. Pass all \
+                     three (--pcr0 --pcr1 --pcr2) to pin an image, or none of them with \
+                     --insecure-no-pcrs to skip PCR matching entirely."
+                        .into(),
+                ));
             }
             _ => {
                 return Err(KeepError::InvalidInput(
@@ -176,6 +184,9 @@ pub fn cmd_enclave_verify(
             Err(e) => {
                 spinner.finish();
                 out.error(&format!("Verification failed: {e}"));
+                return Err(KeepError::Runtime(format!(
+                    "attestation verification failed: {e}"
+                )));
             }
         }
     }

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -648,6 +648,7 @@ fn dispatch_enclave(out: &Output, path: &std::path::Path, command: EnclaveComman
             pcr1,
             pcr2,
             local,
+            insecure_no_pcrs,
         } => commands::enclave::cmd_enclave_verify(
             out,
             cid,
@@ -655,6 +656,7 @@ fn dispatch_enclave(out: &Output, path: &std::path::Path, command: EnclaveComman
             pcr1.as_deref(),
             pcr2.as_deref(),
             local,
+            insecure_no_pcrs,
         ),
         EnclaveCommands::GenerateKey { name, cid, local } => {
             commands::enclave::cmd_enclave_generate_key(out, &name, cid, local)

--- a/keep-enclave/host/src/attestation.rs
+++ b/keep-enclave/host/src/attestation.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use x509_cert::der::{Decode, Encode};
 use x509_cert::Certificate;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ExpectedPcrs {
     pub pcr0: [u8; 48],
     pub pcr1: [u8; 48],

--- a/keep-enclave/host/src/attestation.rs
+++ b/keep-enclave/host/src/attestation.rs
@@ -73,10 +73,33 @@ fn parse_pem_cert(pem: &str) -> Certificate {
 }
 
 impl AttestationVerifier {
-    pub fn new(expected_pcrs: Option<ExpectedPcrs>) -> Self {
+    /// Construct a production attestation verifier that enforces PCR matching
+    /// against `expected_pcrs`. The cert-chain, nonce-replay, and signature
+    /// checks all run regardless, but a verifier that never matches PCRs
+    /// silently discards the reproducible-build guarantee (#577): a caller
+    /// gets a valid AWS-signed attestation that is not bound to any known
+    /// enclave image. Production callers MUST pin PCRs here; dev or test
+    /// code that genuinely needs to skip PCR matching must opt in via
+    /// `insecure_without_pcrs` so the unsafe path can never be reached by
+    /// accident.
+    pub fn new(expected_pcrs: ExpectedPcrs) -> Self {
         let root_cert = parse_pem_cert(AWS_NITRO_ROOT_CERT_PEM);
         Self {
-            expected_pcrs,
+            expected_pcrs: Some(expected_pcrs),
+            root_cert,
+        }
+    }
+
+    /// **INSECURE — for dev/test only.** Construct a verifier that runs the
+    /// cert-chain, nonce-replay, and signature checks but does NOT match
+    /// PCRs against a pinned image. Skipping PCR matching means the
+    /// attestation is not bound to any known enclave image; an AWS-signed
+    /// document from a *different* enclave still verifies. Never call this
+    /// from production paths.
+    pub fn insecure_without_pcrs() -> Self {
+        let root_cert = parse_pem_cert(AWS_NITRO_ROOT_CERT_PEM);
+        Self {
+            expected_pcrs: None,
             root_cert,
         }
     }
@@ -378,5 +401,36 @@ mod tests {
         assert_eq!(pcrs.pcr0[0], 0x00);
         assert_eq!(pcrs.pcr1[0], 0x11);
         assert_eq!(pcrs.pcr2[0], 0x22);
+    }
+
+    /// #577: `AttestationVerifier::new` MUST require pinned PCRs by
+    /// construction. The signature `new(ExpectedPcrs)` (no `Option`) is the
+    /// fail-closed contract; any future regression that re-introduces
+    /// `Option<ExpectedPcrs>` would let production callers silently skip PCR
+    /// matching and break the reproducible-build binding.
+    #[test]
+    fn production_verifier_requires_pcrs_by_construction() {
+        let pcrs = ExpectedPcrs::from_hex(&"0".repeat(96), &"1".repeat(96), &"2".repeat(96))
+            .expect("ExpectedPcrs hex");
+        let verifier = AttestationVerifier::new(pcrs);
+        assert!(
+            verifier.expected_pcrs.is_some(),
+            "production constructor MUST persist the pinned PCRs"
+        );
+    }
+
+    /// `AttestationVerifier::insecure_without_pcrs` is the explicit opt-in
+    /// path for dev/test code that genuinely needs to skip PCR matching.
+    /// Calling it MUST yield `expected_pcrs: None` so the existing
+    /// `verify()` branch (line ~117) skips PCR matching. The name is the
+    /// gate; this test pins both the constructor and the documented
+    /// behavior so the unsafe path can never be reached by accident.
+    #[test]
+    fn insecure_constructor_yields_verifier_without_pcrs() {
+        let verifier = AttestationVerifier::insecure_without_pcrs();
+        assert!(
+            verifier.expected_pcrs.is_none(),
+            "insecure_without_pcrs MUST construct a verifier with no pinned PCRs"
+        );
     }
 }

--- a/keep-enclave/host/src/attestation.rs
+++ b/keep-enclave/host/src/attestation.rs
@@ -26,8 +26,16 @@ impl ExpectedPcrs {
                 .try_into()
                 .map_err(|_| EnclaveError::Attestation("PCR must be 48 bytes".into()))
         };
+        let pcr0 = parse(pcr0)?;
+        if pcr0.iter().all(|&b| b == 0) {
+            return Err(EnclaveError::Attestation(
+                "PCR0 is all zeros, which indicates a debug-mode enclave; refusing to pin it. \
+                 Use --insecure-no-pcrs if you genuinely intend to verify a debug enclave."
+                    .into(),
+            ));
+        }
         Ok(Self {
-            pcr0: parse(pcr0)?,
+            pcr0,
             pcr1: parse(pcr1)?,
             pcr2: parse(pcr2)?,
         })
@@ -83,9 +91,13 @@ impl AttestationVerifier {
     /// `insecure_without_pcrs` so the unsafe path can never be reached by
     /// accident.
     pub fn new(expected_pcrs: ExpectedPcrs) -> Self {
+        Self::with_pcrs(Some(expected_pcrs))
+    }
+
+    fn with_pcrs(expected_pcrs: Option<ExpectedPcrs>) -> Self {
         let root_cert = parse_pem_cert(AWS_NITRO_ROOT_CERT_PEM);
         Self {
-            expected_pcrs: Some(expected_pcrs),
+            expected_pcrs,
             root_cert,
         }
     }
@@ -96,12 +108,9 @@ impl AttestationVerifier {
     /// attestation is not bound to any known enclave image; an AWS-signed
     /// document from a *different* enclave still verifies. Never call this
     /// from production paths.
+    #[doc(hidden)]
     pub fn insecure_without_pcrs() -> Self {
-        let root_cert = parse_pem_cert(AWS_NITRO_ROOT_CERT_PEM);
-        Self {
-            expected_pcrs: None,
-            root_cert,
-        }
+        Self::with_pcrs(None)
     }
 
     pub fn verify(&self, attestation_doc: &[u8], nonce: &[u8; 32]) -> Result<VerifiedAttestation> {
@@ -393,14 +402,21 @@ mod tests {
 
     #[test]
     fn test_expected_pcrs_from_hex() {
-        let pcr0 = "0".repeat(96);
+        let pcr0 = "9".repeat(96);
         let pcr1 = "1".repeat(96);
         let pcr2 = "2".repeat(96);
 
         let pcrs = ExpectedPcrs::from_hex(&pcr0, &pcr1, &pcr2).unwrap();
-        assert_eq!(pcrs.pcr0[0], 0x00);
+        assert_eq!(pcrs.pcr0[0], 0x99);
         assert_eq!(pcrs.pcr1[0], 0x11);
         assert_eq!(pcrs.pcr2[0], 0x22);
+    }
+
+    #[test]
+    fn from_hex_rejects_all_zero_pcr0() {
+        let err = ExpectedPcrs::from_hex(&"0".repeat(96), &"1".repeat(96), &"2".repeat(96))
+            .expect_err("all-zero PCR0 must be rejected");
+        assert!(matches!(err, EnclaveError::Attestation(_)));
     }
 
     /// #577: `AttestationVerifier::new` MUST require pinned PCRs by
@@ -410,7 +426,7 @@ mod tests {
     /// matching and break the reproducible-build binding.
     #[test]
     fn production_verifier_requires_pcrs_by_construction() {
-        let pcrs = ExpectedPcrs::from_hex(&"0".repeat(96), &"1".repeat(96), &"2".repeat(96))
+        let pcrs = ExpectedPcrs::from_hex(&"9".repeat(96), &"1".repeat(96), &"2".repeat(96))
             .expect("ExpectedPcrs hex");
         let verifier = AttestationVerifier::new(pcrs);
         assert!(

--- a/keep-frost-net/src/attestation.rs
+++ b/keep-frost-net/src/attestation.rs
@@ -54,7 +54,7 @@ pub fn verify_peer_attestation(
     use keep_enclave_host::{AttestationVerifier, ExpectedPcrs as HostPcrs};
 
     let host_pcrs = HostPcrs::new(expected_pcrs.pcr0, expected_pcrs.pcr1, expected_pcrs.pcr2);
-    let verifier = AttestationVerifier::new(Some(host_pcrs));
+    let verifier = AttestationVerifier::new(host_pcrs);
     let nonce = derive_attestation_nonce(group_pubkey);
 
     let verified = verifier

--- a/keep-frost-net/src/attestation.rs
+++ b/keep-frost-net/src/attestation.rs
@@ -30,8 +30,16 @@ impl ExpectedPcrs {
                 .try_into()
                 .map_err(|_| FrostNetError::Attestation("PCR must be 48 bytes".into()))
         };
+        let pcr0 = parse(pcr0)?;
+        if pcr0.iter().all(|&b| b == 0) {
+            return Err(FrostNetError::Attestation(
+                "PCR0 is all zeros, which indicates a debug-mode enclave; refusing to pin it. \
+                 Use the explicit insecure path if you genuinely intend a debug enclave."
+                    .into(),
+            ));
+        }
         Ok(Self {
-            pcr0: parse(pcr0)?,
+            pcr0,
             pcr1: parse(pcr1)?,
             pcr2: parse(pcr2)?,
         })
@@ -153,13 +161,19 @@ mod tests {
 
     #[test]
     fn test_expected_pcrs_from_hex() {
-        let pcr0 = "0".repeat(96);
+        let pcr0 = "9".repeat(96);
         let pcr1 = "1".repeat(96);
         let pcr2 = "2".repeat(96);
         let pcrs = ExpectedPcrs::from_hex(&pcr0, &pcr1, &pcr2).unwrap();
-        assert_eq!(pcrs.pcr0[0], 0x00);
+        assert_eq!(pcrs.pcr0[0], 0x99);
         assert_eq!(pcrs.pcr1[0], 0x11);
         assert_eq!(pcrs.pcr2[0], 0x22);
+    }
+
+    #[test]
+    fn test_expected_pcrs_from_hex_rejects_all_zero_pcr0() {
+        let result = ExpectedPcrs::from_hex(&"0".repeat(96), &"1".repeat(96), &"2".repeat(96));
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
Closes #577.

## Bug

`AttestationVerifier::new(expected_pcrs: Option<ExpectedPcrs>)` silently skipped PCR matching when called with `None`. The cert-chain, nonce-replay, and signature checks still ran, so a caller got a valid AWS-signed attestation that was never bound to a known enclave image. The reproducible-build + PCR pinning story (`Dockerfile.reproducible`, CI double-build SHA256 check) is exactly what makes attestation meaningful here; the no-PCR path silently discarded that guarantee.

The CLI made this trivially reachable: `cmd_enclave_verify` collected `--pcr0` / `--pcr1` / `--pcr2` as `Option<String>` and passed `None` to the verifier when any were omitted.

## Fix

### `keep-enclave/host/src/attestation.rs`

- `AttestationVerifier::new(expected_pcrs: ExpectedPcrs)` — required by construction, no `Option`. Doc comment names the threat model explicitly.
- `AttestationVerifier::insecure_without_pcrs() -> Self` — the only path that produces a PCR-skipping verifier. The name is the gate; production code that calls this would not pass review.

### `keep-frost-net/src/attestation.rs`

The single production caller already passed `Some(host_pcrs)`. Updated to drop the `Some(_)` wrap; semantics unchanged.

### `keep-cli/src/commands/enclave.rs` + `cli.rs`

`keep enclave verify` now:
- **Default**: requires all three PCRs (`--pcr0 --pcr1 --pcr2`). Returns `InvalidInput` if any is missing, with an error message naming the requirement and the new opt-in flag.
- **`--insecure-no-pcrs`**: explicit operator opt-in to the PCR-skipping path. Prints a loud `INSECURE:` warning before proceeding.

The flag's clap help text names #577 so a future operator hitting it can trace the rationale.

## Tests added

Two inline tests in `keep-enclave-host` pinning the construction contract:

- `production_verifier_requires_pcrs_by_construction`: builds `AttestationVerifier::new(pcrs)`, asserts `expected_pcrs.is_some()`. Pins that the signature has no `Option` — a future regression that re-introduces `Option<ExpectedPcrs>` would break this test.
- `insecure_constructor_yields_verifier_without_pcrs`: pins that `insecure_without_pcrs()` produces `expected_pcrs: None` so the existing skip branch in `verify()` fires. Documents the intentional semantics of the named opt-in.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--insecure-no-pcrs` CLI flag to allow attestation verification without PCR validation for development and testing scenarios.

* **Security Improvements**
  * Now explicitly rejects debug-mode enclave attestations with clear error messaging, directing users to appropriate verification paths.
  * Enforced stricter PCR validation to ensure production attestations are properly pinned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->