### PR TITLE
nip46: persist bunker remember-grants; engine is single source of truth

### DIFF
--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -431,6 +431,10 @@ pub struct KeepMobile {
     session_store_path: Arc<std::sync::Mutex<Option<String>>>,
     descriptor_write_lock: Arc<std::sync::Mutex<()>>,
     pub(crate) bunker_config_lock: Arc<std::sync::Mutex<()>>,
+    /// Serializes load-modify-store of the relay config (relays + bunker
+    /// permission grants) so a relay edit and an engine grant/revoke write do
+    /// not clobber each other's section.
+    pub(crate) relay_config_lock: Arc<std::sync::Mutex<()>>,
 }
 
 struct PendingRequest {
@@ -571,6 +575,7 @@ impl KeepMobile {
             session_store_path: Arc::new(std::sync::Mutex::new(None)),
             descriptor_write_lock: Arc::new(std::sync::Mutex::new(())),
             bunker_config_lock: Arc::new(std::sync::Mutex::new(())),
+            relay_config_lock: Arc::new(std::sync::Mutex::new(())),
         })
     }
 
@@ -1686,6 +1691,10 @@ impl KeepMobile {
                 Ok(normalized)
             };
         let key = relay_config_key(group_pubkey.as_deref());
+        let _guard = self
+            .relay_config_lock
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let existing = match persistence::load_relay_config(&self.storage, &key) {
             Ok(Some(c)) => c,
             Ok(None) => persistence::StoredRelayConfig::default(),
@@ -2408,6 +2417,45 @@ fn build_wallet_policy(
 }
 
 impl KeepMobile {
+    /// Load the persisted NIP-46 bunker permission grants from the global relay
+    /// config, returning them ready to seed `ServerConfig::pre_grants` so
+    /// remembered grants survive a bunker restart.
+    pub(crate) fn load_bunker_permissions(
+        &self,
+    ) -> Vec<keep_core::relay::StoredBunkerPermission> {
+        let key = relay_config_key(None);
+        match persistence::load_relay_config(&self.storage, &key) {
+            Ok(Some(c)) => c.bunker_permissions,
+            _ => Vec::new(),
+        }
+    }
+
+    /// Replace the persisted NIP-46 bunker permission grants with `grants`,
+    /// preserving the relay lists. Called from the engine's `persist_permissions`
+    /// callback after every grant write or revoke, so the durable store mirrors
+    /// the in-memory engine (the single source of truth).
+    pub(crate) fn persist_bunker_permissions(
+        &self,
+        grants: Vec<keep_core::relay::StoredBunkerPermission>,
+    ) -> Result<(), KeepMobileError> {
+        let key = relay_config_key(None);
+        let _guard = self
+            .relay_config_lock
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let mut stored = match persistence::load_relay_config(&self.storage, &key) {
+            Ok(Some(c)) => c,
+            Ok(None) => persistence::StoredRelayConfig::default(),
+            Err(e) => {
+                return Err(KeepMobileError::StorageError {
+                    msg: format!("failed to load existing relay config: {e}"),
+                });
+            }
+        };
+        stored.bunker_permissions = grants;
+        persistence::persist_relay_config(&self.storage, &key, &stored)
+    }
+
     fn do_initialize(
         &self,
         relays: Vec<String>,

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1719,6 +1719,13 @@ impl KeepMobile {
             validate_hex_pubkey(pk)?;
         }
         let key = relay_config_key(group_pubkey.as_deref());
+        // Serialize against save_relay_config / persist_bunker_permissions, which
+        // do a read-modify-write on this same key; without the lock a concurrent
+        // persist could resurrect the record after the delete.
+        let _guard = self
+            .relay_config_lock
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         self.storage
             .delete_share_by_key(key)
             .map_err(|e| KeepMobileError::StorageError {
@@ -2420,13 +2427,24 @@ impl KeepMobile {
     /// Load the persisted NIP-46 bunker permission grants from the global relay
     /// config, returning them ready to seed `ServerConfig::pre_grants` so
     /// remembered grants survive a bunker restart.
-    pub(crate) fn load_bunker_permissions(
-        &self,
-    ) -> Vec<keep_core::relay::StoredBunkerPermission> {
+    pub(crate) fn load_bunker_permissions(&self) -> Vec<keep_core::relay::StoredBunkerPermission> {
         let key = relay_config_key(None);
         match persistence::load_relay_config(&self.storage, &key) {
             Ok(Some(c)) => c.bunker_permissions,
-            _ => Vec::new(),
+            Ok(None) => Vec::new(),
+            // A real load error (decrypt/deserialize failure, corruption, or
+            // tampering) is NOT the same as "no config yet". Seeding empty
+            // grants is fail-safe (more prompting), but the next grant's persist
+            // would then overwrite the durable store and erase the remembered
+            // grants for good, so surface the error loudly rather than swallow it.
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "failed to load persisted bunker permissions; starting with \
+                     none (a subsequent grant will overwrite the durable store)"
+                );
+                Vec::new()
+            }
         }
     }
 

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -7,7 +7,8 @@ use keep_nip46::types::{
     ApprovalRequest, ApprovalResult, LogEvent, RememberDuration, ServerCallbacks,
 };
 use keep_nip46::{
-    NetworkFrostSigner, Permission, RateLimitConfig, Server, ServerConfig, SignerHandler,
+    NetworkFrostSigner, Permission, PreGrantedApp, RateLimitConfig, Server, ServerConfig,
+    SignerHandler,
 };
 use nostr_sdk::{Kind, PublicKey};
 use std::sync::atomic::{AtomicU8, Ordering};
@@ -125,6 +126,7 @@ pub trait BunkerCallbacks: Send + Sync {
 
 struct CallbackBridge {
     callbacks: Arc<dyn BunkerCallbacks>,
+    mobile: Arc<KeepMobile>,
 }
 
 impl ServerCallbacks for CallbackBridge {
@@ -153,6 +155,12 @@ impl ServerCallbacks for CallbackBridge {
     fn on_connect(&self, pubkey: &str, name: &str) {
         self.callbacks
             .on_connect(pubkey.to_string(), name.to_string());
+    }
+
+    fn persist_permissions(&self, grants: Vec<keep_core::relay::StoredBunkerPermission>) {
+        if let Err(e) = self.mobile.persist_bunker_permissions(grants) {
+            tracing::warn!("failed to persist bunker permissions: {e}");
+        }
     }
 }
 
@@ -444,9 +452,21 @@ impl BunkerHandler {
 
             let (transport_secret, connect_secret) = load_or_create_bunker_keys(&self.mobile)?;
 
+            // Restore persisted per-(app, kind) remember-grants so they survive a
+            // bunker restart. The engine is the single source of truth for these
+            // grants; they are durably mirrored to the relay config on every
+            // grant/revoke via the `persist_permissions` callback below.
+            let pre_grants: Vec<PreGrantedApp> = self
+                .mobile
+                .load_bunker_permissions()
+                .iter()
+                .filter_map(PreGrantedApp::from_stored)
+                .collect();
+
             let config = ServerConfig {
                 rate_limit: Some(RateLimitConfig::default()),
                 expected_secret: Some(connect_secret.as_str().to_owned()),
+                pre_grants,
                 // Approving the bunker connection (the secret in the bunker URL
                 // is the grant) must let the client sign, mirroring the
                 // always-on bunker in keep-web. Without this the client only
@@ -471,7 +491,10 @@ impl BunkerHandler {
                 network_signer,
                 *transport_secret,
                 &relays,
-                Some(Arc::new(CallbackBridge { callbacks }) as Arc<dyn ServerCallbacks>),
+                Some(Arc::new(CallbackBridge {
+                    callbacks,
+                    mobile: Arc::clone(&self.mobile),
+                }) as Arc<dyn ServerCallbacks>),
                 config,
                 proxy,
             )

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -471,6 +471,7 @@ impl SignerHandler {
                                 .with_event_kind(kind)
                                 .with_reason("grant kind forever"),
                         );
+                        self.persist_permissions().await;
                     }
                 }
                 timed => {
@@ -486,6 +487,7 @@ impl SignerHandler {
                                     .with_event_kind(kind)
                                     .with_reason(format!("grant kind for {secs}s")),
                             );
+                            self.persist_permissions().await;
                         }
                     }
                 }
@@ -774,13 +776,26 @@ impl SignerHandler {
     }
 
     pub async fn revoke_client(&self, pubkey: &PublicKey) {
-        let mut pm = self.permissions.lock().await;
-        pm.revoke(pubkey);
+        self.permissions.lock().await.revoke(pubkey);
+        self.persist_permissions().await;
     }
 
     pub async fn revoke_all_clients(&self) {
-        let mut pm = self.permissions.lock().await;
-        pm.revoke_all();
+        self.permissions.lock().await.revoke_all();
+        self.persist_permissions().await;
+    }
+
+    /// Snapshot the current grants and hand them to the consumer's persistence
+    /// callback. No-op when no callbacks are configured (e.g. headless CLI use).
+    /// Called after every grant write or revoke so the durable store always
+    /// mirrors the in-memory engine state, keeping the engine the single source
+    /// of truth for NIP-46 remember-grants.
+    async fn persist_permissions(&self) {
+        let Some(ref callbacks) = self.callbacks else {
+            return;
+        };
+        let snapshot = self.permissions.lock().await.stored_snapshot();
+        callbacks.persist_permissions(snapshot);
     }
 
     pub async fn revoke_session_apps(&self) {

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -748,6 +748,7 @@ impl SignerHandler {
             AuditEntry::new(AuditAction::PermissionChanged, *pubkey)
                 .with_reason(format!("permissions={permissions:?}")),
         );
+        self.persist_permissions().await;
     }
 
     pub async fn update_client_duration(&self, pubkey: &PublicKey, duration: PermissionDuration) {
@@ -758,6 +759,7 @@ impl SignerHandler {
             AuditEntry::new(AuditAction::PermissionChanged, *pubkey)
                 .with_reason(format!("duration={duration:?}")),
         );
+        self.persist_permissions().await;
     }
 
     pub async fn update_client_auto_kinds(&self, pubkey: &PublicKey, kinds: HashSet<Kind>) {
@@ -768,6 +770,7 @@ impl SignerHandler {
             AuditEntry::new(AuditAction::PermissionChanged, *pubkey)
                 .with_reason("auto_approve_kinds updated"),
         );
+        self.persist_permissions().await;
     }
 
     pub async fn list_clients(&self) -> Vec<AppPermission> {
@@ -794,7 +797,13 @@ impl SignerHandler {
         let Some(ref callbacks) = self.callbacks else {
             return;
         };
-        let snapshot = self.permissions.lock().await.stored_snapshot();
+        // Hold the permissions lock across both the snapshot and the durable
+        // write so concurrent grant/revoke persists commit in the same order
+        // they were snapshotted. Dropping the lock before the callback lets two
+        // persists race (snapshot in one order, write in the reverse) and
+        // durably resurrect a revoked client on the next restart.
+        let pm = self.permissions.lock().await;
+        let snapshot = pm.stored_snapshot();
         callbacks.persist_permissions(snapshot);
     }
 
@@ -1575,6 +1584,77 @@ mod tests {
         assert!(
             !granted.has_unexpired_timed_grant(NIP98_HTTP_AUTH),
             "NIP-98 must not be persisted as a timed grant"
+        );
+    }
+
+    /// Captures every `persist_permissions` snapshot so a test can assert the
+    /// durable store mirrors the engine after a remember-grant and after a revoke.
+    struct PersistCapturingCallbacks {
+        snapshots: std::sync::Mutex<Vec<Vec<keep_core::relay::StoredBunkerPermission>>>,
+    }
+    impl crate::types::ServerCallbacks for PersistCapturingCallbacks {
+        fn on_log(&self, _event: crate::types::LogEvent) {}
+        fn request_approval(&self, _request: ApprovalRequest) -> ApprovalResult {
+            ApprovalResult {
+                approved: true,
+                remember: RememberDuration::Forever,
+            }
+        }
+        fn on_connect(&self, _pubkey: &str, _name: &str) {}
+        fn persist_permissions(&self, grants: Vec<keep_core::relay::StoredBunkerPermission>) {
+            self.snapshots.lock().unwrap().push(grants);
+        }
+    }
+
+    #[tokio::test]
+    async fn remember_grant_and_revoke_persist_engine_snapshot() {
+        let keyring = setup_keyring();
+        let permissions = Arc::new(Mutex::new(PermissionManager::new()));
+        let audit = Arc::new(Mutex::new(AuditLog::new(100)));
+        let cb = Arc::new(PersistCapturingCallbacks {
+            snapshots: std::sync::Mutex::new(Vec::new()),
+        });
+        let handler = SignerHandler::new(keyring, permissions, audit, Some(cb.clone()))
+            .with_connect_grant(Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT);
+
+        let app = Keys::generate().public_key();
+        handler.handle_connect(app, None, None, None).await.unwrap();
+        let signer_pk = handler.our_pubkey().await.unwrap();
+
+        // A remembered (Forever) sign grant must fire persist with the granted
+        // kind captured in the durable snapshot.
+        let unsigned = UnsignedEvent::new(signer_pk, Timestamp::now(), Kind::TextNote, vec![], "x");
+        handler.handle_sign_event(app, unsigned).await.unwrap();
+
+        let app_hex = app.to_hex();
+        let after_grant = cb
+            .snapshots
+            .lock()
+            .unwrap()
+            .last()
+            .cloned()
+            .expect("a remember-grant must persist a snapshot");
+        let row = after_grant
+            .iter()
+            .find(|p| p.pubkey_hex == app_hex)
+            .expect("granted app must be in the persisted snapshot");
+        assert!(
+            row.auto_approve_kinds.contains(&Kind::TextNote.as_u16()),
+            "remembered kind must be captured in the persisted snapshot"
+        );
+
+        // Revoking the client must fire persist with the app absent.
+        handler.revoke_client(&app).await;
+        let after_revoke = cb
+            .snapshots
+            .lock()
+            .unwrap()
+            .last()
+            .cloned()
+            .expect("revoke must persist a snapshot");
+        assert!(
+            !after_revoke.iter().any(|p| p.pubkey_hex == app_hex),
+            "revoked app must be removed from the persisted snapshot"
         );
     }
 }

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -396,6 +396,41 @@ impl PermissionManager {
         self.apps.values()
     }
 
+    /// Serialize the current grants into the persisted `StoredBunkerPermission`
+    /// form, the inverse of `restore_persisted`. Session apps are skipped (they
+    /// are never persisted and `restore_persisted` would drop them anyway); each
+    /// app's forever and timed per-kind grants are captured so a consumer can
+    /// write a durable snapshot and reload it via `apply_pre_grants` on restart.
+    pub fn stored_snapshot(&self) -> Vec<keep_core::relay::StoredBunkerPermission> {
+        use keep_core::relay::{
+            StoredBunkerPermission, StoredPermissionDuration, StoredTimedKindGrant,
+        };
+        self.apps
+            .values()
+            .filter(|app| !matches!(app.duration, PermissionDuration::Session))
+            .map(|app| StoredBunkerPermission {
+                pubkey_hex: app.pubkey.to_hex(),
+                name: app.name.clone(),
+                permissions: app.permissions.bits(),
+                auto_approve_kinds: app.auto_approve_kinds.iter().map(|k| k.as_u16()).collect(),
+                duration: match app.duration {
+                    PermissionDuration::Session => StoredPermissionDuration::Session,
+                    PermissionDuration::Seconds(s) => StoredPermissionDuration::Seconds(s),
+                    PermissionDuration::Forever => StoredPermissionDuration::Forever,
+                },
+                connected_at: app.connected_at.as_secs(),
+                timed_kind_grants: app
+                    .timed_kind_grants
+                    .iter()
+                    .map(|(k, expiry)| StoredTimedKindGrant {
+                        kind: k.as_u16(),
+                        expires_at: *expiry,
+                    })
+                    .collect(),
+            })
+            .collect()
+    }
+
     pub fn set_auto_approve_kinds(&mut self, kinds: HashSet<Kind>) {
         self.global_auto_approve = kinds;
     }
@@ -834,6 +869,65 @@ mod tests {
         assert!(
             restored.needs_approval(&pubkey, NIP98_HTTP_AUTH),
             "NIP-98 must not survive the round trip"
+        );
+    }
+
+    #[test]
+    fn stored_snapshot_round_trips_through_restore() {
+        // The mobile bunker persists grants by serializing `stored_snapshot()`
+        // and reloads them via `restore_persisted` on the next start. Prove that
+        // a forever grant and a timed grant survive that exact round trip.
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+        assert!(pm.grant_kind_forever(&pubkey, Kind::TextNote));
+        assert!(pm.grant_kind_for(&pubkey, Kind::Custom(30023), 3600));
+
+        let snapshot = pm.stored_snapshot();
+        assert_eq!(snapshot.len(), 1, "one connected app is serialized");
+        let stored = &snapshot[0];
+        assert_eq!(stored.pubkey_hex, pubkey.to_hex());
+        assert!(stored.auto_approve_kinds.contains(&Kind::TextNote.as_u16()));
+        assert!(stored
+            .timed_kind_grants
+            .iter()
+            .any(|g| g.kind == Kind::Custom(30023).as_u16()));
+
+        let auto: HashSet<Kind> = stored.auto_approve_kinds.iter().copied().map(Kind::from).collect();
+        let timed: HashMap<Kind, u64> = stored
+            .timed_kind_grants
+            .iter()
+            .map(|g| (Kind::from(g.kind), g.expires_at))
+            .collect();
+        let duration = match &stored.duration {
+            keep_core::relay::StoredPermissionDuration::Session => PermissionDuration::Session,
+            keep_core::relay::StoredPermissionDuration::Seconds(s) => {
+                PermissionDuration::Seconds(*s)
+            }
+            keep_core::relay::StoredPermissionDuration::Forever => PermissionDuration::Forever,
+        };
+        let mut restored = PermissionManager::new();
+        restored.restore_persisted(
+            pubkey,
+            stored.name.clone(),
+            Permission::from_bits_truncate(stored.permissions),
+            auto,
+            duration,
+            Timestamp::from_secs(stored.connected_at),
+            timed,
+        );
+
+        assert!(
+            !restored.needs_approval(&pubkey, Kind::TextNote),
+            "forever grant survives the snapshot/restore round trip"
+        );
+        assert!(
+            !restored.needs_approval(&pubkey, Kind::Custom(30023)),
+            "timed grant survives the snapshot/restore round trip"
+        );
+        assert!(
+            restored.needs_approval(&pubkey, Kind::Metadata),
+            "an ungranted kind still prompts after restore"
         );
     }
 

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -405,6 +405,7 @@ impl PermissionManager {
         use keep_core::relay::{
             StoredBunkerPermission, StoredPermissionDuration, StoredTimedKindGrant,
         };
+        let now = now_unix_secs();
         self.apps
             .values()
             .filter(|app| !matches!(app.duration, PermissionDuration::Session))
@@ -422,6 +423,7 @@ impl PermissionManager {
                 timed_kind_grants: app
                     .timed_kind_grants
                     .iter()
+                    .filter(|(_, expiry)| now < **expiry)
                     .map(|(k, expiry)| StoredTimedKindGrant {
                         kind: k.as_u16(),
                         expires_at: *expiry,
@@ -893,7 +895,12 @@ mod tests {
             .iter()
             .any(|g| g.kind == Kind::Custom(30023).as_u16()));
 
-        let auto: HashSet<Kind> = stored.auto_approve_kinds.iter().copied().map(Kind::from).collect();
+        let auto: HashSet<Kind> = stored
+            .auto_approve_kinds
+            .iter()
+            .copied()
+            .map(Kind::from)
+            .collect();
         let timed: HashMap<Kind, u64> = stored
             .timed_kind_grants
             .iter()

--- a/keep-nip46/src/types.rs
+++ b/keep-nip46/src/types.rs
@@ -97,6 +97,13 @@ pub trait ServerCallbacks: Send + Sync + 'static {
     fn on_log(&self, event: LogEvent);
     fn request_approval(&self, request: ApprovalRequest) -> ApprovalResult;
     fn on_connect(&self, _pubkey: &str, _name: &str) {}
+    /// Called after the in-memory permission grants change (a remember-grant is
+    /// written or a client is revoked), passing a full snapshot of the current
+    /// grants so the consumer can persist them durably. Default no-op: keep-web
+    /// and the CLI manage persistence out-of-band; the mobile bunker overrides
+    /// this to write the snapshot to its relay-config storage so remembered
+    /// grants survive a service restart.
+    fn persist_permissions(&self, _grants: Vec<keep_core::relay::StoredBunkerPermission>) {}
 }
 
 #[derive(Debug, serde::Deserialize)]


### PR DESCRIPTION
## Summary

Makes the Rust bunker engine the single durable source of truth for NIP-46 per-(app, kind) remember-grants. Previously the mobile bunker held grants in memory only (lost on restart), while keep-android kept a parallel copy in its NIP-55 `PermissionStore`. This persists the engine's grants to relay-config storage and restores them on start, so the Android duplicate can be removed (keep-android side, separate PR).

Companion to keep-android 301.

## Changes

**keep-nip46**
- `ServerCallbacks::persist_permissions(grants)` — new trait method with a **default no-op**, so keep-web and the CLI are unaffected.
- `PermissionManager::stored_snapshot()` — serializes the current grants into `StoredBunkerPermission` (the inverse of `restore_persisted`); Session apps are skipped, NIP-98 is never carried.
- The handler calls `persist_permissions()` after every grant write (`grant_kind_forever` / `grant_kind_for`) and after `revoke_client` / `revoke_all_clients`, so the durable store always mirrors the in-memory engine.

**keep-mobile**
- `CallbackBridge` implements `persist_permissions`, writing the snapshot to the global relay config (`bunker_permissions`); persistence stays entirely in Rust.
- `do_start_bunker` loads persisted grants into `ServerConfig::pre_grants` so remembered grants survive a restart.
- New `relay_config_lock` serializes the relay-config read-modify-write so a relay edit and a grant/revoke write cannot clobber each other (which could otherwise resurrect a revoked grant on restart).

## Testing
- `cargo test -p keep-nip46` (132 lib tests incl. new `stored_snapshot_round_trips_through_restore`), `cargo test -p keep-mobile` (84) — green
- `cargo clippy -p keep-nip46 -p keep-mobile` — clean
- `cargo check -p keep-web -p keep-cli` — green (default no-op trait method)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Permission grants for NIP-46 bunker apps are now persistently remembered across app restarts, eliminating the need to re-approve familiar applications with each launch.
  * Enhanced permission synchronization ensures approval decisions are durably stored.

* **Bug Fixes**
  * Fixed potential data loss that could occur when updating relay configuration and bunker permissions concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->