### PR TITLE
nip46: sign 1-of-1 bunker shares locally instead of networked FROST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4587,6 +4587,7 @@ version = "0.4.9"
 dependencies = [
  "bitflags 2.13.0",
  "chrono",
+ "frost-secp256k1-tr",
  "hex",
  "keep-core",
  "keep-frost-net",

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1002,6 +1002,14 @@ impl KfpNode {
         self.share.metadata.identifier
     }
 
+    /// The node's already-decrypted share material, held in memory since init.
+    /// Lets callers build a local signer without re-reading and re-decrypting
+    /// from storage (which, on mobile, requires a biometric-gated key that is
+    /// unavailable in a background service context).
+    pub fn share_package(&self) -> &SharePackage {
+        &self.share
+    }
+
     /// Test-only: inject a fully-formed descriptor session directly into the
     /// node's session manager. Used by integration tests that need a
     /// `Complete` migration session as a precondition for sweep coordination,

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -3284,7 +3284,7 @@ impl KeepMobile {
         }
     }
 
-    fn load_share_package(&self) -> Result<SharePackage, KeepMobileError> {
+    pub(crate) fn load_share_package(&self) -> Result<SharePackage, KeepMobileError> {
         let key = match self.storage.get_active_share_key() {
             Some(k) => k,
             None => self.resolve_active_share()?,

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -3284,7 +3284,7 @@ impl KeepMobile {
         }
     }
 
-    pub(crate) fn load_share_package(&self) -> Result<SharePackage, KeepMobileError> {
+    fn load_share_package(&self) -> Result<SharePackage, KeepMobileError> {
         let key = match self.storage.get_active_share_key() {
             Some(k) => k,
             None => self.resolve_active_share()?,

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -452,9 +452,15 @@ impl BunkerHandler {
             // instead of dispatching a networked FROST session that no peer will
             // ever answer (which otherwise times out). Multi-share groups still
             // need the network to gather co-signers.
-            let active_share = self.mobile.load_share_package()?;
-            let local_complete = active_share.metadata.threshold == 1
-                && active_share.metadata.total_shares == 1;
+            //
+            // The threshold is read from plaintext metadata; the share secret is
+            // taken from the node's already-decrypted in-memory copy (loaded at
+            // init while biometric auth was available). Re-decrypting from
+            // storage here would fail: the bunker auto-starts in a background
+            // service with no staged biometric cipher, so the storage callback
+            // throws StorageException.
+            let local_complete =
+                share_info.threshold == 1 && share_info.total_shares == 1;
 
             let (transport_secret, connect_secret) = load_or_create_bunker_keys(&self.mobile)?;
 
@@ -499,12 +505,14 @@ impl BunkerHandler {
             }) as Arc<dyn ServerCallbacks>);
 
             let server = if local_complete {
-                // Wrap the active share in a FrostSigner for local signing. The
-                // share is re-encrypted under an ephemeral data key purely to
-                // satisfy the FrostSigner API; it never leaves the process.
+                // Wrap the node's in-memory share in a FrostSigner for local
+                // signing. The share is re-encrypted under an ephemeral data key
+                // purely to satisfy the FrostSigner API; it never leaves the
+                // process.
+                let active_share = node.share_package();
                 let data_key = keep_core::crypto::SecretKey::generate()
                     .map_err(|e| KeepMobileError::FrostError { msg: e.to_string() })?;
-                let stored = keep_core::frost::StoredShare::encrypt(&active_share, &data_key)
+                let stored = keep_core::frost::StoredShare::encrypt(active_share, &data_key)
                     .map_err(|e| KeepMobileError::FrostError { msg: e.to_string() })?;
                 let frost_signer = FrostSigner::new(group_pubkey_bytes, vec![stored], data_key)
                     .map_err(|e| KeepMobileError::FrostError { msg: e.to_string() })?;

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -453,14 +453,20 @@ impl BunkerHandler {
             // ever answer (which otherwise times out). Multi-share groups still
             // need the network to gather co-signers.
             //
-            // The threshold is read from plaintext metadata; the share secret is
-            // taken from the node's already-decrypted in-memory copy (loaded at
-            // init while biometric auth was available). Re-decrypting from
-            // storage here would fail: the bunker auto-starts in a background
-            // service with no staged biometric cipher, so the storage callback
-            // throws StorageException.
-            let local_complete =
-                share_info.threshold == 1 && share_info.total_shares == 1;
+            // The gate and the signer must agree on a single source of truth.
+            // Both the threshold check and the share secret come from the node's
+            // already-decrypted, authenticated in-memory copy (loaded at init
+            // while biometric auth was available); reading the gate from
+            // plaintext storage metadata instead could disagree with the share
+            // FrostSigner is built from and fail the bunker outright rather than
+            // fall back to the network path. Re-decrypting from storage here
+            // would also fail: the bunker auto-starts in a background service
+            // with no staged biometric cipher, so the storage callback throws
+            // StorageException.
+            let local_complete = {
+                let meta = &node.share_package().metadata;
+                meta.threshold == 1 && meta.total_shares == 1
+            };
 
             let (transport_secret, connect_secret) = load_or_create_bunker_keys(&self.mobile)?;
 
@@ -526,7 +532,7 @@ impl BunkerHandler {
                     proxy,
                 )
                 .await
-                .map_err(|e| KeepMobileError::NetworkError { msg: e.to_string() })?
+                .map_err(|e| KeepMobileError::FrostError { msg: e.to_string() })?
             } else {
                 let network_signer =
                     NetworkFrostSigner::with_shared_node(group_pubkey_bytes, Arc::clone(node));

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -7,8 +7,8 @@ use keep_nip46::types::{
     ApprovalRequest, ApprovalResult, LogEvent, RememberDuration, ServerCallbacks,
 };
 use keep_nip46::{
-    NetworkFrostSigner, Permission, PreGrantedApp, RateLimitConfig, Server, ServerConfig,
-    SignerHandler,
+    FrostSigner, NetworkFrostSigner, Permission, PreGrantedApp, RateLimitConfig, Server,
+    ServerConfig, SignerHandler,
 };
 use nostr_sdk::{Kind, PublicKey};
 use std::sync::atomic::{AtomicU8, Ordering};
@@ -447,8 +447,14 @@ impl BunkerHandler {
                     msg: "Invalid group pubkey length".into(),
                 })?;
 
-            let network_signer =
-                NetworkFrostSigner::with_shared_node(group_pubkey_bytes, Arc::clone(node));
+            // An imported nsec is a 1-of-1 FROST share; its single locally-held
+            // share satisfies the threshold, so the bunker can sign locally
+            // instead of dispatching a networked FROST session that no peer will
+            // ever answer (which otherwise times out). Multi-share groups still
+            // need the network to gather co-signers.
+            let active_share = self.mobile.load_share_package()?;
+            let local_complete = active_share.metadata.threshold == 1
+                && active_share.metadata.total_shares == 1;
 
             let (transport_secret, connect_secret) = load_or_create_bunker_keys(&self.mobile)?;
 
@@ -487,19 +493,47 @@ impl BunkerHandler {
                 ..ServerConfig::default()
             };
 
-            let server = Server::new_network_frost_with_proxy(
-                network_signer,
-                *transport_secret,
-                &relays,
-                Some(Arc::new(CallbackBridge {
-                    callbacks,
-                    mobile: Arc::clone(&self.mobile),
-                }) as Arc<dyn ServerCallbacks>),
-                config,
-                proxy,
-            )
-            .await
-            .map_err(|e| KeepMobileError::NetworkError { msg: e.to_string() })?;
+            let server_callbacks = Some(Arc::new(CallbackBridge {
+                callbacks,
+                mobile: Arc::clone(&self.mobile),
+            }) as Arc<dyn ServerCallbacks>);
+
+            let server = if local_complete {
+                // Wrap the active share in a FrostSigner for local signing. The
+                // share is re-encrypted under an ephemeral data key purely to
+                // satisfy the FrostSigner API; it never leaves the process.
+                let data_key = keep_core::crypto::SecretKey::generate()
+                    .map_err(|e| KeepMobileError::FrostError { msg: e.to_string() })?;
+                let stored = keep_core::frost::StoredShare::encrypt(&active_share, &data_key)
+                    .map_err(|e| KeepMobileError::FrostError { msg: e.to_string() })?;
+                let frost_signer = FrostSigner::new(group_pubkey_bytes, vec![stored], data_key)
+                    .map_err(|e| KeepMobileError::FrostError { msg: e.to_string() })?;
+
+                Server::new_frost_with_proxy(
+                    frost_signer,
+                    *transport_secret,
+                    &relays,
+                    server_callbacks,
+                    config,
+                    proxy,
+                )
+                .await
+                .map_err(|e| KeepMobileError::NetworkError { msg: e.to_string() })?
+            } else {
+                let network_signer =
+                    NetworkFrostSigner::with_shared_node(group_pubkey_bytes, Arc::clone(node));
+
+                Server::new_network_frost_with_proxy(
+                    network_signer,
+                    *transport_secret,
+                    &relays,
+                    server_callbacks,
+                    config,
+                    proxy,
+                )
+                .await
+                .map_err(|e| KeepMobileError::NetworkError { msg: e.to_string() })?
+            };
 
             *self.bunker_url.lock().unwrap_or_else(|e| e.into_inner()) = Some(server.bunker_url());
             *self.handler.lock().unwrap_or_else(|e| e.into_inner()) = Some(server.handler());

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -433,36 +433,25 @@ impl BunkerHandler {
             let node_guard = self.mobile.node.read().await;
             let node = node_guard.as_ref().ok_or(KeepMobileError::NotInitialized)?;
 
-            let share_info = self
-                .mobile
-                .get_share_info()
-                .ok_or(KeepMobileError::NotInitialized)?;
-
-            let group_pubkey_bytes: [u8; 32] = hex::decode(&share_info.group_pubkey)
-                .map_err(|_| KeepMobileError::FrostError {
-                    msg: "Invalid group pubkey hex".into(),
-                })?
-                .try_into()
-                .map_err(|_| KeepMobileError::FrostError {
-                    msg: "Invalid group pubkey length".into(),
-                })?;
-
             // An imported nsec is a 1-of-1 FROST share; its single locally-held
             // share satisfies the threshold, so the bunker can sign locally
             // instead of dispatching a networked FROST session that no peer will
             // ever answer (which otherwise times out). Multi-share groups still
             // need the network to gather co-signers.
             //
-            // The gate and the signer must agree on a single source of truth.
-            // Both the threshold check and the share secret come from the node's
-            // already-decrypted, authenticated in-memory copy (loaded at init
-            // while biometric auth was available); reading the gate from
-            // plaintext storage metadata instead could disagree with the share
-            // FrostSigner is built from and fail the bunker outright rather than
-            // fall back to the network path. Re-decrypting from storage here
-            // would also fail: the bunker auto-starts in a background service
-            // with no staged biometric cipher, so the storage callback throws
-            // StorageException.
+            // The gate, the group pubkey, and the signer share all come from the
+            // node's in-memory, decrypted-at-init copy (loaded while biometric
+            // auth was available). Deriving the group pubkey from plaintext
+            // storage metadata instead could disagree with the share FrostSigner
+            // is built from and fail the bunker outright rather than fall back to
+            // the network path. Note the in-memory metadata is not itself
+            // cryptographically authenticated (ShareMetadata is stored plaintext
+            // beside the AEAD ciphertext; only the key_package is integrity-
+            // protected), but using it consistently keeps the gate and signer in
+            // agreement. Re-decrypting from storage here would also fail: the
+            // bunker auto-starts in a background service with no staged biometric
+            // cipher, so the storage callback throws StorageException.
+            let group_pubkey_bytes: [u8; 32] = node.share_package().metadata.group_pubkey;
             let local_complete = {
                 let meta = &node.share_package().metadata;
                 meta.threshold == 1 && meta.total_shares == 1

--- a/keep-nip46/Cargo.toml
+++ b/keep-nip46/Cargo.toml
@@ -27,6 +27,7 @@ zeroize.workspace = true
 
 [dev-dependencies]
 keep-core = { path = "../keep-core", features = ["allow-ws", "allow-internal"] }
+frost-secp256k1-tr = { workspace = true }
 nostr-relay-builder = "0.44"
 rustls = { version = "0.23", features = ["ring"] }
 tracing-subscriber = "0.3"

--- a/keep-nip46/src/frost_signer.rs
+++ b/keep-nip46/src/frost_signer.rs
@@ -103,6 +103,7 @@ impl NetworkFrostSigner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use keep_core::crypto::SecretKey;
     use keep_core::frost::{ShareMetadata, SharePackage};
     use nostr_sdk::prelude::*;
 

--- a/keep-nip46/src/frost_signer.rs
+++ b/keep-nip46/src/frost_signer.rs
@@ -99,3 +99,80 @@ impl NetworkFrostSigner {
             .map_err(|e| KeepError::Frost(e.to_string()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use keep_core::frost::{ShareMetadata, SharePackage};
+    use nostr_sdk::prelude::*;
+
+    // Build a 1-of-1 FROST share the same way an imported nsec does: the lone
+    // signing share is the full secret key, so the single holder satisfies the
+    // threshold and can sign without any co-signer.
+    fn make_1of1_share() -> ([u8; 32], SharePackage) {
+        use frost_secp256k1_tr as frost;
+
+        let secret = [0x11u8; 32];
+        let signing_key = frost::SigningKey::deserialize(&secret).unwrap();
+        let vk = frost::VerifyingKey::from(&signing_key);
+        let vk_bytes = vk.serialize().unwrap();
+
+        let identifier = frost::Identifier::try_from(1u16).unwrap();
+        let signing_share = frost::keys::SigningShare::deserialize(&secret).unwrap();
+        let verifying_share = frost::keys::VerifyingShare::deserialize(&vk_bytes).unwrap();
+        let key_package =
+            frost::keys::KeyPackage::new(identifier, signing_share, verifying_share, vk, 1);
+
+        let mut verifying_shares = std::collections::BTreeMap::new();
+        verifying_shares.insert(identifier, verifying_share);
+        let pubkey_package = frost::keys::PublicKeyPackage::new(verifying_shares, vk, Some(1));
+
+        let group_pubkey: [u8; 32] = vk_bytes[1..33].try_into().unwrap();
+        let metadata = ShareMetadata::new(1, 1, 1, group_pubkey, "test".to_string());
+        let share = SharePackage::new(metadata, &key_package, &pubkey_package).unwrap();
+
+        (group_pubkey, share)
+    }
+
+    // The local-signing path: a 1-of-1 share builds a FrostSigner that produces
+    // a BIP340 signature verifiable under the group pubkey, exactly as the
+    // nip46 handler signs an event id and assembles the signed event.
+    #[test]
+    fn frost_signer_1of1_signs_and_verifies_against_group_pubkey() {
+        let (group_pubkey, share) = make_1of1_share();
+
+        let data_key = SecretKey::generate().unwrap();
+        let stored = StoredShare::encrypt(&share, &data_key).unwrap();
+        let signer = FrostSigner::new(group_pubkey, vec![stored], data_key).unwrap();
+        assert_eq!(signer.group_pubkey(), &group_pubkey);
+
+        let author = PublicKey::from_slice(&group_pubkey).unwrap();
+        let mut unsigned = UnsignedEvent::new(
+            author,
+            Timestamp::from(1_700_000_000),
+            Kind::TextNote,
+            Vec::<Tag>::new(),
+            "local frost signing",
+        );
+        unsigned.ensure_id();
+        let event_id = unsigned.id.unwrap();
+
+        let sig_bytes = signer.sign(event_id.as_bytes()).unwrap();
+
+        let sig = nostr_sdk::secp256k1::schnorr::Signature::from_slice(&sig_bytes).unwrap();
+        let event = Event::new(
+            event_id,
+            author,
+            unsigned.created_at,
+            unsigned.kind,
+            unsigned.tags.clone(),
+            unsigned.content.clone(),
+            sig,
+        );
+
+        assert!(
+            event.verify().is_ok(),
+            "1-of-1 local FROST signature must verify under group_pubkey"
+        );
+    }
+}

--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -392,6 +392,27 @@ impl Server {
         .await
     }
 
+    pub async fn new_frost_with_proxy(
+        frost_signer: FrostSigner,
+        transport_secret: [u8; 32],
+        relay_urls: &[String],
+        callbacks: Option<Arc<dyn ServerCallbacks>>,
+        config: ServerConfig,
+        proxy: Option<SocketAddr>,
+    ) -> Result<Self> {
+        let keyring = Arc::new(Mutex::new(Keyring::new()));
+        Self::new_with_config_and_proxy(
+            keyring,
+            Some(frost_signer),
+            Some(transport_secret),
+            relay_urls,
+            callbacks,
+            config,
+            proxy,
+        )
+        .await
+    }
+
     pub async fn new_network_frost(
         network_signer: NetworkFrostSigner,
         transport_secret: [u8; 32],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for single-share FROST key recovery.
  * Enhanced proxy support for signing server initialization.

* **Tests**
  * Added test coverage for local FROST key signing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->