### PR TITLE
keep-frost-net: threshold-OPRF unlock session + #621 eval-oracle ship-gate

### DIFF
--- a/keep-desktop/src/frost.rs
+++ b/keep-desktop/src/frost.rs
@@ -808,6 +808,11 @@ pub(crate) async fn frost_event_listener(
                             new_version,
                         ));
                     }
+                    // Threshold-OPRF unlock events are not surfaced in the
+                    // desktop UI yet (KeepNode appliance flow).
+                    Ok(KfpNodeEvent::OprfEvalRequested { .. })
+                    | Ok(KfpNodeEvent::OprfUnlockComplete { .. })
+                    | Ok(KfpNodeEvent::OprfUnlockFailed { .. }) => {}
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                 }

--- a/keep-frost-net/Cargo.toml
+++ b/keep-frost-net/Cargo.toml
@@ -13,7 +13,7 @@ testing = ["keep-core/allow-ws"]
 
 [dependencies]
 keep-bitcoin = { path = "../keep-bitcoin" }
-keep-core = { path = "../keep-core" }
+keep-core = { path = "../keep-core", features = ["oprf"] }
 keep-enclave-host = { path = "../keep-enclave/host", optional = true }
 
 nostr-sdk = { version = "0.44", features = ["nip04", "nip44"] }
@@ -50,7 +50,7 @@ tokio-test = "0.4"
 nostr-relay-builder = "0.44"
 chrono = "0.4"
 proptest = "1.11"
-keep-core = { path = "../keep-core", features = ["allow-ws", "allow-internal"] }
+keep-core = { path = "../keep-core", features = ["allow-ws", "allow-internal", "oprf"] }
 
 [[test]]
 name = "multinode_test"

--- a/keep-frost-net/src/error.rs
+++ b/keep-frost-net/src/error.rs
@@ -54,6 +54,9 @@ pub enum FrostNetError {
     #[error("Replay detected: {0}")]
     ReplayDetected(String),
 
+    #[error("Rate limited: {0}")]
+    RateLimited(String),
+
     #[error("Nonce already consumed for session: {0}")]
     NonceConsumed(String),
 

--- a/keep-frost-net/src/event.rs
+++ b/keep-frost-net/src/event.rs
@@ -311,6 +311,56 @@ impl KfpEventBuilder {
             .map_err(|e| FrostNetError::Nostr(e.to_string()))
     }
 
+    pub fn oprf_eval_request(
+        keys: &Keys,
+        recipient: &PublicKey,
+        request: OprfEvalRequestPayload,
+    ) -> Result<Event> {
+        let msg = KfpMessage::OprfEvalRequest(request.clone());
+        let content = msg.to_json()?;
+
+        let encrypted = nip44::encrypt(keys.secret_key(), recipient, &content, nip44::Version::V2)
+            .map_err(|e| FrostNetError::Crypto(e.to_string()))?;
+
+        EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), encrypted)
+            .custom_created_at(Timestamp::tweaked(TIMESTAMP_TWEAK_RANGE))
+            .tag(Tag::public_key(*recipient))
+            .tag(Tag::custom(
+                TagKind::custom("g"),
+                [hex::encode(request.group_pubkey)],
+            ))
+            .tag(Tag::custom(
+                TagKind::custom("s"),
+                [hex::encode(request.session_id)],
+            ))
+            .tag(Tag::custom(TagKind::custom("t"), ["oprf_eval_request"]))
+            .sign_with_keys(keys)
+            .map_err(|e| FrostNetError::Nostr(e.to_string()))
+    }
+
+    pub fn oprf_eval_share(
+        keys: &Keys,
+        recipient: &PublicKey,
+        payload: OprfEvalSharePayload,
+    ) -> Result<Event> {
+        let msg = KfpMessage::OprfEvalShare(payload.clone());
+        let content = msg.to_json()?;
+
+        let encrypted = nip44::encrypt(keys.secret_key(), recipient, &content, nip44::Version::V2)
+            .map_err(|e| FrostNetError::Crypto(e.to_string()))?;
+
+        EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), encrypted)
+            .custom_created_at(Timestamp::tweaked(TIMESTAMP_TWEAK_RANGE))
+            .tag(Tag::public_key(*recipient))
+            .tag(Tag::custom(
+                TagKind::custom("s"),
+                [hex::encode(payload.session_id)],
+            ))
+            .tag(Tag::custom(TagKind::custom("t"), ["oprf_eval_share"]))
+            .sign_with_keys(keys)
+            .map_err(|e| FrostNetError::Nostr(e.to_string()))
+    }
+
     pub fn xpub_announce(
         keys: &Keys,
         recipient: &PublicKey,

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -67,6 +67,7 @@ mod event;
 mod node;
 mod nonce_pool;
 mod nonce_store;
+mod oprf_session;
 mod peer;
 pub mod proof;
 mod protocol;
@@ -98,28 +99,33 @@ pub use node::{
 };
 pub use nonce_pool::{NonceId, NoncePool, DEFAULT_POOL_TARGET, MAX_POOL_ENTRIES};
 pub use nonce_store::{FileNonceStore, MemoryNonceStore, NonceStore};
+pub use oprf_session::{
+    derive_oprf_session_id, OprfEvalRateLimiter, OprfUnlockSession, OprfUnlockSessionManager,
+    OprfUnlockSessionState, MAX_OPRF_EVALS_PER_WINDOW, OPRF_EVAL_WINDOW,
+};
 pub use peer::{AttestationStatus, Peer, PeerManager, PeerStatus};
 pub use protocol::{
     AnnouncePayload, AnnouncedXpub, CommitmentPayload, DescriptorAckPayload,
     DescriptorContributePayload, DescriptorFinalizePayload, DescriptorNackPayload,
     DescriptorProposePayload, EcdhCompletePayload, EcdhRequestPayload, EcdhSharePayload,
     EnclaveAttestation, ErrorPayload, KeySlot, KfpMessage, NonceCommitmentPayload, NonceRef,
-    PingPayload, PolicyTier, PongPayload, PreExchangedCommitment, PsbtAbortPayload,
-    PsbtFinalizePayload, PsbtInputInfo, PsbtOutputInfo, PsbtProposePayload, PsbtSignPayload,
-    RefreshCompletePayload, RefreshRequestPayload, RefreshRound1Payload, RefreshRound2Payload,
-    SignRequestPayload, SignatureCompletePayload, SignatureSharePayload, WalletPolicy,
-    XpubAnnouncePayload, DEFAULT_REPLAY_WINDOW_SECS, DESCRIPTOR_ACK_PHASE_TIMEOUT_SECS,
-    DESCRIPTOR_ACK_TIMEOUT_SECS, DESCRIPTOR_CONTRIBUTION_TIMEOUT_SECS,
-    DESCRIPTOR_FINALIZE_TIMEOUT_SECS, DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS,
-    DESCRIPTOR_SESSION_TIMEOUT_SECS, KFP_EVENT_KIND, KFP_VERSION, MAX_CAPABILITIES,
-    MAX_CAPABILITY_LENGTH, MAX_COMMITMENT_SIZE, MAX_DESCRIPTOR_LENGTH, MAX_ERROR_CODE_LENGTH,
-    MAX_ERROR_MESSAGE_LENGTH, MAX_FINGERPRINT_LENGTH, MAX_KEYS_PER_TIER, MAX_MESSAGE_SIZE,
-    MAX_MESSAGE_TYPE_LENGTH, MAX_NACK_REASON_LENGTH, MAX_NAME_LENGTH, MAX_NONCE_COMMITMENTS,
-    MAX_PARTICIPANTS, MAX_PSBT_ADDRESS_LENGTH, MAX_PSBT_INPUTS, MAX_PSBT_OUTPUTS, MAX_PSBT_SIZE,
-    MAX_RECOVERY_TIERS, MAX_RECOVERY_XPUBS, MAX_SIGNATURE_SHARE_SIZE, MAX_XPUB_LABEL_LENGTH,
-    MAX_XPUB_LENGTH, MIN_XPUB_LENGTH, MSG_TYPE_NOSTR_EVENT, MSG_TYPE_RAW,
-    PSBT_FINALIZE_PHASE_TIMEOUT_SECS, PSBT_SESSION_MAX_TIMEOUT_SECS, PSBT_SESSION_TIMEOUT_SECS,
-    PSBT_SIGNING_PHASE_TIMEOUT_SECS, VALID_NETWORKS, VALID_XPUB_PREFIXES,
+    OprfEvalRequestPayload, OprfEvalSharePayload, PingPayload, PolicyTier, PongPayload,
+    PreExchangedCommitment, PsbtAbortPayload, PsbtFinalizePayload, PsbtInputInfo, PsbtOutputInfo,
+    PsbtProposePayload, PsbtSignPayload, RefreshCompletePayload, RefreshRequestPayload,
+    RefreshRound1Payload, RefreshRound2Payload, SignRequestPayload, SignatureCompletePayload,
+    SignatureSharePayload, WalletPolicy, XpubAnnouncePayload, DEFAULT_REPLAY_WINDOW_SECS,
+    DESCRIPTOR_ACK_PHASE_TIMEOUT_SECS, DESCRIPTOR_ACK_TIMEOUT_SECS,
+    DESCRIPTOR_CONTRIBUTION_TIMEOUT_SECS, DESCRIPTOR_FINALIZE_TIMEOUT_SECS,
+    DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS, DESCRIPTOR_SESSION_TIMEOUT_SECS, KFP_EVENT_KIND,
+    KFP_VERSION, MAX_CAPABILITIES, MAX_CAPABILITY_LENGTH, MAX_COMMITMENT_SIZE,
+    MAX_DESCRIPTOR_LENGTH, MAX_ERROR_CODE_LENGTH, MAX_ERROR_MESSAGE_LENGTH, MAX_FINGERPRINT_LENGTH,
+    MAX_KEYS_PER_TIER, MAX_MESSAGE_SIZE, MAX_MESSAGE_TYPE_LENGTH, MAX_NACK_REASON_LENGTH,
+    MAX_NAME_LENGTH, MAX_NONCE_COMMITMENTS, MAX_PARTICIPANTS, MAX_PSBT_ADDRESS_LENGTH,
+    MAX_PSBT_INPUTS, MAX_PSBT_OUTPUTS, MAX_PSBT_SIZE, MAX_RECOVERY_TIERS, MAX_RECOVERY_XPUBS,
+    MAX_SIGNATURE_SHARE_SIZE, MAX_XPUB_LABEL_LENGTH, MAX_XPUB_LENGTH, MIN_XPUB_LENGTH,
+    MSG_TYPE_NOSTR_EVENT, MSG_TYPE_RAW, OPRF_PARTIAL_LEN, PSBT_FINALIZE_PHASE_TIMEOUT_SECS,
+    PSBT_SESSION_MAX_TIMEOUT_SECS, PSBT_SESSION_TIMEOUT_SECS, PSBT_SIGNING_PHASE_TIMEOUT_SECS,
+    VALID_NETWORKS, VALID_XPUB_PREFIXES,
 };
 pub use psbt_session::{
     derive_psbt_session_id, PsbtSession, PsbtSessionManager, PsbtSessionState, SignerId,

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 mod descriptor;
 mod ecdh;
+mod oprf;
 mod psbt;
 mod signing;
 
@@ -35,6 +36,7 @@ use crate::error::{FrostNetError, Result};
 use crate::event::KfpEventBuilder;
 use crate::nonce_pool::{NonceId, NoncePool};
 use crate::nonce_store::{FileNonceStore, NonceStore};
+use crate::oprf_session::{OprfEvalRateLimiter, OprfUnlockSessionManager};
 use crate::peer::{AttestationStatus, Peer, PeerManager, PeerStatus};
 use crate::protocol::*;
 use crate::psbt_session::PsbtSessionManager;
@@ -353,6 +355,23 @@ pub trait SigningHooks: Send + Sync {
     /// This is for notification purposes and cannot fail. Long-running
     /// operations should be offloaded to a separate task.
     fn post_sign(&self, session: &SessionInfo, signature: &[u8; 64]);
+
+    /// Called by an OPRF-unlock holder before it evaluates a requester's blinded
+    /// element. Returning `false` declines the evaluation without producing a
+    /// partial. The default permits every (already attested and rate-limited)
+    /// request so existing `SigningHooks` impls compile unchanged.
+    ///
+    /// Returns a boxed future rather than using `async fn` so the trait stays
+    /// object-safe (`Arc<dyn SigningHooks>`), avoiding an `async-trait`
+    /// dependency for one method.
+    fn approve_oprf_eval(
+        &self,
+        requester_share_index: u16,
+        session_id: [u8; 32],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>> {
+        let _ = (requester_share_index, session_id);
+        Box::pin(async { true })
+    }
 }
 
 pub struct NoOpHooks;
@@ -450,6 +469,21 @@ pub enum KfpNodeEvent {
         shared_secret: Zeroizing<[u8; 32]>,
     },
     EcdhFailed {
+        session_id: [u8; 32],
+        error: String,
+    },
+    /// A holder received and accepted an OPRF evaluation request (emitted around
+    /// the approval hook, before the partial is produced).
+    OprfEvalRequested {
+        session_id: [u8; 32],
+        requester_index: u16,
+    },
+    /// The box collected a quorum of partials and derived the LUKS key locally.
+    OprfUnlockComplete {
+        session_id: [u8; 32],
+        luks_key: Zeroizing<[u8; 32]>,
+    },
+    OprfUnlockFailed {
         session_id: [u8; 32],
         error: String,
     },
@@ -585,6 +619,24 @@ impl std::fmt::Debug for KfpNodeEvent {
                 .finish(),
             Self::EcdhFailed { session_id, error } => f
                 .debug_struct("EcdhFailed")
+                .field("session_id", &hex::encode(session_id))
+                .field("error", error)
+                .finish(),
+            Self::OprfEvalRequested {
+                session_id,
+                requester_index,
+            } => f
+                .debug_struct("OprfEvalRequested")
+                .field("session_id", &hex::encode(session_id))
+                .field("requester_index", requester_index)
+                .finish(),
+            Self::OprfUnlockComplete { session_id, .. } => f
+                .debug_struct("OprfUnlockComplete")
+                .field("session_id", &hex::encode(session_id))
+                .field("luks_key", &"[REDACTED]")
+                .finish(),
+            Self::OprfUnlockFailed { session_id, error } => f
+                .debug_struct("OprfUnlockFailed")
                 .field("session_id", &hex::encode(session_id))
                 .field("error", error)
                 .finish(),
@@ -725,6 +777,15 @@ pub struct KfpNode {
     pub(crate) sessions: Arc<RwLock<SessionManager>>,
     pub(crate) nonce_pool: NoncePool,
     pub(crate) ecdh_sessions: Arc<RwLock<EcdhSessionManager>>,
+    /// Dedicated OPRF key share for the threshold-OPRF unlock. SEPARATE from the
+    /// FROST signing share: the holder applies this via
+    /// `keep_core::oprf::unlock::evaluate`, never the signing share. `None` on a
+    /// node that is not an OPRF holder, which then ignores eval requests.
+    pub(crate) oprf_key_share: Option<keep_core::oprf::threshold::KeyShare>,
+    /// Box-side OPRF unlock sessions (initiator only). Holders keep no session.
+    pub(crate) oprf_sessions: Arc<RwLock<OprfUnlockSessionManager>>,
+    /// Per-requester sliding-window limiter guarding the holder eval oracle.
+    pub(crate) oprf_rate_limiter: Arc<RwLock<OprfEvalRateLimiter>>,
     pub(crate) descriptor_sessions: Arc<RwLock<DescriptorSessionManager>>,
     pub(crate) psbt_sessions: Arc<RwLock<PsbtSessionManager>>,
     pub(crate) peers: Arc<RwLock<PeerManager>>,
@@ -895,6 +956,11 @@ impl KfpNode {
             None => EcdhSessionManager::new(),
         };
 
+        let oprf_manager = match session_timeout {
+            Some(t) => OprfUnlockSessionManager::new().with_timeout(t),
+            None => OprfUnlockSessionManager::new(),
+        };
+
         let audit_hmac_key = derive_audit_hmac_key(&keys, &group_pubkey);
         let audit_log = Arc::new(SigningAuditLog::new(audit_hmac_key));
 
@@ -906,6 +972,9 @@ impl KfpNode {
             sessions: Arc::new(RwLock::new(session_manager)),
             nonce_pool: NoncePool::new(),
             ecdh_sessions: Arc::new(RwLock::new(ecdh_manager)),
+            oprf_key_share: None,
+            oprf_sessions: Arc::new(RwLock::new(oprf_manager)),
+            oprf_rate_limiter: Arc::new(RwLock::new(OprfEvalRateLimiter::new())),
             descriptor_sessions: Arc::new(RwLock::new(descriptor_manager)),
             psbt_sessions: Arc::new(RwLock::new(psbt_manager)),
             peers: Arc::new(RwLock::new(PeerManager::new(our_index))),
@@ -1147,6 +1216,20 @@ impl KfpNode {
             .read()
             .get_peer_recovery_xpubs(share_index)
             .map(|xpubs| xpubs.to_vec())
+    }
+
+    /// Install this node's dedicated OPRF key share, making it an OPRF-unlock
+    /// holder and enabling `request_oprf_unlock` as an initiator. This is a
+    /// separate key from the FROST signing share; the holder applies it only via
+    /// `keep_core::oprf::unlock::evaluate`.
+    pub fn set_oprf_key_share(&mut self, share: keep_core::oprf::threshold::KeyShare) {
+        self.oprf_key_share = Some(share);
+    }
+
+    /// Builder form of [`set_oprf_key_share`](Self::set_oprf_key_share).
+    pub fn with_oprf_key_share(mut self, share: keep_core::oprf::threshold::KeyShare) -> Self {
+        self.oprf_key_share = Some(share);
+        self
     }
 
     pub fn set_descriptor_proposers(&self, indices: HashSet<u16>) {
@@ -1405,6 +1488,7 @@ impl KfpNode {
                 _ = cleanup_interval.tick() => {
                     self.sessions.write().cleanup_expired();
                     self.ecdh_sessions.write().cleanup_expired();
+                    self.oprf_sessions.write().cleanup_expired();
                     let expired = self.descriptor_sessions.write().cleanup_expired();
                     for (session_id, reason) in expired {
                         let _ = self.event_tx.send(KfpNodeEvent::DescriptorFailed {
@@ -1486,7 +1570,10 @@ impl KfpNode {
 
         if !matches!(
             msg,
-            KfpMessage::Announce(_) | KfpMessage::SignRequest(_) | KfpMessage::EcdhRequest(_)
+            KfpMessage::Announce(_)
+                | KfpMessage::SignRequest(_)
+                | KfpMessage::EcdhRequest(_)
+                | KfpMessage::OprfEvalRequest(_)
         ) && !self.peers.read().is_trusted_peer(&event.pubkey)
         {
             debug!(from = %event.pubkey, "Rejecting message from untrusted peer");
@@ -1521,6 +1608,12 @@ impl KfpNode {
             }
             KfpMessage::EcdhComplete(payload) => {
                 self.handle_ecdh_complete(event.pubkey, payload).await?;
+            }
+            KfpMessage::OprfEvalRequest(payload) => {
+                self.handle_oprf_eval_request(event.pubkey, payload).await?;
+            }
+            KfpMessage::OprfEvalShare(payload) => {
+                self.handle_oprf_eval_share(event.pubkey, payload).await?;
             }
             KfpMessage::RefreshRequest(_)
             | KfpMessage::RefreshRound1(_)

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -358,8 +358,15 @@ pub trait SigningHooks: Send + Sync {
 
     /// Called by an OPRF-unlock holder before it evaluates a requester's blinded
     /// element. Returning `false` declines the evaluation without producing a
-    /// partial. The default permits every (already attested and rate-limited)
-    /// request so existing `SigningHooks` impls compile unchanged.
+    /// partial.
+    ///
+    /// SECURITY: the default is DENY. The OPRF input is a fixed, low-entropy
+    /// label and the box already holds one share, so in a 2-of-3 a single
+    /// auto-answered evaluation is enough to derive the volume key (the rate
+    /// limit does not help: one eval suffices). A holder MUST therefore opt in
+    /// explicitly by overriding this with a real policy (human approval on the
+    /// phone, an out-of-band confirmation on the replica). Leaving the default
+    /// keeps the oracle closed.
     ///
     /// Returns a boxed future rather than using `async fn` so the trait stays
     /// object-safe (`Arc<dyn SigningHooks>`), avoiding an `async-trait`
@@ -370,7 +377,7 @@ pub trait SigningHooks: Send + Sync {
         session_id: [u8; 32],
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>> {
         let _ = (requester_share_index, session_id);
-        Box::pin(async { true })
+        Box::pin(async { false })
     }
 }
 
@@ -479,6 +486,12 @@ pub enum KfpNodeEvent {
         requester_index: u16,
     },
     /// The box collected a quorum of partials and derived the LUKS key locally.
+    ///
+    /// SECURITY: this carries the derived key on the shared broadcast bus, so any
+    /// `subscribe()`er in-process sees it (the `Debug` impl redacts it, and it is
+    /// never serialized to the wire). This mirrors `EcdhComplete`; prefer the
+    /// `request_oprf_unlock` return value and do not log the event payload. See
+    /// the follow-up to move both off the broadcast bus to a per-session channel.
     OprfUnlockComplete {
         session_id: [u8; 32],
         luks_key: Zeroizing<[u8; 32]>,
@@ -1093,6 +1106,40 @@ impl KfpNode {
         self.descriptor_sessions
             .write()
             .test_insert_session(session);
+    }
+
+    /// Test-only: inject a peer directly into the peer table, bypassing the
+    /// announce/proof-of-share flow. Used by OPRF integration tests that need a
+    /// requester peer present with a specific `AttestationStatus` (e.g.
+    /// `Verified`) without standing up the full attestation machinery.
+    #[doc(hidden)]
+    #[cfg(any(test, feature = "testing"))]
+    pub fn test_inject_peer(&self, peer: Peer) {
+        self.peers.write().add_peer(peer);
+    }
+
+    /// Test-only: override the attestation status of an already-known peer. The
+    /// happy-path OPRF test discovers peers naturally, then flips the requester's
+    /// status to `Verified` to satisfy the holder's strict attestation gate.
+    #[doc(hidden)]
+    #[cfg(any(test, feature = "testing"))]
+    pub fn test_set_peer_attestation(&self, share_index: u16, status: AttestationStatus) {
+        if let Some(peer) = self.peers.write().get_peer_mut(share_index) {
+            peer.attestation_status = status;
+        }
+    }
+
+    /// Test-only: drive the holder-side OPRF eval handler directly. Lets the
+    /// negative-path tests assert on the returned `Result` (gate rejections,
+    /// rate limiting, replay) without a full box round-trip.
+    #[doc(hidden)]
+    #[cfg(any(test, feature = "testing"))]
+    pub async fn test_handle_oprf_eval_request(
+        &self,
+        from: PublicKey,
+        request: OprfEvalRequestPayload,
+    ) -> Result<()> {
+        self.handle_oprf_eval_request(from, request).await
     }
 
     pub fn set_replay_window(&mut self, secs: u64) {

--- a/keep-frost-net/src/node/oprf.rs
+++ b/keep-frost-net/src/node/oprf.rs
@@ -21,6 +21,8 @@ use crate::event::KfpEventBuilder;
 use crate::oprf_session::derive_oprf_session_id;
 use crate::protocol::*;
 
+use crate::peer::AttestationStatus;
+
 use super::{KfpNode, KfpNodeEvent};
 
 impl KfpNode {
@@ -73,7 +75,11 @@ impl KfpNode {
         // Bind the requester's pubkey to its claimed share index.
         self.verify_peer_share_index(from, request.requester_share_index)?;
 
-        // Attestation gate: the eval oracle only answers attested holders/boxes.
+        // Attestation gate: the eval oracle requires VERIFIED attestation of the
+        // requester, not merely `is_attested()`. `is_attested()` also accepts
+        // `NotConfigured` (this node set no expected PCRs); for the OPRF oracle
+        // that would be fail-open, so a node guarding a real vault MUST configure
+        // expected PCRs and only answer a requester whose measured boot verified.
         {
             let peers = self.peers.read();
             let peer = peers
@@ -84,10 +90,10 @@ impl KfpNode {
                         request.requester_share_index
                     ))
                 })?;
-            if !peer.is_attested() {
+            if !matches!(peer.attestation_status, AttestationStatus::Verified) {
                 return Err(FrostNetError::UntrustedPeer(format!(
-                    "OPRF requester share {} is not attested",
-                    request.requester_share_index
+                    "OPRF requester share {} attestation not Verified ({:?})",
+                    request.requester_share_index, peer.attestation_status
                 )));
             }
         }
@@ -176,7 +182,22 @@ impl KfpNode {
             session.add_partial(payload.share_index, payload.partial.clone())?;
 
             if session.has_quorum() {
-                session.try_finalize()?
+                // On a finalize failure (e.g. a wrong partial from a misbehaving
+                // holder) emit OprfUnlockFailed so the box fails fast instead of
+                // blocking on its 30s timeout.
+                match session.try_finalize() {
+                    Ok(key) => key,
+                    Err(e) => {
+                        // Use the already-held write guard; re-locking would
+                        // deadlock (parking_lot is not reentrant).
+                        oprf_sessions.complete_session(&payload.session_id);
+                        let _ = self.event_tx.send(KfpNodeEvent::OprfUnlockFailed {
+                            session_id: payload.session_id,
+                            error: e.to_string(),
+                        });
+                        return Err(e);
+                    }
+                }
             } else {
                 None
             }
@@ -204,6 +225,15 @@ impl KfpNode {
     /// Box public API: blind `input`, gather a quorum of holder partial
     /// evaluations, and derive the 32-byte LUKS key. The node must hold an OPRF
     /// key share. Mirrors [`KfpNode::request_ecdh`].
+    ///
+    /// PROVISIONING CONTRACT: eligible peers are the FROST signing peers, and a
+    /// selected peer with no OPRF key share silently does not answer (it is not a
+    /// holder), so the box would miss quorum and time out. Therefore every
+    /// signing peer MUST be issued an OPRF key share 1:1, and the OPRF key MUST be
+    /// split with the SAME threshold `t` as the FROST group (this method passes
+    /// the FROST threshold to `finalize_luks_key`); a mismatch makes every
+    /// finalize fail. The node with FROST identifier `i` must hold the OPRF share
+    /// at vsss index `i`.
     pub async fn request_oprf_unlock(
         &self,
         input: &[u8],

--- a/keep-frost-net/src/node/oprf.rs
+++ b/keep-frost-net/src/node/oprf.rs
@@ -118,8 +118,9 @@ impl KfpNode {
             requester_index: request.requester_share_index,
         });
 
-        // Operator approval hook (default-allow). Clone the Arc so the read guard
-        // is dropped before awaiting.
+        // Operator approval hook (default-DENY; a holder must opt in with an
+        // explicit policy). Clone the Arc so the read guard is dropped before
+        // awaiting.
         let hooks = self.hooks.read().clone();
         if !hooks
             .approve_oprf_eval(request.requester_share_index, request.session_id)
@@ -294,13 +295,25 @@ impl KfpNode {
         // ECDH #561.
         let mut rx = self.event_tx.subscribe();
 
-        for (share_index, pubkey) in participant_peers {
-            let event = KfpEventBuilder::oprf_eval_request(&self.keys, &pubkey, request.clone())?;
-            self.client
-                .send_event(&event)
-                .await
-                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
-            debug!(share_index, "Sent OPRF eval request");
+        // Tear the just-created session down on any send failure, instead of
+        // letting it linger until cleanup_expired reaps it (matches the teardown
+        // on the timeout/error path below).
+        let send_result: Result<()> = async {
+            for (share_index, pubkey) in participant_peers {
+                let event =
+                    KfpEventBuilder::oprf_eval_request(&self.keys, &pubkey, request.clone())?;
+                self.client
+                    .send_event(&event)
+                    .await
+                    .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+                debug!(share_index, "Sent OPRF eval request");
+            }
+            Ok(())
+        }
+        .await;
+        if let Err(e) = send_result {
+            self.oprf_sessions.write().complete_session(&session_id);
+            return Err(e);
         }
 
         // Single-participant (threshold=1) or quorum already met by our own

--- a/keep-frost-net/src/node/oprf.rs
+++ b/keep-frost-net/src/node/oprf.rs
@@ -1,0 +1,353 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+//! Threshold-OPRF unlock session wired over KFP.
+//!
+//! The "box" (initiator) blinds a fixed unlock input, asks a quorum of holders
+//! to evaluate it with their dedicated OPRF key shares, and combines the partial
+//! evaluations locally into a 32-byte LUKS key. The OPRF key is NEVER
+//! reconstructed and the derived key NEVER crosses the wire. Mirrors the ECDH
+//! session in [`super::ecdh`], with the holder-side asymmetry and the #621
+//! ship-gate (attestation + rate limit + approval) on the eval oracle.
+
+use std::time::Duration;
+
+use nostr_sdk::prelude::*;
+use tracing::{debug, info, warn};
+use zeroize::Zeroizing;
+
+use crate::error::{FrostNetError, Result};
+use crate::event::KfpEventBuilder;
+use crate::oprf_session::derive_oprf_session_id;
+use crate::protocol::*;
+
+use super::{KfpNode, KfpNodeEvent};
+
+impl KfpNode {
+    /// Holder side: evaluate a box's blinded element with this node's dedicated
+    /// OPRF key share, after passing every #621 gate, in order:
+    /// group/participant/replay/policy, pubkey↔share binding, attestation,
+    /// rate limit, then the operator approval hook. Only then is the eval oracle
+    /// invoked and the partial returned.
+    pub(crate) async fn handle_oprf_eval_request(
+        &self,
+        from: PublicKey,
+        request: OprfEvalRequestPayload,
+    ) -> Result<()> {
+        if request.group_pubkey != self.group_pubkey {
+            return Ok(());
+        }
+
+        if !request
+            .participants
+            .contains(&self.share.metadata.identifier)
+        {
+            return Ok(());
+        }
+
+        // A node with no OPRF key share is not an OPRF holder; ignore silently.
+        let oprf_share = match &self.oprf_key_share {
+            Some(s) => s,
+            None => return Ok(()),
+        };
+
+        if !request.is_within_replay_window(self.replay_window_secs) {
+            warn!(
+                session_id = %hex::encode(request.session_id),
+                created_at = request.created_at,
+                "Rejecting OPRF eval request: outside replay window"
+            );
+            return Err(FrostNetError::ReplayDetected(format!(
+                "OPRF eval request created_at {} outside {} second window",
+                request.created_at, self.replay_window_secs
+            )));
+        }
+
+        if !self.can_receive_from(&from) {
+            debug!(from = %from, "Rejecting OPRF eval request: policy denies receive");
+            return Err(FrostNetError::PolicyViolation(format!(
+                "Peer {from} not allowed to send OPRF eval requests"
+            )));
+        }
+
+        // Bind the requester's pubkey to its claimed share index.
+        self.verify_peer_share_index(from, request.requester_share_index)?;
+
+        // Attestation gate: the eval oracle only answers attested holders/boxes.
+        {
+            let peers = self.peers.read();
+            let peer = peers
+                .get_peer(request.requester_share_index)
+                .ok_or_else(|| {
+                    FrostNetError::UntrustedPeer(format!(
+                        "OPRF requester share {} not announced",
+                        request.requester_share_index
+                    ))
+                })?;
+            if !peer.is_attested() {
+                return Err(FrostNetError::UntrustedPeer(format!(
+                    "OPRF requester share {} is not attested",
+                    request.requester_share_index
+                )));
+            }
+        }
+
+        // Rate-limit the oracle per requester. Bounding evaluations is what keeps
+        // the fixed, low-entropy unlock input from being brute-forced offline.
+        if !self.oprf_rate_limiter.write().check_and_record(from) {
+            warn!(from = %from, "Rejecting OPRF eval request: rate limit exceeded");
+            return Err(FrostNetError::RateLimited(format!(
+                "OPRF eval rate limit exceeded for {from}"
+            )));
+        }
+
+        info!(
+            session_id = %hex::encode(request.session_id),
+            requester = request.requester_share_index,
+            "Received OPRF eval request"
+        );
+
+        let _ = self.event_tx.send(KfpNodeEvent::OprfEvalRequested {
+            session_id: request.session_id,
+            requester_index: request.requester_share_index,
+        });
+
+        // Operator approval hook (default-allow). Clone the Arc so the read guard
+        // is dropped before awaiting.
+        let hooks = self.hooks.read().clone();
+        if !hooks
+            .approve_oprf_eval(request.requester_share_index, request.session_id)
+            .await
+        {
+            info!(
+                session_id = %hex::encode(request.session_id),
+                "OPRF eval declined by approval hook"
+            );
+            return Ok(());
+        }
+
+        let partial = keep_core::oprf::unlock::evaluate(oprf_share, &request.blinded)
+            .map_err(|e| FrostNetError::Crypto(e.to_string()))?;
+
+        let payload = OprfEvalSharePayload::new(
+            request.session_id,
+            self.share.metadata.identifier,
+            partial.to_vec(),
+        );
+
+        let event = KfpEventBuilder::oprf_eval_share(&self.keys, &from, payload)?;
+        self.client
+            .send_event(&event)
+            .await
+            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+
+        debug!(
+            session_id = %hex::encode(request.session_id),
+            "Sent OPRF eval share"
+        );
+
+        Ok(())
+    }
+
+    /// Box side: collect a holder partial, and on quorum derive the LUKS key
+    /// locally and emit [`KfpNodeEvent::OprfUnlockComplete`].
+    pub(crate) async fn handle_oprf_eval_share(
+        &self,
+        from: PublicKey,
+        payload: OprfEvalSharePayload,
+    ) -> Result<()> {
+        self.verify_peer_share_index(from, payload.share_index)?;
+
+        self.peers.write().update_last_seen(payload.share_index);
+
+        let luks_key = {
+            let mut oprf_sessions = self.oprf_sessions.write();
+            let session = match oprf_sessions.get_session_mut(&payload.session_id) {
+                Some(s) => s,
+                None => {
+                    debug!(
+                        session_id = %hex::encode(payload.session_id),
+                        "No OPRF unlock session for share"
+                    );
+                    return Ok(());
+                }
+            };
+
+            session.add_partial(payload.share_index, payload.partial.clone())?;
+
+            if session.has_quorum() {
+                session.try_finalize()?
+            } else {
+                None
+            }
+        };
+
+        if let Some(key) = luks_key {
+            info!(
+                session_id = %hex::encode(payload.session_id),
+                "OPRF unlock complete!"
+            );
+
+            self.oprf_sessions
+                .write()
+                .complete_session(&payload.session_id);
+
+            let _ = self.event_tx.send(KfpNodeEvent::OprfUnlockComplete {
+                session_id: payload.session_id,
+                luks_key: key,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Box public API: blind `input`, gather a quorum of holder partial
+    /// evaluations, and derive the 32-byte LUKS key. The node must hold an OPRF
+    /// key share. Mirrors [`KfpNode::request_ecdh`].
+    pub async fn request_oprf_unlock(
+        &self,
+        input: &[u8],
+        volume_id: &str,
+        epoch: u32,
+    ) -> Result<Zeroizing<[u8; 32]>> {
+        let oprf_share = self.oprf_key_share.as_ref().ok_or_else(|| {
+            FrostNetError::Crypto("Node has no OPRF key share; cannot initiate unlock".into())
+        })?;
+
+        let threshold = self.share.metadata.threshold;
+
+        let (participants, participant_peers) =
+            self.select_eligible_peers(threshold as usize, &[])?;
+
+        let (client, blinded) = keep_core::oprf::unlock::blind(input)
+            .map_err(|e| FrostNetError::Crypto(e.to_string()))?;
+        let blinded_arr: [u8; 33] = blinded
+            .as_slice()
+            .try_into()
+            .map_err(|_| FrostNetError::Crypto("Invalid blinded element length".into()))?;
+
+        let session_id = derive_oprf_session_id(&blinded_arr, &participants);
+
+        info!(
+            session_id = %hex::encode(session_id),
+            participants = ?participants,
+            "Initiating OPRF unlock request"
+        );
+
+        let our_partial = keep_core::oprf::unlock::evaluate(oprf_share, &blinded)
+            .map_err(|e| FrostNetError::Crypto(e.to_string()))?;
+
+        {
+            let mut oprf_sessions = self.oprf_sessions.write();
+            let session = oprf_sessions.create_session(
+                session_id,
+                client,
+                threshold as usize,
+                participants.clone(),
+                volume_id.to_string(),
+                epoch,
+            )?;
+            session.add_partial(self.share.metadata.identifier, our_partial.to_vec())?;
+        }
+
+        let request = OprfEvalRequestPayload::new(
+            session_id,
+            self.group_pubkey,
+            blinded_arr,
+            participants.clone(),
+            self.share.metadata.identifier,
+        );
+
+        // Subscribe BEFORE sending so a fast holder's share, processed by our run
+        // loop, cannot fire `OprfUnlockComplete` before we start listening
+        // (broadcast does not replay to late subscribers). Same flake class as
+        // ECDH #561.
+        let mut rx = self.event_tx.subscribe();
+
+        for (share_index, pubkey) in participant_peers {
+            let event = KfpEventBuilder::oprf_eval_request(&self.keys, &pubkey, request.clone())?;
+            self.client
+                .send_event(&event)
+                .await
+                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+            debug!(share_index, "Sent OPRF eval request");
+        }
+
+        // Single-participant (threshold=1) or quorum already met by our own
+        // partial: finalize locally without waiting on the network.
+        let immediate = {
+            let mut oprf_sessions = self.oprf_sessions.write();
+            match oprf_sessions.get_session_mut(&session_id) {
+                Some(s) if s.has_quorum() => match s.try_finalize() {
+                    Ok(key) => key,
+                    Err(e) => {
+                        oprf_sessions.complete_session(&session_id);
+                        return Err(e);
+                    }
+                },
+                _ => None,
+            }
+        };
+        if let Some(key) = immediate {
+            info!(
+                session_id = %hex::encode(session_id),
+                "OPRF unlock complete (single-party)!"
+            );
+            self.oprf_sessions.write().complete_session(&session_id);
+            if let Err(e) = self.event_tx.send(KfpNodeEvent::OprfUnlockComplete {
+                session_id,
+                luks_key: key,
+            }) {
+                warn!(
+                    session_id = %hex::encode(session_id),
+                    error = %e,
+                    "Failed to send OprfUnlockComplete event (single-party)"
+                );
+            }
+        }
+
+        let timeout = Duration::from_secs(30);
+
+        let result = tokio::time::timeout(timeout, async {
+            loop {
+                match rx.recv().await {
+                    Ok(KfpNodeEvent::OprfUnlockComplete {
+                        session_id: sid,
+                        luks_key,
+                    }) => {
+                        if sid == session_id {
+                            return Ok(luks_key);
+                        }
+                    }
+                    Ok(KfpNodeEvent::OprfUnlockFailed {
+                        session_id: sid,
+                        error,
+                    }) => {
+                        if sid == session_id {
+                            return Err(FrostNetError::Session(error));
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        return Err(FrostNetError::Transport("Event channel closed".into()));
+                    }
+                    _ => {}
+                }
+            }
+        })
+        .await;
+
+        let result = match result {
+            Ok(r) => r,
+            Err(_) => Err(FrostNetError::Timeout(
+                "OPRF unlock request timed out".into(),
+            )),
+        };
+        // Tear down the session on any non-success exit so it does not linger
+        // until cleanup_expired reaps it (matches request_ecdh).
+        if result.is_err() {
+            self.oprf_sessions.write().complete_session(&session_id);
+        }
+        result
+    }
+}

--- a/keep-frost-net/src/oprf_session.rs
+++ b/keep-frost-net/src/oprf_session.rs
@@ -1,0 +1,542 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+//! Box-side session state for the threshold-OPRF unlock and the holder-side
+//! rate limiter that bounds the evaluation oracle.
+//!
+//! Mirrors the ECDH session machinery ([`crate::ecdh`]) but with a hard
+//! asymmetry: only the initiator (the "box") holds blinding state. The box owns
+//! the [`keep_core::oprf::unlock::Client`], collects holder partial evaluations
+//! as 65-byte wire `Vec<u8>` keyed by FROST share index, and on quorum derives
+//! the LUKS key locally. Holders keep no unlock session; they only answer the
+//! eval oracle, which the [`OprfEvalRateLimiter`] keeps bounded.
+
+use std::collections::{BTreeMap, HashMap};
+use std::time::{Duration, Instant};
+
+use nostr_sdk::PublicKey;
+use zeroize::Zeroizing;
+
+use keep_core::oprf::unlock::Client;
+
+use crate::error::{FrostNetError, Result};
+use crate::protocol::OPRF_PARTIAL_LEN;
+
+/// Domain-separated session id for an OPRF unlock, binding the blinded element
+/// to the participant set. Mirrors [`crate::ecdh::derive_ecdh_session_id`].
+pub fn derive_oprf_session_id(blinded: &[u8; 33], participants: &[u16]) -> [u8; 32] {
+    let mut sorted_participants = participants.to_vec();
+    sorted_participants.sort();
+
+    let mut preimage = Vec::with_capacity(64 + participants.len() * 2);
+    preimage.extend_from_slice(b"keep-frost-oprf-v1");
+    preimage.extend_from_slice(blinded);
+    preimage.extend_from_slice(&(sorted_participants.len() as u16).to_be_bytes());
+    for p in &sorted_participants {
+        preimage.extend_from_slice(&p.to_be_bytes());
+    }
+
+    keep_core::crypto::blake2b_256(&preimage)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OprfUnlockSessionState {
+    Collecting,
+    Complete,
+    Failed(String),
+    Expired,
+}
+
+/// Box-side state for one unlock attempt. Owns the OPRF [`Client`] (the blinding
+/// secret), collects holder partials keyed by share index, and derives the LUKS
+/// key once a quorum is present. The derived key never crosses the wire.
+pub struct OprfUnlockSession {
+    session_id: [u8; 32],
+    client: Client,
+    threshold: usize,
+    participants: Vec<u16>,
+    volume_id: String,
+    epoch: u32,
+    state: OprfUnlockSessionState,
+    created_at: Instant,
+    timeout: Duration,
+    partials: BTreeMap<u16, Vec<u8>>,
+}
+
+impl OprfUnlockSession {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        session_id: [u8; 32],
+        client: Client,
+        threshold: usize,
+        participants: Vec<u16>,
+        volume_id: String,
+        epoch: u32,
+    ) -> Self {
+        Self {
+            session_id,
+            client,
+            threshold,
+            participants,
+            volume_id,
+            epoch,
+            state: OprfUnlockSessionState::Collecting,
+            created_at: Instant::now(),
+            timeout: Duration::from_secs(30),
+            partials: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn session_id(&self) -> &[u8; 32] {
+        &self.session_id
+    }
+
+    pub fn threshold(&self) -> usize {
+        self.threshold
+    }
+
+    pub fn participants(&self) -> &[u16] {
+        &self.participants
+    }
+
+    pub fn volume_id(&self) -> &str {
+        &self.volume_id
+    }
+
+    pub fn epoch(&self) -> u32 {
+        self.epoch
+    }
+
+    pub fn state(&self) -> OprfUnlockSessionState {
+        if self.created_at.elapsed() > self.timeout
+            && self.state == OprfUnlockSessionState::Collecting
+        {
+            return OprfUnlockSessionState::Expired;
+        }
+        self.state.clone()
+    }
+
+    pub fn is_participant(&self, share_index: u16) -> bool {
+        self.participants.contains(&share_index)
+    }
+
+    /// Record one holder partial. Rejects a non-participant, a duplicate share
+    /// index, or a wrong-length partial (the OPRF wire encoding is fixed-size).
+    pub fn add_partial(&mut self, share_index: u16, partial: Vec<u8>) -> Result<()> {
+        if share_index == 0 {
+            return Err(FrostNetError::Protocol(
+                "Invalid share_index: must be non-zero".into(),
+            ));
+        }
+        if self.state != OprfUnlockSessionState::Collecting {
+            return Err(FrostNetError::Session("Not accepting OPRF partials".into()));
+        }
+        if !self.is_participant(share_index) {
+            return Err(FrostNetError::Session(format!(
+                "Share {share_index} not a participant"
+            )));
+        }
+        if partial.len() != OPRF_PARTIAL_LEN {
+            return Err(FrostNetError::Protocol(
+                "Invalid OPRF partial length".into(),
+            ));
+        }
+        if self.partials.contains_key(&share_index) {
+            return Err(FrostNetError::Session("Duplicate OPRF partial".into()));
+        }
+        self.partials.insert(share_index, partial);
+        Ok(())
+    }
+
+    pub fn has_quorum(&self) -> bool {
+        self.partials.len() >= self.threshold
+    }
+
+    /// Derive the LUKS key once a quorum of partials is present. Below quorum
+    /// returns `Ok(None)`; a finalize failure marks the session `Failed` and
+    /// surfaces the error.
+    pub fn try_finalize(&mut self) -> Result<Option<Zeroizing<[u8; 32]>>> {
+        if !self.has_quorum() {
+            return Ok(None);
+        }
+
+        let parts: Vec<Vec<u8>> = self.partials.values().cloned().collect();
+        match self
+            .client
+            .finalize_luks_key(&parts, self.threshold, &self.volume_id, self.epoch)
+        {
+            Ok(key) => {
+                self.state = OprfUnlockSessionState::Complete;
+                Ok(Some(key))
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                self.state = OprfUnlockSessionState::Failed(msg.clone());
+                Err(FrostNetError::Crypto(msg))
+            }
+        }
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.state == OprfUnlockSessionState::Complete
+    }
+
+    pub fn is_expired(&self) -> bool {
+        self.state() == OprfUnlockSessionState::Expired
+    }
+}
+
+pub struct OprfUnlockSessionManager {
+    active_sessions: HashMap<[u8; 32], OprfUnlockSession>,
+    session_timeout: Duration,
+}
+
+impl OprfUnlockSessionManager {
+    pub fn new() -> Self {
+        Self {
+            active_sessions: HashMap::new(),
+            session_timeout: Duration::from_secs(30),
+        }
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.session_timeout = timeout;
+        self
+    }
+
+    const MAX_ACTIVE_SESSIONS: usize = 256;
+
+    pub fn create_session(
+        &mut self,
+        session_id: [u8; 32],
+        client: Client,
+        threshold: usize,
+        participants: Vec<u16>,
+        volume_id: String,
+        epoch: u32,
+    ) -> Result<&mut OprfUnlockSession> {
+        if let Some(existing) = self.active_sessions.get(&session_id) {
+            if !existing.is_expired() {
+                return Err(FrostNetError::Session(
+                    "OPRF unlock session already active".into(),
+                ));
+            }
+            self.active_sessions.remove(&session_id);
+        }
+
+        self.cleanup_expired();
+        if self.active_sessions.len() >= Self::MAX_ACTIVE_SESSIONS {
+            return Err(FrostNetError::Session(
+                "Too many active OPRF unlock sessions".into(),
+            ));
+        }
+
+        let session = OprfUnlockSession::new(
+            session_id,
+            client,
+            threshold,
+            participants,
+            volume_id,
+            epoch,
+        )
+        .with_timeout(self.session_timeout);
+
+        self.active_sessions.insert(session_id, session);
+        Ok(self
+            .active_sessions
+            .get_mut(&session_id)
+            .expect("just inserted"))
+    }
+
+    pub fn get_session(&self, session_id: &[u8; 32]) -> Option<&OprfUnlockSession> {
+        self.active_sessions.get(session_id)
+    }
+
+    pub fn get_session_mut(&mut self, session_id: &[u8; 32]) -> Option<&mut OprfUnlockSession> {
+        self.active_sessions.get_mut(session_id)
+    }
+
+    pub fn complete_session(&mut self, session_id: &[u8; 32]) {
+        self.active_sessions.remove(session_id);
+    }
+
+    pub fn cleanup_expired(&mut self) {
+        self.active_sessions
+            .retain(|_, session| !session.is_expired());
+    }
+}
+
+impl Default for OprfUnlockSessionManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Per-requester sliding-window rate limiter for the holder-side OPRF evaluation
+/// oracle.
+///
+/// SECURITY: the OPRF-unlock input is a fixed, low-entropy label, so the
+/// unlock's resistance to offline guessing depends on bounding how many
+/// evaluations any one identity can obtain (see
+/// `keep_core::oprf::threshold::partial_eval`). This caps each requester at
+/// [`MAX_OPRF_EVALS_PER_WINDOW`] evaluations per [`OPRF_EVAL_WINDOW`]; beyond
+/// that the holder refuses with [`FrostNetError::RateLimited`].
+///
+/// Memory ceiling: tracked identities are pruned lazily once their window
+/// empties, and the table is capped at [`MAX_TRACKED_REQUESTERS`]. If a
+/// finer-grained guarantee is ever needed (e.g. global eval budget), upgrade
+/// this to a token-bucket keyed by both identity and group.
+pub const MAX_OPRF_EVALS_PER_WINDOW: u32 = 8;
+pub const OPRF_EVAL_WINDOW: Duration = Duration::from_secs(60);
+const MAX_TRACKED_REQUESTERS: usize = 1024;
+
+pub struct OprfEvalRateLimiter {
+    window: Duration,
+    max_per_window: u32,
+    events: HashMap<PublicKey, Vec<Instant>>,
+}
+
+impl OprfEvalRateLimiter {
+    pub fn new() -> Self {
+        Self {
+            window: OPRF_EVAL_WINDOW,
+            max_per_window: MAX_OPRF_EVALS_PER_WINDOW,
+            events: HashMap::new(),
+        }
+    }
+
+    /// Record an evaluation request from `requester` at the current instant.
+    /// Returns `true` if it is within the per-window budget, `false` if the
+    /// requester has exceeded [`MAX_OPRF_EVALS_PER_WINDOW`].
+    pub fn check_and_record(&mut self, requester: PublicKey) -> bool {
+        self.check_and_record_at(requester, Instant::now())
+    }
+
+    /// Time-injectable core of [`check_and_record`], exposed for deterministic
+    /// tests of the window logic.
+    pub fn check_and_record_at(&mut self, requester: PublicKey, now: Instant) -> bool {
+        let window = self.window;
+        let cutoff = now.checked_sub(window);
+
+        // Bound memory: drop identities whose window has fully emptied before
+        // inserting a new one.
+        if self.events.len() >= MAX_TRACKED_REQUESTERS && !self.events.contains_key(&requester) {
+            self.events.retain(|_, ts| {
+                ts.retain(|&t| cutoff.map(|c| t >= c).unwrap_or(true));
+                !ts.is_empty()
+            });
+        }
+
+        let entry = self.events.entry(requester).or_default();
+        entry.retain(|&t| cutoff.map(|c| t >= c).unwrap_or(true));
+
+        if entry.len() as u32 >= self.max_per_window {
+            return false;
+        }
+        entry.push(now);
+        true
+    }
+}
+
+impl Default for OprfEvalRateLimiter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use keep_core::oprf::threshold;
+    use keep_core::oprf::unlock;
+
+    // rand_core 0.6 OsRng, reached through k256's elliptic-curve re-export so no
+    // extra dependency is pulled in (split_key wants the rand_core 0.6 traits).
+    use k256::elliptic_curve::rand_core::OsRng;
+
+    fn split_2of3() -> Vec<threshold::KeyShare> {
+        use k256::Scalar;
+        let mut rng = OsRng;
+        let s = <Scalar as k256::elliptic_curve::Field>::random(&mut rng);
+        threshold::split_key(&s, 2, 3, rng).expect("split")
+    }
+
+    /// End-to-end through the box session: a real `unlock::Client` plus two real
+    /// partials must finalize to the SAME LUKS key that a different quorum of the
+    /// SAME key split derives directly through the byte API. Because `finalize`
+    /// strips the per-attempt blinding, the same input + key yields a stable
+    /// OPRF output, so every 2-of-3 quorum must land on one key. This mirrors the
+    /// oracle in `keep-core/src/oprf.rs` `unlock_wire_api_matches_single_key`
+    /// using only the public `keep_core::oprf` surface.
+    #[test]
+    fn session_finalizes_matching_other_quorum() {
+        let input: &[u8] = b"keep-node-vault-v1";
+        let shares = split_2of3();
+
+        // Reference key: a fresh blind, the {0,2} quorum, finalized directly.
+        let (ref_client, ref_blinded) = unlock::blind(input).expect("blind");
+        let rp0 = unlock::evaluate(&shares[0], &ref_blinded).expect("p0");
+        let rp2 = unlock::evaluate(&shares[2], &ref_blinded).expect("p2");
+        let k_ref = ref_client
+            .finalize_luks_key(&[rp0.to_vec(), rp2.to_vec()], 2, "vault0", 1)
+            .expect("reference finalize");
+
+        // Box session: independent fresh blind, the {1,2} quorum.
+        let (client, blinded) = unlock::blind(input).expect("blind");
+        let p0 = unlock::evaluate(&shares[0], &blinded).expect("p0");
+        let p1 = unlock::evaluate(&shares[1], &blinded).expect("p1");
+
+        let session_id = [0x11u8; 32];
+        let mut session =
+            OprfUnlockSession::new(session_id, client, 2, vec![1, 2, 3], "vault0".into(), 1);
+
+        session.add_partial(1, p0.to_vec()).unwrap();
+        assert!(
+            session.try_finalize().unwrap().is_none(),
+            "1/2 partials must not finalize"
+        );
+        session.add_partial(2, p1.to_vec()).unwrap();
+        assert!(session.has_quorum());
+
+        let k = session
+            .try_finalize()
+            .unwrap()
+            .expect("quorum must finalize");
+        assert_eq!(
+            *k, *k_ref,
+            "every 2-of-3 quorum must derive the same LUKS key"
+        );
+        assert_eq!(k.len(), 32);
+        assert!(session.is_complete());
+    }
+
+    /// `add_partial` rejects a duplicate share index and a wrong-length partial.
+    #[test]
+    fn add_partial_rejects_duplicate_and_wrong_length() {
+        let shares = split_2of3();
+        let (client, blinded) = unlock::blind(b"keep-node-vault-v1").expect("blind");
+        let p0 = unlock::evaluate(&shares[0], &blinded).expect("p0");
+
+        let mut session =
+            OprfUnlockSession::new([0x22u8; 32], client, 2, vec![1, 2, 3], "vault0".into(), 1);
+
+        session.add_partial(1, p0.to_vec()).unwrap();
+        assert!(
+            session.add_partial(1, p0.to_vec()).is_err(),
+            "duplicate share index must be rejected"
+        );
+        assert!(
+            session.add_partial(2, vec![0u8; 64]).is_err(),
+            "a 64-byte partial must be rejected"
+        );
+        assert!(
+            session.add_partial(2, vec![0u8; 66]).is_err(),
+            "a 66-byte partial must be rejected"
+        );
+        assert!(
+            session.add_partial(4, p0.to_vec()).is_err(),
+            "a non-participant share index must be rejected"
+        );
+    }
+
+    /// Below quorum, `try_finalize` short-circuits to `Ok(None)` rather than
+    /// fabricating a key.
+    #[test]
+    fn try_finalize_below_quorum_returns_none() {
+        let shares = split_2of3();
+        let (client, blinded) = unlock::blind(b"keep-node-vault-v1").expect("blind");
+        let p0 = unlock::evaluate(&shares[0], &blinded).expect("p0");
+
+        let mut session =
+            OprfUnlockSession::new([0x33u8; 32], client, 2, vec![1, 2, 3], "vault0".into(), 1);
+        session.add_partial(1, p0.to_vec()).unwrap();
+
+        assert!(!session.has_quorum());
+        assert!(session.try_finalize().unwrap().is_none());
+        assert_eq!(session.state(), OprfUnlockSessionState::Collecting);
+    }
+
+    /// Rate limiter: `MAX + 1` requests from one identity rejects the last, a
+    /// different identity is unaffected, and the window resets once it elapses.
+    #[test]
+    fn rate_limiter_bounds_per_identity_and_resets() {
+        let mut rl = OprfEvalRateLimiter::new();
+        let a = nostr_sdk::Keys::generate().public_key();
+        let b = nostr_sdk::Keys::generate().public_key();
+
+        let base = Instant::now();
+        for i in 0..MAX_OPRF_EVALS_PER_WINDOW {
+            assert!(
+                rl.check_and_record_at(a, base + Duration::from_millis(i as u64)),
+                "request {i} within budget must be allowed"
+            );
+        }
+        // The (MAX+1)th from the same identity, still inside the window, is rejected.
+        assert!(
+            !rl.check_and_record_at(
+                a,
+                base + Duration::from_millis(MAX_OPRF_EVALS_PER_WINDOW as u64)
+            ),
+            "exceeding the per-window budget must be rejected"
+        );
+
+        // A different identity is unaffected.
+        assert!(
+            rl.check_and_record_at(b, base + Duration::from_millis(1)),
+            "a distinct identity must not be rate limited by another's usage"
+        );
+
+        // After the window fully elapses, the first identity resets.
+        assert!(
+            rl.check_and_record_at(a, base + OPRF_EVAL_WINDOW + Duration::from_secs(1)),
+            "the budget must reset after the window elapses"
+        );
+    }
+
+    #[test]
+    fn derive_oprf_session_id_is_deterministic_and_input_sensitive() {
+        let blinded = [0x02u8; 33];
+        assert_eq!(
+            derive_oprf_session_id(&blinded, &[1, 2, 3]),
+            derive_oprf_session_id(&blinded, &[3, 2, 1]),
+            "participant order must not matter"
+        );
+        assert_ne!(
+            derive_oprf_session_id(&blinded, &[1, 2, 3]),
+            derive_oprf_session_id(&[0x03u8; 33], &[1, 2, 3]),
+            "a different blinded element must yield a distinct id"
+        );
+        assert_ne!(
+            derive_oprf_session_id(&blinded, &[1, 2, 3]),
+            derive_oprf_session_id(&blinded, &[1, 2, 4]),
+            "a different participant set must yield a distinct id"
+        );
+    }
+
+    #[test]
+    fn manager_lifecycle_and_duplicate_guard() {
+        let shares = split_2of3();
+        let (client, blinded) = unlock::blind(b"keep-node-vault-v1").expect("blind");
+        let _ = unlock::evaluate(&shares[0], &blinded).expect("p0");
+
+        let mut mgr = OprfUnlockSessionManager::new();
+        let sid = [0x44u8; 32];
+        mgr.create_session(sid, client, 2, vec![1, 2, 3], "vault0".into(), 1)
+            .unwrap();
+        assert!(mgr.get_session(&sid).is_some());
+
+        // A duplicate active session id is refused.
+        let (client2, _) = unlock::blind(b"keep-node-vault-v1").expect("blind");
+        assert!(mgr
+            .create_session(sid, client2, 2, vec![1, 2, 3], "vault0".into(), 1)
+            .is_err());
+
+        mgr.complete_session(&sid);
+        assert!(mgr.get_session(&sid).is_none());
+    }
+}

--- a/keep-frost-net/src/oprf_session.rs
+++ b/keep-frost-net/src/oprf_session.rs
@@ -330,6 +330,13 @@ impl OprfEvalRateLimiter {
                 ts.retain(|&t| cutoff.map(|c| t >= c).unwrap_or(true));
                 !ts.is_empty()
             });
+            // Hard cap: if pruning emptied nothing, refuse to track a new
+            // identity rather than grow without bound. Only attested, announced
+            // peers reach the limiter, so this is never hit in practice; it is a
+            // backstop, and refusing fails closed (the request is rejected).
+            if self.events.len() >= MAX_TRACKED_REQUESTERS {
+                return false;
+            }
         }
 
         let entry = self.events.entry(requester).or_default();
@@ -495,6 +502,25 @@ mod tests {
         assert!(
             rl.check_and_record_at(a, base + OPRF_EVAL_WINDOW + Duration::from_secs(1)),
             "the budget must reset after the window elapses"
+        );
+    }
+
+    /// The limiter table is a hard cap: once `MAX_TRACKED_REQUESTERS` identities
+    /// have live windows, a new identity is refused (fail-closed) rather than
+    /// growing the table without bound.
+    #[test]
+    fn rate_limiter_table_is_hard_capped() {
+        let mut rl = OprfEvalRateLimiter::new();
+        let now = Instant::now();
+        for _ in 0..MAX_TRACKED_REQUESTERS {
+            let id = nostr_sdk::Keys::generate().public_key();
+            assert!(rl.check_and_record_at(id, now));
+        }
+        // Table is full of live windows; a brand-new identity is refused.
+        let overflow = nostr_sdk::Keys::generate().public_key();
+        assert!(
+            !rl.check_and_record_at(overflow, now),
+            "a new identity past the table cap must be refused"
         );
     }
 

--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -16,6 +16,9 @@ pub const MAX_COMMITMENT_SIZE: usize = 128;
 pub const MAX_NONCE_COMMITMENTS: usize = 256;
 pub const MAX_SIGNATURE_SHARE_SIZE: usize = 64;
 pub const MAX_PARTICIPANTS: usize = 255;
+/// Serialized length of a threshold-OPRF partial evaluation: a 32-byte identifier
+/// scalar followed by a 33-byte compressed point (`keep_core::oprf::threshold`).
+pub const OPRF_PARTIAL_LEN: usize = 65;
 pub const MAX_NAME_LENGTH: usize = 256;
 pub const MAX_CAPABILITY_LENGTH: usize = 64;
 pub const MAX_CAPABILITIES: usize = 32;
@@ -99,6 +102,8 @@ pub enum KfpMessage {
     EcdhRequest(EcdhRequestPayload),
     EcdhShare(EcdhSharePayload),
     EcdhComplete(EcdhCompletePayload),
+    OprfEvalRequest(OprfEvalRequestPayload),
+    OprfEvalShare(OprfEvalSharePayload),
     RefreshRequest(RefreshRequestPayload),
     RefreshRound1(RefreshRound1Payload),
     RefreshRound2(RefreshRound2Payload),
@@ -131,6 +136,8 @@ impl KfpMessage {
             KfpMessage::EcdhRequest(_) => "ecdh_request",
             KfpMessage::EcdhShare(_) => "ecdh_share",
             KfpMessage::EcdhComplete(_) => "ecdh_complete",
+            KfpMessage::OprfEvalRequest(_) => "oprf_eval_request",
+            KfpMessage::OprfEvalShare(_) => "oprf_eval_share",
             KfpMessage::RefreshRequest(_) => "refresh_request",
             KfpMessage::RefreshRound1(_) => "refresh_round1",
             KfpMessage::RefreshRound2(_) => "refresh_round2",
@@ -161,6 +168,8 @@ impl KfpMessage {
             KfpMessage::EcdhRequest(p) => Some(&p.session_id),
             KfpMessage::EcdhShare(p) => Some(&p.session_id),
             KfpMessage::EcdhComplete(p) => Some(&p.session_id),
+            KfpMessage::OprfEvalRequest(p) => Some(&p.session_id),
+            KfpMessage::OprfEvalShare(p) => Some(&p.session_id),
             KfpMessage::RefreshRequest(p) => Some(&p.session_id),
             KfpMessage::RefreshRound1(p) => Some(&p.session_id),
             KfpMessage::RefreshRound2(p) => Some(&p.session_id),
@@ -186,6 +195,7 @@ impl KfpMessage {
             KfpMessage::SignRequest(p) => Some(&p.group_pubkey),
             KfpMessage::NonceCommitment(p) => Some(&p.group_pubkey),
             KfpMessage::EcdhRequest(p) => Some(&p.group_pubkey),
+            KfpMessage::OprfEvalRequest(p) => Some(&p.group_pubkey),
             KfpMessage::RefreshRequest(p) => Some(&p.group_pubkey),
             KfpMessage::DescriptorPropose(p) => Some(&p.group_pubkey),
             KfpMessage::DescriptorContribute(p) => Some(&p.group_pubkey),
@@ -322,6 +332,27 @@ impl KfpMessage {
             KfpMessage::EcdhComplete(p) => {
                 if p.shared_secret.len() != 32 {
                     return Err("Invalid shared secret size");
+                }
+            }
+            KfpMessage::OprfEvalRequest(p) => {
+                if p.participants.is_empty() {
+                    return Err("Participants list must not be empty");
+                }
+                if p.participants.len() > MAX_PARTICIPANTS {
+                    return Err("Participants list exceeds maximum size");
+                }
+                if p.requester_share_index == 0 {
+                    return Err("requester_share_index must be non-zero");
+                }
+            }
+            KfpMessage::OprfEvalShare(p) => {
+                if p.share_index == 0 {
+                    return Err("share_index must be non-zero");
+                }
+                // Wire layout of an OPRF partial: 32-byte identifier scalar plus a
+                // 33-byte compressed point (see keep_core::oprf::threshold).
+                if p.partial.len() != OPRF_PARTIAL_LEN {
+                    return Err("Invalid OPRF partial size");
                 }
             }
             KfpMessage::RefreshRequest(p) => {
@@ -1141,6 +1172,67 @@ impl EcdhCompletePayload {
         Self {
             session_id,
             shared_secret: Zeroizing::new(shared_secret.to_vec()),
+        }
+    }
+}
+
+/// Box → holder: a request to evaluate the box's blinded element with the
+/// holder's dedicated OPRF key share. Mirrors [`EcdhRequestPayload`] but carries
+/// a 33-byte blinded element instead of a recipient pubkey, plus the requester's
+/// share index so the holder can bind the requester pubkey to a known peer.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct OprfEvalRequestPayload {
+    #[serde(with = "hex_bytes")]
+    pub session_id: [u8; 32],
+    #[serde(with = "hex_bytes")]
+    pub group_pubkey: [u8; 32],
+    #[serde(with = "hex_bytes_33")]
+    pub blinded: [u8; 33],
+    pub participants: Vec<u16>,
+    pub requester_share_index: u16,
+    pub created_at: u64,
+}
+
+impl OprfEvalRequestPayload {
+    pub fn new(
+        session_id: [u8; 32],
+        group_pubkey: [u8; 32],
+        blinded: [u8; 33],
+        participants: Vec<u16>,
+        requester_share_index: u16,
+    ) -> Self {
+        Self {
+            session_id,
+            group_pubkey,
+            blinded,
+            participants,
+            requester_share_index,
+            created_at: Timestamp::now().as_secs(),
+        }
+    }
+
+    pub fn is_within_replay_window(&self, window_secs: u64) -> bool {
+        within_replay_window(self.created_at, window_secs)
+    }
+}
+
+/// Holder → box: a partial OPRF evaluation. `partial` is the 65-byte wire
+/// encoding from `keep_core::oprf::unlock::evaluate`.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct OprfEvalSharePayload {
+    #[serde(with = "hex_bytes")]
+    pub session_id: [u8; 32],
+    pub share_index: u16,
+    #[serde(with = "hex_vec")]
+    pub partial: Vec<u8>,
+}
+
+impl OprfEvalSharePayload {
+    pub fn new(session_id: [u8; 32], share_index: u16, partial: Vec<u8>) -> Self {
+        Self {
+            session_id,
+            share_index,
+            partial,
         }
     }
 }

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -2261,3 +2261,381 @@ async fn test_psbt_migration_sweep_end_to_end() {
     graceful_shutdown(shutdown1, node1_handle).await;
     graceful_shutdown(shutdown2, node2_handle).await;
 }
+
+// ---------------------------------------------------------------------------
+// Threshold-OPRF unlock session tests.
+//
+// These mirror the ECDH harness above: a 2-of-3 FROST group on a MockRelay
+// where the "box" (initiator) gathers holder partial evaluations and derives a
+// LUKS key locally. The OPRF oracle defaults CLOSED (security fixes #621), so a
+// happy-path holder MUST (a) install a SigningHooks impl whose
+// `approve_oprf_eval` returns true and (b) see the box peer as
+// `AttestationStatus::Verified`. The negative-path tests drive the holder
+// handler directly to assert each gate rejects without producing a share.
+// ---------------------------------------------------------------------------
+
+const OPRF_INPUT: &[u8] = b"keep-node-vault-v1";
+
+/// Holder-side hook that approves every OPRF evaluation. Required for the happy
+/// path because `approve_oprf_eval` defaults to DENY.
+struct ApproveOprfHooks;
+
+impl keep_frost_net::SigningHooks for ApproveOprfHooks {
+    fn pre_sign(&self, _session: &keep_frost_net::SessionInfo) -> keep_frost_net::Result<()> {
+        Ok(())
+    }
+    fn post_sign(&self, _session: &keep_frost_net::SessionInfo, _signature: &[u8; 64]) {}
+    fn approve_oprf_eval(
+        &self,
+        _requester_share_index: u16,
+        _session_id: [u8; 32],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>> {
+        Box::pin(async { true })
+    }
+}
+
+/// Split one OPRF key 2-of-3. `KeyShare` at index `i` is the vsss share for
+/// FROST identifier `i + 1`.
+fn split_oprf_key_2of3() -> Vec<keep_core::oprf::threshold::KeyShare> {
+    use k256::elliptic_curve::rand_core::OsRng;
+    use k256::Scalar;
+    let mut rng = OsRng;
+    let secret = <Scalar as k256::elliptic_curve::Field>::random(&mut rng);
+    keep_core::oprf::threshold::split_key(&secret, 2, 3, rng).expect("split oprf key")
+}
+
+/// Happy path: a 2-of-3 group with the box (id 1) and one holder (id 2) online,
+/// both carrying an OPRF share. The holder approves evaluations and sees the box
+/// as Verified, so `request_oprf_unlock` collects the holder's partial, reaches
+/// quorum, and derives a 32-byte LUKS key. Two independent runs (fresh blinds)
+/// must derive the SAME key, since finalize strips the per-attempt blinding.
+#[tokio::test]
+async fn test_oprf_unlock_completes_with_one_holder() {
+    use std::sync::Arc;
+
+    let mock_relay = MockRelay::run().await.expect("Failed to start mock relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let config = ThresholdConfig::two_of_three();
+    let dealer = TrustedDealer::new(config);
+    let (mut shares, _pkg) = dealer.generate("test-oprf-unlock").unwrap();
+    let share1 = shares.remove(0); // FROST id 1 = box
+    let share2 = shares.remove(0); // FROST id 2 = holder
+
+    let oprf = split_oprf_key_2of3();
+
+    let mut node1 = KfpNode::new(share1, vec![relay.clone()])
+        .await
+        .expect("Failed to create box node");
+    node1.set_oprf_key_share(oprf[0]); // box holds vsss index 1
+    let mut node2 = KfpNode::new(share2, vec![relay])
+        .await
+        .expect("Failed to create holder node");
+    node2.set_oprf_key_share(oprf[1]); // holder holds vsss index 2
+    node2.set_hooks(Arc::new(ApproveOprfHooks));
+
+    let mut rx1 = node1.subscribe();
+    let mut rx2 = node2.subscribe();
+    let shutdown1 = node1.take_shutdown_handle();
+    let shutdown2 = node2.take_shutdown_handle();
+
+    let node1 = Arc::new(node1);
+    let node2 = Arc::new(node2);
+    let node1_run = Arc::clone(&node1);
+    let node2_run = Arc::clone(&node2);
+    let node1_handle = tokio::spawn(async move {
+        let _ = node1_run.run().await;
+    });
+    let node2_handle = tokio::spawn(async move {
+        let _ = node2_run.run().await;
+    });
+
+    let mut n1 = 0u32;
+    let mut n2 = 0u32;
+    let discovery = timeout(Duration::from_secs(45), async {
+        loop {
+            tokio::select! {
+                Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx1.recv() => n1 += 1,
+                Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx2.recv() => n2 += 1,
+            }
+            if n1 >= 1 && n2 >= 1 {
+                return;
+            }
+        }
+    })
+    .await;
+    if discovery.is_err() {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        panic!("Peer discovery timed out: node1={n1}, node2={n2}");
+    }
+
+    // Let the reciprocal announces flush, then mark the box Verified on the
+    // holder. Re-announces are 20s apart, so this stays Verified for the brief
+    // window the (sub-second) request occupies.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    node2.test_set_peer_attestation(1, keep_frost_net::AttestationStatus::Verified);
+
+    let key1 = match timeout(
+        Duration::from_secs(45),
+        node1.request_oprf_unlock(OPRF_INPUT, "vault0", 1),
+    )
+    .await
+    {
+        Ok(Ok(k)) => k,
+        Ok(Err(e)) => {
+            graceful_shutdown(shutdown1, node1_handle).await;
+            graceful_shutdown(shutdown2, node2_handle).await;
+            panic!("request_oprf_unlock failed: {e}");
+        }
+        Err(_) => {
+            graceful_shutdown(shutdown1, node1_handle).await;
+            graceful_shutdown(shutdown2, node2_handle).await;
+            panic!("request_oprf_unlock timed out");
+        }
+    };
+    assert_eq!(key1.len(), 32, "derived LUKS key must be 32 bytes");
+
+    // Second independent run (fresh blind) must derive the same key: the OPRF
+    // output is a deterministic PRF of (input, key, volume, epoch).
+    node2.test_set_peer_attestation(1, keep_frost_net::AttestationStatus::Verified);
+    let key2 = match timeout(
+        Duration::from_secs(45),
+        node1.request_oprf_unlock(OPRF_INPUT, "vault0", 1),
+    )
+    .await
+    {
+        Ok(Ok(k)) => k,
+        Ok(Err(e)) => {
+            graceful_shutdown(shutdown1, node1_handle).await;
+            graceful_shutdown(shutdown2, node2_handle).await;
+            panic!("second request_oprf_unlock failed: {e}");
+        }
+        Err(_) => {
+            graceful_shutdown(shutdown1, node1_handle).await;
+            graceful_shutdown(shutdown2, node2_handle).await;
+            panic!("second request_oprf_unlock timed out");
+        }
+    };
+
+    graceful_shutdown(shutdown1, node1_handle).await;
+    graceful_shutdown(shutdown2, node2_handle).await;
+
+    assert_eq!(
+        *key1, *key2,
+        "two independent unlock runs must derive the same LUKS key (PRF determinism)"
+    );
+}
+
+/// Build a well-formed OPRF eval request for `holder` from a synthetic box at
+/// FROST share index 1, returning the box pubkey, the request payload (with a
+/// real blinded element), and the raw blinded bytes for box-side partials.
+fn make_oprf_request(
+    holder: &KfpNode,
+) -> (
+    nostr_sdk::PublicKey,
+    keep_frost_net::OprfEvalRequestPayload,
+    Vec<u8>,
+) {
+    let box_pubkey = nostr_sdk::Keys::generate().public_key();
+    let (_client, blinded) = keep_core::oprf::unlock::blind(OPRF_INPUT).expect("blind");
+    let blinded_arr: [u8; 33] = blinded.as_slice().try_into().expect("33-byte blinded");
+    let payload = keep_frost_net::OprfEvalRequestPayload::new(
+        [0x01u8; 32],
+        *holder.group_pubkey(),
+        blinded_arr,
+        vec![1, 2, 3],
+        1,
+    );
+    (box_pubkey, payload, blinded)
+}
+
+/// Gate (approval declined): a Verified, in-budget requester whose evaluation
+/// the holder's hook declines (the default DENY hook) gets NO partial. The
+/// handler returns `Ok(())` (declined, not errored) and emits `OprfEvalRequested`
+/// (proving every prior gate passed, so the decline is the hook), but produces
+/// no share, so a box with only its own partial never reaches quorum.
+#[tokio::test]
+async fn test_oprf_eval_declined_by_hook_sends_no_share() {
+    let mock_relay = MockRelay::run().await.expect("relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pkg) = dealer.generate("test-oprf-decline").unwrap();
+    let _ = shares.remove(0); // id 1 (box is synthetic)
+    let holder_share = shares.remove(0); // id 2 = holder
+
+    let oprf = split_oprf_key_2of3();
+    let mut holder = KfpNode::new(holder_share, vec![relay])
+        .await
+        .expect("holder");
+    holder.set_oprf_key_share(oprf[1]);
+    // No approving hook installed: the default NoOpHooks denies every eval.
+
+    let (box_pubkey, payload, blinded) = make_oprf_request(&holder);
+    holder.test_inject_peer(
+        keep_frost_net::Peer::new(box_pubkey, 1)
+            .with_attestation_status(keep_frost_net::AttestationStatus::Verified),
+    );
+
+    let mut rx = holder.subscribe();
+    let result = holder
+        .test_handle_oprf_eval_request(box_pubkey, payload)
+        .await;
+    assert!(
+        result.is_ok(),
+        "a declined eval must return Ok(()), got {result:?}"
+    );
+
+    // The holder accepted the request (passed every gate) and only then declined
+    // at the hook.
+    let requested = rx.try_recv();
+    assert!(
+        matches!(
+            requested,
+            Ok(KfpNodeEvent::OprfEvalRequested {
+                requester_index: 1,
+                ..
+            })
+        ),
+        "holder must emit OprfEvalRequested before the hook declines, got {requested:?}"
+    );
+
+    // No share was produced, so a box holding only its own partial cannot reach
+    // the 2-of-3 quorum.
+    let (client, _) = keep_core::oprf::unlock::blind(OPRF_INPUT).expect("blind");
+    let box_partial = keep_core::oprf::unlock::evaluate(&oprf[0], &blinded).expect("box partial");
+    let mut session = keep_frost_net::OprfUnlockSession::new(
+        [0x01u8; 32],
+        client,
+        2,
+        vec![1, 2, 3],
+        "vault0".into(),
+        1,
+    );
+    session
+        .add_partial(1, box_partial.to_vec())
+        .expect("add box partial");
+    assert!(
+        !session.has_quorum(),
+        "box must not reach quorum without the holder's declined partial"
+    );
+}
+
+/// Gate (attestation): a requester whose peer is NOT `Verified` (default
+/// `NotProvided`) is rejected with `UntrustedPeer` before any partial is
+/// produced, and the holder emits no `OprfEvalRequested`.
+#[tokio::test]
+async fn test_oprf_eval_rejects_unattested_requester() {
+    let mock_relay = MockRelay::run().await.expect("relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pkg) = dealer.generate("test-oprf-unattested").unwrap();
+    let _ = shares.remove(0);
+    let holder_share = shares.remove(0);
+
+    let oprf = split_oprf_key_2of3();
+    let mut holder = KfpNode::new(holder_share, vec![relay])
+        .await
+        .expect("holder");
+    holder.set_oprf_key_share(oprf[1]);
+    holder.set_hooks(std::sync::Arc::new(ApproveOprfHooks));
+
+    let (box_pubkey, payload, _blinded) = make_oprf_request(&holder);
+    // Inject the requester with the DEFAULT attestation status (NotProvided).
+    holder.test_inject_peer(keep_frost_net::Peer::new(box_pubkey, 1));
+
+    let mut rx = holder.subscribe();
+    let result = holder
+        .test_handle_oprf_eval_request(box_pubkey, payload)
+        .await;
+    assert!(
+        matches!(result, Err(keep_frost_net::FrostNetError::UntrustedPeer(_))),
+        "an unattested requester must be rejected with UntrustedPeer, got {result:?}"
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "no OprfEvalRequested may be emitted for a rejected unattested requester"
+    );
+}
+
+/// Gate (rate limit): from one Verified + approved requester, the first
+/// `MAX_OPRF_EVALS_PER_WINDOW` evaluations succeed; the next is refused with
+/// `RateLimited`. The limiter keys on the requester pubkey, so distinct
+/// session_ids share one budget.
+#[tokio::test]
+async fn test_oprf_eval_rate_limited_after_budget() {
+    let mock_relay = MockRelay::run().await.expect("relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pkg) = dealer.generate("test-oprf-ratelimit").unwrap();
+    let _ = shares.remove(0);
+    let holder_share = shares.remove(0);
+
+    let oprf = split_oprf_key_2of3();
+    let mut holder = KfpNode::new(holder_share, vec![relay])
+        .await
+        .expect("holder");
+    holder.set_oprf_key_share(oprf[1]);
+    holder.set_hooks(std::sync::Arc::new(ApproveOprfHooks));
+
+    let (box_pubkey, base_payload, _blinded) = make_oprf_request(&holder);
+    holder.test_inject_peer(
+        keep_frost_net::Peer::new(box_pubkey, 1)
+            .with_attestation_status(keep_frost_net::AttestationStatus::Verified),
+    );
+
+    for i in 0..keep_frost_net::MAX_OPRF_EVALS_PER_WINDOW {
+        let mut payload = base_payload.clone();
+        payload.session_id = [i as u8; 32];
+        let r = holder
+            .test_handle_oprf_eval_request(box_pubkey, payload)
+            .await;
+        assert!(r.is_ok(), "eval {i} within budget must succeed, got {r:?}");
+    }
+
+    let mut over = base_payload.clone();
+    over.session_id = [0xFFu8; 32];
+    let result = holder.test_handle_oprf_eval_request(box_pubkey, over).await;
+    assert!(
+        matches!(result, Err(keep_frost_net::FrostNetError::RateLimited(_))),
+        "exceeding the per-window budget must be rejected with RateLimited, got {result:?}"
+    );
+}
+
+/// Gate (replay): a request whose `created_at` predates the replay window is
+/// rejected with `ReplayDetected` before any peer/attestation check, and no
+/// share is produced.
+#[tokio::test]
+async fn test_oprf_eval_rejects_replayed_request() {
+    let mock_relay = MockRelay::run().await.expect("relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pkg) = dealer.generate("test-oprf-replay").unwrap();
+    let _ = shares.remove(0);
+    let holder_share = shares.remove(0);
+
+    let oprf = split_oprf_key_2of3();
+    let mut holder = KfpNode::new(holder_share, vec![relay])
+        .await
+        .expect("holder");
+    holder.set_oprf_key_share(oprf[1]);
+
+    let (box_pubkey, mut payload, _blinded) = make_oprf_request(&holder);
+    // Backdate well past the default 300s replay window.
+    payload.created_at = nostr_sdk::Timestamp::now().as_secs() - 400;
+
+    let result = holder
+        .test_handle_oprf_eval_request(box_pubkey, payload)
+        .await;
+    assert!(
+        matches!(
+            result,
+            Err(keep_frost_net::FrostNetError::ReplayDetected(_))
+        ),
+        "a stale request must be rejected with ReplayDetected, got {result:?}"
+    );
+}


### PR DESCRIPTION
Wires the merged `keep-core::oprf` primitive (#618, #620) into a working 2-of-3 threshold-OPRF unlock over KFP, and enforces the #621 eval-oracle ship-gate. Completes the keep-frost-net side of the threshold-OPRF unlock.

## What

A new OPRF-eval session, mirroring the existing ECDH session as its structural template:

- **Protocol** (`protocol.rs`, `event.rs`): `OprfEvalRequest` / `OprfEvalShare` messages, NIP-44 encrypted, wired through `KfpMessage` dispatch / validate / extractors / event builders.
- **Box side** (`oprf_session.rs`, `node/oprf.rs`): `OprfUnlockSession` owns the `oprf::unlock::Client`, collects holder partials by share index, and on quorum derives the LUKS key **locally** (the key never crosses the wire). `request_oprf_unlock` mirrors `request_ecdh` (subscribe-before-send, single-party fast path, 30s timeout, teardown on every exit).
- **Holder side**: `handle_oprf_eval_request` evaluates the blinded element with a **dedicated OPRF key share, never the FROST signing share** (no cross-protocol key reuse).

## #621 ship-gate (the security spine)

The holder eval oracle enforces, in order: group → membership → holder-share → replay window → receive policy → **pubkey↔share-index binding → strict `Verified` attestation → per-identity rate-limit (8/60s sliding window, hard-capped table) → operator approval hook** → only then `evaluate`.

The oracle **defaults closed**: `approve_oprf_eval` defaults to deny, and attestation must be `Verified` (not `NotConfigured`). Rationale: the OPRF input is a fixed low-entropy label and the box already holds one share, so a single auto-answered eval would reveal the key (the rate limit alone is insufficient). Holders must opt in with an explicit approval policy.

## Review

Both findings rounds folded in before this PR:
- **security-review H1** (default-open oracle) → default-deny approval + strict-Verified attestation.
- **security-review L1 / pr-review** (soft rate-limit cap) → real hard cap, fail-closed.
- **pr-review** (slow-fail on bad partial) → emit `OprfUnlockFailed` so the box fails fast.
- L2 (derived key on broadcast bus, parity with ECDH) documented + tracked as a follow-up to fix both sessions together.

## Tests

- 7 unit tests (`oprf_session.rs`): cross-quorum LUKS-key equality oracle, rate-limiter window + hard cap, add_partial rejection, below-quorum, session-id derivation, manager lifecycle.
- 5 multinode tests (`tests/multinode_test.rs`): happy-path 2-of-3 unlock (+ PRF determinism), and each gate independently — approval-declined sends no share, unattested requester rejected, rate-limit after budget, replay rejected.
- Full suite green (264 lib + 21 multinode + integration, 0 failures); clippy `-D warnings` clean (default + `testing`).

Provisioning contract (for the consuming application): every FROST signing peer must be issued an OPRF share 1:1, split with the same threshold, with vsss index aligned to FROST id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Threshold-OPRF unlock-evaluation support so unlock flows can derive a shared volume key via multi-party approval.
  * Added new protocol message types and corresponding node event handling for OPRF request/share and unlock completion/failure.

* **Bug Fixes**
  * Added stricter validation for replayed, untrusted, invalid, and rate-limited OPRF requests.
  * Improved OPRF session lifecycle handling to reduce stale/lingering unlock state.
  * Desktop event listener now properly ignores OPRF-related events.

* **Tests**
  * Added integration/regression tests for successful unlock determinism, approval denial behavior, attestation gating, rate limiting, and replay detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
