### PR TITLE
nip46: drop silent NIP-98 grant; prompt-on-first-use with remember-duration

### DIFF
--- a/keep-cli/src/commands/nip46.rs
+++ b/keep-cli/src/commands/nip46.rs
@@ -149,6 +149,7 @@ pub fn cmd_nip46_grant(
         auto_approve_kinds: auto_kinds,
         duration: parsed_duration,
         connected_at: now,
+        timed_kind_grants: Vec::new(),
     };
     let replaced = match existing {
         Some(idx) => {

--- a/keep-cli/src/commands/serve.rs
+++ b/keep-cli/src/commands/serve.rs
@@ -38,7 +38,7 @@ impl ServerCallbacks for TuiCallbacks {
         ));
     }
 
-    fn request_approval(&self, request: ApprovalRequest) -> bool {
+    fn request_approval(&self, request: ApprovalRequest) -> keep_nip46::types::ApprovalResult {
         let (response_tx, response_rx) = std::sync::mpsc::channel();
         let tui_req = TuiApprovalRequest {
             id: 0,
@@ -50,9 +50,14 @@ impl ServerCallbacks for TuiCallbacks {
         };
 
         if self.tx.send(TuiEvent::Approval(tui_req)).is_err() {
-            return false;
+            return false.into();
         }
+        // The TUI does not (yet) capture a remember-duration, so a positive
+        // response is one-shot. The new persistent-grant semantics (#575)
+        // only apply to bunkers whose callback returns a non-`JustThisTime`
+        // `RememberDuration` (today: keep-mobile).
         tokio::task::block_in_place(|| response_rx.recv_timeout(APPROVAL_TIMEOUT).unwrap_or(false))
+            .into()
     }
 }
 

--- a/keep-core/src/backup.rs
+++ b/keep-core/src/backup.rs
@@ -743,6 +743,7 @@ mod tests {
             auto_approve_kinds: vec![1, 7],
             duration: StoredPermissionDuration::Forever,
             connected_at: 1_700_000_000,
+            timed_kind_grants: Vec::new(),
         });
         relay_cfg.auto_approve_kinds = vec![22242];
         keep.store_relay_config(&relay_cfg).unwrap();

--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -1388,6 +1388,7 @@ mod tests {
             auto_approve_kinds: vec![1, 7],
             duration: StoredPermissionDuration::Forever,
             connected_at: 100,
+            timed_kind_grants: Vec::new(),
         });
         cfg.auto_approve_kinds = vec![22242];
 

--- a/keep-core/src/relay.rs
+++ b/keep-core/src/relay.rs
@@ -46,6 +46,16 @@ pub enum StoredPermissionDuration {
     Forever,
 }
 
+/// A single timed per-kind auto-approve grant persisted for a bunker client.
+/// Survives restart; pruned on restore once `expires_at` has passed.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StoredTimedKindGrant {
+    /// Event kind this grant auto-approves.
+    pub kind: u16,
+    /// Unix timestamp (seconds) when the grant expires.
+    pub expires_at: u64,
+}
+
 /// Persisted permission state for a connected bunker (NIP-46) client.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StoredBunkerPermission {
@@ -61,6 +71,10 @@ pub struct StoredBunkerPermission {
     pub duration: StoredPermissionDuration,
     /// Unix timestamp when the client first connected.
     pub connected_at: u64,
+    /// Per-kind timed auto-approve grants that survive restart. Expired entries
+    /// are pruned when the bunker restores this client.
+    #[serde(default)]
+    pub timed_kind_grants: Vec<StoredTimedKindGrant>,
 }
 
 /// Per-peer send/receive policy entry, stored alongside relay configuration.
@@ -191,6 +205,12 @@ impl RelayConfig {
                     bp.auto_approve_kinds.len()
                 )));
             }
+            if bp.timed_kind_grants.len() > MAX_AUTO_KINDS {
+                return Err(KeepError::InvalidInput(format!(
+                    "Too many timed kind grants: {} (max {MAX_AUTO_KINDS})",
+                    bp.timed_kind_grants.len()
+                )));
+            }
             bunker_permissions.push(StoredBunkerPermission {
                 pubkey_hex: bp.pubkey_hex.to_ascii_lowercase(),
                 name: bp.name,
@@ -198,6 +218,7 @@ impl RelayConfig {
                 auto_approve_kinds: bp.auto_approve_kinds,
                 duration: bp.duration,
                 connected_at: bp.connected_at,
+                timed_kind_grants: bp.timed_kind_grants,
             });
         }
 

--- a/keep-desktop/src/bunker_service.rs
+++ b/keep-desktop/src/bunker_service.rs
@@ -73,7 +73,10 @@ impl keep_nip46::types::ServerCallbacks for DesktopCallbacks {
         });
     }
 
-    fn request_approval(&self, request: keep_nip46::types::ApprovalRequest) -> bool {
+    fn request_approval(
+        &self,
+        request: keep_nip46::types::ApprovalRequest,
+    ) -> keep_nip46::types::ApprovalResult {
         let (response_tx, response_rx) = std::sync::mpsc::channel();
         let display = PendingApprovalDisplay {
             app_pubkey: request.app_pubkey.to_hex(),
@@ -91,13 +94,14 @@ impl keep_nip46::types::ServerCallbacks for DesktopCallbacks {
             })
             .is_err()
         {
-            return false;
+            return false.into();
         }
         tokio::task::block_in_place(|| {
             response_rx
                 .recv_timeout(BUNKER_APPROVAL_TIMEOUT)
                 .unwrap_or(false)
         })
+        .into()
     }
 
     fn on_connect(&self, pubkey: &str, _name: &str) {

--- a/keep-desktop/src/bunker_service.rs
+++ b/keep-desktop/src/bunker_service.rs
@@ -8,7 +8,7 @@ use iced::Task;
 use keep_core::relay::{normalize_relay_url, validate_relay_url};
 use zeroize::Zeroizing;
 
-use keep_core::relay::{StoredBunkerPermission, StoredPermissionDuration};
+use keep_core::relay::{StoredBunkerPermission, StoredPermissionDuration, StoredTimedKindGrant};
 
 use crate::app::{
     lock_keep, save_settings, App, ToastKind, BUNKER_APPROVAL_TIMEOUT, MAX_BUNKER_LOG_ENTRIES,
@@ -703,6 +703,11 @@ impl App {
                         .unwrap_or(StoredPermissionDuration::Session),
                 },
                 connected_at: c.connected_at,
+                timed_kind_grants: c
+                    .timed_kind_grants
+                    .iter()
+                    .map(|&(kind, expires_at)| StoredTimedKindGrant { kind, expires_at })
+                    .collect(),
             })
             .collect();
         self.update_relay_config(|config| config.bunker_permissions = stored);
@@ -728,6 +733,7 @@ impl App {
                     app.auto_approve_kinds,
                     app.duration,
                     app.connected_at,
+                    app.timed_kind_grants,
                 )
                 .await;
         }
@@ -775,6 +781,11 @@ impl App {
                             duration: duration_str,
                             duration_seconds,
                             connected_at: app.connected_at.as_secs(),
+                            timed_kind_grants: app
+                                .timed_kind_grants
+                                .iter()
+                                .map(|(k, &expiry)| (k.as_u16(), expiry))
+                                .collect(),
                         }
                     })
                     .collect()

--- a/keep-desktop/src/local_signer_service.rs
+++ b/keep-desktop/src/local_signer_service.rs
@@ -48,7 +48,10 @@ impl keep_nip46::types::ServerCallbacks for LocalSignerCallbacks {
         });
     }
 
-    fn request_approval(&self, request: keep_nip46::types::ApprovalRequest) -> bool {
+    fn request_approval(
+        &self,
+        request: keep_nip46::types::ApprovalRequest,
+    ) -> keep_nip46::types::ApprovalResult {
         let (response_tx, response_rx) = std::sync::mpsc::channel();
         let display = PendingApprovalDisplay {
             app_name: request.app_name,
@@ -64,7 +67,7 @@ impl keep_nip46::types::ServerCallbacks for LocalSignerCallbacks {
             })
             .is_err()
         {
-            return false;
+            return false.into();
         }
         let tx = self.tx.clone();
         tokio::task::block_in_place(|| match response_rx.recv_timeout(BUNKER_APPROVAL_TIMEOUT) {
@@ -74,6 +77,7 @@ impl keep_nip46::types::ServerCallbacks for LocalSignerCallbacks {
                 false
             }
         })
+        .into()
     }
 
     fn on_connect(&self, client_id: &str, name: &str) {

--- a/keep-desktop/src/screen/bunker.rs
+++ b/keep-desktop/src/screen/bunker.rs
@@ -18,6 +18,7 @@ pub struct ConnectedClient {
     pub duration: String,
     pub duration_seconds: Option<u64>,
     pub connected_at: u64,
+    pub timed_kind_grants: Vec<(u16, u64)>,
 }
 
 const PERM_FLAGS: &[(&str, u32)] = &[

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -6,8 +6,10 @@ use crate::{KeepMobile, KeepMobileError};
 use keep_nip46::types::{
     ApprovalRequest, ApprovalResult, LogEvent, RememberDuration, ServerCallbacks,
 };
-use keep_nip46::{NetworkFrostSigner, Permission, RateLimitConfig, Server, ServerConfig};
-use nostr_sdk::Kind;
+use keep_nip46::{
+    NetworkFrostSigner, Permission, RateLimitConfig, Server, ServerConfig, SignerHandler,
+};
+use nostr_sdk::{Kind, PublicKey};
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 use zeroize::{Zeroize, Zeroizing};
@@ -160,6 +162,7 @@ pub struct BunkerHandler {
     status: Arc<AtomicU8>,
     bunker_url: std::sync::Mutex<Option<String>>,
     shutdown_tx: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    handler: std::sync::Mutex<Option<Arc<SignerHandler>>>,
 }
 
 impl BunkerHandler {
@@ -181,6 +184,7 @@ impl BunkerHandler {
             status: Arc::new(AtomicU8::new(STATUS_STOPPED)),
             bunker_url: std::sync::Mutex::new(None),
             shutdown_tx: std::sync::Mutex::new(None),
+            handler: std::sync::Mutex::new(None),
         }
     }
 
@@ -213,6 +217,44 @@ impl BunkerHandler {
             let _ = tx.send(());
         }
         *self.bunker_url.lock().unwrap_or_else(|e| e.into_inner()) = None;
+        *self.handler.lock().unwrap_or_else(|e| e.into_inner()) = None;
+    }
+
+    /// Revokes a single client, dropping its in-memory permission grants in the
+    /// running engine so any remembered (auto-approved) kinds stop signing
+    /// immediately. No-op when the bunker is not running. The pubkey is the
+    /// client's hex-encoded x-only public key.
+    pub fn revoke_client(&self, pubkey: String) -> Result<(), KeepMobileError> {
+        let handler = self
+            .handler
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        let Some(handler) = handler else {
+            return Ok(());
+        };
+        let pubkey = PublicKey::from_hex(&pubkey).map_err(|_| KeepMobileError::InvalidInput {
+            msg: "Invalid client pubkey hex".into(),
+        })?;
+        self.mobile
+            .runtime
+            .block_on(async { handler.revoke_client(&pubkey).await });
+        Ok(())
+    }
+
+    /// Revokes every client, clearing all in-memory permission grants in the
+    /// running engine. No-op when the bunker is not running.
+    pub fn revoke_all_clients(&self) {
+        let handler = self
+            .handler
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        if let Some(handler) = handler {
+            self.mobile
+                .runtime
+                .block_on(async { handler.revoke_all_clients().await });
+        }
     }
 
     pub fn get_bunker_url(&self) -> Option<String> {
@@ -437,6 +479,7 @@ impl BunkerHandler {
             .map_err(|e| KeepMobileError::NetworkError { msg: e.to_string() })?;
 
             *self.bunker_url.lock().unwrap_or_else(|e| e.into_inner()) = Some(server.bunker_url());
+            *self.handler.lock().unwrap_or_else(|e| e.into_inner()) = Some(server.handler());
 
             let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
             *self.shutdown_tx.lock().unwrap_or_else(|e| e.into_inner()) = Some(shutdown_tx);

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -3,7 +3,9 @@
 
 use crate::network::validate_relay_url;
 use crate::{KeepMobile, KeepMobileError};
-use keep_nip46::types::{ApprovalRequest, LogEvent, ServerCallbacks};
+use keep_nip46::types::{
+    ApprovalRequest, ApprovalResult, LogEvent, RememberDuration, ServerCallbacks,
+};
 use keep_nip46::{NetworkFrostSigner, Permission, RateLimitConfig, Server, ServerConfig};
 use nostr_sdk::Kind;
 use std::sync::atomic::{AtomicU8, Ordering};
@@ -41,6 +43,56 @@ pub struct BunkerApprovalRequest {
     pub requested_permissions: Option<String>,
 }
 
+/// How long an approval persists. Mirrors keep-android's
+/// `nip55/PermissionEntities.kt::PermissionDuration` and Amber's `RememberType`
+/// so the same enum maps cleanly to the existing `Nip46ApprovalScreen` picker.
+/// `JustThisTime` is the one-shot default (no grant persisted); `Forever`
+/// permanently auto-approves the (app, kind) pair; the timed variants persist
+/// a per-(app, kind) grant with the matching expiry.
+#[derive(uniffi::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BunkerRememberDuration {
+    JustThisTime,
+    OneMinute,
+    FiveMinutes,
+    TenMinutes,
+    OneHour,
+    OneDay,
+    Forever,
+}
+
+impl From<BunkerRememberDuration> for RememberDuration {
+    fn from(d: BunkerRememberDuration) -> Self {
+        match d {
+            BunkerRememberDuration::JustThisTime => RememberDuration::JustThisTime,
+            BunkerRememberDuration::OneMinute => RememberDuration::OneMinute,
+            BunkerRememberDuration::FiveMinutes => RememberDuration::FiveMinutes,
+            BunkerRememberDuration::TenMinutes => RememberDuration::TenMinutes,
+            BunkerRememberDuration::OneHour => RememberDuration::OneHour,
+            BunkerRememberDuration::OneDay => RememberDuration::OneDay,
+            BunkerRememberDuration::Forever => RememberDuration::Forever,
+        }
+    }
+}
+
+/// Result of an approval prompt as returned by the native UI. `approved=false`
+/// always means reject and `remember` is ignored. `approved=true` plus a non-
+/// `JustThisTime` duration persists a per-(app, kind) grant in the bunker so
+/// subsequent requests within the window auto-approve without re-prompting.
+#[derive(uniffi::Record, Clone, Copy, Debug)]
+pub struct BunkerApprovalResult {
+    pub approved: bool,
+    pub remember: BunkerRememberDuration,
+}
+
+impl From<BunkerApprovalResult> for ApprovalResult {
+    fn from(r: BunkerApprovalResult) -> Self {
+        ApprovalResult {
+            approved: r.approved,
+            remember: r.remember.into(),
+        }
+    }
+}
+
 #[derive(uniffi::Record, Clone, Debug)]
 pub struct ParsedBunkerUrl {
     pub pubkey: String,
@@ -62,7 +114,7 @@ pub fn parse_bunker_url(url: &str) -> Result<ParsedBunkerUrl, KeepMobileError> {
 #[uniffi::export(with_foreign)]
 pub trait BunkerCallbacks: Send + Sync {
     fn on_log(&self, event: BunkerLogEvent);
-    fn request_approval(&self, request: BunkerApprovalRequest) -> bool;
+    fn request_approval(&self, request: BunkerApprovalRequest) -> BunkerApprovalResult;
     /// Fired when an app completes the NIP-46 connect handshake. `pubkey` and
     /// `name` are untrusted, remote-derived values: render them as inert text,
     /// never as markup.
@@ -83,15 +135,17 @@ impl ServerCallbacks for CallbackBridge {
         });
     }
 
-    fn request_approval(&self, request: ApprovalRequest) -> bool {
-        self.callbacks.request_approval(BunkerApprovalRequest {
-            app_pubkey: request.app_pubkey.to_hex(),
-            app_name: request.app_name,
-            method: request.method,
-            event_kind: request.event_kind.map(|k| k.as_u16() as u32),
-            event_content: request.event_content,
-            requested_permissions: request.requested_permissions,
-        })
+    fn request_approval(&self, request: ApprovalRequest) -> ApprovalResult {
+        self.callbacks
+            .request_approval(BunkerApprovalRequest {
+                app_pubkey: request.app_pubkey.to_hex(),
+                app_name: request.app_name,
+                method: request.method,
+                event_kind: request.event_kind.map(|k| k.as_u16() as u32),
+                event_content: request.event_content,
+                requested_permissions: request.requested_permissions,
+            })
+            .into()
     }
 
     fn on_connect(&self, pubkey: &str, name: &str) {
@@ -186,23 +240,23 @@ fn bunker_auto_approve_kinds() -> std::collections::HashSet<Kind> {
 }
 
 /// Event kinds auto-approved per-app for each client that completes the connect
-/// handshake, scoped to that client's pubkey instead of granted globally. Kind
-/// 27235 (NIP-98 HTTP auth) is required by web clients such as nostr-tools'
-/// `BunkerSigner`, which sign a fresh auth event for *every* API call and time
-/// out (~60s) if the signer prompts per request.
+/// handshake, scoped to that client's pubkey instead of granted globally.
 ///
-/// TRUST MODEL: auto-approving kind 27235 makes the bunker URL + connect secret
-/// an HTTP-auth bearer credential. Any client that completes the connect
-/// handshake can silently mint NIP-98 auth tokens for *any* URL and method with
-/// no per-request prompt, exactly like handing out an HTTP `Authorization`
-/// header. Amber behaves the same way. The grant is now scoped to each
-/// connected app's pubkey (revocable and auditable per app) rather than a
-/// blanket global rule, but the connect secret is still shared across clients,
-/// so treat the bunker URL as a secret of equivalent power to the signing key
-/// for HTTP-auth purposes. A per-app/URL-method allowlist is tracked as
-/// follow-up work.
+/// **Empty by default as of #575.** Previously this returned `{NIP98_HTTP_AUTH}`
+/// so web clients such as nostr-tools' `BunkerSigner` (which signs a fresh NIP-98
+/// event per HTTP call) would not be blocked by a 60s-per-request prompt. That
+/// silent grant turned the bunker URL + connect secret into an HTTP-auth bearer
+/// credential: anyone holding it could mint NIP-98 tokens authenticating as the
+/// user to any URL/method with no prompt. Per-app scoping does not bound that
+/// threat as long as the connect secret is reusable.
+///
+/// NIP-98 sign requests now fall through to the existing per-request approval
+/// callback. The next step (mobile UI, tracked as a follow-up under #575) is to
+/// extend the approval response with a remember-duration so the user can opt in
+/// to "remember for 1 hour / 1 day / always" after seeing the first request,
+/// matching Amber's UX without the silent-grant trade-off.
 fn bunker_connect_auto_approve_kinds() -> std::collections::HashSet<Kind> {
-    std::collections::HashSet::from([keep_nip46::NIP98_HTTP_AUTH])
+    std::collections::HashSet::new()
 }
 
 /// Decodes a persisted transport secret, returning `None` when the stored value

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -453,14 +453,14 @@ impl BunkerHandler {
                 // gets get_public_key and every sign_event is denied — the
                 // client logs in but its signed-request calls all fail.
                 //
-                // TRUST MODEL: this connect grant plus the per-app
-                // connect_auto_approve_kinds (see
-                // `bunker_connect_auto_approve_kinds`) means a single shared
-                // connect secret authorizes signing and silent NIP-98 (kind
-                // 27235) token minting for every connected client. NIP-98 is
-                // granted per connected app pubkey (revocable/auditable), not
-                // globally. The connect secret is still a shared bearer
-                // credential; a per-app/URL-method allowlist is follow-up work.
+                // TRUST MODEL: this connect grant authorizes signing, but
+                // NIP-98 (kind 27235) is NEVER auto-approved. Per #575 it always
+                // falls through to the per-request approval prompt and is never
+                // remembered (see `bunker_connect_auto_approve_kinds`, now
+                // empty), so a shared connect secret cannot silently mint NIP-98
+                // HTTP-auth tokens. The connect secret is still a shared bearer
+                // credential for non-NIP-98 signing; a per-app/URL-method
+                // allowlist is follow-up work.
                 connect_grant: Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT,
                 auto_approve_kinds: bunker_auto_approve_kinds(),
                 connect_auto_approve_kinds: bunker_connect_auto_approve_kinds(),

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -19,7 +19,7 @@ use crate::audit::{AuditAction, AuditEntry, AuditLog};
 use crate::frost_signer::{FrostSigner, NetworkFrostSigner};
 use crate::permissions::{AppPermission, Permission, PermissionDuration, PermissionManager};
 use crate::rate_limit::{RateLimitConfig, RateLimiter};
-use crate::types::{ApprovalRequest, ServerCallbacks};
+use crate::types::{ApprovalRequest, ApprovalResult, RememberDuration, ServerCallbacks};
 
 fn prepare_frost_event(
     pubkey: PublicKey,
@@ -326,7 +326,11 @@ impl SignerHandler {
                 return Err(KeepError::PermissionDenied("invalid secret".into()));
             }
         } else if !self.auto_approve {
-            let approved = self
+            // Connect-time approval ignores the remember-duration today: the
+            // app-level lifetime is configured separately via the bunker's
+            // existing connect path. Per-kind remember semantics apply at
+            // `sign_event` (where #575 surfaced the silent NIP-98 grant).
+            let result = self
                 .request_approval(ApprovalRequest {
                     app_pubkey,
                     app_name: name.clone(),
@@ -336,7 +340,7 @@ impl SignerHandler {
                     requested_permissions: permissions.clone(),
                 })
                 .await;
-            if !approved {
+            if !result.approved {
                 return Err(KeepError::UserRejected);
             }
         }
@@ -417,7 +421,7 @@ impl SignerHandler {
             .needs_approval(&app_pubkey, kind);
 
         if needs_approval {
-            let approved = self
+            let result = self
                 .request_approval(ApprovalRequest {
                     app_pubkey,
                     app_name: self.get_app_name(&app_pubkey).await,
@@ -428,13 +432,35 @@ impl SignerHandler {
                 })
                 .await;
 
-            if !approved {
+            if !result.approved {
                 self.audit.lock().await.log(
                     AuditEntry::new(AuditAction::UserRejected, app_pubkey)
                         .with_event_kind(kind)
                         .with_success(false),
                 );
                 return Err(KeepError::UserRejected);
+            }
+
+            // #575: when the user approves with a remember-duration, persist
+            // a per-app, per-kind grant so subsequent requests within the
+            // window skip the prompt. `JustThisTime` is the one-shot default
+            // and does not persist; the next request prompts again.
+            match result.remember {
+                RememberDuration::JustThisTime => {}
+                RememberDuration::Forever => {
+                    self.permissions
+                        .lock()
+                        .await
+                        .grant_kind_forever(&app_pubkey, kind);
+                }
+                timed => {
+                    if let Some(secs) = timed.as_seconds() {
+                        self.permissions
+                            .lock()
+                            .await
+                            .grant_kind_for(&app_pubkey, kind, secs);
+                    }
+                }
             }
         }
 
@@ -509,7 +535,7 @@ impl SignerHandler {
             event_content: None,
             requested_permissions: None,
         };
-        if self.request_approval(request).await {
+        if self.request_approval(request).await.approved {
             Ok(())
         } else {
             self.audit
@@ -738,16 +764,16 @@ impl SignerHandler {
             .unwrap_or_else(|| pubkey.to_hex()[..8].to_string())
     }
 
-    async fn request_approval(&self, request: ApprovalRequest) -> bool {
+    async fn request_approval(&self, request: ApprovalRequest) -> ApprovalResult {
         if let Some(ref callbacks) = self.callbacks {
             return callbacks.request_approval(request);
         }
         if self.auto_approve {
             warn!(method = %request.method, "auto-approving in headless mode");
-            return true;
+            return ApprovalResult::approved_once();
         }
         warn!(method = %request.method, "denying request: no approval callbacks configured");
-        false
+        ApprovalResult::rejected()
     }
 }
 
@@ -788,9 +814,9 @@ mod tests {
     }
     impl crate::types::ServerCallbacks for RecordingCallbacks {
         fn on_log(&self, _event: crate::types::LogEvent) {}
-        fn request_approval(&self, request: ApprovalRequest) -> bool {
+        fn request_approval(&self, request: ApprovalRequest) -> ApprovalResult {
             self.methods.lock().unwrap().push(request.method);
-            true
+            ApprovalResult::approved_once()
         }
         fn on_connect(&self, _pubkey: &str, _name: &str) {}
     }

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -19,7 +19,9 @@ use crate::audit::{AuditAction, AuditEntry, AuditLog};
 use crate::frost_signer::{FrostSigner, NetworkFrostSigner};
 use crate::permissions::{AppPermission, Permission, PermissionDuration, PermissionManager};
 use crate::rate_limit::{RateLimitConfig, RateLimiter};
-use crate::types::{ApprovalRequest, ApprovalResult, RememberDuration, ServerCallbacks};
+use crate::types::{
+    ApprovalRequest, ApprovalResult, RememberDuration, ServerCallbacks, NIP98_HTTP_AUTH,
+};
 
 fn prepare_frost_event(
     pubkey: PublicKey,
@@ -445,13 +447,28 @@ impl SignerHandler {
             // a per-app, per-kind grant so subsequent requests within the
             // window skip the prompt. `JustThisTime` is the one-shot default
             // and does not persist; the next request prompts again.
-            match result.remember {
+            //
+            // NIP-98 (kind 27235) is never remembered: its security-relevant
+            // url/method live in tags the prompt does not surface, so a
+            // per-(app,kind) grant would auto-approve any url/method after one
+            // tap (bearer-credential threat). Force per-request approval.
+            let remember = if kind == NIP98_HTTP_AUTH {
+                RememberDuration::JustThisTime
+            } else {
+                result.remember
+            };
+            match remember {
                 RememberDuration::JustThisTime => {}
                 RememberDuration::Forever => {
                     self.permissions
                         .lock()
                         .await
                         .grant_kind_forever(&app_pubkey, kind);
+                    self.audit.lock().await.log(
+                        AuditEntry::new(AuditAction::PermissionChanged, app_pubkey)
+                            .with_event_kind(kind)
+                            .with_reason("grant kind forever"),
+                    );
                 }
                 timed => {
                     if let Some(secs) = timed.as_seconds() {
@@ -459,6 +476,11 @@ impl SignerHandler {
                             .lock()
                             .await
                             .grant_kind_for(&app_pubkey, kind, secs);
+                        self.audit.lock().await.log(
+                            AuditEntry::new(AuditAction::PermissionChanged, app_pubkey)
+                                .with_event_kind(kind)
+                                .with_reason(format!("grant kind for {secs}s")),
+                        );
                     }
                 }
             }
@@ -1421,5 +1443,108 @@ mod tests {
 
         handler.revoke_all_clients().await;
         assert_eq!(handler.list_clients().await.len(), 0);
+    }
+
+    /// Approves every request with a fixed `remember` value and counts how many
+    /// `sign_event` prompts fired, so a test can assert whether a remembered
+    /// grant skipped the prompt on the next request.
+    struct RememberingCallbacks {
+        remember: RememberDuration,
+        sign_event_prompts: std::sync::atomic::AtomicUsize,
+    }
+    impl crate::types::ServerCallbacks for RememberingCallbacks {
+        fn on_log(&self, _event: crate::types::LogEvent) {}
+        fn request_approval(&self, request: ApprovalRequest) -> ApprovalResult {
+            if request.method == "sign_event" {
+                self.sign_event_prompts
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+            ApprovalResult {
+                approved: true,
+                remember: self.remember,
+            }
+        }
+        fn on_connect(&self, _pubkey: &str, _name: &str) {}
+    }
+
+    #[tokio::test]
+    async fn remembered_grant_skips_next_same_kind_prompt() {
+        let keyring = setup_keyring();
+        let permissions = Arc::new(Mutex::new(PermissionManager::new()));
+        let audit = Arc::new(Mutex::new(AuditLog::new(100)));
+        let cb = Arc::new(RememberingCallbacks {
+            remember: RememberDuration::Forever,
+            sign_event_prompts: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let handler = SignerHandler::new(keyring, permissions, audit, Some(cb.clone()))
+            .with_connect_grant(Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT);
+
+        let app = Keys::generate().public_key();
+        handler.handle_connect(app, None, None, None).await.unwrap();
+        let signer_pk = handler.our_pubkey().await.unwrap();
+
+        let first = UnsignedEvent::new(signer_pk, Timestamp::now(), Kind::TextNote, vec![], "one");
+        handler.handle_sign_event(app, first).await.unwrap();
+
+        let second = UnsignedEvent::new(signer_pk, Timestamp::now(), Kind::TextNote, vec![], "two");
+        handler.handle_sign_event(app, second).await.unwrap();
+
+        assert_eq!(
+            cb.sign_event_prompts
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a Forever grant must skip the prompt on the next same-kind request"
+        );
+    }
+
+    #[tokio::test]
+    async fn nip98_is_never_remembered_even_when_approved_forever() {
+        let keyring = setup_keyring();
+        let permissions = Arc::new(Mutex::new(PermissionManager::new()));
+        let audit = Arc::new(Mutex::new(AuditLog::new(100)));
+        let cb = Arc::new(RememberingCallbacks {
+            remember: RememberDuration::Forever,
+            sign_event_prompts: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let handler =
+            SignerHandler::new(keyring, Arc::clone(&permissions), audit, Some(cb.clone()))
+                .with_connect_grant(Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT);
+
+        let app = Keys::generate().public_key();
+        handler.handle_connect(app, None, None, None).await.unwrap();
+        let signer_pk = handler.our_pubkey().await.unwrap();
+
+        let tags = vec![
+            Tag::parse(["u", "https://a.example/api"]).unwrap(),
+            Tag::parse(["method", "GET"]).unwrap(),
+        ];
+        let first = UnsignedEvent::new(
+            signer_pk,
+            Timestamp::now(),
+            NIP98_HTTP_AUTH,
+            tags.clone(),
+            "",
+        );
+        handler.handle_sign_event(app, first).await.unwrap();
+
+        let second = UnsignedEvent::new(signer_pk, Timestamp::now(), NIP98_HTTP_AUTH, tags, "");
+        handler.handle_sign_event(app, second).await.unwrap();
+
+        assert_eq!(
+            cb.sign_event_prompts
+                .load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "NIP-98 must prompt on every request even after approve=Forever"
+        );
+        let pm = permissions.lock().await;
+        let granted = pm.get_app(&app).unwrap();
+        assert!(
+            !granted.auto_approve_kinds.contains(&NIP98_HTTP_AUTH),
+            "NIP-98 must not be persisted as an auto-approve kind"
+        );
+        assert!(
+            !granted.has_unexpired_timed_grant(NIP98_HTTP_AUTH),
+            "NIP-98 must not be persisted as a timed grant"
+        );
     }
 }

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -879,12 +879,12 @@ mod tests {
         );
     }
 
-    // The fix: with `connect_grant` including SIGN_EVENT and kind 27235 in the
-    // global auto-approve set, a client that connected without requesting
-    // permissions can sign a NIP-98 event immediately, and NO per-request
-    // approval prompt fires (only the connection itself is gated).
+    // #575: even with `connect_grant` including SIGN_EVENT and kind 27235 in
+    // the global auto-approve set, a NIP-98 sign request MUST still fire the
+    // per-request approval prompt. The sign succeeds only because the prompt is
+    // approved; it must never be silently auto-signed.
     #[tokio::test]
-    async fn http_auth_signed_without_per_request_prompt() {
+    async fn http_auth_always_triggers_per_request_prompt() {
         let keyring = setup_keyring();
         let permissions = Arc::new(Mutex::new(PermissionManager::new()));
         permissions
@@ -910,22 +910,21 @@ mod tests {
         let signed = handler
             .handle_sign_event(app, unsigned)
             .await
-            .expect("kind 27235 must auto-sign for an authorized client");
+            .expect("kind 27235 signs once the prompt is approved");
         assert_eq!(signed.kind, NIP98_HTTP_AUTH);
 
         let methods = cb.methods.lock().unwrap().clone();
         assert!(
-            !methods.iter().any(|m| m == "sign_event"),
-            "kind 27235 must not trigger a per-request approval prompt, saw: {methods:?}"
+            methods.iter().any(|m| m == "sign_event"),
+            "kind 27235 MUST trigger a per-request approval prompt, saw: {methods:?}"
         );
     }
 
-    // App-scoped grant: `connect_auto_approve_kinds` auto-approves kind 27235
-    // only for clients that completed the connect handshake (scoped to their
-    // pubkey), and does NOT leak to apps that never connected — unlike the
-    // global `auto_approve_kinds` set.
+    // #575: NIP-98 (kind 27235) is never auto-approved, not even per-app via
+    // `connect_auto_approve_kinds`. The 27235 grant is stripped on connect, so
+    // both the connected app and an unconnected one still need approval.
     #[tokio::test]
-    async fn connect_auto_approve_kinds_are_per_app_not_global() {
+    async fn connect_auto_approve_kinds_never_cover_nip98() {
         let keyring = setup_keyring();
         let permissions = Arc::new(Mutex::new(PermissionManager::new()));
         let audit = Arc::new(Mutex::new(AuditLog::new(100)));
@@ -943,12 +942,19 @@ mod tests {
         let never_connected = Keys::generate().public_key();
         let pm = permissions.lock().await;
         assert!(
-            !pm.needs_approval(&connected, NIP98_HTTP_AUTH),
-            "connected app must have NIP-98 auto-approved per-app"
+            pm.needs_approval(&connected, NIP98_HTTP_AUTH),
+            "NIP-98 must always prompt even for a connected app"
         );
         assert!(
             pm.needs_approval(&never_connected, NIP98_HTTP_AUTH),
-            "NIP-98 must NOT be globally auto-approved for unconnected apps"
+            "NIP-98 must always prompt for unconnected apps"
+        );
+        assert!(
+            !pm.get_app(&connected)
+                .unwrap()
+                .auto_approve_kinds
+                .contains(&NIP98_HTTP_AUTH),
+            "NIP-98 must be stripped from the per-app auto-approve set on connect"
         );
     }
 

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -475,11 +475,11 @@ impl SignerHandler {
                 }
                 timed => {
                     if let Some(secs) = timed.as_seconds() {
-                        let granted = self
-                            .permissions
-                            .lock()
-                            .await
-                            .grant_kind_for(&app_pubkey, kind, secs);
+                        let granted =
+                            self.permissions
+                                .lock()
+                                .await
+                                .grant_kind_for(&app_pubkey, kind, secs);
                         if granted {
                             self.audit.lock().await.log(
                                 AuditEntry::new(AuditAction::PermissionChanged, app_pubkey)
@@ -723,6 +723,7 @@ impl SignerHandler {
         auto_kinds: HashSet<Kind>,
         duration: PermissionDuration,
         connected_at: Timestamp,
+        timed_kind_grants: HashMap<Kind, u64>,
     ) {
         let mut pm = self.permissions.lock().await;
         pm.restore_persisted(
@@ -732,6 +733,7 @@ impl SignerHandler {
             auto_kinds,
             duration,
             connected_at,
+            timed_kind_grants,
         );
     }
 

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -460,27 +460,33 @@ impl SignerHandler {
             match remember {
                 RememberDuration::JustThisTime => {}
                 RememberDuration::Forever => {
-                    self.permissions
+                    let granted = self
+                        .permissions
                         .lock()
                         .await
                         .grant_kind_forever(&app_pubkey, kind);
-                    self.audit.lock().await.log(
-                        AuditEntry::new(AuditAction::PermissionChanged, app_pubkey)
-                            .with_event_kind(kind)
-                            .with_reason("grant kind forever"),
-                    );
-                }
-                timed => {
-                    if let Some(secs) = timed.as_seconds() {
-                        self.permissions
-                            .lock()
-                            .await
-                            .grant_kind_for(&app_pubkey, kind, secs);
+                    if granted {
                         self.audit.lock().await.log(
                             AuditEntry::new(AuditAction::PermissionChanged, app_pubkey)
                                 .with_event_kind(kind)
-                                .with_reason(format!("grant kind for {secs}s")),
+                                .with_reason("grant kind forever"),
                         );
+                    }
+                }
+                timed => {
+                    if let Some(secs) = timed.as_seconds() {
+                        let granted = self
+                            .permissions
+                            .lock()
+                            .await
+                            .grant_kind_for(&app_pubkey, kind, secs);
+                        if granted {
+                            self.audit.lock().await.log(
+                                AuditEntry::new(AuditAction::PermissionChanged, app_pubkey)
+                                    .with_event_kind(kind)
+                                    .with_reason(format!("grant kind for {secs}s")),
+                            );
+                        }
                     }
                 }
             }

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -715,6 +715,7 @@ impl SignerHandler {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn restore_client(
         &self,
         pubkey: PublicKey,

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -3,9 +3,12 @@
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 
+use keep_core::relay::MAX_AUTO_KINDS;
 use nostr_sdk::prelude::*;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
+
+use crate::types::NIP98_HTTP_AUTH;
 
 bitflags::bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -104,9 +107,12 @@ pub struct AppPermission {
     pub auto_approve_kinds: HashSet<Kind>,
     /// Per-app, per-kind grants with an explicit expiry (unix epoch seconds).
     /// Set by the user picking a timed remember-duration on the per-request
-    /// prompt (#575). Skipped on read once `now() >= expiry`. Intentionally
-    /// process-lifetime only: `#[serde(skip)]` because the restore path does
-    /// not carry timed grants, so they must not appear to survive a restart.
+    /// prompt (#575). Skipped on read once `now() >= expiry`. `#[serde(skip)]`
+    /// on direct `AppPermission` serialization, but the grants ARE persisted
+    /// and restored out-of-band via the `StoredBunkerPermission` path: on save
+    /// they are written to `StoredTimedKindGrant`, and `restore_persisted`
+    /// reloads them, pruning any entry that expired while the bunker was down
+    /// and excluding NIP-98 (kind 27235), which is never remembered.
     #[serde(skip)]
     pub timed_kind_grants: HashMap<Kind, u64>,
     pub connected_at: Timestamp,
@@ -239,6 +245,9 @@ impl PermissionManager {
             Entry::Vacant(entry) => {
                 let mut app = AppPermission::new(pubkey, name);
                 app.permissions = requested & Permission::ALL;
+                // #575: NIP-98 (kind 27235) is never auto-approved.
+                let mut auto_kinds = auto_kinds;
+                auto_kinds.remove(&NIP98_HTTP_AUTH);
                 if !auto_kinds.is_empty() {
                     app.auto_approve_kinds.extend(auto_kinds);
                 }
@@ -279,6 +288,13 @@ impl PermissionManager {
     }
 
     pub fn needs_approval(&self, pubkey: &PublicKey, kind: Kind) -> bool {
+        // #575: NIP-98 (kind 27235) must ALWAYS prompt per-request and can
+        // never be auto-approved by any per-app, global, or timed grant. This
+        // is the authoritative chokepoint: even a 27235 entry that slipped into
+        // a grant set or a persisted/upgraded config cannot bypass the prompt.
+        if kind == NIP98_HTTP_AUTH {
+            return true;
+        }
         if let Some(app) = self.apps.get(pubkey) {
             if !app.duration.is_expired(app.connected_at) {
                 if app.auto_approve_kinds.contains(&kind) {
@@ -300,7 +316,18 @@ impl PermissionManager {
     /// (#575) when the user picks `RememberDuration::Forever`. Returns whether a
     /// grant was actually written, so callers only audit real state changes.
     pub fn grant_kind_forever(&mut self, pubkey: &PublicKey, kind: Kind) -> bool {
+        // #575: NIP-98 (kind 27235) is never remembered.
+        if kind == NIP98_HTTP_AUTH {
+            return false;
+        }
         if let Some(app) = self.apps.get_mut(pubkey) {
+            // Enforce the persisted-config cap (MAX_AUTO_KINDS) in memory so an
+            // app cannot exceed what `RelayConfig` validation will later accept.
+            if !app.auto_approve_kinds.contains(&kind)
+                && app.auto_approve_kinds.len() >= MAX_AUTO_KINDS
+            {
+                return false;
+            }
             app.auto_approve_kinds.insert(kind);
             // A Forever grant supersedes any timed grant for the same kind.
             app.timed_kind_grants.remove(&kind);
@@ -320,6 +347,10 @@ impl PermissionManager {
         if secs == 0 {
             return false;
         }
+        // #575: NIP-98 (kind 27235) is never remembered.
+        if kind == NIP98_HTTP_AUTH {
+            return false;
+        }
         let now = now_unix_secs();
         // Clock error reads as u64::MAX (fail-closed for expiry checks); refuse
         // to write a grant we could not bound, otherwise it would read as
@@ -331,6 +362,14 @@ impl PermissionManager {
             app.prune_expired_kind_grants();
             // A Forever grant already covers this kind; don't downgrade it.
             if app.auto_approve_kinds.contains(&kind) {
+                return false;
+            }
+            // Enforce the persisted-config cap (MAX_AUTO_KINDS) in memory. A
+            // re-approval of an already-granted kind is allowed (it replaces the
+            // existing window) and does not count against the cap.
+            if !app.timed_kind_grants.contains_key(&kind)
+                && app.timed_kind_grants.len() >= MAX_AUTO_KINDS
+            {
                 return false;
             }
             // An explicit re-approval sets the new expiry, even if shorter, so
@@ -406,15 +445,20 @@ impl PermissionManager {
         }
         let mut app = AppPermission::new(pubkey, name);
         app.permissions = permissions & Permission::ALL;
+        // #575: drop any persisted NIP-98 (kind 27235) grant; it must never be
+        // remembered, even if an older/upgraded config carried it.
+        let mut auto_kinds = auto_kinds;
+        auto_kinds.remove(&NIP98_HTTP_AUTH);
         app.auto_approve_kinds = auto_kinds;
         app.duration = duration;
         app.connected_at = connected_at;
-        // Drop grants that expired while the bunker was down; a clock error
-        // reads as u64::MAX so every grant prunes (fail-closed).
+        // Drop grants that expired while the bunker was down (a clock error
+        // reads as u64::MAX so every grant prunes, fail-closed) and any NIP-98
+        // grant that should never have been persisted.
         let now = now_unix_secs();
         app.timed_kind_grants = timed_kind_grants
             .into_iter()
-            .filter(|(_, expiry)| now < *expiry)
+            .filter(|(kind, expiry)| *kind != NIP98_HTTP_AUTH && now < *expiry)
             .collect();
         self.insert(app);
         true
@@ -426,7 +470,9 @@ impl PermissionManager {
         self.apps.insert(key, app);
     }
 
-    pub fn set_auto_approve_kinds_for_app(&mut self, pubkey: &PublicKey, kinds: HashSet<Kind>) {
+    pub fn set_auto_approve_kinds_for_app(&mut self, pubkey: &PublicKey, mut kinds: HashSet<Kind>) {
+        // #575: NIP-98 (kind 27235) is never auto-approved.
+        kinds.remove(&NIP98_HTTP_AUTH);
         if let Some(app) = self.apps.get_mut(pubkey) {
             app.auto_approve_kinds = kinds;
             app.last_used = Timestamp::now();
@@ -698,6 +744,140 @@ mod tests {
             .unwrap()
             .timed_kind_grants
             .contains_key(&expired_kind));
+    }
+
+    #[test]
+    fn nip98_always_needs_approval_despite_every_grant() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+
+        // Force NIP-98 into every auto-approve channel directly, bypassing the
+        // write-path guards, to prove the read-path chokepoint is authoritative.
+        pm.set_auto_approve_kinds(HashSet::from([NIP98_HTTP_AUTH]));
+        if let Some(app) = pm.apps.get_mut(&pubkey) {
+            app.auto_approve_kinds.insert(NIP98_HTTP_AUTH);
+            app.timed_kind_grants
+                .insert(NIP98_HTTP_AUTH, now_unix_secs() + 3600);
+        }
+
+        assert!(
+            pm.needs_approval(&pubkey, NIP98_HTTP_AUTH),
+            "NIP-98 must always need approval even when present in per-app, \
+             global, and unexpired timed grant sets"
+        );
+    }
+
+    #[test]
+    fn restore_persisted_strips_nip98_grants() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        let now = now_unix_secs();
+
+        let mut grants = HashMap::new();
+        grants.insert(NIP98_HTTP_AUTH, now + 3600);
+        grants.insert(Kind::TextNote, now + 3600);
+
+        let restored = pm.restore_persisted(
+            pubkey,
+            "App".into(),
+            Permission::SIGN_EVENT,
+            HashSet::from([NIP98_HTTP_AUTH, Kind::Reaction]),
+            PermissionDuration::Forever,
+            Timestamp::now(),
+            grants,
+        );
+        assert!(restored);
+
+        let app = pm.get_app(&pubkey).unwrap();
+        assert!(!app.auto_approve_kinds.contains(&NIP98_HTTP_AUTH));
+        assert!(!app.timed_kind_grants.contains_key(&NIP98_HTTP_AUTH));
+        // Non-NIP-98 grants survive the restore.
+        assert!(app.auto_approve_kinds.contains(&Kind::Reaction));
+        assert!(app.timed_kind_grants.contains_key(&Kind::TextNote));
+        assert!(pm.needs_approval(&pubkey, NIP98_HTTP_AUTH));
+    }
+
+    #[test]
+    fn timed_grant_round_trips_but_nip98_does_not() {
+        // Create a non-NIP-98 timed grant, capture it as the persistence layer
+        // would, restore it, and confirm it survives; a 27235 grant captured the
+        // same way must not survive the restore.
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+
+        pm.grant_kind_for(&pubkey, Kind::TextNote, 3600);
+        // grant_kind_for refuses NIP-98, so inject it directly to model a
+        // hostile/legacy persisted row.
+        if let Some(app) = pm.apps.get_mut(&pubkey) {
+            app.timed_kind_grants
+                .insert(NIP98_HTTP_AUTH, now_unix_secs() + 3600);
+        }
+        let persisted = pm.get_app(&pubkey).unwrap().timed_kind_grants.clone();
+
+        let mut restored = PermissionManager::new();
+        restored.restore_persisted(
+            pubkey,
+            "App".into(),
+            Permission::SIGN_EVENT,
+            HashSet::new(),
+            PermissionDuration::Forever,
+            Timestamp::now(),
+            persisted,
+        );
+
+        assert!(
+            !restored.needs_approval(&pubkey, Kind::TextNote),
+            "non-NIP-98 timed grant must survive the round trip"
+        );
+        assert!(
+            restored.needs_approval(&pubkey, NIP98_HTTP_AUTH),
+            "NIP-98 must not survive the round trip"
+        );
+    }
+
+    #[test]
+    fn grant_kind_forever_enforces_max_auto_kinds_cap() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+
+        // Fill auto_approve_kinds up to the cap with distinct custom kinds.
+        if let Some(app) = pm.apps.get_mut(&pubkey) {
+            app.auto_approve_kinds.clear();
+            for k in 0..MAX_AUTO_KINDS as u16 {
+                app.auto_approve_kinds.insert(Kind::Custom(k));
+            }
+        }
+        assert_eq!(
+            pm.get_app(&pubkey).unwrap().auto_approve_kinds.len(),
+            MAX_AUTO_KINDS
+        );
+
+        // A new kind is refused once at the cap.
+        assert!(!pm.grant_kind_forever(&pubkey, Kind::Custom(60000)));
+        // Re-granting an already-present kind still succeeds.
+        assert!(pm.grant_kind_forever(&pubkey, Kind::Custom(0)));
+    }
+
+    #[test]
+    fn grant_kind_for_enforces_max_auto_kinds_cap() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+
+        let now = now_unix_secs();
+        if let Some(app) = pm.apps.get_mut(&pubkey) {
+            for k in 0..MAX_AUTO_KINDS as u16 {
+                app.timed_kind_grants.insert(Kind::Custom(k), now + 3600);
+            }
+        }
+
+        // A new kind is refused once at the cap.
+        assert!(!pm.grant_kind_for(&pubkey, Kind::Custom(60000), 3600));
+        // Re-granting an already-present kind replaces its window, still ok.
+        assert!(pm.grant_kind_for(&pubkey, Kind::Custom(0), 60));
     }
 
     #[test]

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -98,7 +98,15 @@ pub struct AppPermission {
     pub pubkey: PublicKey,
     pub name: String,
     pub permissions: Permission,
+    /// Per-app, per-kind grants that never expire. Set via the
+    /// `connect_auto_approve_kinds` startup config OR by the user picking
+    /// "Forever" on the per-request prompt (#575).
     pub auto_approve_kinds: HashSet<Kind>,
+    /// Per-app, per-kind grants with an explicit expiry (unix epoch seconds).
+    /// Set by the user picking a timed remember-duration on the per-request
+    /// prompt (#575). Skipped on read once `now() >= expiry`.
+    #[serde(default)]
+    pub timed_kind_grants: HashMap<Kind, u64>,
     pub connected_at: Timestamp,
     pub last_used: Timestamp,
     pub request_count: u64,
@@ -117,12 +125,36 @@ impl AppPermission {
             name,
             permissions: Permission::DEFAULT,
             auto_approve_kinds: HashSet::from([Kind::Reaction]),
+            timed_kind_grants: HashMap::new(),
             connected_at: Timestamp::now(),
             last_used: Timestamp::now(),
             request_count: 0,
             duration: PermissionDuration::Forever,
         }
     }
+
+    /// Returns true if a timed grant exists for `kind` AND the grant has not
+    /// expired. Expired entries are skipped here and garbage-collected by the
+    /// next mutation through `prune_expired_kind_grants`.
+    pub fn has_unexpired_timed_grant(&self, kind: Kind) -> bool {
+        self.timed_kind_grants
+            .get(&kind)
+            .map(|expiry| now_unix_secs() < *expiry)
+            .unwrap_or(false)
+    }
+
+    fn prune_expired_kind_grants(&mut self) {
+        let now = now_unix_secs();
+        self.timed_kind_grants.retain(|_, expiry| now < *expiry);
+    }
+}
+
+fn now_unix_secs() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 pub struct PermissionManager {
@@ -244,15 +276,61 @@ impl PermissionManager {
 
     pub fn needs_approval(&self, pubkey: &PublicKey, kind: Kind) -> bool {
         if let Some(app) = self.apps.get(pubkey) {
-            if !app.duration.is_expired(app.connected_at) && app.auto_approve_kinds.contains(&kind)
-            {
-                return false;
+            if !app.duration.is_expired(app.connected_at) {
+                if app.auto_approve_kinds.contains(&kind) {
+                    return false;
+                }
+                if app.has_unexpired_timed_grant(kind) {
+                    return false;
+                }
             }
         }
         if self.global_auto_approve.contains(&kind) {
             return false;
         }
         true
+    }
+
+    /// Persist a forever-grant for `kind` on the connected app at `pubkey`.
+    /// No-op when the app is unknown. Used by the per-request approval prompt
+    /// (#575) when the user picks `RememberDuration::Forever`.
+    pub fn grant_kind_forever(&mut self, pubkey: &PublicKey, kind: Kind) {
+        if let Some(app) = self.apps.get_mut(pubkey) {
+            app.auto_approve_kinds.insert(kind);
+            // A Forever grant supersedes any timed grant for the same kind.
+            app.timed_kind_grants.remove(&kind);
+            app.last_used = Timestamp::now();
+        }
+    }
+
+    /// Persist a timed grant for `kind` on the connected app at `pubkey` that
+    /// expires `secs` seconds from now. No-op when the app is unknown or when
+    /// `secs == 0`. Used by the per-request approval prompt (#575) when the
+    /// user picks a `RememberDuration::OneMinute / FiveMinutes / TenMinutes /
+    /// OneHour / OneDay` value.
+    pub fn grant_kind_for(&mut self, pubkey: &PublicKey, kind: Kind, secs: u64) {
+        if secs == 0 {
+            return;
+        }
+        if let Some(app) = self.apps.get_mut(pubkey) {
+            app.prune_expired_kind_grants();
+            // A Forever grant already covers this kind; don't downgrade it.
+            if app.auto_approve_kinds.contains(&kind) {
+                return;
+            }
+            let expiry = now_unix_secs().saturating_add(secs);
+            // Take the LATER of any existing expiry and the new one so a user
+            // re-approving with a shorter window does not shrink an existing
+            // longer window unintentionally.
+            let final_expiry = app
+                .timed_kind_grants
+                .get(&kind)
+                .copied()
+                .map(|existing| existing.max(expiry))
+                .unwrap_or(expiry);
+            app.timed_kind_grants.insert(kind, final_expiry);
+            app.last_used = Timestamp::now();
+        }
     }
 
     pub fn record_usage(&mut self, pubkey: &PublicKey) {
@@ -504,6 +582,85 @@ mod tests {
 
         // Replacing the global list with an empty set restores approval.
         pm.set_auto_approve_kinds(HashSet::new());
+        assert!(pm.needs_approval(&pubkey, Kind::TextNote));
+    }
+
+    #[test]
+    fn timed_grant_skips_approval_until_pruned() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+
+        // No grant yet: approval required.
+        assert!(pm.needs_approval(&pubkey, Kind::TextNote));
+
+        // A non-zero timed grant is honored.
+        pm.grant_kind_for(&pubkey, Kind::TextNote, 60);
+        assert!(!pm.needs_approval(&pubkey, Kind::TextNote));
+
+        // Force the grant to expire and verify needs_approval returns true
+        // again once the expired entry is pruned.
+        if let Some(app) = pm.apps.get_mut(&pubkey) {
+            app.timed_kind_grants.insert(Kind::TextNote, 1);
+        }
+        assert!(pm.needs_approval(&pubkey, Kind::TextNote));
+    }
+
+    #[test]
+    fn forever_grant_is_not_downgraded_by_timed_grant() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+
+        pm.grant_kind_forever(&pubkey, Kind::TextNote);
+        pm.grant_kind_for(&pubkey, Kind::TextNote, 60);
+
+        let app = pm.get_app(&pubkey).unwrap();
+        assert!(app.auto_approve_kinds.contains(&Kind::TextNote));
+        assert!(!app.timed_kind_grants.contains_key(&Kind::TextNote));
+    }
+
+    #[test]
+    fn forever_grant_removes_pre_existing_timed_grant() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+
+        pm.grant_kind_for(&pubkey, Kind::TextNote, 60);
+        pm.grant_kind_forever(&pubkey, Kind::TextNote);
+
+        let app = pm.get_app(&pubkey).unwrap();
+        assert!(app.auto_approve_kinds.contains(&Kind::TextNote));
+        assert!(!app.timed_kind_grants.contains_key(&Kind::TextNote));
+    }
+
+    #[test]
+    fn timed_grant_keeps_longer_existing_window() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+
+        pm.grant_kind_for(&pubkey, Kind::TextNote, 24 * 60 * 60);
+        let before = pm.get_app(&pubkey).unwrap().timed_kind_grants[&Kind::TextNote];
+
+        // Re-approve with a shorter window: the longer existing expiry stands.
+        pm.grant_kind_for(&pubkey, Kind::TextNote, 60);
+        let after = pm.get_app(&pubkey).unwrap().timed_kind_grants[&Kind::TextNote];
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn grant_kind_for_zero_seconds_is_noop() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+
+        pm.grant_kind_for(&pubkey, Kind::TextNote, 0);
+        assert!(!pm
+            .get_app(&pubkey)
+            .unwrap()
+            .timed_kind_grants
+            .contains_key(&Kind::TextNote));
         assert!(pm.needs_approval(&pubkey, Kind::TextNote));
     }
 }

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -147,8 +147,7 @@ impl AppPermission {
     pub fn has_unexpired_timed_grant(&self, kind: Kind) -> bool {
         self.timed_kind_grants
             .get(&kind)
-            .map(|expiry| now_unix_secs() < *expiry)
-            .unwrap_or(false)
+            .is_some_and(|expiry| now_unix_secs() < *expiry)
     }
 
     fn prune_expired_kind_grants(&mut self) {

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -104,8 +104,10 @@ pub struct AppPermission {
     pub auto_approve_kinds: HashSet<Kind>,
     /// Per-app, per-kind grants with an explicit expiry (unix epoch seconds).
     /// Set by the user picking a timed remember-duration on the per-request
-    /// prompt (#575). Skipped on read once `now() >= expiry`.
-    #[serde(default)]
+    /// prompt (#575). Skipped on read once `now() >= expiry`. Intentionally
+    /// process-lifetime only: `#[serde(skip)]` because the restore path does
+    /// not carry timed grants, so they must not appear to survive a restart.
+    #[serde(skip)]
     pub timed_kind_grants: HashMap<Kind, u64>,
     pub connected_at: Timestamp,
     pub last_used: Timestamp,
@@ -151,10 +153,12 @@ impl AppPermission {
 
 fn now_unix_secs() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
+    // On clock error saturate to u64::MAX so timed-grant expiry checks
+    // (`now < expiry`) read as expired (fail-closed) rather than eternal.
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
-        .unwrap_or(0)
+        .unwrap_or(u64::MAX)
 }
 
 pub struct PermissionManager {
@@ -312,23 +316,23 @@ impl PermissionManager {
         if secs == 0 {
             return;
         }
+        let now = now_unix_secs();
+        // Clock error reads as u64::MAX (fail-closed for expiry checks); refuse
+        // to write a grant we could not bound, otherwise it would read as
+        // eternal once the clock recovers.
+        if now == u64::MAX {
+            return;
+        }
         if let Some(app) = self.apps.get_mut(pubkey) {
             app.prune_expired_kind_grants();
             // A Forever grant already covers this kind; don't downgrade it.
             if app.auto_approve_kinds.contains(&kind) {
                 return;
             }
-            let expiry = now_unix_secs().saturating_add(secs);
-            // Take the LATER of any existing expiry and the new one so a user
-            // re-approving with a shorter window does not shrink an existing
-            // longer window unintentionally.
-            let final_expiry = app
-                .timed_kind_grants
-                .get(&kind)
-                .copied()
-                .map(|existing| existing.max(expiry))
-                .unwrap_or(expiry);
-            app.timed_kind_grants.insert(kind, final_expiry);
+            // An explicit re-approval sets the new expiry, even if shorter, so
+            // a user can deliberately shrink an over-granted window.
+            let expiry = now.saturating_add(secs);
+            app.timed_kind_grants.insert(kind, expiry);
             app.last_used = Timestamp::now();
         }
     }
@@ -598,8 +602,9 @@ mod tests {
         pm.grant_kind_for(&pubkey, Kind::TextNote, 60);
         assert!(!pm.needs_approval(&pubkey, Kind::TextNote));
 
-        // Force the grant to expire and verify needs_approval returns true
-        // again once the expired entry is pruned.
+        // Force the grant to expire: needs_approval skips the expired entry and
+        // returns true again. The stale entry stays in the map until the next
+        // mutation prunes it; the read path does not remove it.
         if let Some(app) = pm.apps.get_mut(&pubkey) {
             app.timed_kind_grants.insert(Kind::TextNote, 1);
         }
@@ -635,7 +640,7 @@ mod tests {
     }
 
     #[test]
-    fn timed_grant_keeps_longer_existing_window() {
+    fn timed_grant_replaces_window_on_reapproval() {
         let mut pm = PermissionManager::new();
         let pubkey = Keys::generate().public_key();
         pm.connect(pubkey, "App".into());
@@ -643,10 +648,11 @@ mod tests {
         pm.grant_kind_for(&pubkey, Kind::TextNote, 24 * 60 * 60);
         let before = pm.get_app(&pubkey).unwrap().timed_kind_grants[&Kind::TextNote];
 
-        // Re-approve with a shorter window: the longer existing expiry stands.
+        // An explicit re-approval with a shorter window replaces the existing
+        // expiry so a user can deliberately shrink an over-granted window.
         pm.grant_kind_for(&pubkey, Kind::TextNote, 60);
         let after = pm.get_app(&pubkey).unwrap().timed_kind_grants[&Kind::TextNote];
-        assert_eq!(before, after);
+        assert!(after < before);
     }
 
     #[test]

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -422,6 +422,7 @@ impl PermissionManager {
     /// shared by `SignerHandler::restore_client` and the `apply_pre_grants`
     /// startup hook. Returns `true` if the app was inserted, `false` if it
     /// was skipped (Session, expired, or capacity full).
+    #[allow(clippy::too_many_arguments)]
     pub fn restore_persisted(
         &mut self,
         pubkey: PublicKey,

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -297,44 +297,50 @@ impl PermissionManager {
 
     /// Persist a forever-grant for `kind` on the connected app at `pubkey`.
     /// No-op when the app is unknown. Used by the per-request approval prompt
-    /// (#575) when the user picks `RememberDuration::Forever`.
-    pub fn grant_kind_forever(&mut self, pubkey: &PublicKey, kind: Kind) {
+    /// (#575) when the user picks `RememberDuration::Forever`. Returns whether a
+    /// grant was actually written, so callers only audit real state changes.
+    pub fn grant_kind_forever(&mut self, pubkey: &PublicKey, kind: Kind) -> bool {
         if let Some(app) = self.apps.get_mut(pubkey) {
             app.auto_approve_kinds.insert(kind);
             // A Forever grant supersedes any timed grant for the same kind.
             app.timed_kind_grants.remove(&kind);
             app.last_used = Timestamp::now();
+            return true;
         }
+        false
     }
 
     /// Persist a timed grant for `kind` on the connected app at `pubkey` that
     /// expires `secs` seconds from now. No-op when the app is unknown or when
     /// `secs == 0`. Used by the per-request approval prompt (#575) when the
     /// user picks a `RememberDuration::OneMinute / FiveMinutes / TenMinutes /
-    /// OneHour / OneDay` value.
-    pub fn grant_kind_for(&mut self, pubkey: &PublicKey, kind: Kind, secs: u64) {
+    /// OneHour / OneDay` value. Returns whether a grant was actually written, so
+    /// callers only audit real state changes.
+    pub fn grant_kind_for(&mut self, pubkey: &PublicKey, kind: Kind, secs: u64) -> bool {
         if secs == 0 {
-            return;
+            return false;
         }
         let now = now_unix_secs();
         // Clock error reads as u64::MAX (fail-closed for expiry checks); refuse
         // to write a grant we could not bound, otherwise it would read as
         // eternal once the clock recovers.
         if now == u64::MAX {
-            return;
+            return false;
         }
         if let Some(app) = self.apps.get_mut(pubkey) {
             app.prune_expired_kind_grants();
             // A Forever grant already covers this kind; don't downgrade it.
             if app.auto_approve_kinds.contains(&kind) {
-                return;
+                return false;
             }
             // An explicit re-approval sets the new expiry, even if shorter, so
             // a user can deliberately shrink an over-granted window.
             let expiry = now.saturating_add(secs);
             app.timed_kind_grants.insert(kind, expiry);
             app.last_used = Timestamp::now();
+            return true;
         }
+        false
     }
 
     pub fn record_usage(&mut self, pubkey: &PublicKey) {

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -392,6 +392,7 @@ impl PermissionManager {
         auto_kinds: HashSet<Kind>,
         duration: PermissionDuration,
         connected_at: Timestamp,
+        timed_kind_grants: HashMap<Kind, u64>,
     ) -> bool {
         match duration {
             PermissionDuration::Session => return false,
@@ -408,6 +409,13 @@ impl PermissionManager {
         app.auto_approve_kinds = auto_kinds;
         app.duration = duration;
         app.connected_at = connected_at;
+        // Drop grants that expired while the bunker was down; a clock error
+        // reads as u64::MAX so every grant prunes (fail-closed).
+        let now = now_unix_secs();
+        app.timed_kind_grants = timed_kind_grants
+            .into_iter()
+            .filter(|(_, expiry)| now < *expiry)
+            .collect();
         self.insert(app);
         true
     }
@@ -659,6 +667,37 @@ mod tests {
         pm.grant_kind_for(&pubkey, Kind::TextNote, 60);
         let after = pm.get_app(&pubkey).unwrap().timed_kind_grants[&Kind::TextNote];
         assert!(after < before);
+    }
+
+    #[test]
+    fn restore_persisted_keeps_future_grant_prunes_expired() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        let now = now_unix_secs();
+        let expired_kind = Kind::Custom(30023);
+        let mut grants = HashMap::new();
+        grants.insert(Kind::TextNote, now + 3600);
+        grants.insert(expired_kind, 1);
+
+        let restored = pm.restore_persisted(
+            pubkey,
+            "App".into(),
+            Permission::SIGN_EVENT,
+            HashSet::new(),
+            PermissionDuration::Forever,
+            Timestamp::now(),
+            grants,
+        );
+        assert!(restored);
+
+        // Future-dated grant survives the restart; the expired one is pruned.
+        assert!(!pm.needs_approval(&pubkey, Kind::TextNote));
+        assert!(pm.needs_approval(&pubkey, expired_kind));
+        assert!(!pm
+            .get_app(&pubkey)
+            .unwrap()
+            .timed_kind_grants
+            .contains_key(&expired_kind));
     }
 
     #[test]

--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -949,6 +949,45 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn apply_pre_grants_round_trips_timed_grant_but_drops_nip98() {
+        use crate::NIP98_HTTP_AUTH;
+
+        let pm = Arc::new(Mutex::new(PermissionManager::new()));
+        let pk_hex = good_pubkey_hex();
+        let mut stored = sample_stored(
+            &pk_hex,
+            keep_core::relay::StoredPermissionDuration::Forever,
+            0,
+        );
+        // A persisted (legacy/hostile) config carrying both a NIP-98 grant and a
+        // benign TextNote grant in every channel.
+        stored.auto_approve_kinds = vec![NIP98_HTTP_AUTH.as_u16(), 1];
+        stored.timed_kind_grants = vec![
+            keep_core::relay::StoredTimedKindGrant {
+                kind: NIP98_HTTP_AUTH.as_u16(),
+                expires_at: 1_900_000_000,
+            },
+            keep_core::relay::StoredTimedKindGrant {
+                kind: 1,
+                expires_at: 1_900_000_000,
+            },
+        ];
+
+        let pre = PreGrantedApp::from_stored(&stored).expect("valid stored row");
+        apply_pre_grants(&pm, &[pre]).await;
+
+        let pubkey = nostr_sdk::PublicKey::from_hex(&pk_hex).unwrap();
+        let guard = pm.lock().await;
+        // Benign grant survives the persistence round trip.
+        assert!(!guard.needs_approval(&pubkey, nostr_sdk::Kind::TextNote));
+        // NIP-98 is dropped and always prompts.
+        assert!(guard.needs_approval(&pubkey, NIP98_HTTP_AUTH));
+        let app = guard.get_app(&pubkey).unwrap();
+        assert!(!app.auto_approve_kinds.contains(&NIP98_HTTP_AUTH));
+        assert!(!app.timed_kind_grants.contains_key(&NIP98_HTTP_AUTH));
+    }
+
     // === #417 round 5: targeted unit tests killing the surviving mutations ===
 
     /// `PreGrantedApp::from_stored` MUST reject pubkey-hex strings whose

--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -62,6 +62,7 @@ pub struct PreGrantedApp {
     pub auto_approve_kinds: std::collections::HashSet<nostr_sdk::Kind>,
     pub duration: PermissionDuration,
     pub connected_at: Timestamp,
+    pub timed_kind_grants: std::collections::HashMap<nostr_sdk::Kind, u64>,
 }
 
 impl PreGrantedApp {
@@ -96,6 +97,11 @@ impl PreGrantedApp {
             .copied()
             .map(nostr_sdk::Kind::from)
             .collect();
+        let timed_kind_grants: std::collections::HashMap<nostr_sdk::Kind, u64> = stored
+            .timed_kind_grants
+            .iter()
+            .map(|g| (nostr_sdk::Kind::from(g.kind), g.expires_at))
+            .collect();
         let duration = match &stored.duration {
             keep_core::relay::StoredPermissionDuration::Session => PermissionDuration::Session,
             keep_core::relay::StoredPermissionDuration::Seconds(s) => {
@@ -110,6 +116,7 @@ impl PreGrantedApp {
             auto_approve_kinds,
             duration,
             connected_at: Timestamp::from_secs(stored.connected_at),
+            timed_kind_grants,
         })
     }
 }
@@ -183,6 +190,7 @@ async fn apply_pre_grants(
             app.auto_approve_kinds.clone(),
             app.duration,
             app.connected_at,
+            app.timed_kind_grants.clone(),
         );
     }
 }
@@ -846,6 +854,7 @@ mod tests {
             auto_approve_kinds: vec![1, 7],
             duration,
             connected_at,
+            timed_kind_grants: Vec::new(),
         }
     }
 
@@ -884,6 +893,24 @@ mod tests {
         assert!(matches!(app.duration, PermissionDuration::Seconds(3600)));
         assert!(app.auto_approve_kinds.contains(&nostr_sdk::Kind::Custom(1)));
         assert!(app.permissions.contains(Permission::SIGN_EVENT));
+    }
+
+    #[test]
+    fn from_stored_maps_timed_kind_grants() {
+        let mut stored = sample_stored(
+            &good_pubkey_hex(),
+            keep_core::relay::StoredPermissionDuration::Forever,
+            42,
+        );
+        stored.timed_kind_grants = vec![keep_core::relay::StoredTimedKindGrant {
+            kind: 1,
+            expires_at: 1_900_000_000,
+        }];
+        let app = PreGrantedApp::from_stored(&stored).expect("valid stored row");
+        assert_eq!(
+            app.timed_kind_grants.get(&nostr_sdk::Kind::Custom(1)),
+            Some(&1_900_000_000)
+        );
     }
 
     #[tokio::test]

--- a/keep-nip46/src/types.rs
+++ b/keep-nip46/src/types.rs
@@ -147,3 +147,19 @@ pub(crate) struct PartialEvent {
     pub tags: Vec<Vec<String>>,
     pub created_at: i64,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remember_duration_as_seconds_mapping() {
+        assert_eq!(RememberDuration::JustThisTime.as_seconds(), None);
+        assert_eq!(RememberDuration::Forever.as_seconds(), None);
+        assert_eq!(RememberDuration::OneMinute.as_seconds(), Some(60));
+        assert_eq!(RememberDuration::FiveMinutes.as_seconds(), Some(5 * 60));
+        assert_eq!(RememberDuration::TenMinutes.as_seconds(), Some(10 * 60));
+        assert_eq!(RememberDuration::OneHour.as_seconds(), Some(60 * 60));
+        assert_eq!(RememberDuration::OneDay.as_seconds(), Some(24 * 60 * 60));
+    }
+}

--- a/keep-nip46/src/types.rs
+++ b/keep-nip46/src/types.rs
@@ -25,9 +25,77 @@ pub struct ApprovalRequest {
     pub requested_permissions: Option<String>,
 }
 
+/// How long an approval extends beyond the current request, captured from the
+/// per-request prompt UI. Mirrors keep-android's
+/// `nip55/PermissionEntities.kt::PermissionDuration` and Amber's
+/// `SettingsScreen.kt::RememberType` 1:1 so the same UX maps cleanly across
+/// signers. `JustThisTime` is the one-shot default: the request is approved
+/// but no grant is persisted, so the next request prompts again.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum RememberDuration {
+    JustThisTime,
+    OneMinute,
+    FiveMinutes,
+    TenMinutes,
+    OneHour,
+    OneDay,
+    Forever,
+}
+
+impl RememberDuration {
+    /// Duration in seconds for timed variants, `None` for `JustThisTime` and
+    /// `Forever` (which have no expiry semantics).
+    pub fn as_seconds(&self) -> Option<u64> {
+        match self {
+            Self::JustThisTime | Self::Forever => None,
+            Self::OneMinute => Some(60),
+            Self::FiveMinutes => Some(5 * 60),
+            Self::TenMinutes => Some(10 * 60),
+            Self::OneHour => Some(60 * 60),
+            Self::OneDay => Some(24 * 60 * 60),
+        }
+    }
+}
+
+/// Result of a per-request approval prompt. `approved == false` always means
+/// reject (with `remember = JustThisTime`). `approved == true` plus a non-
+/// `JustThisTime` duration persists a per-app, per-kind grant so subsequent
+/// requests within the window auto-approve without re-prompting.
+#[derive(Debug, Clone, Copy)]
+pub struct ApprovalResult {
+    pub approved: bool,
+    pub remember: RememberDuration,
+}
+
+impl ApprovalResult {
+    pub fn approved_once() -> Self {
+        Self {
+            approved: true,
+            remember: RememberDuration::JustThisTime,
+        }
+    }
+
+    pub fn rejected() -> Self {
+        Self {
+            approved: false,
+            remember: RememberDuration::JustThisTime,
+        }
+    }
+}
+
+impl From<bool> for ApprovalResult {
+    fn from(b: bool) -> Self {
+        if b {
+            Self::approved_once()
+        } else {
+            Self::rejected()
+        }
+    }
+}
+
 pub trait ServerCallbacks: Send + Sync + 'static {
     fn on_log(&self, event: LogEvent);
-    fn request_approval(&self, request: ApprovalRequest) -> bool;
+    fn request_approval(&self, request: ApprovalRequest) -> ApprovalResult;
     fn on_connect(&self, _pubkey: &str, _name: &str) {}
 }
 

--- a/keep-nip46/tests/bunker_integration.rs
+++ b/keep-nip46/tests/bunker_integration.rs
@@ -7,7 +7,7 @@ use tokio::sync::Mutex;
 
 use keep_core::keyring::Keyring;
 use keep_core::keys::{KeyType, NostrKeypair};
-use keep_nip46::types::{ApprovalRequest, LogEvent, ServerCallbacks};
+use keep_nip46::types::{ApprovalRequest, ApprovalResult, LogEvent, ServerCallbacks};
 use keep_nip46::{Server, ServerConfig};
 
 /// Test-only `ServerCallbacks` that approves every request. Used by tests
@@ -17,8 +17,8 @@ use keep_nip46::{Server, ServerConfig};
 struct AlwaysApprove;
 impl ServerCallbacks for AlwaysApprove {
     fn on_log(&self, _event: LogEvent) {}
-    fn request_approval(&self, _request: ApprovalRequest) -> bool {
-        true
+    fn request_approval(&self, _request: ApprovalRequest) -> ApprovalResult {
+        ApprovalResult::approved_once()
     }
 }
 

--- a/keep-web/src/bunker.rs
+++ b/keep-web/src/bunker.rs
@@ -63,7 +63,7 @@ impl ServerCallbacks for WebCallbacks {
         });
     }
 
-    fn request_approval(&self, request: ApprovalRequest) -> bool {
+    fn request_approval(&self, request: ApprovalRequest) -> keep_nip46::types::ApprovalResult {
         // Co-signing is off (kill switch): refuse signing without bothering the
         // operator with a prompt that would only fail at the FROST layer.
         if request.method == "sign_event"
@@ -78,7 +78,7 @@ impl ServerCallbacks for WebCallbacks {
                 success: false,
                 detail: Some("enable co-signing to approve requests".into()),
             });
-            return false;
+            return false.into();
         }
         let id = random_approval_id();
         let (tx, rx) = channel();
@@ -101,7 +101,7 @@ impl ServerCallbacks for WebCallbacks {
         if let Ok(mut map) = self.approvals.lock() {
             map.remove(&id);
         }
-        decision
+        decision.into()
     }
 }
 


### PR DESCRIPTION
## Summary

Replaces the silent NIP-98 grant with a prompt-on-first-use flow backed by a per-app, per-kind grant store, and hardens the NIP-98 invariant so it cannot regress.

**Security: silent NIP-98 grant removed.** `bunker_connect_auto_approve_kinds()` previously seeded the bunker with kind 27235 (NIP-98 HTTP Auth) so web clients using `BunkerSigner` would not time out on the per-request prompt. That meant any connected client could mint a NIP-98 auth event silently. The seed set is now empty, and the invariant is enforced centrally in `PermissionManager` rather than at a single call site: `needs_approval` short-circuits to always-prompt for kind 27235, and every grant-write path (`connect_with_permissions`, `grant_kind_forever`, `grant_kind_for`, `set_auto_approve_kinds_for_app`, `restore_persisted`) strips/refuses it. A 27235 grant can never be stored or auto-approved, regardless of how it is introduced (connect string, CLI, desktop input, or legacy persisted state).

**UX: prompt-on-first-use with remember-duration.** To keep the prompt usable without a confirmation tap on every web-API call, the approval callback now returns `ApprovalResult { approved, remember: RememberDuration }` instead of a bare bool. When the user picks a non-`JustThisTime` duration, the handler records a per-app, per-kind grant in `PermissionManager` (forever via the existing `auto_approve_kinds`, or timed via a new `timed_kind_grants` map). Subsequent requests within the window auto-approve without re-prompting. Grants are capped at `MAX_AUTO_KINDS` per app.

The `RememberDuration` enum matches keep-android's `nip55::PermissionDuration` and Amber's `RememberType` variants 1:1 so the same UX maps cleanly across signers.

**Persistence across restart.** Timed and forever kind grants are persisted via `StoredBunkerPermission` and restored on startup through `restore_persisted` / `apply_pre_grants`, with expired grants pruned fail-closed and NIP-98 stripped on load. A grant chosen as "forever" or for a duration survives a bunker restart instead of re-prompting.

**Mobile revocation.** `BunkerHandler` exposes `revoke_client` and `revoke_all_clients`, dropping an app's full permission set (permissions, auto-approve kinds, and timed grants) so revocation removes all access including persisted grants.

## Closes

Closes #575.
Closes #591.

## Cross-repo

This PR + keep-android PR #300 (https://github.com/privkeyio/keep-android/pull/300) ship together. Android wires its existing `Nip46ApprovalScreen` duration picker through to the bunker callback so the new persistent-grant path actually flows from the screen. Headless bunkers (cli, desktop, web) keep one-shot semantics by wrapping the existing bool with the `From<bool>` conversion; their UIs can opt into remember-durations later.

## Test plan

- [x] `cargo test --workspace` (1000+ tests pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] Remember-duration grant tests: `timed_grant_skips_approval_until_pruned`, `forever_grant_is_not_downgraded_by_timed_grant`, `forever_grant_removes_pre_existing_timed_grant`, `grant_kind_for_zero_seconds_is_noop`
- [x] NIP-98 invariant tests: `nip98_always_needs_approval_despite_every_grant`, `restore_persisted_strips_nip98_grants`, `timed_grant_round_trips_but_nip98_does_not`, `connect_auto_approve_kinds_never_cover_nip98`, `http_auth_always_triggers_per_request_prompt`
- [x] Cap + restart-persistence tests: `grant_kind_forever_enforces_max_auto_kinds_cap`, `grant_kind_for_enforces_max_auto_kinds_cap`, `apply_pre_grants_round_trips_timed_grant_but_drops_nip98`, `restore_persisted_keeps_future_grant_prunes_expired`
- [x] Existing test doubles (`RecordingCallbacks`, `AlwaysApprove`) updated to return `ApprovalResult`
- [x] keep-android compiles + unit tests pass against this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Approval Memory Options**: Approval requests now support time-based persistence—approve actions once, for a specific duration, or indefinitely to reduce repeated prompts for the same operation.
* **Persistent Grants**: App permissions are now tracked per-kind with automatic expiry, allowing legitimate operations to proceed without repeated approval requests within the approved window.
* **Enhanced Mobile Security**: Mobile app now requires explicit approval for HTTP authentication signing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
