### PR TITLE
Threshold OPRF over secp256k1 for FROST-gated LUKS unlock (opt-in, guards no data yet)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2160,6 +2160,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4426,12 +4437,14 @@ dependencies = [
  "memsecurity",
  "proptest",
  "rand 0.10.1",
+ "rand_core 0.6.4",
  "redb 2.6.3",
  "redb 4.1.0",
  "scrypt 0.12.0",
  "secrecy",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "sha2 0.11.0",
  "subtle",
  "temp-env",
@@ -4439,6 +4452,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "unicode-normalization",
+ "voprf",
  "zeroize",
 ]
 
@@ -9512,6 +9526,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "voprf"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28f59c30c76e2fea54cdece6a054e2662feffa7ab19658a7887524265ee39470"
+dependencies = [
+ "curve25519-dalek",
+ "derive-where",
+ "digest 0.10.7",
+ "displaydoc",
+ "elliptic-curve",
+ "generic-array",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common 0.1.7",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -899,6 +899,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 
 [[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,7 +945,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -951,7 +963,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1932,8 +1944,22 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96272c2ff28b807e09250b180ad1fb7889a3258f7455759b5c3c58b719467130"
+dependencies = [
+ "num-traits",
+ "rand_core 0.6.4",
+ "serdect 0.3.0",
  "subtle",
  "zeroize",
 ]
@@ -1944,7 +1970,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "typenum",
 ]
@@ -2347,10 +2373,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
- "crypto-bigint",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff",
- "generic-array",
+ "generic-array 0.14.7",
  "group",
  "hkdf 0.12.4",
  "pem-rfc7468",
@@ -2358,6 +2384,21 @@ dependencies = [
  "rand_core 0.6.4",
  "sec1",
  "subtle",
+ "tap",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve-tools"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de2b6fae800f08032a6ea32995b52925b1d451bff9d445c8ab2932323277faf"
+dependencies = [
+ "elliptic-curve",
+ "heapless 0.8.0",
+ "hex",
+ "multiexp",
+ "serde",
  "zeroize",
 ]
 
@@ -2566,6 +2607,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
+ "bitvec",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2646,7 +2688,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -2774,7 +2816,7 @@ dependencies = [
  "postcard",
  "rand_core 0.6.4",
  "serde",
- "serdect",
+ "serdect 0.2.0",
  "thiserror 2.0.18",
  "visibility",
  "zeroize",
@@ -2846,6 +2888,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -3015,6 +3063,17 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "generic-array"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
+dependencies = [
+ "rustversion",
+ "serde_core",
+ "typenum",
 ]
 
 [[package]]
@@ -3410,6 +3469,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,10 +3515,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
- "hash32",
+ "hash32 0.2.1",
  "rustc_version",
  "serde",
- "spin",
+ "spin 0.9.8",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -3610,6 +3688,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
+ "serde",
  "typenum",
 ]
 
@@ -4103,7 +4182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding 0.3.3",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -4322,6 +4401,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "keep-agent"
 version = "0.4.9"
 dependencies = [
@@ -4453,6 +4541,7 @@ dependencies = [
  "tracing",
  "unicode-normalization",
  "voprf",
+ "vsss-rs",
  "zeroize",
 ]
 
@@ -5260,6 +5349,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiexp"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ec2ce93a6f06ac6cae04c1da3f2a6a24fcfc1f0eb0b4e0f3d302f0df45326cb"
+dependencies = [
+ "ff",
+ "group",
+ "rand_core 0.6.4",
+ "rustversion",
+ "std-shims",
+ "zeroize",
+]
+
+[[package]]
 name = "mundy"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5661,6 +5764,8 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "rand 0.8.6",
+ "serde",
 ]
 
 [[package]]
@@ -5670,6 +5775,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
+ "rand 0.8.6",
+ "serde",
 ]
 
 [[package]]
@@ -5718,6 +5825,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -6675,7 +6783,7 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
- "heapless",
+ "heapless 0.7.17",
  "serde",
 ]
 
@@ -6967,6 +7075,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -7720,7 +7834,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der 0.7.10",
- "generic-array",
+ "generic-array 0.14.7",
  "pkcs8",
  "subtle",
  "zeroize",
@@ -7898,6 +8012,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "serialport"
 version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7947,6 +8071,16 @@ dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]
@@ -8252,6 +8386,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8281,6 +8421,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "std-shims"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227c4f8561598188d0df96dbe749824576174bba278b5b6bb2eacff1066067d0"
+dependencies = [
+ "hashbrown 0.16.1",
+ "rustversion",
+ "spin 0.10.0",
+]
 
 [[package]]
 name = "strict-num"
@@ -8401,6 +8552,12 @@ dependencies = [
  "toml 0.8.2",
  "version-compare",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -9539,7 +9696,7 @@ dependencies = [
  "digest 0.10.7",
  "displaydoc",
  "elliptic-curve",
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
@@ -9555,6 +9712,27 @@ checksum = "6ba782755fc073877e567c2253c0be48e4aa9a254c232d36d3985dfae0bd5205"
 dependencies = [
  "libc",
  "nix 0.31.3",
+]
+
+[[package]]
+name = "vsss-rs"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ec751bdcc8bda099e269b24cc6b4ad14f9ce8b0490c1599174070e792ecd70c"
+dependencies = [
+ "crypto-bigint 0.5.5",
+ "crypto-bigint 0.6.1",
+ "elliptic-curve",
+ "elliptic-curve-tools",
+ "generic-array 1.4.3",
+ "hex",
+ "hybrid-array",
+ "num",
+ "rand_core 0.6.4",
+ "serde",
+ "sha3",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -10880,6 +11058,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x11"

--- a/keep-core/Cargo.toml
+++ b/keep-core/Cargo.toml
@@ -14,7 +14,7 @@ allow-ws = []
 allow-internal = []
 ed25519 = ["dep:frost-ed25519"]
 # Threshold-OPRF unlock primitive (frost-gate v2 / KeepNode). Opt-in; pulls voprf.
-oprf = ["dep:voprf", "dep:sha2_010", "dep:rand_core_06"]
+oprf = ["dep:voprf", "dep:sha2_010", "dep:rand_core_06", "dep:vsss-rs"]
 
 [dependencies]
 argon2 = "0.5"
@@ -36,6 +36,9 @@ frost-ed25519 = { version = "3.0.0", optional = true }
 voprf = { version = "0.5", optional = true }
 sha2_010 = { package = "sha2", version = "0.10", optional = true }
 rand_core_06 = { package = "rand_core", version = "0.6", features = ["getrandom"], optional = true }
+# Vetted Shamir/VSS over secp256k1 (Apache-2.0 OR MIT). Used for the t-of-n key split and the
+# in-exponent Lagrange combination of partial evaluations (combine_shares_group).
+vsss-rs = { version = "5", optional = true }
 
 bip39 = { workspace = true }
 bitcoin = { workspace = true }

--- a/keep-core/Cargo.toml
+++ b/keep-core/Cargo.toml
@@ -14,7 +14,8 @@ allow-ws = []
 allow-internal = []
 ed25519 = ["dep:frost-ed25519"]
 # Threshold-OPRF unlock primitive (frost-gate v2 / KeepNode). Opt-in; pulls voprf.
-oprf = ["dep:voprf", "dep:sha2_010", "dep:rand_core_06", "dep:vsss-rs"]
+# hash2curve (k256 GroupDigest / RFC 9380) is only needed for the OPRF path, so gate it here.
+oprf = ["dep:voprf", "dep:sha2_010", "dep:rand_core_06", "dep:vsss-rs", "k256/hash2curve"]
 
 [dependencies]
 argon2 = "0.5"
@@ -26,7 +27,7 @@ blake2 = "0.10"
 sha2 = "0.11"
 hkdf = "0.13"
 hmac = "0.13"
-k256 = { version = "0.13", features = ["schnorr", "ecdh", "hash2curve"] }
+k256 = { version = "0.13", features = ["schnorr", "ecdh"] }
 rand = "0.10"
 frost-secp256k1-tr = "3.0.0"
 frost-ed25519 = { version = "3.0.0", optional = true }

--- a/keep-core/Cargo.toml
+++ b/keep-core/Cargo.toml
@@ -13,6 +13,8 @@ allow-ws = []
 # WARNING: allow-internal disables SSRF internal-host checks. MUST NOT be enabled in production.
 allow-internal = []
 ed25519 = ["dep:frost-ed25519"]
+# Threshold-OPRF unlock primitive (frost-gate v2 / KeepNode). Opt-in; pulls voprf.
+oprf = ["dep:voprf", "dep:sha2_010", "dep:rand_core_06"]
 
 [dependencies]
 argon2 = "0.5"
@@ -24,10 +26,16 @@ blake2 = "0.10"
 sha2 = "0.11"
 hkdf = "0.13"
 hmac = "0.13"
-k256 = { version = "0.13", features = ["schnorr", "ecdh"] }
+k256 = { version = "0.13", features = ["schnorr", "ecdh", "hash2curve"] }
 rand = "0.10"
 frost-secp256k1-tr = "3.0.0"
 frost-ed25519 = { version = "3.0.0", optional = true }
+# RFC 9497 OPRF reference implementation (MIT). secp256k1 bound via a local CipherSuite.
+# voprf rides the elliptic-curve 0.13 / digest 0.10 ecosystem, so the OPRF hash must be the
+# matching sha2 0.10 (coexists with keep-core's sha2 0.11 via Cargo multi-versioning).
+voprf = { version = "0.5", optional = true }
+sha2_010 = { package = "sha2", version = "0.10", optional = true }
+rand_core_06 = { package = "rand_core", version = "0.6", features = ["getrandom"], optional = true }
 
 bip39 = { workspace = true }
 bitcoin = { workspace = true }

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -59,6 +59,9 @@ pub mod keys;
 pub mod migration;
 /// BIP-39 mnemonic generation and validation.
 pub mod mnemonic;
+/// Threshold-OPRF unlock primitive (frost-gate v2). Opt-in via the `oprf` feature.
+#[cfg(feature = "oprf")]
+pub mod oprf;
 /// NIP-06 key derivation from mnemonic seed phrase.
 pub mod nip06;
 pub(crate) mod rate_limit;

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -59,11 +59,11 @@ pub mod keys;
 pub mod migration;
 /// BIP-39 mnemonic generation and validation.
 pub mod mnemonic;
+/// NIP-06 key derivation from mnemonic seed phrase.
+pub mod nip06;
 /// Threshold-OPRF unlock primitive (frost-gate v2). Opt-in via the `oprf` feature.
 #[cfg(feature = "oprf")]
 pub mod oprf;
-/// NIP-06 key derivation from mnemonic seed phrase.
-pub mod nip06;
 pub(crate) mod rate_limit;
 /// Relay configuration for FROST shares.
 pub mod relay;

--- a/keep-core/src/oprf.rs
+++ b/keep-core/src/oprf.rs
@@ -27,6 +27,74 @@ impl CipherSuite for Secp256k1Sha256 {
     type Hash = sha2_010::Sha256;
 }
 
+/// 2-of-3 (configurable t-of-n) threshold layer over the secp256k1 OPRF.
+///
+/// The OPRF key is Shamir-shared across the share-holders (box / phone / replica). Each holder
+/// returns a partial evaluation `s_i * B` of the client's blinded element `B`; a quorum is
+/// combined in the exponent (Lagrange) to `B^s` WITHOUT reconstructing the key. The combined
+/// element is fed back into voprf's unchanged `finalize`.
+///
+/// Vetted libraries do the dangerous parts: `vsss-rs` for the Shamir split and the in-exponent
+/// Lagrange combination (`combine_shares_group`), `k256` for the group arithmetic, `voprf` for
+/// blind/finalize. The only bespoke step is `s_i * B`. DLEQ verifiability (malicious-server
+/// protection) is a follow-on; this layer proves the threshold combination is correct.
+pub mod threshold {
+    use super::Secp256k1Sha256;
+    use k256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
+    use k256::{EncodedPoint, ProjectivePoint, Scalar};
+    use voprf::{BlindedElement, EvaluationElement};
+    use vsss_rs::{
+        DefaultShare, IdentifierPrimeField, ReadableShareSet, Share, ValueGroup, ValuePrimeField,
+    };
+
+    type Id = IdentifierPrimeField<Scalar>;
+    /// A scalar share of the OPRF key (held by a box / phone / replica).
+    pub type KeyShare = DefaultShare<Id, ValuePrimeField<Scalar>>;
+    /// A share-holder's partial evaluation `s_i * B` (a group element, same identifier).
+    pub type PartialEval = DefaultShare<Id, ValueGroup<ProjectivePoint>>;
+
+    /// Split an OPRF key into `n` shares with threshold `t` over secp256k1's scalar field.
+    pub fn split_key(
+        secret: &Scalar,
+        t: usize,
+        n: usize,
+        rng: impl rand_core_06::RngCore + rand_core_06::CryptoRng,
+    ) -> Result<Vec<KeyShare>, String> {
+        vsss_rs::shamir::split_secret::<KeyShare>(t, n, &IdentifierPrimeField(*secret), rng)
+            .map_err(|e| format!("split: {e:?}"))
+    }
+
+    /// A share-holder's partial evaluation: `P_i = s_i * B`, carrying the same identifier so the
+    /// combination knows its Lagrange index. The share `s_i` never leaves the holder.
+    pub fn partial_eval(
+        share: &KeyShare,
+        blinded: &BlindedElement<Secp256k1Sha256>,
+    ) -> Result<PartialEval, String> {
+        let b = point_from_bytes(blinded.serialize().as_slice())?;
+        let s_i: Scalar = **share.value();
+        Ok(DefaultShare::with_identifier_and_value(
+            *share.identifier(),
+            ValueGroup::from(b * s_i),
+        ))
+    }
+
+    /// Combine >= t partial evaluations into the evaluation element `B^s` (Lagrange in the
+    /// exponent, via vsss-rs), then hand back a voprf `EvaluationElement` for `finalize`. The
+    /// key is never reconstructed.
+    pub fn combine(partials: &[PartialEval]) -> Result<EvaluationElement<Secp256k1Sha256>, String> {
+        let bs: ValueGroup<ProjectivePoint> =
+            partials.combine().map_err(|e| format!("combine: {e:?}"))?;
+        EvaluationElement::deserialize(bs.0.to_encoded_point(true).as_bytes())
+            .map_err(|e| format!("deserialize eval: {e:?}"))
+    }
+
+    fn point_from_bytes(bytes: &[u8]) -> Result<ProjectivePoint, String> {
+        let ep = EncodedPoint::from_bytes(bytes).map_err(|e| format!("encoded point: {e:?}"))?;
+        Option::<ProjectivePoint>::from(ProjectivePoint::from_encoded_point(&ep))
+            .ok_or_else(|| "bad point".into())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -59,5 +127,38 @@ mod tests {
         let e3 = server.blind_evaluate(&b3.message);
         let out3 = b3.state.finalize(other, &e3).expect("finalize");
         assert_ne!(out1, out3, "different input must give a different output");
+    }
+
+    /// Correctness oracle for the threshold layer: for the SAME blinded element, the 2-of-3
+    /// threshold combination must produce exactly the same OPRF output as a single-key server
+    /// holding the un-split key, for every quorum pair. If they match, the in-exponent Lagrange
+    /// combination is correct and no party ever reconstructed the key.
+    #[test]
+    fn threshold_matches_single_key() {
+        use k256::Scalar;
+        let mut rng = rand_core_06::OsRng;
+        let input: &[u8] = b"keep-node-vault-v1";
+
+        // One key, two ways: a single-key voprf server, and a 2-of-3 Shamir split of the same key.
+        let s = <Scalar as k256::elliptic_curve::Field>::random(&mut rng);
+        let server = OprfServer::<Secp256k1Sha256>::new_with_key(s.to_bytes().as_slice())
+            .expect("server from key");
+        let shares = threshold::split_key(&s, 2, 3, &mut rng).expect("split");
+        assert_eq!(shares.len(), 3);
+
+        // One blind; evaluate it both ways and finalize with the same client state.
+        let b = OprfClient::<Secp256k1Sha256>::blind(input, &mut rng).expect("blind");
+        let single = b
+            .state
+            .finalize(input, &server.blind_evaluate(&b.message))
+            .expect("single finalize");
+
+        for (i, j) in [(0, 1), (0, 2), (1, 2)] {
+            let p_i = threshold::partial_eval(&shares[i], &b.message).expect("partial i");
+            let p_j = threshold::partial_eval(&shares[j], &b.message).expect("partial j");
+            let eval = threshold::combine(&[p_i, p_j]).expect("combine");
+            let thresh = b.state.finalize(input, &eval).expect("threshold finalize");
+            assert_eq!(single, thresh, "quorum {{{i},{j}}} must equal the single-key output");
+        }
     }
 }

--- a/keep-core/src/oprf.rs
+++ b/keep-core/src/oprf.rs
@@ -141,7 +141,10 @@ mod tests {
         let b2 = OprfClient::<Secp256k1Sha256>::blind(input, &mut rng).expect("blind");
         let e2 = server.blind_evaluate(&b2.message);
         let out2 = b2.state.finalize(input, &e2).expect("finalize");
-        assert_eq!(out1, out2, "same input + key must give a stable OPRF output");
+        assert_eq!(
+            out1, out2,
+            "same input + key must give a stable OPRF output"
+        );
 
         // Different input -> different output.
         let other: &[u8] = b"keep-node-other";
@@ -180,7 +183,10 @@ mod tests {
             let p_j = threshold::partial_eval(&shares[j], &b.message).expect("partial j");
             let eval = threshold::combine(&[p_i, p_j]).expect("combine");
             let thresh = b.state.finalize(input, &eval).expect("threshold finalize");
-            assert_eq!(single, thresh, "quorum {{{i},{j}}} must equal the single-key output");
+            assert_eq!(
+                single, thresh,
+                "quorum {{{i},{j}}} must equal the single-key output"
+            );
 
             // End to end: the LUKS key derived from the threshold output matches the single-key
             // one, and is a stable 32 bytes.
@@ -196,7 +202,11 @@ mod tests {
         let out = b"oprf-output-bytes-for-the-kdf-test--";
         let k = derive_luks_key(out, "vault0", 1);
         assert_eq!(k, derive_luks_key(out, "vault0", 1), "stable");
-        assert_ne!(k, derive_luks_key(out, "vault1", 1), "separated by volume id");
+        assert_ne!(
+            k,
+            derive_luks_key(out, "vault1", 1),
+            "separated by volume id"
+        );
         assert_ne!(k, derive_luks_key(out, "vault0", 2), "separated by epoch");
     }
 }

--- a/keep-core/src/oprf.rs
+++ b/keep-core/src/oprf.rs
@@ -3,9 +3,10 @@
 //!
 //! RFC 9497 standardizes OPRF/VOPRF but defines no secp256k1 ciphersuite, so we bind the
 //! generic 2HashDH construction to secp256k1 by implementing [`voprf::CipherSuite`] over
-//! `k256::Secp256k1`. k256's `GroupDigest` provides the RFC 9380
-//! `secp256k1_XMD:SHA-256_SSWU_RO_` hash-to-curve, and voprf's `Group` is blanket-implemented
-//! for any `GroupDigest`, so no upstream patch is needed.
+//! `k256::Secp256k1`. k256's `GroupDigest` (the `hash2curve` feature) provides the RFC 9380
+//! `secp256k1_XMD:SHA-256_SSWU_RO_` hash-to-curve. voprf 0.5 implements `Group` for any `C`
+//! where `C: GroupDigest` and `ProjectivePoint<C>: CofactorGroup + ToEncodedPoint<C>`;
+//! `k256::Secp256k1` with `hash2curve` satisfies those bounds, so no upstream patch is needed.
 //!
 //! The suite `ID` is KeepNode-specific (no standard secp256k1 suite exists) and MUST be
 //! pinned: it feeds the RFC 9497 context string / DST, so changing it changes every derived

--- a/keep-core/src/oprf.rs
+++ b/keep-core/src/oprf.rs
@@ -46,6 +46,7 @@ impl CipherSuite for Secp256k1Sha256 {
 /// DoS-resistant one; it does not change what an attacker can learn.
 pub mod threshold {
     use super::Secp256k1Sha256;
+    use crate::error::CryptoError;
     use k256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
     use k256::{EncodedPoint, ProjectivePoint, Scalar};
     use voprf::{BlindedElement, EvaluationElement};
@@ -60,28 +61,39 @@ pub mod threshold {
     pub type PartialEval = DefaultShare<Id, ValueGroup<ProjectivePoint>>;
 
     /// Split an OPRF key into `n` shares with threshold `t` over secp256k1's scalar field.
+    ///
+    /// SECURITY (caller contract): the returned [`KeyShare`]s hold plaintext scalar key shares.
+    /// `KeyShare` is `Copy` and implements `Zeroize` but NOT `ZeroizeOnDrop`, so dropping a share
+    /// (or any copy of one) leaves the secret scalar in memory. The caller OWNS the returned
+    /// shares and MUST `zeroize()` each one (and any copy) once it is distributed to its holder.
+    /// Treat each share as live key material until then.
     pub fn split_key(
         secret: &Scalar,
         t: usize,
         n: usize,
         rng: impl rand_core_06::RngCore + rand_core_06::CryptoRng,
-    ) -> Result<Vec<KeyShare>, String> {
+    ) -> Result<Vec<KeyShare>, CryptoError> {
         use zeroize::Zeroize;
         // Our transient copy of the key; zeroize it once split. (The caller owns the original
         // `secret` and the returned shares, and is responsible for their secure handling.)
         let mut wrapped = IdentifierPrimeField(*secret);
         let res = vsss_rs::shamir::split_secret::<KeyShare>(t, n, &wrapped, rng)
-            .map_err(|e| format!("split: {e:?}"));
+            .map_err(|_| CryptoError::key_derivation("OPRF Shamir key split failed"));
         wrapped.0.zeroize();
         res
     }
 
     /// A share-holder's partial evaluation: `P_i = s_i * B`, carrying the same identifier so the
     /// combination knows its Lagrange index. The share `s_i` never leaves the holder.
+    ///
+    /// SECURITY: the transport layer that exposes this evaluation oracle to clients MUST enforce
+    /// per-identity authentication and strict rate limiting. The OPRF-unlock's resistance to
+    /// low-entropy-input guessing depends on bounding the number of evaluations an attacker can
+    /// obtain; an unbounded or unauthenticated oracle reduces it to an offline brute force.
     pub fn partial_eval(
         share: &KeyShare,
         blinded: &BlindedElement<Secp256k1Sha256>,
-    ) -> Result<PartialEval, String> {
+    ) -> Result<PartialEval, CryptoError> {
         use zeroize::Zeroize;
         let b = point_from_bytes(blinded.serialize().as_slice())?;
         let mut s_i: Scalar = **share.value();
@@ -95,33 +107,41 @@ pub mod threshold {
 
     /// Combine partial evaluations into the evaluation element `B^s` (Lagrange in the exponent,
     /// via vsss-rs), then hand back a voprf `EvaluationElement` for `finalize`. The key is never
-    /// reconstructed. `threshold` is the configured `t`: fewer than `t` partials silently
-    /// interpolate a wrong key (still fail-safe at LUKS, but rejected here explicitly).
+    /// reconstructed.
+    ///
+    /// `threshold` MUST equal the `t` passed to [`split_key`]. This check is defense-in-depth, not
+    /// the security boundary: with fewer than `t` partials Shamir interpolates a wrong key, which
+    /// yields a wrong derived key that LUKS rejects at the keyslot digest. vsss-rs `combine()`
+    /// already rejects zero/duplicate identifiers and fewer than two shares, so no extra dedup is
+    /// done here.
     pub fn combine(
         partials: &[PartialEval],
         threshold: usize,
-    ) -> Result<EvaluationElement<Secp256k1Sha256>, String> {
+    ) -> Result<EvaluationElement<Secp256k1Sha256>, CryptoError> {
         if partials.len() < threshold {
-            return Err(format!(
-                "combine: need >= {threshold} partials, got {}",
-                partials.len()
+            return Err(CryptoError::invalid_key(
+                "OPRF combine: fewer partial evaluations than the configured threshold",
             ));
         }
-        let bs: ValueGroup<ProjectivePoint> =
-            partials.combine().map_err(|e| format!("combine: {e:?}"))?;
+        let bs: ValueGroup<ProjectivePoint> = partials.combine().map_err(|_| {
+            CryptoError::key_derivation("OPRF partial-evaluation combination failed")
+        })?;
         EvaluationElement::deserialize(bs.0.to_encoded_point(true).as_bytes())
-            .map_err(|e| format!("deserialize eval: {e:?}"))
+            .map_err(|_| CryptoError::invalid_key("OPRF combined evaluation element is invalid"))
     }
 
-    fn point_from_bytes(bytes: &[u8]) -> Result<ProjectivePoint, String> {
+    fn point_from_bytes(bytes: &[u8]) -> Result<ProjectivePoint, CryptoError> {
         use k256::elliptic_curve::group::Group;
-        let ep = EncodedPoint::from_bytes(bytes).map_err(|e| format!("encoded point: {e:?}"))?;
+        let ep = EncodedPoint::from_bytes(bytes)
+            .map_err(|_| CryptoError::invalid_key("OPRF point: malformed SEC1 encoding"))?;
         let p = Option::<ProjectivePoint>::from(ProjectivePoint::from_encoded_point(&ep))
-            .ok_or_else(|| "bad point".to_string())?;
+            .ok_or_else(|| CryptoError::invalid_key("OPRF point: not a valid curve point"))?;
         // Defense in depth: reject the identity (the sole caller already passes voprf-validated
         // bytes, but never let an identity element through if this is reused on raw input).
         if bool::from(p.is_identity()) {
-            return Err("identity point rejected".into());
+            return Err(CryptoError::invalid_key(
+                "OPRF point: identity element rejected",
+            ));
         }
         Ok(p)
     }
@@ -146,6 +166,9 @@ pub fn derive_luks_key(
     info.extend_from_slice(&(volume_id.len() as u64).to_be_bytes());
     info.extend_from_slice(volume_id.as_bytes());
     info.extend_from_slice(&epoch.to_be_bytes());
+    // hkdf 0.12 exposes no handle to the extracted PRK held inside `Hkdf` and does not zeroize it
+    // on drop, so the PRK cannot be wiped cleanly here. Acceptable for a spike: the PRK is a
+    // one-way HKDF-Extract of the already-uniform OPRF output, not the OPRF key itself.
     let hk = hkdf::Hkdf::<sha2::Sha256>::new(None, oprf_output);
     let mut key = zeroize::Zeroizing::new([0u8; 32]);
     hk.expand(&info, &mut key[..])
@@ -250,6 +273,132 @@ mod tests {
             *derive_luks_key(out, "a/b", 1),
             *derive_luks_key(out, "a", 1),
             "length-prefixed info is injective over volume_id"
+        );
+    }
+
+    /// Fail-safe: a quorum that mixes in a share from a DIFFERENT key (a foreign/wrong share)
+    /// must produce a different combined evaluation, hence a different OPRF output and a different
+    /// derived LUKS key, than the correct quorum. This validates the documented "wrong partial =>
+    /// wrong key, LUKS rejects" guarantee.
+    #[test]
+    fn foreign_share_yields_different_key() {
+        use k256::Scalar;
+        let mut rng = rand_core_06::OsRng;
+        let input: &[u8] = b"keep-node-vault-v1";
+
+        let s = <Scalar as k256::elliptic_curve::Field>::random(&mut rng);
+        let shares = threshold::split_key(&s, 2, 3, &mut rng).expect("split");
+
+        // A second, independent key split with the SAME identifiers/threshold/n.
+        let s_other = <Scalar as k256::elliptic_curve::Field>::random(&mut rng);
+        let shares_other = threshold::split_key(&s_other, 2, 3, &mut rng).expect("split other");
+
+        // One blind; evaluate the correct and the mixed quorum against the SAME blinded element
+        // and finalize both with the same client state.
+        let b = OprfClient::<Secp256k1Sha256>::blind(input, &mut rng).expect("blind");
+
+        // Correct quorum {0,1} from the real key.
+        let good = threshold::combine(
+            &[
+                threshold::partial_eval(&shares[0], &b.message).expect("p0"),
+                threshold::partial_eval(&shares[1], &b.message).expect("p1"),
+            ],
+            2,
+        )
+        .expect("combine good");
+
+        // Mixed quorum: one real share + one foreign share (a wrong/compromised holder). Still a
+        // valid group element, just interpolating the wrong key.
+        let bad = threshold::combine(
+            &[
+                threshold::partial_eval(&shares[0], &b.message).expect("p0"),
+                threshold::partial_eval(&shares_other[1], &b.message).expect("p1 foreign"),
+            ],
+            2,
+        )
+        .expect("combine bad");
+
+        let out_good = b.state.finalize(input, &good).expect("finalize good");
+        let out_bad = b.state.finalize(input, &bad).expect("finalize bad");
+
+        assert_ne!(
+            out_good, out_bad,
+            "a foreign share in the quorum must change the OPRF output"
+        );
+        assert_ne!(
+            *derive_luks_key(out_good.as_slice(), "vault0", 1),
+            *derive_luks_key(out_bad.as_slice(), "vault0", 1),
+            "a foreign share must change the derived LUKS key (LUKS would reject it)"
+        );
+    }
+
+    /// `combine` with fewer partials than the configured threshold must return Err.
+    #[test]
+    fn combine_below_threshold_errors() {
+        use k256::Scalar;
+        let mut rng = rand_core_06::OsRng;
+        let input: &[u8] = b"keep-node-vault-v1";
+
+        let s = <Scalar as k256::elliptic_curve::Field>::random(&mut rng);
+        let shares = threshold::split_key(&s, 2, 3, &mut rng).expect("split");
+        let b = OprfClient::<Secp256k1Sha256>::blind(input, &mut rng).expect("blind");
+        let p0 = threshold::partial_eval(&shares[0], &b.message).expect("p0");
+
+        assert!(
+            threshold::combine(&[p0], 2).is_err(),
+            "a single partial against threshold 2 must be rejected"
+        );
+    }
+
+    /// `split_key` with invalid parameters (t > n, t < 2) must return Err.
+    #[test]
+    fn split_key_rejects_invalid_params() {
+        use k256::Scalar;
+        let mut rng = rand_core_06::OsRng;
+        let s = <Scalar as k256::elliptic_curve::Field>::random(&mut rng);
+
+        assert!(
+            threshold::split_key(&s, 4, 3, &mut rng).is_err(),
+            "t > n must be rejected"
+        );
+        assert!(
+            threshold::split_key(&s, 1, 3, &mut rng).is_err(),
+            "t < 2 must be rejected"
+        );
+    }
+
+    /// `point_from_bytes` (exercised via `partial_eval`'s point parsing) must reject malformed and
+    /// identity encodings. We test the parser directly through a crafted blinded-element path:
+    /// the identity point and garbage bytes must both fail to decode to a usable curve point.
+    #[test]
+    fn point_parsing_rejects_bad_and_identity() {
+        use k256::elliptic_curve::group::Group;
+        use k256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
+        use k256::{EncodedPoint, ProjectivePoint};
+
+        // Identity (point at infinity) encodes to a single 0x00 byte in SEC1; from_encoded_point
+        // accepts it, so our explicit identity rejection is what guards this case.
+        let id = <ProjectivePoint as Group>::identity();
+        let id_bytes = id.to_encoded_point(true);
+        let decoded = Option::<ProjectivePoint>::from(ProjectivePoint::from_encoded_point(
+            &EncodedPoint::from_bytes(id_bytes.as_bytes()).expect("identity sec1 parses"),
+        ))
+        .expect("identity decodes");
+        assert!(
+            bool::from(decoded.is_identity()),
+            "identity must be recognized so the parser can reject it"
+        );
+
+        // Garbage compressed point: valid prefix tag, but x is not on the curve.
+        let mut garbage = [0u8; 33];
+        garbage[0] = 0x02;
+        garbage[1..].fill(0xff);
+        let parsed = EncodedPoint::from_bytes(garbage).ok().and_then(|ep| {
+            Option::<ProjectivePoint>::from(ProjectivePoint::from_encoded_point(&ep))
+        });
+        assert!(
+            parsed.is_none(),
+            "an off-curve x must not decode to a point"
         );
     }
 }

--- a/keep-core/src/oprf.rs
+++ b/keep-core/src/oprf.rs
@@ -66,8 +66,14 @@ pub mod threshold {
         n: usize,
         rng: impl rand_core_06::RngCore + rand_core_06::CryptoRng,
     ) -> Result<Vec<KeyShare>, String> {
-        vsss_rs::shamir::split_secret::<KeyShare>(t, n, &IdentifierPrimeField(*secret), rng)
-            .map_err(|e| format!("split: {e:?}"))
+        use zeroize::Zeroize;
+        // Our transient copy of the key; zeroize it once split. (The caller owns the original
+        // `secret` and the returned shares, and is responsible for their secure handling.)
+        let mut wrapped = IdentifierPrimeField(*secret);
+        let res = vsss_rs::shamir::split_secret::<KeyShare>(t, n, &wrapped, rng)
+            .map_err(|e| format!("split: {e:?}"));
+        wrapped.0.zeroize();
+        res
     }
 
     /// A share-holder's partial evaluation: `P_i = s_i * B`, carrying the same identifier so the
@@ -76,18 +82,31 @@ pub mod threshold {
         share: &KeyShare,
         blinded: &BlindedElement<Secp256k1Sha256>,
     ) -> Result<PartialEval, String> {
+        use zeroize::Zeroize;
         let b = point_from_bytes(blinded.serialize().as_slice())?;
-        let s_i: Scalar = **share.value();
+        let mut s_i: Scalar = **share.value();
+        let p_i = b * s_i;
+        s_i.zeroize();
         Ok(DefaultShare::with_identifier_and_value(
             *share.identifier(),
-            ValueGroup::from(b * s_i),
+            ValueGroup::from(p_i),
         ))
     }
 
-    /// Combine >= t partial evaluations into the evaluation element `B^s` (Lagrange in the
-    /// exponent, via vsss-rs), then hand back a voprf `EvaluationElement` for `finalize`. The
-    /// key is never reconstructed.
-    pub fn combine(partials: &[PartialEval]) -> Result<EvaluationElement<Secp256k1Sha256>, String> {
+    /// Combine partial evaluations into the evaluation element `B^s` (Lagrange in the exponent,
+    /// via vsss-rs), then hand back a voprf `EvaluationElement` for `finalize`. The key is never
+    /// reconstructed. `threshold` is the configured `t`: fewer than `t` partials silently
+    /// interpolate a wrong key (still fail-safe at LUKS, but rejected here explicitly).
+    pub fn combine(
+        partials: &[PartialEval],
+        threshold: usize,
+    ) -> Result<EvaluationElement<Secp256k1Sha256>, String> {
+        if partials.len() < threshold {
+            return Err(format!(
+                "combine: need >= {threshold} partials, got {}",
+                partials.len()
+            ));
+        }
         let bs: ValueGroup<ProjectivePoint> =
             partials.combine().map_err(|e| format!("combine: {e:?}"))?;
         EvaluationElement::deserialize(bs.0.to_encoded_point(true).as_bytes())
@@ -95,24 +114,41 @@ pub mod threshold {
     }
 
     fn point_from_bytes(bytes: &[u8]) -> Result<ProjectivePoint, String> {
+        use k256::elliptic_curve::group::Group;
         let ep = EncodedPoint::from_bytes(bytes).map_err(|e| format!("encoded point: {e:?}"))?;
-        Option::<ProjectivePoint>::from(ProjectivePoint::from_encoded_point(&ep))
-            .ok_or_else(|| "bad point".into())
+        let p = Option::<ProjectivePoint>::from(ProjectivePoint::from_encoded_point(&ep))
+            .ok_or_else(|| "bad point".to_string())?;
+        // Defense in depth: reject the identity (the sole caller already passes voprf-validated
+        // bytes, but never let an identity element through if this is reused on raw input).
+        if bool::from(p.is_identity()) {
+            return Err("identity point rejected".into());
+        }
+        Ok(p)
     }
 }
 
-/// Derive a 32-byte LUKS key from an OPRF output via HKDF-Expand (RFC 5869).
+/// Derive a 32-byte LUKS key from an OPRF output via HKDF (RFC 5869).
 ///
-/// The OPRF `Finalize` output is already uniform and high-entropy, so HKDF-Extract is not
-/// needed; HKDF-Expand with a domain-separating `info` is sufficient. The `info` separates
-/// multiple volumes and supports rotation without changing the OPRF key:
-/// `keep-node/luks/v1/<volume_id>/<epoch>`. Feed the result to a LUKS2 keyslot
-/// (`cryptsetup luksFormat/open --key-file - --keyfile-size 32`).
-pub fn derive_luks_key(oprf_output: &[u8], volume_id: &str, epoch: u32) -> [u8; 32] {
-    let info = format!("keep-node/luks/v1/{volume_id}/{epoch}");
+/// `Hkdf::new(None, ...)` runs HKDF-Extract with a zero salt, then Expand. The OPRF `Finalize`
+/// output is already a uniform SHA-256 PRF value, so Extract is not strictly required, but a
+/// zero-salt Extract is sound. The `info` is built INJECTIVELY (length-prefixed) so two distinct
+/// `(volume_id, epoch)` pairs can never collide into the same key: a fixed label, then the
+/// big-endian length of `volume_id`, then `volume_id`, then the big-endian `epoch`. This
+/// separates multiple volumes and supports rotation without changing the OPRF key. Feed the
+/// result to a LUKS2 keyslot (`cryptsetup luksFormat/open --key-file - --keyfile-size 32`).
+pub fn derive_luks_key(
+    oprf_output: &[u8],
+    volume_id: &str,
+    epoch: u32,
+) -> zeroize::Zeroizing<[u8; 32]> {
+    let mut info = Vec::with_capacity(25 + volume_id.len() + 4);
+    info.extend_from_slice(b"keep-node/luks/v1");
+    info.extend_from_slice(&(volume_id.len() as u64).to_be_bytes());
+    info.extend_from_slice(volume_id.as_bytes());
+    info.extend_from_slice(&epoch.to_be_bytes());
     let hk = hkdf::Hkdf::<sha2::Sha256>::new(None, oprf_output);
-    let mut key = [0u8; 32];
-    hk.expand(info.as_bytes(), &mut key)
+    let mut key = zeroize::Zeroizing::new([0u8; 32]);
+    hk.expand(&info, &mut key[..])
         .expect("32 bytes is within HKDF output limit");
     key
 }
@@ -181,7 +217,7 @@ mod tests {
         for (i, j) in [(0, 1), (0, 2), (1, 2)] {
             let p_i = threshold::partial_eval(&shares[i], &b.message).expect("partial i");
             let p_j = threshold::partial_eval(&shares[j], &b.message).expect("partial j");
-            let eval = threshold::combine(&[p_i, p_j]).expect("combine");
+            let eval = threshold::combine(&[p_i, p_j], 2).expect("combine");
             let thresh = b.state.finalize(input, &eval).expect("threshold finalize");
             assert_eq!(
                 single, thresh,
@@ -192,7 +228,7 @@ mod tests {
             // one, and is a stable 32 bytes.
             let k_single = derive_luks_key(single.as_slice(), "vault0", 1);
             let k_thresh = derive_luks_key(thresh.as_slice(), "vault0", 1);
-            assert_eq!(k_single, k_thresh);
+            assert_eq!(*k_single, *k_thresh);
             assert_eq!(k_thresh.len(), 32);
         }
     }
@@ -201,12 +237,19 @@ mod tests {
     fn luks_key_derivation_is_stable_and_domain_separated() {
         let out = b"oprf-output-bytes-for-the-kdf-test--";
         let k = derive_luks_key(out, "vault0", 1);
-        assert_eq!(k, derive_luks_key(out, "vault0", 1), "stable");
+        assert_eq!(*k, *derive_luks_key(out, "vault0", 1), "stable");
         assert_ne!(
-            k,
-            derive_luks_key(out, "vault1", 1),
+            *k,
+            *derive_luks_key(out, "vault1", 1),
             "separated by volume id"
         );
-        assert_ne!(k, derive_luks_key(out, "vault0", 2), "separated by epoch");
+        assert_ne!(*k, *derive_luks_key(out, "vault0", 2), "separated by epoch");
+        // Injectivity: a volume_id containing the old '/' separator must NOT collide with a
+        // different (volume_id, epoch) pair (the length-prefixed info prevents this).
+        assert_ne!(
+            *derive_luks_key(out, "a/b", 1),
+            *derive_luks_key(out, "a", 1),
+            "length-prefixed info is injective over volume_id"
+        );
     }
 }

--- a/keep-core/src/oprf.rs
+++ b/keep-core/src/oprf.rs
@@ -1,23 +1,23 @@
-//! KeepNode threshold-OPRF unlock primitive (frost-gate v2), step 1: the secp256k1 OPRF
-//! ciphersuite.
+//! Threshold Oblivious PRF over secp256k1, for deriving a symmetric key from a t-of-n quorum
+//! without any single party reconstructing the key.
 //!
-//! RFC 9497 standardizes OPRF/VOPRF but defines no secp256k1 ciphersuite, so we bind the
-//! generic 2HashDH construction to secp256k1 by implementing [`voprf::CipherSuite`] over
+//! RFC 9497 standardizes the OPRF/VOPRF construction but defines no secp256k1 ciphersuite, so the
+//! generic 2HashDH construction is bound to secp256k1 by implementing [`voprf::CipherSuite`] over
 //! `k256::Secp256k1`. k256's `GroupDigest` (the `hash2curve` feature) provides the RFC 9380
-//! `secp256k1_XMD:SHA-256_SSWU_RO_` hash-to-curve. voprf 0.5 implements `Group` for any `C`
-//! where `C: GroupDigest` and `ProjectivePoint<C>: CofactorGroup + ToEncodedPoint<C>`;
-//! `k256::Secp256k1` with `hash2curve` satisfies those bounds, so no upstream patch is needed.
+//! `secp256k1_XMD:SHA-256_SSWU_RO_` hash-to-curve. voprf implements `Group` for any `C` where
+//! `C: GroupDigest` and `ProjectivePoint<C>: CofactorGroup + ToEncodedPoint<C>`, which
+//! `k256::Secp256k1` satisfies, so no upstream changes are required.
 //!
-//! The suite `ID` is KeepNode-specific (no standard secp256k1 suite exists) and MUST be
-//! pinned: it feeds the RFC 9497 context string / DST, so changing it changes every derived
-//! key. This module is the single-server primitive only; the 2-of-3 threshold layer (Shamir
-//! key-sharing + Lagrange combination + DLEQ verifiability) lands on top of it.
+//! The suite `ID` is non-standard (RFC 9497 defines no secp256k1 suite) and is pinned here. It
+//! feeds the RFC 9497 context string / DST, so it must never change once it has derived keys that
+//! protect data: changing it changes every derived key.
 //!
-//! Design + threat model: see SPIKE-frost-unlock-v2.
+//! This module provides the ciphersuite, the [`threshold`] layer (Shamir-shared key, in-exponent
+//! Lagrange combination of partial evaluations), and [`derive_luks_key`].
 
 use voprf::CipherSuite;
 
-/// KeepNode's secp256k1 OPRF ciphersuite: the RFC 9497 construction on secp256k1 with SHA-256.
+/// The secp256k1 OPRF ciphersuite: the RFC 9497 construction on secp256k1 with SHA-256.
 #[derive(Debug, Clone, Copy)]
 pub struct Secp256k1Sha256;
 
@@ -167,9 +167,9 @@ pub fn derive_luks_key(
     info.extend_from_slice(&(volume_id.len() as u64).to_be_bytes());
     info.extend_from_slice(volume_id.as_bytes());
     info.extend_from_slice(&epoch.to_be_bytes());
-    // hkdf 0.12 exposes no handle to the extracted PRK held inside `Hkdf` and does not zeroize it
-    // on drop, so the PRK cannot be wiped cleanly here. Acceptable for a spike: the PRK is a
-    // one-way HKDF-Extract of the already-uniform OPRF output, not the OPRF key itself.
+    // The `hkdf` crate exposes no handle to the extracted PRK held inside `Hkdf` and does not
+    // zeroize it on drop, so the PRK is not wiped here. The PRK is a one-way HKDF-Extract of the
+    // already-uniform OPRF output, not the OPRF key, so it exposes no recoverable key material.
     let hk = hkdf::Hkdf::<sha2::Sha256>::new(None, oprf_output);
     let mut key = zeroize::Zeroizing::new([0u8; 32]);
     hk.expand(&info, &mut key[..])

--- a/keep-core/src/oprf.rs
+++ b/keep-core/src/oprf.rs
@@ -130,7 +130,7 @@ pub mod threshold {
             .map_err(|_| CryptoError::invalid_key("OPRF combined evaluation element is invalid"))
     }
 
-    fn point_from_bytes(bytes: &[u8]) -> Result<ProjectivePoint, CryptoError> {
+    pub(crate) fn point_from_bytes(bytes: &[u8]) -> Result<ProjectivePoint, CryptoError> {
         use k256::elliptic_curve::group::Group;
         let ep = EncodedPoint::from_bytes(bytes)
             .map_err(|_| CryptoError::invalid_key("OPRF point: malformed SEC1 encoding"))?;
@@ -373,32 +373,24 @@ mod tests {
     #[test]
     fn point_parsing_rejects_bad_and_identity() {
         use k256::elliptic_curve::group::Group;
-        use k256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
-        use k256::{EncodedPoint, ProjectivePoint};
+        use k256::elliptic_curve::sec1::ToEncodedPoint;
+        use k256::ProjectivePoint;
 
-        // Identity (point at infinity) encodes to a single 0x00 byte in SEC1; from_encoded_point
-        // accepts it, so our explicit identity rejection is what guards this case.
-        let id = <ProjectivePoint as Group>::identity();
-        let id_bytes = id.to_encoded_point(true);
-        let decoded = Option::<ProjectivePoint>::from(ProjectivePoint::from_encoded_point(
-            &EncodedPoint::from_bytes(id_bytes.as_bytes()).expect("identity sec1 parses"),
-        ))
-        .expect("identity decodes");
+        // Identity (point at infinity) encodes to a single 0x00 byte in SEC1 and from_encoded_point
+        // accepts it, so point_from_bytes' explicit identity rejection is what must guard this case.
+        let id_bytes = <ProjectivePoint as Group>::identity().to_encoded_point(true);
         assert!(
-            bool::from(decoded.is_identity()),
-            "identity must be recognized so the parser can reject it"
+            threshold::point_from_bytes(id_bytes.as_bytes()).is_err(),
+            "identity element must be rejected by point_from_bytes"
         );
 
         // Garbage compressed point: valid prefix tag, but x is not on the curve.
         let mut garbage = [0u8; 33];
         garbage[0] = 0x02;
         garbage[1..].fill(0xff);
-        let parsed = EncodedPoint::from_bytes(garbage).ok().and_then(|ep| {
-            Option::<ProjectivePoint>::from(ProjectivePoint::from_encoded_point(&ep))
-        });
         assert!(
-            parsed.is_none(),
-            "an off-curve x must not decode to a point"
+            threshold::point_from_bytes(&garbage).is_err(),
+            "an off-curve x must be rejected by point_from_bytes"
         );
     }
 }

--- a/keep-core/src/oprf.rs
+++ b/keep-core/src/oprf.rs
@@ -36,8 +36,14 @@ impl CipherSuite for Secp256k1Sha256 {
 ///
 /// Vetted libraries do the dangerous parts: `vsss-rs` for the Shamir split and the in-exponent
 /// Lagrange combination (`combine_shares_group`), `k256` for the group arithmetic, `voprf` for
-/// blind/finalize. The only bespoke step is `s_i * B`. DLEQ verifiability (malicious-server
-/// protection) is a follow-on; this layer proves the threshold combination is correct.
+/// blind/finalize. The only bespoke step is `s_i * B`.
+///
+/// DLEQ verifiability (a per-partial proof that a share-holder used its committed share) is a
+/// deliberate follow-on, NOT a security gate for the core guarantee: a wrong partial yields a
+/// wrong combined `B^s`, hence a wrong derived key, which LUKS rejects at the keyslot digest
+/// check. So a misbehaving share-holder (a compromised own-device) causes a *failed unlock*,
+/// never a key leak or silent corruption. DLEQ upgrades that fail-safe into a diagnosable,
+/// DoS-resistant one; it does not change what an attacker can learn.
 pub mod threshold {
     use super::Secp256k1Sha256;
     use k256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
@@ -93,6 +99,22 @@ pub mod threshold {
         Option::<ProjectivePoint>::from(ProjectivePoint::from_encoded_point(&ep))
             .ok_or_else(|| "bad point".into())
     }
+}
+
+/// Derive a 32-byte LUKS key from an OPRF output via HKDF-Expand (RFC 5869).
+///
+/// The OPRF `Finalize` output is already uniform and high-entropy, so HKDF-Extract is not
+/// needed; HKDF-Expand with a domain-separating `info` is sufficient. The `info` separates
+/// multiple volumes and supports rotation without changing the OPRF key:
+/// `keep-node/luks/v1/<volume_id>/<epoch>`. Feed the result to a LUKS2 keyslot
+/// (`cryptsetup luksFormat/open --key-file - --keyfile-size 32`).
+pub fn derive_luks_key(oprf_output: &[u8], volume_id: &str, epoch: u32) -> [u8; 32] {
+    let info = format!("keep-node/luks/v1/{volume_id}/{epoch}");
+    let hk = hkdf::Hkdf::<sha2::Sha256>::new(None, oprf_output);
+    let mut key = [0u8; 32];
+    hk.expand(info.as_bytes(), &mut key)
+        .expect("32 bytes is within HKDF output limit");
+    key
 }
 
 #[cfg(test)]
@@ -159,6 +181,22 @@ mod tests {
             let eval = threshold::combine(&[p_i, p_j]).expect("combine");
             let thresh = b.state.finalize(input, &eval).expect("threshold finalize");
             assert_eq!(single, thresh, "quorum {{{i},{j}}} must equal the single-key output");
+
+            // End to end: the LUKS key derived from the threshold output matches the single-key
+            // one, and is a stable 32 bytes.
+            let k_single = derive_luks_key(single.as_slice(), "vault0", 1);
+            let k_thresh = derive_luks_key(thresh.as_slice(), "vault0", 1);
+            assert_eq!(k_single, k_thresh);
+            assert_eq!(k_thresh.len(), 32);
         }
+    }
+
+    #[test]
+    fn luks_key_derivation_is_stable_and_domain_separated() {
+        let out = b"oprf-output-bytes-for-the-kdf-test--";
+        let k = derive_luks_key(out, "vault0", 1);
+        assert_eq!(k, derive_luks_key(out, "vault0", 1), "stable");
+        assert_ne!(k, derive_luks_key(out, "vault1", 1), "separated by volume id");
+        assert_ne!(k, derive_luks_key(out, "vault0", 2), "separated by epoch");
     }
 }

--- a/keep-core/src/oprf.rs
+++ b/keep-core/src/oprf.rs
@@ -1,0 +1,63 @@
+//! KeepNode threshold-OPRF unlock primitive (frost-gate v2), step 1: the secp256k1 OPRF
+//! ciphersuite.
+//!
+//! RFC 9497 standardizes OPRF/VOPRF but defines no secp256k1 ciphersuite, so we bind the
+//! generic 2HashDH construction to secp256k1 by implementing [`voprf::CipherSuite`] over
+//! `k256::Secp256k1`. k256's `GroupDigest` provides the RFC 9380
+//! `secp256k1_XMD:SHA-256_SSWU_RO_` hash-to-curve, and voprf's `Group` is blanket-implemented
+//! for any `GroupDigest`, so no upstream patch is needed.
+//!
+//! The suite `ID` is KeepNode-specific (no standard secp256k1 suite exists) and MUST be
+//! pinned: it feeds the RFC 9497 context string / DST, so changing it changes every derived
+//! key. This module is the single-server primitive only; the 2-of-3 threshold layer (Shamir
+//! key-sharing + Lagrange combination + DLEQ verifiability) lands on top of it.
+//!
+//! Design + threat model: see SPIKE-frost-unlock-v2.
+
+use voprf::CipherSuite;
+
+/// KeepNode's secp256k1 OPRF ciphersuite: the RFC 9497 construction on secp256k1 with SHA-256.
+#[derive(Debug, Clone, Copy)]
+pub struct Secp256k1Sha256;
+
+impl CipherSuite for Secp256k1Sha256 {
+    const ID: &'static str = "secp256k1-SHA256";
+    type Group = k256::Secp256k1;
+    // sha2 0.10 to match voprf's digest 0.10 ecosystem (see Cargo.toml note).
+    type Hash = sha2_010::Sha256;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use voprf::{OprfClient, OprfServer};
+
+    /// Full single-server OPRF round-trip on secp256k1: blind -> blind_evaluate -> finalize.
+    /// The same input under the same key must reproduce the same output (the PRF property the
+    /// LUKS key derivation relies on), while a different input must not.
+    #[test]
+    fn secp256k1_oprf_round_trip() {
+        // rand_core 0.6 OsRng to match voprf's rng traits (digest 0.10 ecosystem).
+        let mut rng = rand_core_06::OsRng;
+        let input: &[u8] = b"keep-node-vault-v1";
+
+        let server = OprfServer::<Secp256k1Sha256>::new(&mut rng).expect("server key");
+
+        let b1 = OprfClient::<Secp256k1Sha256>::blind(input, &mut rng).expect("blind");
+        let e1 = server.blind_evaluate(&b1.message);
+        let out1 = b1.state.finalize(input, &e1).expect("finalize");
+
+        // Fresh blind, same key + input -> same OPRF output (stable derived key).
+        let b2 = OprfClient::<Secp256k1Sha256>::blind(input, &mut rng).expect("blind");
+        let e2 = server.blind_evaluate(&b2.message);
+        let out2 = b2.state.finalize(input, &e2).expect("finalize");
+        assert_eq!(out1, out2, "same input + key must give a stable OPRF output");
+
+        // Different input -> different output.
+        let other: &[u8] = b"keep-node-other";
+        let b3 = OprfClient::<Secp256k1Sha256>::blind(other, &mut rng).expect("blind");
+        let e3 = server.blind_evaluate(&b3.message);
+        let out3 = b3.state.finalize(other, &e3).expect("finalize");
+        assert_ne!(out1, out3, "different input must give a different output");
+    }
+}


### PR DESCRIPTION
## What

Adds a **2-of-3 threshold Oblivious PRF** over secp256k1 (`keep-core/src/oprf.rs`, behind a new opt-in `oprf` feature) that derives a 32-byte LUKS full-disk-encryption key from a quorum (box + phone + replica) **without any single party reconstructing the key**. This is the cryptographic foundation for a threshold volume-unlock scheme: shares never leave their holder; each returns a partial evaluation `sᵢ·B`, combined in the exponent via Lagrange.

This PR is the **crypto primitive only**. It guards no real data yet (opt-in feature, no wiring). The end-to-end unlock (Nostr unlock-session + appliance integration) is a separate follow-up.

## Construction (grounded in standards + vetted libs)

- RFC 9497 (OPRF/2HashDH) via **`voprf`** (MIT reference impl), bound to secp256k1 with a local `CipherSuite` (no upstream patch); hash-to-curve is `k256`'s RFC 9380 `secp256k1_XMD:SHA-256_SSWU_RO_`.
- Shamir split + in-exponent Lagrange combination via **`vsss-rs`** (`combine_shares_group`).
- The only bespoke crypto is `sᵢ·B`. HKDF (RFC 5869) → 32-byte LUKS key with length-prefixed domain separation.

## Tests

- Single-server OPRF round-trip on secp256k1.
- **Threshold-equals-single-key oracle** across all three quorum pairs (proves the Lagrange combination is correct and the key is never reconstructed).
- KDF stability + domain-separation/injectivity.

Behind the `oprf` feature; default `keep-core` build/tests are unchanged. `cargo clippy`/`fmt` clean.

## Security review

Reviewed by the internal security-review pass (no external crypto reviewer available). Verdict: construction correct, "no single share derives the key" holds, no critical/high exploitable issue. The review's must-fixes are applied in this PR: **zeroize** the derived key / `sᵢ` / the dealer's transient copy; **injective** KDF `info` (length-prefixed, no `volume_id` collision); **reject the identity point**; explicit **quorum-count check** in `combine`.

### Deferred before this guards a real vault (tracked, not in this PR)
- **DLEQ verifiability** — documented fail-safe follow-on: a bad partial yields a wrong key that LUKS rejects (failed unlock), never a leak; DLEQ only adds attribution / DoS-resistance.
- Replace `String` errors with a typed enum.
- Add `cargo audit` / `cargo deny` to CI for the added supply-chain surface.

Do not enable the `oprf` feature to guard real data until DLEQ + the typed-error cleanup land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added an opt-in Threshold-OPRF unlock primitive (feature-flagged) with secp256k1/SHA-256 support, including threshold key splitting, partial evaluation, and combination.
- Introduced deterministic LUKS key derivation from OPRF output, volume ID, and epoch using HKDF with domain-separated context.

## Security & Validation
- Strengthened public-key/curve-point validation and added explicit errors for invalid inputs (including combining with too few partials).

## Tests
- Expanded coverage for OPRF determinism, threshold correctness, share-mixing resistance, parameter validation, and LUKS key stability/injectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
