### PR TITLE
nip55: parse the get_public_key permissions array into declared grants

### DIFF
--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -75,6 +75,55 @@ pub struct Nip55Response {
     pub id: Option<String>,
 }
 
+// A single method (+ optional sign_event kind) a client requests to pre-authorize
+// via the NIP-55 `permissions` array passed with get_public_key.
+#[derive(uniffi::Record, Clone, Debug, PartialEq, Eq)]
+pub struct Nip55DeclaredPermission {
+    pub request_type: Nip55RequestType,
+    pub kind: Option<i32>,
+}
+
+// Parses the NIP-55 `permissions` array (`[{"type":"sign_event","kind":22242},
+// {"type":"nip44_decrypt"}]`) into the methods/kinds a client wants pre-authorized.
+// Unknown method types are dropped; `kind` is honored only for sign_event, and a
+// kind-less sign_event entry is dropped (a sign grant must name a kind). Malformed
+// input parses to an empty list (fail-closed: nothing pre-authorized).
+#[uniffi::export]
+pub fn nip55_parse_permissions(json: Option<String>) -> Vec<Nip55DeclaredPermission> {
+    let Some(json) = json else {
+        return Vec::new();
+    };
+    let entries: Vec<serde_json::Value> = match serde_json::from_str(&json) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    for entry in &entries {
+        let Some(type_str) = entry.get("type").and_then(|t| t.as_str()) else {
+            continue;
+        };
+        let Ok(request_type) = parse_request_type(type_str) else {
+            continue;
+        };
+        let kind = if request_type == Nip55RequestType::SignEvent {
+            match entry
+                .get("kind")
+                .and_then(|k| k.as_i64())
+                .and_then(|k| i32::try_from(k).ok())
+                .filter(|k| (0..=65535).contains(k))
+            {
+                Some(k) => Some(k),
+                // A sign_event permission with no (valid) kind cannot be granted.
+                None => continue,
+            }
+        } else {
+            None
+        };
+        out.push(Nip55DeclaredPermission { request_type, kind });
+    }
+    out
+}
+
 impl Nip55Response {
     fn ok(result: String) -> Self {
         Self {
@@ -880,6 +929,50 @@ mod tests {
         assert!(obj["signature"].is_null());
         assert!(obj["result"].is_null());
         assert_eq!(obj["rejected"], true);
+    }
+
+    #[test]
+    fn parse_permissions_spec_example() {
+        let json = r#"[{"type":"sign_event","kind":22242},{"type":"nip44_decrypt"}]"#;
+        let perms = nip55_parse_permissions(Some(json.into()));
+        assert_eq!(
+            perms,
+            vec![
+                Nip55DeclaredPermission {
+                    request_type: Nip55RequestType::SignEvent,
+                    kind: Some(22242),
+                },
+                Nip55DeclaredPermission {
+                    request_type: Nip55RequestType::Nip44Decrypt,
+                    kind: None,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_permissions_drops_kindless_sign_event_and_unknown_types() {
+        let json = r#"[{"type":"sign_event"},{"type":"bogus"},{"type":"nip04_encrypt","kind":4}]"#;
+        let perms = nip55_parse_permissions(Some(json.into()));
+        // kindless sign_event dropped, unknown dropped, non-sign kind ignored.
+        assert_eq!(
+            perms,
+            vec![Nip55DeclaredPermission {
+                request_type: Nip55RequestType::Nip04Encrypt,
+                kind: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_permissions_fail_closed_on_garbage_or_none() {
+        assert!(nip55_parse_permissions(None).is_empty());
+        assert!(nip55_parse_permissions(Some("not json".into())).is_empty());
+        assert!(nip55_parse_permissions(Some("{}".into())).is_empty());
+        assert!(
+            nip55_parse_permissions(Some(r#"[{"type":"sign_event","kind":99999}]"#.into()))
+                .is_empty()
+        );
     }
 
     #[test]

--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -32,6 +32,9 @@ const MAX_REQUESTS_PER_WINDOW: u32 = 60;
 const MAX_BACKOFF: Duration = Duration::from_secs(300);
 const MAX_BATCH_SIZE: usize = 20;
 const MAX_RATE_LIMIT_ENTRIES: usize = 1000;
+const MAX_PERMISSIONS_COUNT: usize = 32;
+const MAX_PERMISSIONS_JSON_BYTES: usize = 8 * 1024;
+const MAX_EVENT_KIND: i32 = 65535;
 
 fn pubkey_eq(a: &str, b: &str) -> bool {
     a.as_bytes().ct_eq(b.as_bytes()).unwrap_u8() == 1
@@ -85,41 +88,58 @@ pub struct Nip55DeclaredPermission {
 
 // Parses the NIP-55 `permissions` array (`[{"type":"sign_event","kind":22242},
 // {"type":"nip44_decrypt"}]`) into the methods/kinds a client wants pre-authorized.
-// Unknown method types are dropped; `kind` is honored only for sign_event, and a
-// kind-less sign_event entry is dropped (a sign grant must name a kind). Malformed
-// input parses to an empty list (fail-closed: nothing pre-authorized).
+// Unknown method types are dropped, as are `get_public_key` entries (that is the
+// entry method itself, not a grantable permission); `kind` is honored only for
+// sign_event, and a kind-less sign_event entry is dropped (a sign grant must name
+// a kind). Duplicate `(request_type, kind)` entries collapse to the first seen, and
+// at most `MAX_PERMISSIONS_COUNT` entries are accepted. Input over
+// `MAX_PERMISSIONS_JSON_BYTES` and malformed input both parse to an empty list
+// (fail-closed: nothing pre-authorized).
 #[uniffi::export]
 pub fn nip55_parse_permissions(json: Option<String>) -> Vec<Nip55DeclaredPermission> {
     let Some(json) = json else {
         return Vec::new();
     };
+    if json.len() > MAX_PERMISSIONS_JSON_BYTES {
+        return Vec::new();
+    }
     let entries: Vec<serde_json::Value> = match serde_json::from_str(&json) {
         Ok(v) => v,
         Err(_) => return Vec::new(),
     };
-    let mut out = Vec::new();
+    let mut out: Vec<Nip55DeclaredPermission> = Vec::new();
     for entry in &entries {
+        if out.len() >= MAX_PERMISSIONS_COUNT {
+            break;
+        }
         let Some(type_str) = entry.get("type").and_then(|t| t.as_str()) else {
             continue;
         };
         let Ok(request_type) = parse_request_type(type_str) else {
             continue;
         };
+        if request_type == Nip55RequestType::GetPublicKey {
+            continue;
+        }
         let kind = if request_type == Nip55RequestType::SignEvent {
-            match entry
+            let Some(kind) = entry
                 .get("kind")
                 .and_then(|k| k.as_i64())
                 .and_then(|k| i32::try_from(k).ok())
-                .filter(|k| (0..=65535).contains(k))
-            {
-                Some(k) => Some(k),
+                .filter(|k| (0..=MAX_EVENT_KIND).contains(k))
+            else {
                 // A sign_event permission with no (valid) kind cannot be granted.
-                None => continue,
-            }
+                continue;
+            };
+            Some(kind)
         } else {
             None
         };
-        out.push(Nip55DeclaredPermission { request_type, kind });
+        let permission = Nip55DeclaredPermission { request_type, kind };
+        if out.contains(&permission) {
+            continue;
+        }
+        out.push(permission);
     }
     out
 }
@@ -973,6 +993,74 @@ mod tests {
             nip55_parse_permissions(Some(r#"[{"type":"sign_event","kind":99999}]"#.into()))
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn parse_permissions_empty_array_is_empty() {
+        assert!(nip55_parse_permissions(Some("[]".into())).is_empty());
+    }
+
+    #[test]
+    fn parse_permissions_dedups_to_first_seen() {
+        let json = r#"[{"type":"nip44_decrypt"},{"type":"nip44_decrypt"},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1}]"#;
+        let perms = nip55_parse_permissions(Some(json.into()));
+        assert_eq!(
+            perms,
+            vec![
+                Nip55DeclaredPermission {
+                    request_type: Nip55RequestType::Nip44Decrypt,
+                    kind: None,
+                },
+                Nip55DeclaredPermission {
+                    request_type: Nip55RequestType::SignEvent,
+                    kind: Some(1),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_permissions_drops_get_public_key() {
+        let json = r#"[{"type":"get_public_key"},{"type":"nip44_decrypt"}]"#;
+        let perms = nip55_parse_permissions(Some(json.into()));
+        assert_eq!(
+            perms,
+            vec![Nip55DeclaredPermission {
+                request_type: Nip55RequestType::Nip44Decrypt,
+                kind: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_permissions_drops_non_object_elements() {
+        let perms = nip55_parse_permissions(Some(r#"["sign_event",42,null]"#.into()));
+        assert!(perms.is_empty());
+    }
+
+    #[test]
+    fn parse_permissions_drops_string_kind() {
+        let json = r#"[{"type":"sign_event","kind":"22242"}]"#;
+        assert!(nip55_parse_permissions(Some(json.into())).is_empty());
+    }
+
+    #[test]
+    fn parse_permissions_enforces_count_cap() {
+        let entries: Vec<String> = (0..MAX_PERMISSIONS_COUNT as i32 + 10)
+            .map(|k| format!(r#"{{"type":"sign_event","kind":{k}}}"#))
+            .collect();
+        let json = format!("[{}]", entries.join(","));
+        let perms = nip55_parse_permissions(Some(json));
+        assert_eq!(perms.len(), MAX_PERMISSIONS_COUNT);
+    }
+
+    #[test]
+    fn parse_permissions_rejects_oversized_input() {
+        let entry = r#"{"type":"nip44_decrypt"}"#;
+        let count = MAX_PERMISSIONS_JSON_BYTES / entry.len() + 10;
+        let json = format!("[{}]", vec![entry; count].join(","));
+        assert!(json.len() > MAX_PERMISSIONS_JSON_BYTES);
+        assert!(nip55_parse_permissions(Some(json)).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `nip55_parse_permissions(json) -> Vec<Nip55DeclaredPermission { request_type, kind }>` — parses the NIP-55 `permissions` array a client passes with `get_public_key` (`[{"type":"sign_event","kind":22242},{"type":"nip44_decrypt"}]`) into the methods/kinds it wants pre-authorized.

Validation (matches the reference signer):
- unknown method `type` → dropped
- `kind` honored only for `sign_event`; a kind-less (or out-of-range) `sign_event` entry → dropped (a sign grant must name a kind)
- malformed / missing input → empty list (fail-closed: nothing pre-authorized)

`kind` is `Option<i32>` to feed directly into the existing grant path (`nip55_effective_grant_duration`).

## Why

The `permissions` array is currently parsed onto `Nip55Request.permissions` but never consumed (gh keep-android #321). This is the Rust half: parsing + validation live here per the RMP boundary; the Android side will render the requested scope as a checklist on the connect approval and grant the checked bundle via the existing per-app/per-kind grant + Rust duration clamp.

## Tests

`nip55_parse_permissions` unit tests: spec example, drop-kindless-sign/unknown-types, fail-closed on garbage/None/out-of-range kind. `cargo test`, `cargo fmt --check`, `cargo clippy` clean.