### PR TITLE
nip46: opt-in short-clamped timed-remember for NIP-98 auth

### DIFF
--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -21,10 +21,8 @@ use crate::permissions::{AppPermission, Permission, PermissionDuration, Permissi
 use crate::rate_limit::{RateLimitConfig, RateLimiter};
 use crate::types::{
     ApprovalRequest, ApprovalResult, RememberDuration, ServerCallbacks, NIP98_HTTP_AUTH,
+    NIP98_MAX_REMEMBER_SECS,
 };
-
-// #613: short clamp for the kind-27235 bearer-credential threat (10 minutes).
-const NIP98_MAX_REMEMBER_SECS: u64 = 600;
 
 fn clamp_nip98_remember(remember: RememberDuration) -> RememberDuration {
     match remember.as_seconds() {
@@ -1630,14 +1628,24 @@ mod tests {
         );
         handler.handle_sign_event(app, first).await.unwrap();
 
-        let second = UnsignedEvent::new(signer_pk, Timestamp::now(), NIP98_HTTP_AUTH, tags, "");
+        // Second request uses a DIFFERENT url/method: the grant is scoped to
+        // (app, kind) only, so within the window it covers any url/method. This
+        // documents the time-only scope boundary (#613) rather than implying
+        // per-url scoping.
+        let other_tags = vec![
+            Tag::parse(["u", "https://b.example/other"]).unwrap(),
+            Tag::parse(["method", "POST"]).unwrap(),
+        ];
+        let second =
+            UnsignedEvent::new(signer_pk, Timestamp::now(), NIP98_HTTP_AUTH, other_tags, "");
         handler.handle_sign_event(app, second).await.unwrap();
 
         assert_eq!(
             cb.sign_event_prompts
                 .load(std::sync::atomic::Ordering::SeqCst),
             1,
-            "an opt-in OneMinute remember must skip the prompt on the next NIP-98 request"
+            "an opt-in OneMinute remember skips the prompt on the next NIP-98 request, \
+             even for a different url/method within the clamped window"
         );
         let pm = permissions.lock().await;
         let granted = pm.get_app(&app).unwrap();
@@ -1648,6 +1656,11 @@ mod tests {
     #[test]
     fn clamp_nip98_remember_never_exceeds_max() {
         use RememberDuration::*;
+        // Lock the over-limit fallback to the constant: the clamp returns
+        // `TenMinutes` for anything past the cap, which is only safe while
+        // `TenMinutes` equals `NIP98_MAX_REMEMBER_SECS`. Catches drift if either
+        // the constant or the variant's seconds change independently.
+        assert_eq!(TenMinutes.as_seconds(), Some(NIP98_MAX_REMEMBER_SECS));
         assert_eq!(clamp_nip98_remember(JustThisTime), JustThisTime);
         assert_eq!(clamp_nip98_remember(OneMinute), OneMinute);
         assert_eq!(clamp_nip98_remember(FiveMinutes), FiveMinutes);

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -23,6 +23,18 @@ use crate::types::{
     ApprovalRequest, ApprovalResult, RememberDuration, ServerCallbacks, NIP98_HTTP_AUTH,
 };
 
+// #613: short clamp for the kind-27235 bearer-credential threat (10 minutes).
+const NIP98_MAX_REMEMBER_SECS: u64 = 600;
+
+fn clamp_nip98_remember(remember: RememberDuration) -> RememberDuration {
+    match remember.as_seconds() {
+        None if remember == RememberDuration::JustThisTime => RememberDuration::JustThisTime,
+        None => RememberDuration::TenMinutes,
+        Some(secs) if secs <= NIP98_MAX_REMEMBER_SECS => remember,
+        Some(_) => RememberDuration::TenMinutes,
+    }
+}
+
 fn prepare_frost_event(
     pubkey: PublicKey,
     unsigned: &UnsignedEvent,
@@ -448,12 +460,13 @@ impl SignerHandler {
             // window skip the prompt. `JustThisTime` is the one-shot default
             // and does not persist; the next request prompts again.
             //
-            // NIP-98 (kind 27235) is never remembered: its security-relevant
-            // url/method live in tags the prompt does not surface, so a
-            // per-(app,kind) grant would auto-approve any url/method after one
-            // tap (bearer-credential threat). Force per-request approval.
+            // #613: NIP-98 (kind 27235) carries security-relevant url/method
+            // in tags the prompt does not surface, so a long-lived grant would
+            // auto-approve any url/method after one tap (bearer-credential
+            // threat). The remember is opt-in and clamped to a short window
+            // (`NIP98_MAX_REMEMBER_SECS`); `Forever` is never honored.
             let remember = if kind == NIP98_HTTP_AUTH {
-                RememberDuration::JustThisTime
+                clamp_nip98_remember(result.remember)
             } else {
                 result.remember
             };
@@ -1537,7 +1550,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn nip98_is_never_remembered_even_when_approved_forever() {
+    async fn nip98_forever_is_clamped_to_timed_remember() {
         let keyring = setup_keyring();
         let permissions = Arc::new(Mutex::new(PermissionManager::new()));
         let audit = Arc::new(Mutex::new(AuditLog::new(100)));
@@ -1572,19 +1585,92 @@ mod tests {
         assert_eq!(
             cb.sign_event_prompts
                 .load(std::sync::atomic::Ordering::SeqCst),
-            2,
-            "NIP-98 must prompt on every request even after approve=Forever"
+            1,
+            "NIP-98 Forever is clamped to a timed remember, so the second request must skip the prompt"
         );
         let pm = permissions.lock().await;
         let granted = pm.get_app(&app).unwrap();
         assert!(
             !granted.auto_approve_kinds.contains(&NIP98_HTTP_AUTH),
-            "NIP-98 must not be persisted as an auto-approve kind"
+            "NIP-98 must never be granted forever (auto-approve kind)"
         );
         assert!(
-            !granted.has_unexpired_timed_grant(NIP98_HTTP_AUTH),
-            "NIP-98 must not be persisted as a timed grant"
+            granted.has_unexpired_timed_grant(NIP98_HTTP_AUTH),
+            "NIP-98 Forever must be persisted as a short timed grant"
         );
+    }
+
+    #[tokio::test]
+    async fn nip98_opt_in_short_remember_skips_next_prompt() {
+        let keyring = setup_keyring();
+        let permissions = Arc::new(Mutex::new(PermissionManager::new()));
+        let audit = Arc::new(Mutex::new(AuditLog::new(100)));
+        let cb = Arc::new(RememberingCallbacks {
+            remember: RememberDuration::OneMinute,
+            sign_event_prompts: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let handler =
+            SignerHandler::new(keyring, Arc::clone(&permissions), audit, Some(cb.clone()))
+                .with_connect_grant(Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT);
+
+        let app = Keys::generate().public_key();
+        handler.handle_connect(app, None, None, None).await.unwrap();
+        let signer_pk = handler.our_pubkey().await.unwrap();
+
+        let tags = vec![
+            Tag::parse(["u", "https://a.example/api"]).unwrap(),
+            Tag::parse(["method", "GET"]).unwrap(),
+        ];
+        let first = UnsignedEvent::new(
+            signer_pk,
+            Timestamp::now(),
+            NIP98_HTTP_AUTH,
+            tags.clone(),
+            "",
+        );
+        handler.handle_sign_event(app, first).await.unwrap();
+
+        let second = UnsignedEvent::new(signer_pk, Timestamp::now(), NIP98_HTTP_AUTH, tags, "");
+        handler.handle_sign_event(app, second).await.unwrap();
+
+        assert_eq!(
+            cb.sign_event_prompts
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "an opt-in OneMinute remember must skip the prompt on the next NIP-98 request"
+        );
+        let pm = permissions.lock().await;
+        let granted = pm.get_app(&app).unwrap();
+        assert!(granted.has_unexpired_timed_grant(NIP98_HTTP_AUTH));
+        assert!(!granted.auto_approve_kinds.contains(&NIP98_HTTP_AUTH));
+    }
+
+    #[test]
+    fn clamp_nip98_remember_never_exceeds_max() {
+        use RememberDuration::*;
+        assert_eq!(clamp_nip98_remember(JustThisTime), JustThisTime);
+        assert_eq!(clamp_nip98_remember(OneMinute), OneMinute);
+        assert_eq!(clamp_nip98_remember(FiveMinutes), FiveMinutes);
+        assert_eq!(clamp_nip98_remember(TenMinutes), TenMinutes);
+        assert_eq!(clamp_nip98_remember(OneHour), TenMinutes);
+        assert_eq!(clamp_nip98_remember(OneDay), TenMinutes);
+        assert_eq!(clamp_nip98_remember(Forever), TenMinutes);
+        for variant in [
+            JustThisTime,
+            OneMinute,
+            FiveMinutes,
+            TenMinutes,
+            OneHour,
+            OneDay,
+            Forever,
+        ] {
+            if let Some(secs) = clamp_nip98_remember(variant).as_seconds() {
+                assert!(
+                    secs <= NIP98_MAX_REMEMBER_SECS,
+                    "{variant:?} clamped above the NIP-98 max"
+                );
+            }
+        }
     }
 
     /// Captures every `persist_permissions` snapshot so a test can assert the

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -8,7 +8,7 @@ use nostr_sdk::prelude::*;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
-use crate::types::NIP98_HTTP_AUTH;
+use crate::types::{NIP98_HTTP_AUTH, NIP98_MAX_REMEMBER_SECS};
 
 bitflags::bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -112,7 +112,9 @@ pub struct AppPermission {
     /// and restored out-of-band via the `StoredBunkerPermission` path: on save
     /// they are written to `StoredTimedKindGrant`, and `restore_persisted`
     /// reloads them, pruning any entry that expired while the bunker was down
-    /// and excluding NIP-98 (kind 27235), which is never remembered.
+    /// and excluding NIP-98 (kind 27235): a NIP-98 timed grant (#613) is
+    /// remembered in memory for a short clamped window but is never persisted
+    /// or restored across a restart.
     #[serde(skip)]
     pub timed_kind_grants: HashMap<Kind, u64>,
     pub connected_at: Timestamp,
@@ -293,6 +295,17 @@ impl PermissionManager {
         // channels stay blocked here so a 27235 entry that slipped into a grant
         // set or a persisted/upgraded config cannot bypass the prompt. Only a
         // live, clamped timed grant skips it.
+        //
+        // Scope: the grant is keyed on (app pubkey, kind) only, so within the
+        // clamped window it covers any url/method/relay. This matches Amber,
+        // whose NIP-98 remember is also keyed on (app, kind) with no relay or
+        // url/method scoping (it reserves relay scoping for NIP-42 relay auth,
+        // kind 22242). Per-url scoping is intentionally not used: NIP-98 signs a
+        // fresh `u` per request, so it would re-prompt on every API call and
+        // defeat the fix. Keep is stricter than Amber on duration: Amber allows
+        // a forever/one-week NIP-98 remember, while Keep hard-clamps it to
+        // NIP98_MAX_REMEMBER_SECS. The bound is that short clamp plus the
+        // client's existing NIP-46 authorization.
         if kind == NIP98_HTTP_AUTH {
             return !self.apps.get(pubkey).is_some_and(|app| {
                 !app.duration.is_expired(app.connected_at) && app.has_unexpired_timed_grant(kind)
@@ -350,6 +363,15 @@ impl PermissionManager {
         if secs == 0 {
             return false;
         }
+        // #613 defense-in-depth: NIP-98 (kind 27235) is a bearer-credential
+        // grant, so its lifetime bound is enforced here at the authoritative
+        // write path, not only in the approval-path clamp. Even if a future
+        // caller forgets to clamp, the grant can never exceed the cap.
+        let secs = if kind == NIP98_HTTP_AUTH {
+            secs.min(NIP98_MAX_REMEMBER_SECS)
+        } else {
+            secs
+        };
         let now = now_unix_secs();
         // Clock error reads as u64::MAX (fail-closed for expiry checks); refuse
         // to write a grant we could not bound, otherwise it would read as
@@ -834,6 +856,76 @@ mod tests {
             pm.needs_approval(&pubkey, NIP98_HTTP_AUTH),
             "an expired app duration must override a live NIP-98 timed grant"
         );
+    }
+
+    #[test]
+    fn nip98_re_prompts_after_grant_own_expiry() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+
+        // A grant whose own expiry is already in the past must re-prompt, even
+        // while the app duration still holds.
+        if let Some(app) = pm.apps.get_mut(&pubkey) {
+            app.timed_kind_grants
+                .insert(NIP98_HTTP_AUTH, now_unix_secs() - 1);
+        }
+        assert!(
+            pm.needs_approval(&pubkey, NIP98_HTTP_AUTH),
+            "an expired NIP-98 timed grant must re-prompt"
+        );
+    }
+
+    #[test]
+    fn grant_kind_for_caps_nip98_lifetime() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+
+        // Defense-in-depth: an over-long NIP-98 grant request is capped to the
+        // max at the write path, independent of the approval-path clamp.
+        let before = now_unix_secs();
+        assert!(pm.grant_kind_for(&pubkey, NIP98_HTTP_AUTH, 24 * 60 * 60));
+        let expiry = *pm
+            .get_app(&pubkey)
+            .unwrap()
+            .timed_kind_grants
+            .get(&NIP98_HTTP_AUTH)
+            .unwrap();
+        assert!(
+            expiry <= before.saturating_add(NIP98_MAX_REMEMBER_SECS) + 1,
+            "NIP-98 grant lifetime must be capped to NIP98_MAX_REMEMBER_SECS"
+        );
+    }
+
+    #[test]
+    fn stored_snapshot_never_emits_nip98_timed_grant() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+
+        pm.grant_kind_for(&pubkey, Kind::TextNote, 3600);
+        // Inject a NIP-98 timed grant directly past the write-path cap to prove
+        // the save filter is an independent layer.
+        if let Some(app) = pm.apps.get_mut(&pubkey) {
+            app.timed_kind_grants
+                .insert(NIP98_HTTP_AUTH, now_unix_secs() + 600);
+        }
+        let snapshot = pm.stored_snapshot();
+        let app = snapshot
+            .iter()
+            .find(|p| p.pubkey_hex == pubkey.to_hex())
+            .unwrap();
+        assert!(
+            app.timed_kind_grants
+                .iter()
+                .all(|g| g.kind != NIP98_HTTP_AUTH.as_u16()),
+            "stored_snapshot must never persist a NIP-98 timed grant"
+        );
+        assert!(app
+            .timed_kind_grants
+            .iter()
+            .any(|g| g.kind == Kind::TextNote.as_u16()));
     }
 
     #[test]

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -287,12 +287,16 @@ impl PermissionManager {
     }
 
     pub fn needs_approval(&self, pubkey: &PublicKey, kind: Kind) -> bool {
-        // #575: NIP-98 (kind 27235) must ALWAYS prompt per-request and can
-        // never be auto-approved by any per-app, global, or timed grant. This
-        // is the authoritative chokepoint: even a 27235 entry that slipped into
-        // a grant set or a persisted/upgraded config cannot bypass the prompt.
+        // #613: NIP-98 (kind 27235) is opt-in remembered only via an explicit,
+        // short, unexpired per-app timed grant written by the approval path. It
+        // is never covered by a forever (auto_approve) or global grant: those
+        // channels stay blocked here so a 27235 entry that slipped into a grant
+        // set or a persisted/upgraded config cannot bypass the prompt. Only a
+        // live, clamped timed grant skips it.
         if kind == NIP98_HTTP_AUTH {
-            return true;
+            return !self.apps.get(pubkey).is_some_and(|app| {
+                !app.duration.is_expired(app.connected_at) && app.has_unexpired_timed_grant(kind)
+            });
         }
         if let Some(app) = self.apps.get(pubkey) {
             if !app.duration.is_expired(app.connected_at) {
@@ -344,10 +348,6 @@ impl PermissionManager {
     /// callers only audit real state changes.
     pub fn grant_kind_for(&mut self, pubkey: &PublicKey, kind: Kind, secs: u64) -> bool {
         if secs == 0 {
-            return false;
-        }
-        // #575: NIP-98 (kind 27235) is never remembered.
-        if kind == NIP98_HTTP_AUTH {
             return false;
         }
         let now = now_unix_secs();
@@ -423,7 +423,7 @@ impl PermissionManager {
                 timed_kind_grants: app
                     .timed_kind_grants
                     .iter()
-                    .filter(|(_, expiry)| now < **expiry)
+                    .filter(|(kind, expiry)| **kind != NIP98_HTTP_AUTH && now < **expiry)
                     .map(|(k, expiry)| StoredTimedKindGrant {
                         kind: k.as_u16(),
                         expires_at: *expiry,
@@ -784,24 +784,55 @@ mod tests {
     }
 
     #[test]
-    fn nip98_always_needs_approval_despite_every_grant() {
+    fn nip98_skipped_only_by_explicit_timed_grant() {
         let mut pm = PermissionManager::new();
         let pubkey = Keys::generate().public_key();
         pm.connect(pubkey, "App".into());
 
-        // Force NIP-98 into every auto-approve channel directly, bypassing the
-        // write-path guards, to prove the read-path chokepoint is authoritative.
+        // #613: a forever (auto_approve) or global grant must NOT bypass NIP-98,
+        // even when forced directly into the sets past the write-path guards.
         pm.set_auto_approve_kinds(HashSet::from([NIP98_HTTP_AUTH]));
         if let Some(app) = pm.apps.get_mut(&pubkey) {
             app.auto_approve_kinds.insert(NIP98_HTTP_AUTH);
-            app.timed_kind_grants
-                .insert(NIP98_HTTP_AUTH, now_unix_secs() + 3600);
         }
-
         assert!(
             pm.needs_approval(&pubkey, NIP98_HTTP_AUTH),
-            "NIP-98 must always need approval even when present in per-app, \
-             global, and unexpired timed grant sets"
+            "NIP-98 must still prompt when only forever/global grants cover it"
+        );
+
+        // Only an explicit, unexpired per-app timed grant skips the prompt.
+        if let Some(app) = pm.apps.get_mut(&pubkey) {
+            app.timed_kind_grants
+                .insert(NIP98_HTTP_AUTH, now_unix_secs() + 600);
+        }
+        assert!(
+            !pm.needs_approval(&pubkey, NIP98_HTTP_AUTH),
+            "an explicit unexpired NIP-98 timed grant skips the prompt"
+        );
+    }
+
+    #[test]
+    fn nip98_timed_grant_does_not_outlive_app_duration() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+
+        if let Some(app) = pm.apps.get_mut(&pubkey) {
+            app.timed_kind_grants
+                .insert(NIP98_HTTP_AUTH, now_unix_secs() + 600);
+        }
+        assert!(
+            !pm.needs_approval(&pubkey, NIP98_HTTP_AUTH),
+            "a live NIP-98 timed grant skips the prompt while the app duration holds"
+        );
+
+        if let Some(app) = pm.apps.get_mut(&pubkey) {
+            app.duration = PermissionDuration::Seconds(0);
+            app.connected_at = Timestamp::from(1);
+        }
+        assert!(
+            pm.needs_approval(&pubkey, NIP98_HTTP_AUTH),
+            "an expired app duration must override a live NIP-98 timed grant"
         );
     }
 
@@ -845,8 +876,8 @@ mod tests {
         pm.connect(pubkey, "App".into());
 
         pm.grant_kind_for(&pubkey, Kind::TextNote, 3600);
-        // grant_kind_for refuses NIP-98, so inject it directly to model a
-        // hostile/legacy persisted row.
+        // Inject a NIP-98 timed grant directly to model a hostile/legacy
+        // persisted row; restore must drop it regardless of how it got there.
         if let Some(app) = pm.apps.get_mut(&pubkey) {
             app.timed_kind_grants
                 .insert(NIP98_HTTP_AUTH, now_unix_secs() + 3600);

--- a/keep-nip46/src/types.rs
+++ b/keep-nip46/src/types.rs
@@ -7,6 +7,13 @@ use nostr_sdk::prelude::*;
 /// auto-approve this kind to avoid a per-request prompt that would time out.
 pub const NIP98_HTTP_AUTH: Kind = Kind::Custom(27235);
 
+/// #613: maximum lifetime (seconds) for an opt-in NIP-98 (kind 27235) timed
+/// remember-grant. NIP-98 carries a per-request `u`/`method` that the approval
+/// prompt does not surface, so a remembered grant is a short-lived bearer
+/// credential: clamp it hard. Single source of truth for both the approval-path
+/// clamp and the authoritative `grant_kind_for` write-path cap.
+pub const NIP98_MAX_REMEMBER_SECS: u64 = 600;
+
 #[derive(Debug, Clone)]
 pub struct LogEvent {
     pub app: String,


### PR DESCRIPTION
Closes #613

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remembered app permissions for NIP-98 are now limited to a short duration (10 minutes) rather than treating “forever” as an unlimited grant.

* **Bug Fixes**
  * Approval prompts are reduced: prompts are skipped only when there is an explicit, unexpired app-specific NIP-98 timed grant.
  * Global/“forever” grants no longer bypass the approval prompt for NIP-98.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->