### PR TITLE
release: bump workspace to v0.4.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4306,7 +4306,7 @@ dependencies = [
 
 [[package]]
 name = "keep-agent"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "chrono",
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "keep-bitcoin"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "bitcoin",
  "getrandom 0.4.2",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "keep-cli"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4393,7 +4393,7 @@ dependencies = [
 
 [[package]]
 name = "keep-core"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "aes 0.9.1",
  "argon2",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "keep-desktop"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4471,14 +4471,14 @@ dependencies = [
 
 [[package]]
 name = "keep-enclave"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "keep-enclave-host",
 ]
 
 [[package]]
 name = "keep-enclave-host"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "keep-frost-net"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4547,7 +4547,7 @@ dependencies = [
 
 [[package]]
 name = "keep-mobile"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4577,7 +4577,7 @@ dependencies = [
 
 [[package]]
 name = "keep-nip46"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "bitflags 2.13.0",
  "chrono",
@@ -4603,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "keep-web"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "axum",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"


### PR DESCRIPTION
Bumps the workspace version `0.4.8` → `0.4.9` so a `v0.4.9` release can be tagged for keep-android **1.1.0** to pin.

## Why now
keep-android 1.1.0 depends on signer work merged since `v0.4.8`, none of which is in a tagged keep release yet:
- `serialize_batch_results` (#601) — batch signing
- `nip55_parse_permissions` (#602) — permissions bundle
- `nip55_extract_relay_host` / `nip55_relay_auth_gate` (#603) — per-relay NIP-42 + relay-auth whitelist
- `nip44::encrypt_v3` / `decrypt_v3` (#605) — NIP-44 v3 cipher (keep-core only; no FFI surface yet, dormant until the mobile wiring lands)

Tagging `v0.4.9` at this commit gives keep-android a stable, auditable pin for the release.

Version-only change; `Cargo.lock` updated to match. `cargo check` clean.

**After merge:** tag `v0.4.9` on the merge commit so keep-android can pin it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.4.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->