### PR TITLE
nip55: emit Amber-compatible batch results wire format

### DIFF
--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -905,4 +905,28 @@ mod tests {
         assert_eq!(json[1]["id"], "2");
         assert_eq!(json[1]["rejected"], true);
     }
+
+    #[test]
+    fn batch_results_empty_is_empty_array() {
+        assert_eq!(serialize_batch_results_json(&[]), "[]");
+    }
+
+    // Amber's batch wire format puts the signature in BOTH `signature` and
+    // `result` and never emits the assembled event; the per-request `event`
+    // payload is only for the single-result intent path.
+    #[test]
+    fn batch_results_sign_event_uses_signature_not_event() {
+        let responses = vec![Nip55Response {
+            result: "sighex".into(),
+            event: Some("{\"id\":\"deadbeef\",\"sig\":\"sighex\"}".into()),
+            error: None,
+            id: Some("c".into()),
+        }];
+        let json: serde_json::Value =
+            serde_json::from_str(&serialize_batch_results_json(&responses)).unwrap();
+        let obj = &json[0];
+        assert_eq!(obj["signature"], "sighex");
+        assert_eq!(obj["result"], "sighex");
+        assert!(obj.get("event").is_none());
+    }
 }

--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -95,6 +95,34 @@ impl Nip55Response {
     }
 }
 
+// A failed/rejected request carries null signature/result and rejected=true; a
+// success sets both signature and result to the operation output. Matches the
+// `Result` object shape that NIP-55 signer clients parse from the results array.
+fn serialize_batch_results_json(responses: &[Nip55Response]) -> String {
+    let results: Vec<serde_json::Value> = responses
+        .iter()
+        .map(|r| {
+            if r.error.is_some() {
+                serde_json::json!({
+                    "id": r.id,
+                    "package": serde_json::Value::Null,
+                    "signature": serde_json::Value::Null,
+                    "result": serde_json::Value::Null,
+                    "rejected": true,
+                })
+            } else {
+                serde_json::json!({
+                    "id": r.id,
+                    "package": serde_json::Value::Null,
+                    "signature": r.result,
+                    "result": r.result,
+                })
+            }
+        })
+        .collect();
+    serde_json::to_string(&results).unwrap_or_else(|_| "[]".to_string())
+}
+
 #[derive(Default)]
 struct RateLimitState {
     requests: Vec<Instant>,
@@ -278,24 +306,10 @@ impl Nip55Handler {
         Ok(intent)
     }
 
+    // Serializes batch results to the NIP-55 `results` extra wire format used by
+    // signer clients: a JSON array of {id, package, signature, result, rejected?}.
     pub fn serialize_batch_results(&self, responses: Vec<Nip55Response>) -> String {
-        let results: Vec<serde_json::Value> = responses
-            .iter()
-            .map(|r| {
-                let mut obj = serde_json::json!({ "result": r.result });
-                if let Some(ref event) = r.event {
-                    obj["event"] = event.clone().into();
-                }
-                if let Some(ref error) = r.error {
-                    obj["error"] = error.clone().into();
-                }
-                if let Some(ref id) = r.id {
-                    obj["id"] = id.clone().into();
-                }
-                obj
-            })
-            .collect();
-        serde_json::to_string(&results).unwrap_or_else(|_| "[]".to_string())
+        serialize_batch_results_json(&responses)
     }
 }
 
@@ -827,4 +841,68 @@ pub(crate) fn compute_nostr_event_id(
 
     let hash = Sha256::digest(json_str.as_bytes());
     Ok(hash.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_results_success_carries_signature_and_result() {
+        let responses = vec![Nip55Response {
+            result: "sig123".into(),
+            event: None,
+            error: None,
+            id: Some("a".into()),
+        }];
+        let json: serde_json::Value =
+            serde_json::from_str(&serialize_batch_results_json(&responses)).unwrap();
+        let obj = &json[0];
+        assert_eq!(obj["id"], "a");
+        assert!(obj["package"].is_null());
+        assert_eq!(obj["signature"], "sig123");
+        assert_eq!(obj["result"], "sig123");
+        assert!(obj.get("rejected").is_none());
+    }
+
+    #[test]
+    fn batch_results_error_is_rejected_with_null_values() {
+        let responses = vec![Nip55Response {
+            result: String::new(),
+            event: None,
+            error: Some("request failed".into()),
+            id: Some("b".into()),
+        }];
+        let json: serde_json::Value =
+            serde_json::from_str(&serialize_batch_results_json(&responses)).unwrap();
+        let obj = &json[0];
+        assert_eq!(obj["id"], "b");
+        assert!(obj["signature"].is_null());
+        assert!(obj["result"].is_null());
+        assert_eq!(obj["rejected"], true);
+    }
+
+    #[test]
+    fn batch_results_preserves_order_and_mixes_outcomes() {
+        let responses = vec![
+            Nip55Response {
+                result: "ok".into(),
+                event: None,
+                error: None,
+                id: Some("1".into()),
+            },
+            Nip55Response {
+                result: String::new(),
+                event: None,
+                error: Some("boom".into()),
+                id: Some("2".into()),
+            },
+        ];
+        let json: serde_json::Value =
+            serde_json::from_str(&serialize_batch_results_json(&responses)).unwrap();
+        assert_eq!(json.as_array().unwrap().len(), 2);
+        assert_eq!(json[0]["result"], "ok");
+        assert_eq!(json[1]["id"], "2");
+        assert_eq!(json[1]["rejected"], true);
+    }
 }


### PR DESCRIPTION
## What

`serialize_batch_results` now emits the NIP-55 `results` extra wire format that signer clients actually parse — a JSON array of `Result` objects `{id, package, signature, result, rejected?}` — instead of the previous `{result, event, error, id}` shape, which no NIP-55 client understands.

Per-element mapping (matches the reference signer's `Result`):
- success: `signature == result == <output>`, `package: null`, `rejected` omitted
- failed/rejected: `signature: null`, `result: null`, `rejected: true`

## Why

The previous format was written speculatively and is not interop-compatible. Base NIP-55 underspecifies batch, so the response shape is defined by the de-facto signer convention. This unblocks the keep-android batch/multi-event signing feature (gh #320), which builds the `results` extra from this output.

The UniFFI signature is unchanged (`serialize_batch_results(sequence<Nip55Response>) -> string`), so no binding churn.

## Tests

Extracted the pure serialization to `serialize_batch_results_json` and added unit tests: success carries signature+result, error is rejected with null values, and mixed-outcome ordering is preserved. `cargo test`, `cargo fmt --check`, `cargo clippy` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated batch response serialization with enhanced error handling and improved fallback mechanisms for increased reliability.

* **Tests**
  * Added comprehensive unit tests validating batch response format, error cases, and mixed operation outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->