### PR TITLE
Trusted-dealer OPRF enrollment (keep-frost-net) + secret key-share codec

### DIFF
--- a/keep-core/src/oprf.rs
+++ b/keep-core/src/oprf.rs
@@ -67,6 +67,9 @@ pub mod threshold {
     const POINT_LEN: usize = 33;
     /// Total serialized-partial length (`ID_LEN + POINT_LEN`).
     pub(super) const PARTIAL_LEN: usize = ID_LEN + POINT_LEN;
+    /// Serialized SECRET key-share length: a 32-byte identifier scalar followed by a 32-byte
+    /// value scalar (`ID_LEN + ID_LEN`).
+    pub const KEY_SHARE_LEN: usize = ID_LEN + ID_LEN;
 
     /// Split an OPRF key into `n` shares with threshold `t` over secp256k1's scalar field.
     ///
@@ -178,6 +181,52 @@ pub mod threshold {
         Ok(DefaultShare::with_identifier_and_value(
             IdentifierPrimeField(id),
             ValueGroup::from(point),
+        ))
+    }
+
+    /// Parse a canonical secp256k1 scalar from its 32-byte big-endian representation, zeroizing the
+    /// transient buffer (the bytes may be secret key material). Rejects a non-canonical encoding.
+    fn scalar_from_repr(b: &[u8]) -> Result<Scalar, CryptoError> {
+        use k256::elliptic_curve::PrimeField;
+        use zeroize::Zeroize;
+        let mut repr = k256::FieldBytes::default();
+        repr.copy_from_slice(b);
+        let s = Option::<Scalar>::from(Scalar::from_repr(repr));
+        repr.as_mut_slice().zeroize();
+        s.ok_or_else(|| CryptoError::invalid_key("OPRF: non-canonical scalar"))
+    }
+
+    /// Serialize a SECRET key share: the 32-byte identifier scalar followed by the 32-byte value
+    /// scalar.
+    ///
+    /// SECURITY: the output is live key material (the holder's Shamir share). The returned buffer
+    /// is `Zeroizing`, but any copy the caller makes (when sealing to the TPM or placing it in an
+    /// enrollment message) MUST itself be zeroized once consumed. Used to TPM-seal the box's share
+    /// and to carry a share inside the separately encrypted enrollment message.
+    pub fn serialize_key_share(share: &KeyShare) -> zeroize::Zeroizing<[u8; KEY_SHARE_LEN]> {
+        use k256::elliptic_curve::PrimeField;
+        let mut out = zeroize::Zeroizing::new([0u8; KEY_SHARE_LEN]);
+        out[..ID_LEN].copy_from_slice(share.identifier().0.to_repr().as_slice());
+        out[ID_LEN..].copy_from_slice((**share.value()).to_repr().as_slice());
+        out
+    }
+
+    /// Inverse of [`serialize_key_share`]. Rejects a wrong length, a non-canonical scalar, or a
+    /// zero identifier (Shamir's `x = 0` is the secret's own point, never a valid share index).
+    pub fn deserialize_key_share(bytes: &[u8]) -> Result<KeyShare, CryptoError> {
+        if bytes.len() != KEY_SHARE_LEN {
+            return Err(CryptoError::invalid_key("OPRF key share: wrong length"));
+        }
+        let id = scalar_from_repr(&bytes[..ID_LEN])?;
+        if bool::from(id.is_zero()) {
+            return Err(CryptoError::invalid_key("OPRF key share: zero identifier"));
+        }
+        let value = scalar_from_repr(&bytes[ID_LEN..])?;
+        // `ValuePrimeField` is a type alias for `IdentifierPrimeField`, so the value wrapper is
+        // constructed with the same tuple struct.
+        Ok(DefaultShare::with_identifier_and_value(
+            IdentifierPrimeField(id),
+            IdentifierPrimeField(value),
         ))
     }
 
@@ -570,6 +619,42 @@ mod tests {
         assert!(
             client.finalize_luks_key(&[p0, p0], 2, "vault0", 1).is_err(),
             "a replayed partial (duplicate identifier) must not forge a quorum"
+        );
+    }
+
+    /// A key share that is serialized then deserialized must behave identically to the original:
+    /// it produces the same partial evaluation. Malformed encodings are rejected.
+    #[test]
+    fn key_share_serialization_round_trips() {
+        use k256::Scalar;
+        let mut rng = rand_core_06::OsRng;
+        let input: &[u8] = b"keep-node-vault-v1";
+        let s = <Scalar as k256::elliptic_curve::Field>::random(&mut rng);
+        let shares = threshold::split_key(&s, 2, 3, &mut rng).expect("split");
+        let b = OprfClient::<Secp256k1Sha256>::blind(input, &mut rng).expect("blind");
+
+        for share in &shares {
+            let bytes = threshold::serialize_key_share(share);
+            assert_eq!(bytes.len(), threshold::KEY_SHARE_LEN);
+            let restored = threshold::deserialize_key_share(&bytes[..]).expect("deserialize");
+            let p_orig = threshold::partial_eval(share, &b.message).expect("p orig");
+            let p_restored = threshold::partial_eval(&restored, &b.message).expect("p restored");
+            assert_eq!(
+                threshold::serialize_partial(&p_orig),
+                threshold::serialize_partial(&p_restored),
+                "restored share must produce the same partial evaluation"
+            );
+        }
+
+        assert!(
+            threshold::deserialize_key_share(&[0u8; 10]).is_err(),
+            "wrong length must be rejected"
+        );
+        let mut zero_id = [1u8; threshold::KEY_SHARE_LEN];
+        zero_id[..32].fill(0);
+        assert!(
+            threshold::deserialize_key_share(&zero_id).is_err(),
+            "zero identifier must be rejected"
         );
     }
 

--- a/keep-desktop/src/frost.rs
+++ b/keep-desktop/src/frost.rs
@@ -812,7 +812,10 @@ pub(crate) async fn frost_event_listener(
                     // desktop UI yet (KeepNode appliance flow).
                     Ok(KfpNodeEvent::OprfEvalRequested { .. })
                     | Ok(KfpNodeEvent::OprfUnlockComplete { .. })
-                    | Ok(KfpNodeEvent::OprfUnlockFailed { .. }) => {}
+                    | Ok(KfpNodeEvent::OprfUnlockFailed { .. })
+                    | Ok(KfpNodeEvent::OprfShareReceived { .. })
+                    | Ok(KfpNodeEvent::OprfEnrollComplete { .. })
+                    | Ok(KfpNodeEvent::OprfEnrollFailed { .. }) => {}
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                 }

--- a/keep-frost-net/src/enroll_session.rs
+++ b/keep-frost-net/src/enroll_session.rs
@@ -1,0 +1,335 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+//! Dealer-side session state for the trusted-dealer OPRF enrollment.
+//!
+//! The "box" (dealer) has already generated an OPRF secret and Shamir-split it;
+//! it distributes each remote FROST peer (holder) that peer's secret key share
+//! and collects an acknowledgement from each. This session tracks the expected
+//! target indices and the set that has acked, completing once every target has
+//! acknowledged. Mirrors [`crate::oprf_session::OprfUnlockSessionManager`]; the
+//! holder keeps no enrollment session.
+
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
+
+use crate::error::{FrostNetError, Result};
+
+/// Domain-separated session id for an OPRF enrollment, binding the dealer's
+/// group and target set. Mirrors [`crate::oprf_session::derive_oprf_session_id`].
+pub fn derive_oprf_enroll_session_id(
+    group_pubkey: &[u8; 32],
+    targets: &[u16],
+    nonce: u64,
+) -> [u8; 32] {
+    let mut sorted_targets = targets.to_vec();
+    sorted_targets.sort();
+
+    let mut preimage = Vec::with_capacity(64 + targets.len() * 2);
+    preimage.extend_from_slice(b"keep-frost-oprf-enroll-v1");
+    preimage.extend_from_slice(group_pubkey);
+    preimage.extend_from_slice(&nonce.to_be_bytes());
+    preimage.extend_from_slice(&(sorted_targets.len() as u16).to_be_bytes());
+    for t in &sorted_targets {
+        preimage.extend_from_slice(&t.to_be_bytes());
+    }
+
+    keep_core::crypto::blake2b_256(&preimage)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OprfEnrollSessionState {
+    Collecting,
+    Complete,
+    Failed(String),
+    Expired,
+}
+
+/// Dealer-side state for one enrollment round. Tracks the target indices the
+/// dealer expects acks from and which have acked; completes once all are in.
+pub struct OprfEnrollSession {
+    session_id: [u8; 32],
+    group_pubkey: [u8; 32],
+    expected: HashSet<u16>,
+    acked: HashSet<u16>,
+    threshold: u16,
+    total: u16,
+    state: OprfEnrollSessionState,
+    created_at: Instant,
+    timeout: Duration,
+}
+
+impl OprfEnrollSession {
+    pub fn new(
+        session_id: [u8; 32],
+        group_pubkey: [u8; 32],
+        expected: HashSet<u16>,
+        threshold: u16,
+        total: u16,
+    ) -> Self {
+        Self {
+            session_id,
+            group_pubkey,
+            expected,
+            acked: HashSet::new(),
+            threshold,
+            total,
+            state: OprfEnrollSessionState::Collecting,
+            created_at: Instant::now(),
+            timeout: Duration::from_secs(30),
+        }
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn session_id(&self) -> &[u8; 32] {
+        &self.session_id
+    }
+
+    pub fn group_pubkey(&self) -> &[u8; 32] {
+        &self.group_pubkey
+    }
+
+    pub fn threshold(&self) -> u16 {
+        self.threshold
+    }
+
+    pub fn total(&self) -> u16 {
+        self.total
+    }
+
+    pub fn state(&self) -> OprfEnrollSessionState {
+        if self.created_at.elapsed() > self.timeout
+            && self.state == OprfEnrollSessionState::Collecting
+        {
+            return OprfEnrollSessionState::Expired;
+        }
+        self.state.clone()
+    }
+
+    pub fn is_target(&self, share_index: u16) -> bool {
+        self.expected.contains(&share_index)
+    }
+
+    /// Record one holder ack. Rejects a non-expected target, a duplicate, or an
+    /// ack on a session no longer collecting. Flips to `Complete` once every
+    /// expected target has acked.
+    pub fn record_ack(&mut self, share_index: u16) -> Result<()> {
+        if share_index == 0 {
+            return Err(FrostNetError::Protocol(
+                "Invalid share_index: must be non-zero".into(),
+            ));
+        }
+        if self.state != OprfEnrollSessionState::Collecting {
+            return Err(FrostNetError::Session(
+                "Not accepting OPRF enrollment acks".into(),
+            ));
+        }
+        if !self.expected.contains(&share_index) {
+            return Err(FrostNetError::Session(format!(
+                "Share {share_index} not an enrollment target"
+            )));
+        }
+        if !self.acked.insert(share_index) {
+            return Err(FrostNetError::Session(
+                "Duplicate OPRF enrollment ack".into(),
+            ));
+        }
+        if self.acked.len() == self.expected.len() {
+            self.state = OprfEnrollSessionState::Complete;
+        }
+        Ok(())
+    }
+
+    pub fn has_all_acks(&self) -> bool {
+        !self.expected.is_empty() && self.acked.len() == self.expected.len()
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.state == OprfEnrollSessionState::Complete
+    }
+
+    pub fn is_expired(&self) -> bool {
+        self.state() == OprfEnrollSessionState::Expired
+    }
+}
+
+pub struct OprfEnrollSessionManager {
+    active_sessions: HashMap<[u8; 32], OprfEnrollSession>,
+    session_timeout: Duration,
+}
+
+impl OprfEnrollSessionManager {
+    pub fn new() -> Self {
+        Self {
+            active_sessions: HashMap::new(),
+            session_timeout: Duration::from_secs(30),
+        }
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.session_timeout = timeout;
+        self
+    }
+
+    const MAX_ACTIVE_SESSIONS: usize = 256;
+
+    pub fn create_session(
+        &mut self,
+        session_id: [u8; 32],
+        group_pubkey: [u8; 32],
+        expected: HashSet<u16>,
+        threshold: u16,
+        total: u16,
+    ) -> Result<&mut OprfEnrollSession> {
+        if let Some(existing) = self.active_sessions.get(&session_id) {
+            if !existing.is_expired() {
+                return Err(FrostNetError::Session(
+                    "OPRF enrollment session already active".into(),
+                ));
+            }
+            self.active_sessions.remove(&session_id);
+        }
+
+        self.cleanup_expired();
+        if self.active_sessions.len() >= Self::MAX_ACTIVE_SESSIONS {
+            return Err(FrostNetError::Session(
+                "Too many active OPRF enrollment sessions".into(),
+            ));
+        }
+
+        let session = OprfEnrollSession::new(session_id, group_pubkey, expected, threshold, total)
+            .with_timeout(self.session_timeout);
+
+        self.active_sessions.insert(session_id, session);
+        Ok(self
+            .active_sessions
+            .get_mut(&session_id)
+            .expect("just inserted"))
+    }
+
+    pub fn get_session(&self, session_id: &[u8; 32]) -> Option<&OprfEnrollSession> {
+        self.active_sessions.get(session_id)
+    }
+
+    pub fn get_session_mut(&mut self, session_id: &[u8; 32]) -> Option<&mut OprfEnrollSession> {
+        self.active_sessions.get_mut(session_id)
+    }
+
+    pub fn complete_session(&mut self, session_id: &[u8; 32]) {
+        self.active_sessions.remove(session_id);
+    }
+
+    pub fn cleanup_expired(&mut self) {
+        self.active_sessions
+            .retain(|_, session| !session.is_expired());
+    }
+}
+
+impl Default for OprfEnrollSessionManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session_2_targets() -> OprfEnrollSession {
+        let expected: HashSet<u16> = [2u16, 3u16].into_iter().collect();
+        OprfEnrollSession::new([0x11u8; 32], [0x22u8; 32], expected, 2, 3)
+    }
+
+    #[test]
+    fn record_ack_accepts_expected_targets_and_completes() {
+        let mut session = session_2_targets();
+        assert!(!session.has_all_acks());
+
+        session.record_ack(2).expect("first expected ack");
+        assert!(!session.has_all_acks(), "one of two acks must not complete");
+        assert!(!session.is_complete());
+
+        session.record_ack(3).expect("second expected ack");
+        assert!(session.has_all_acks(), "all expected acks present");
+        assert!(session.is_complete());
+        assert_eq!(session.state(), OprfEnrollSessionState::Complete);
+    }
+
+    #[test]
+    fn record_ack_rejects_unexpected_target() {
+        let mut session = session_2_targets();
+        assert!(
+            session.record_ack(4).is_err(),
+            "a non-target share index must be rejected"
+        );
+        assert!(
+            session.record_ack(0).is_err(),
+            "a zero share index must be rejected"
+        );
+        assert!(!session.has_all_acks());
+    }
+
+    #[test]
+    fn record_ack_rejects_duplicate() {
+        let mut session = session_2_targets();
+        session.record_ack(2).expect("first ack");
+        assert!(
+            session.record_ack(2).is_err(),
+            "a duplicate ack must be rejected"
+        );
+        assert!(!session.has_all_acks());
+    }
+
+    #[test]
+    fn record_ack_rejected_after_complete() {
+        let mut session = session_2_targets();
+        session.record_ack(2).unwrap();
+        session.record_ack(3).unwrap();
+        assert!(session.is_complete());
+        // A late ack on a completed session is refused (no longer collecting).
+        assert!(session.record_ack(2).is_err());
+    }
+
+    #[test]
+    fn derive_enroll_session_id_is_deterministic_and_input_sensitive() {
+        let g = [0x01u8; 32];
+        assert_eq!(
+            derive_oprf_enroll_session_id(&g, &[2, 3], 7),
+            derive_oprf_enroll_session_id(&g, &[3, 2], 7),
+            "target order must not matter"
+        );
+        assert_ne!(
+            derive_oprf_enroll_session_id(&g, &[2, 3], 7),
+            derive_oprf_enroll_session_id(&g, &[2, 3], 8),
+            "a different nonce must yield a distinct id"
+        );
+        assert_ne!(
+            derive_oprf_enroll_session_id(&g, &[2, 3], 7),
+            derive_oprf_enroll_session_id(&[0x02u8; 32], &[2, 3], 7),
+            "a different group must yield a distinct id"
+        );
+    }
+
+    #[test]
+    fn manager_lifecycle_and_duplicate_guard() {
+        let mut mgr = OprfEnrollSessionManager::new();
+        let sid = [0x44u8; 32];
+        let expected: HashSet<u16> = [2u16, 3u16].into_iter().collect();
+        mgr.create_session(sid, [0x22u8; 32], expected.clone(), 2, 3)
+            .unwrap();
+        assert!(mgr.get_session(&sid).is_some());
+
+        assert!(
+            mgr.create_session(sid, [0x22u8; 32], expected, 2, 3)
+                .is_err(),
+            "a duplicate active session id must be refused"
+        );
+
+        mgr.complete_session(&sid);
+        assert!(mgr.get_session(&sid).is_none());
+    }
+}

--- a/keep-frost-net/src/enroll_session.rs
+++ b/keep-frost-net/src/enroll_session.rs
@@ -110,10 +110,6 @@ impl OprfEnrollSession {
         self.state.clone()
     }
 
-    pub fn is_target(&self, share_index: u16) -> bool {
-        self.expected.contains(&share_index)
-    }
-
     /// Record one holder ack. Rejects a non-expected target, a duplicate, or an
     /// ack on a session no longer collecting. Flips to `Complete` once every
     /// expected target has acked.

--- a/keep-frost-net/src/enroll_session.rs
+++ b/keep-frost-net/src/enroll_session.rs
@@ -123,6 +123,14 @@ impl OprfEnrollSession {
                 "Invalid share_index: must be non-zero".into(),
             ));
         }
+        // Reject a late ack on a session whose timeout has elapsed: the stored `state` field stays
+        // `Collecting` until something consults the time-based `state()` path, so without this an
+        // ack could still flip an expired session to `Complete`.
+        if self.is_expired() {
+            return Err(FrostNetError::Session(
+                "OPRF enrollment session expired".into(),
+            ));
+        }
         if self.state != OprfEnrollSessionState::Collecting {
             return Err(FrostNetError::Session(
                 "Not accepting OPRF enrollment acks".into(),
@@ -292,6 +300,18 @@ mod tests {
         assert!(session.is_complete());
         // A late ack on a completed session is refused (no longer collecting).
         assert!(session.record_ack(2).is_err());
+    }
+
+    #[test]
+    fn record_ack_rejected_after_expiry() {
+        let expected: HashSet<u16> = [2u16, 3u16].into_iter().collect();
+        let mut session = OprfEnrollSession::new([0x11u8; 32], [0x22u8; 32], expected, 2, 3)
+            .with_timeout(Duration::from_secs(0));
+        assert!(session.is_expired(), "zero timeout expires immediately");
+        // A late ack on an expired session must not transition it to Complete.
+        assert!(session.record_ack(2).is_err());
+        assert!(!session.is_complete());
+        assert!(!session.has_all_acks());
     }
 
     #[test]

--- a/keep-frost-net/src/event.rs
+++ b/keep-frost-net/src/event.rs
@@ -361,6 +361,59 @@ impl KfpEventBuilder {
             .map_err(|e| FrostNetError::Nostr(e.to_string()))
     }
 
+    /// Dealer → holder: the trusted-dealer OPRF enrollment carrying the holder's
+    /// secret key share. NIP-44-encrypted to the target peer so the relay only
+    /// ever sees ciphertext (the `share` is the most sensitive payload).
+    pub fn oprf_enroll(
+        keys: &Keys,
+        recipient: &PublicKey,
+        payload: OprfEnrollPayload,
+    ) -> Result<Event> {
+        let group_pubkey = payload.group_pubkey;
+        let session_id = payload.session_id;
+        let msg = KfpMessage::OprfEnroll(payload);
+        let content = msg.to_json()?;
+
+        let encrypted = nip44::encrypt(keys.secret_key(), recipient, &content, nip44::Version::V2)
+            .map_err(|e| FrostNetError::Crypto(e.to_string()))?;
+
+        EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), encrypted)
+            .custom_created_at(Timestamp::tweaked(TIMESTAMP_TWEAK_RANGE))
+            .tag(Tag::public_key(*recipient))
+            .tag(Tag::custom(
+                TagKind::custom("g"),
+                [hex::encode(group_pubkey)],
+            ))
+            .tag(Tag::custom(TagKind::custom("s"), [hex::encode(session_id)]))
+            .tag(Tag::custom(TagKind::custom("t"), ["oprf_enroll"]))
+            .sign_with_keys(keys)
+            .map_err(|e| FrostNetError::Nostr(e.to_string()))
+    }
+
+    /// Holder → dealer: acknowledgement of a received enrollment share.
+    pub fn oprf_enroll_ack(
+        keys: &Keys,
+        recipient: &PublicKey,
+        payload: OprfEnrollAckPayload,
+    ) -> Result<Event> {
+        let msg = KfpMessage::OprfEnrollAck(payload.clone());
+        let content = msg.to_json()?;
+
+        let encrypted = nip44::encrypt(keys.secret_key(), recipient, &content, nip44::Version::V2)
+            .map_err(|e| FrostNetError::Crypto(e.to_string()))?;
+
+        EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), encrypted)
+            .custom_created_at(Timestamp::tweaked(TIMESTAMP_TWEAK_RANGE))
+            .tag(Tag::public_key(*recipient))
+            .tag(Tag::custom(
+                TagKind::custom("s"),
+                [hex::encode(payload.session_id)],
+            ))
+            .tag(Tag::custom(TagKind::custom("t"), ["oprf_enroll_ack"]))
+            .sign_with_keys(keys)
+            .map_err(|e| FrostNetError::Nostr(e.to_string()))
+    }
+
     pub fn xpub_announce(
         keys: &Keys,
         recipient: &PublicKey,

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -99,8 +99,8 @@ pub use error::{FrostNetError, Result};
 pub use event::KfpEventBuilder;
 pub use node::{
     DescriptorLookupUnavailable, HealthCheckResult, KeepDescriptorLookup, KfpNode, KfpNodeEvent,
-    NoOpHooks, PeerPolicy, PersistedDescriptorLookup, PsbtSessionSnapshot, RefuseRawSignatureHooks,
-    SessionInfo, SigningHooks, SuccessorLookup,
+    NoOpHooks, OprfShareSealAck, PeerPolicy, PersistedDescriptorLookup, PsbtSessionSnapshot,
+    RefuseRawSignatureHooks, SessionInfo, SigningHooks, SuccessorLookup,
 };
 pub use nonce_pool::{NonceId, NoncePool, DEFAULT_POOL_TARGET, MAX_POOL_ENTRIES};
 pub use nonce_store::{FileNonceStore, MemoryNonceStore, NonceStore};

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -62,6 +62,7 @@ mod cert_pin;
 mod descriptor_session;
 mod descriptor_session_store;
 mod ecdh;
+mod enroll_session;
 mod error;
 mod event;
 mod node;
@@ -90,6 +91,10 @@ pub use ecdh::{
     aggregate_ecdh_shares, compute_partial_ecdh, derive_ecdh_session_id, EcdhSession,
     EcdhSessionManager, EcdhSessionState,
 };
+pub use enroll_session::{
+    derive_oprf_enroll_session_id, OprfEnrollSession, OprfEnrollSessionManager,
+    OprfEnrollSessionState,
+};
 pub use error::{FrostNetError, Result};
 pub use event::KfpEventBuilder;
 pub use node::{
@@ -109,23 +114,23 @@ pub use protocol::{
     DescriptorContributePayload, DescriptorFinalizePayload, DescriptorNackPayload,
     DescriptorProposePayload, EcdhCompletePayload, EcdhRequestPayload, EcdhSharePayload,
     EnclaveAttestation, ErrorPayload, KeySlot, KfpMessage, NonceCommitmentPayload, NonceRef,
-    OprfEvalRequestPayload, OprfEvalSharePayload, PingPayload, PolicyTier, PongPayload,
-    PreExchangedCommitment, PsbtAbortPayload, PsbtFinalizePayload, PsbtInputInfo, PsbtOutputInfo,
-    PsbtProposePayload, PsbtSignPayload, RefreshCompletePayload, RefreshRequestPayload,
-    RefreshRound1Payload, RefreshRound2Payload, SignRequestPayload, SignatureCompletePayload,
-    SignatureSharePayload, WalletPolicy, XpubAnnouncePayload, DEFAULT_REPLAY_WINDOW_SECS,
-    DESCRIPTOR_ACK_PHASE_TIMEOUT_SECS, DESCRIPTOR_ACK_TIMEOUT_SECS,
-    DESCRIPTOR_CONTRIBUTION_TIMEOUT_SECS, DESCRIPTOR_FINALIZE_TIMEOUT_SECS,
-    DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS, DESCRIPTOR_SESSION_TIMEOUT_SECS, KFP_EVENT_KIND,
-    KFP_VERSION, MAX_CAPABILITIES, MAX_CAPABILITY_LENGTH, MAX_COMMITMENT_SIZE,
-    MAX_DESCRIPTOR_LENGTH, MAX_ERROR_CODE_LENGTH, MAX_ERROR_MESSAGE_LENGTH, MAX_FINGERPRINT_LENGTH,
-    MAX_KEYS_PER_TIER, MAX_MESSAGE_SIZE, MAX_MESSAGE_TYPE_LENGTH, MAX_NACK_REASON_LENGTH,
-    MAX_NAME_LENGTH, MAX_NONCE_COMMITMENTS, MAX_PARTICIPANTS, MAX_PSBT_ADDRESS_LENGTH,
-    MAX_PSBT_INPUTS, MAX_PSBT_OUTPUTS, MAX_PSBT_SIZE, MAX_RECOVERY_TIERS, MAX_RECOVERY_XPUBS,
-    MAX_SIGNATURE_SHARE_SIZE, MAX_XPUB_LABEL_LENGTH, MAX_XPUB_LENGTH, MIN_XPUB_LENGTH,
-    MSG_TYPE_NOSTR_EVENT, MSG_TYPE_RAW, OPRF_PARTIAL_LEN, PSBT_FINALIZE_PHASE_TIMEOUT_SECS,
-    PSBT_SESSION_MAX_TIMEOUT_SECS, PSBT_SESSION_TIMEOUT_SECS, PSBT_SIGNING_PHASE_TIMEOUT_SECS,
-    VALID_NETWORKS, VALID_XPUB_PREFIXES,
+    OprfEnrollAckPayload, OprfEnrollPayload, OprfEvalRequestPayload, OprfEvalSharePayload,
+    PingPayload, PolicyTier, PongPayload, PreExchangedCommitment, PsbtAbortPayload,
+    PsbtFinalizePayload, PsbtInputInfo, PsbtOutputInfo, PsbtProposePayload, PsbtSignPayload,
+    RefreshCompletePayload, RefreshRequestPayload, RefreshRound1Payload, RefreshRound2Payload,
+    SignRequestPayload, SignatureCompletePayload, SignatureSharePayload, WalletPolicy,
+    XpubAnnouncePayload, DEFAULT_REPLAY_WINDOW_SECS, DESCRIPTOR_ACK_PHASE_TIMEOUT_SECS,
+    DESCRIPTOR_ACK_TIMEOUT_SECS, DESCRIPTOR_CONTRIBUTION_TIMEOUT_SECS,
+    DESCRIPTOR_FINALIZE_TIMEOUT_SECS, DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS,
+    DESCRIPTOR_SESSION_TIMEOUT_SECS, KFP_EVENT_KIND, KFP_VERSION, MAX_CAPABILITIES,
+    MAX_CAPABILITY_LENGTH, MAX_COMMITMENT_SIZE, MAX_DESCRIPTOR_LENGTH, MAX_ERROR_CODE_LENGTH,
+    MAX_ERROR_MESSAGE_LENGTH, MAX_FINGERPRINT_LENGTH, MAX_KEYS_PER_TIER, MAX_MESSAGE_SIZE,
+    MAX_MESSAGE_TYPE_LENGTH, MAX_NACK_REASON_LENGTH, MAX_NAME_LENGTH, MAX_NONCE_COMMITMENTS,
+    MAX_PARTICIPANTS, MAX_PSBT_ADDRESS_LENGTH, MAX_PSBT_INPUTS, MAX_PSBT_OUTPUTS, MAX_PSBT_SIZE,
+    MAX_RECOVERY_TIERS, MAX_RECOVERY_XPUBS, MAX_SIGNATURE_SHARE_SIZE, MAX_XPUB_LABEL_LENGTH,
+    MAX_XPUB_LENGTH, MIN_XPUB_LENGTH, MSG_TYPE_NOSTR_EVENT, MSG_TYPE_RAW, OPRF_PARTIAL_LEN,
+    PSBT_FINALIZE_PHASE_TIMEOUT_SECS, PSBT_SESSION_MAX_TIMEOUT_SECS, PSBT_SESSION_TIMEOUT_SECS,
+    PSBT_SIGNING_PHASE_TIMEOUT_SECS, VALID_NETWORKS, VALID_XPUB_PREFIXES,
 };
 pub use psbt_session::{
     derive_psbt_session_id, PsbtSession, PsbtSessionManager, PsbtSessionState, SignerId,

--- a/keep-frost-net/src/node/enroll.rs
+++ b/keep-frost-net/src/node/enroll.rs
@@ -81,14 +81,14 @@ impl KfpNode {
                 // failing on a holder. Scrub the decoded live scalar immediately.
                 {
                     use zeroize::Zeroize;
-                    let mut decoded =
-                        keep_core::oprf::threshold::deserialize_key_share(&share_bytes).map_err(
-                            |e| {
-                                FrostNetError::Protocol(format!(
-                                    "OPRF enrollment share {target_index} invalid: {e}"
-                                ))
-                            },
-                        )?;
+                    let mut decoded = keep_core::oprf::threshold::deserialize_key_share(
+                        &share_bytes,
+                    )
+                    .map_err(|e| {
+                        FrostNetError::Protocol(format!(
+                            "OPRF enrollment share {target_index} invalid: {e}"
+                        ))
+                    })?;
                     decoded.zeroize();
                 }
                 if target_indices.contains(&target_index) {
@@ -296,7 +296,10 @@ impl KfpNode {
         if self
             .seen_oprf_enrolls
             .write()
-            .insert((payload.dealer_index, payload.session_id), payload.created_at)
+            .insert(
+                (payload.dealer_index, payload.session_id),
+                payload.created_at,
+            )
             .is_some()
         {
             debug!(

--- a/keep-frost-net/src/node/enroll.rs
+++ b/keep-frost-net/src/node/enroll.rs
@@ -1,0 +1,340 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+//! Trusted-dealer OPRF enrollment wired over KFP.
+//!
+//! The "box" (dealer) has already generated an OPRF secret and Shamir-split it.
+//! It distributes each remote FROST peer (holder) that peer's secret key share
+//! inside a NIP-44-encrypted [`OprfEnrollPayload`] and collects an
+//! [`OprfEnrollAckPayload`] from each. The dealer's OWN share is never sent (the
+//! caller TPM-seals it). Mirrors [`super::oprf`] with the same #621 gate ordering
+//! on the holder side; the share is the most sensitive payload in the system and
+//! is never logged.
+
+use std::time::Duration;
+
+use nostr_sdk::prelude::*;
+use tracing::{debug, info, warn};
+use zeroize::Zeroizing;
+
+use crate::enroll_session::derive_oprf_enroll_session_id;
+use crate::error::{FrostNetError, Result};
+use crate::event::KfpEventBuilder;
+use crate::peer::AttestationStatus;
+use crate::protocol::*;
+
+use super::{KfpNode, KfpNodeEvent};
+
+impl KfpNode {
+    /// Dealer side: distribute each remote target's OPRF secret key share and
+    /// await an ack from every target. `shares` maps a target FROST share index
+    /// to the 64-byte `serialize_key_share` output for that target; it MUST NOT
+    /// include the dealer's own share (the caller seals that locally). `threshold`
+    /// and `total` are the OPRF Shamir parameters. Mirrors
+    /// [`KfpNode::request_oprf_unlock`]'s subscribe-before-send + timeout shape.
+    pub async fn distribute_oprf_shares(
+        &self,
+        shares: Vec<(u16, Zeroizing<Vec<u8>>)>,
+        threshold: u16,
+        total: u16,
+    ) -> Result<()> {
+        if shares.is_empty() {
+            return Err(FrostNetError::Protocol(
+                "No OPRF shares to distribute".into(),
+            ));
+        }
+        if threshold < 2 || threshold > total {
+            return Err(FrostNetError::Protocol(
+                "OPRF enrollment requires 2 <= threshold <= total".into(),
+            ));
+        }
+        if total as usize > MAX_PARTICIPANTS {
+            return Err(FrostNetError::Protocol(
+                "OPRF enrollment total exceeds maximum participants".into(),
+            ));
+        }
+
+        let our_index = self.share.metadata.identifier;
+
+        // Resolve every target peer up-front. A missing or non-sendable target,
+        // or the dealer's own index, aborts before any share leaves the box.
+        let mut deliveries: Vec<(u16, PublicKey, Zeroizing<Vec<u8>>)> =
+            Vec::with_capacity(shares.len());
+        let mut target_indices: Vec<u16> = Vec::with_capacity(shares.len());
+        {
+            let peers = self.peers.read();
+            for (target_index, share_bytes) in shares {
+                if target_index == 0 {
+                    return Err(FrostNetError::Protocol(
+                        "OPRF enrollment target index must be non-zero".into(),
+                    ));
+                }
+                if target_index == our_index {
+                    return Err(FrostNetError::Protocol(
+                        "Dealer must not distribute its own OPRF share".into(),
+                    ));
+                }
+                if share_bytes.len() != keep_core::oprf::threshold::KEY_SHARE_LEN {
+                    return Err(FrostNetError::Protocol(
+                        "OPRF enrollment share has wrong length".into(),
+                    ));
+                }
+                if target_indices.contains(&target_index) {
+                    return Err(FrostNetError::Protocol(
+                        "Duplicate OPRF enrollment target index".into(),
+                    ));
+                }
+                let peer = peers.get_peer(target_index).ok_or_else(|| {
+                    FrostNetError::UntrustedPeer(format!(
+                        "OPRF enrollment target share {target_index} not announced"
+                    ))
+                })?;
+                if !self.can_send_to(&peer.pubkey) {
+                    return Err(FrostNetError::PolicyViolation(format!(
+                        "Policy denies sending OPRF enrollment to share {target_index}"
+                    )));
+                }
+                deliveries.push((target_index, peer.pubkey, share_bytes));
+                target_indices.push(target_index);
+            }
+        }
+
+        let nonce = Timestamp::now().as_secs();
+        let session_id = derive_oprf_enroll_session_id(&self.group_pubkey, &target_indices, nonce);
+
+        info!(
+            session_id = %hex::encode(session_id),
+            targets = ?target_indices,
+            "Distributing OPRF enrollment shares"
+        );
+
+        {
+            let mut sessions = self.enroll_sessions.write();
+            sessions.create_session(
+                session_id,
+                self.group_pubkey,
+                target_indices.iter().copied().collect(),
+                threshold,
+                total,
+            )?;
+        }
+
+        // Subscribe BEFORE sending so a fast holder's ack, processed by our run
+        // loop, cannot fire `OprfEnrollComplete` before we start listening
+        // (broadcast does not replay to late subscribers).
+        let mut rx = self.event_tx.subscribe();
+
+        let send_result: Result<()> = async {
+            for (target_index, pubkey, share_bytes) in deliveries {
+                let payload = OprfEnrollPayload::new(
+                    session_id,
+                    self.group_pubkey,
+                    our_index,
+                    target_index,
+                    threshold,
+                    total,
+                    share_bytes,
+                );
+                let event = KfpEventBuilder::oprf_enroll(&self.keys, &pubkey, payload)?;
+                self.client
+                    .send_event(&event)
+                    .await
+                    .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+                debug!(target_index, "Sent OPRF enrollment share");
+            }
+            Ok(())
+        }
+        .await;
+        if let Err(e) = send_result {
+            self.enroll_sessions.write().complete_session(&session_id);
+            return Err(e);
+        }
+
+        let timeout = Duration::from_secs(30);
+        let result = tokio::time::timeout(timeout, async {
+            loop {
+                match rx.recv().await {
+                    Ok(KfpNodeEvent::OprfEnrollComplete { session_id: sid })
+                        if sid == session_id =>
+                    {
+                        return Ok(());
+                    }
+                    Ok(KfpNodeEvent::OprfEnrollFailed {
+                        session_id: sid,
+                        error,
+                    }) if sid == session_id => {
+                        return Err(FrostNetError::Session(error));
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        return Err(FrostNetError::Transport("Event channel closed".into()));
+                    }
+                    _ => {}
+                }
+            }
+        })
+        .await;
+
+        let result = match result {
+            Ok(r) => r,
+            Err(_) => Err(FrostNetError::Timeout("OPRF enrollment timed out".into())),
+        };
+        // Tear the session down on any exit (success or failure) so it does not
+        // linger until cleanup_expired reaps it.
+        self.enroll_sessions.write().complete_session(&session_id);
+        result
+    }
+
+    /// Holder side: take custody of an OPRF secret key share from a trusted
+    /// dealer, after passing every #621 gate, in order: group / addressed-to-us /
+    /// replay / policy, pubkey↔dealer-index binding, STRICT attestation of the
+    /// dealer, then share validation. Only then is `OprfShareReceived` emitted
+    /// (so the node/app seals it) and an ack returned. The share is never logged.
+    pub(crate) async fn handle_oprf_enroll(
+        &self,
+        from: PublicKey,
+        payload: OprfEnrollPayload,
+    ) -> Result<()> {
+        // 1. Group binding.
+        if payload.group_pubkey != self.group_pubkey {
+            return Ok(());
+        }
+
+        // 2. The share must be addressed to this node.
+        if payload.target_index != self.share.metadata.identifier {
+            return Ok(());
+        }
+
+        // 3. Replay window.
+        if !payload.is_within_replay_window(self.replay_window_secs) {
+            warn!(
+                session_id = %hex::encode(payload.session_id),
+                created_at = payload.created_at,
+                "Rejecting OPRF enrollment: outside replay window"
+            );
+            return Err(FrostNetError::ReplayDetected(format!(
+                "OPRF enrollment created_at {} outside {} second window",
+                payload.created_at, self.replay_window_secs
+            )));
+        }
+
+        // 4. Receive policy.
+        if !self.can_receive_from(&from) {
+            debug!(from = %from, "Rejecting OPRF enrollment: policy denies receive");
+            return Err(FrostNetError::PolicyViolation(format!(
+                "Peer {from} not allowed to send OPRF enrollment"
+            )));
+        }
+
+        // 5. Bind the dealer's pubkey to its claimed share index.
+        self.verify_peer_share_index(from, payload.dealer_index)?;
+
+        // 5b. If a designated dealer is pinned, refuse enrollment from any other index, so a
+        // compromised-but-attested group member cannot poison or overwrite this holder's share.
+        if let Some(expected) = self.expected_oprf_dealer {
+            if payload.dealer_index != expected {
+                return Err(FrostNetError::UntrustedPeer(format!(
+                    "OPRF enrollment from share {} but the designated dealer is {expected}",
+                    payload.dealer_index
+                )));
+            }
+        }
+
+        // 6. Attestation gate: taking custody of a key share from an unattested
+        // dealer is unsafe, so require VERIFIED attestation (STRICT, like the eval
+        // oracle), not merely `is_attested()`.
+        {
+            let peers = self.peers.read();
+            let peer = peers.get_peer(payload.dealer_index).ok_or_else(|| {
+                FrostNetError::UntrustedPeer(format!(
+                    "OPRF enrollment dealer share {} not announced",
+                    payload.dealer_index
+                ))
+            })?;
+            if !matches!(peer.attestation_status, AttestationStatus::Verified) {
+                return Err(FrostNetError::UntrustedPeer(format!(
+                    "OPRF enrollment dealer share {} attestation not Verified ({:?})",
+                    payload.dealer_index, peer.attestation_status
+                )));
+            }
+        }
+
+        // 7. Validate the share itself (length / canonical scalars / non-zero id), then scrub the
+        // decoded `KeyShare`: per the keep_core::oprf contract it is Copy + Zeroize but NOT
+        // ZeroizeOnDrop, so the live secret scalar must be wiped once re-serialized rather than
+        // left resident after custody is taken.
+        use zeroize::Zeroize;
+        let mut validated = keep_core::oprf::threshold::deserialize_key_share(&payload.share)
+            .map_err(|e| FrostNetError::Crypto(e.to_string()))?;
+        let share_bytes = keep_core::oprf::threshold::serialize_key_share(&validated);
+        validated.zeroize();
+
+        info!(
+            session_id = %hex::encode(payload.session_id),
+            dealer = payload.dealer_index,
+            "Received OPRF enrollment share"
+        );
+
+        // Hand the validated share to the node/app to seal (TPM or keystore); that
+        // is not this protocol's job. The Debug impl redacts the share.
+        let _ = self.event_tx.send(KfpNodeEvent::OprfShareReceived {
+            dealer_index: payload.dealer_index,
+            threshold: payload.threshold,
+            total: payload.total,
+            share: Zeroizing::new(share_bytes.to_vec()),
+        });
+
+        let ack = OprfEnrollAckPayload::new(payload.session_id, self.share.metadata.identifier);
+        let event = KfpEventBuilder::oprf_enroll_ack(&self.keys, &from, ack)?;
+        self.client
+            .send_event(&event)
+            .await
+            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+
+        debug!(
+            session_id = %hex::encode(payload.session_id),
+            "Sent OPRF enrollment ack"
+        );
+
+        Ok(())
+    }
+
+    /// Dealer side: record a holder ack, and on the full set emit
+    /// [`KfpNodeEvent::OprfEnrollComplete`].
+    pub(crate) async fn handle_oprf_enroll_ack(
+        &self,
+        from: PublicKey,
+        payload: OprfEnrollAckPayload,
+    ) -> Result<()> {
+        self.verify_peer_share_index(from, payload.share_index)?;
+        self.peers.write().update_last_seen(payload.share_index);
+
+        let complete = {
+            let mut sessions = self.enroll_sessions.write();
+            let session = match sessions.get_session_mut(&payload.session_id) {
+                Some(s) => s,
+                None => {
+                    debug!(
+                        session_id = %hex::encode(payload.session_id),
+                        "No OPRF enrollment session for ack"
+                    );
+                    return Ok(());
+                }
+            };
+            session.record_ack(payload.share_index)?;
+            session.has_all_acks()
+        };
+
+        if complete {
+            info!(
+                session_id = %hex::encode(payload.session_id),
+                "OPRF enrollment complete!"
+            );
+            let _ = self.event_tx.send(KfpNodeEvent::OprfEnrollComplete {
+                session_id: payload.session_id,
+            });
+        }
+
+        Ok(())
+    }
+}

--- a/keep-frost-net/src/node/enroll.rs
+++ b/keep-frost-net/src/node/enroll.rs
@@ -11,9 +11,10 @@
 //! on the holder side; the share is the most sensitive payload in the system and
 //! is never logged.
 
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
 
 use nostr_sdk::prelude::*;
+use tokio::sync::oneshot;
 use tracing::{debug, info, warn};
 use zeroize::Zeroizing;
 
@@ -23,7 +24,7 @@ use crate::event::KfpEventBuilder;
 use crate::peer::AttestationStatus;
 use crate::protocol::*;
 
-use super::{KfpNode, KfpNodeEvent};
+use super::{KfpNode, KfpNodeEvent, OprfShareSealAck};
 
 impl KfpNode {
     /// Dealer side: distribute each remote target's OPRF secret key share and
@@ -110,7 +111,10 @@ impl KfpNode {
             }
         }
 
-        let nonce = Timestamp::now().as_secs();
+        // Random, not wall-clock seconds: two enroll rounds for the same target set within the
+        // same second would otherwise derive an identical session_id and the second be refused as
+        // already active. The domain separator and group/target binding live in the derivation.
+        let nonce = ::rand::random::<u64>();
         let session_id = derive_oprf_enroll_session_id(&self.group_pubkey, &target_indices, nonce);
 
         info!(
@@ -161,7 +165,7 @@ impl KfpNode {
             return Err(e);
         }
 
-        let timeout = Duration::from_secs(30);
+        let timeout = self.dealer_wait_timeout();
         let result = tokio::time::timeout(timeout, async {
             loop {
                 match rx.recv().await {
@@ -240,15 +244,45 @@ impl KfpNode {
         // 5. Bind the dealer's pubkey to its claimed share index.
         self.verify_peer_share_index(from, payload.dealer_index)?;
 
-        // 5b. If a designated dealer is pinned, refuse enrollment from any other index, so a
-        // compromised-but-attested group member cannot poison or overwrite this holder's share.
-        if let Some(expected) = self.expected_oprf_dealer {
-            if payload.dealer_index != expected {
+        // 5b. Dealer pin (fail-closed). In a trusted-dealer model only the box deals shares, so a
+        // pinned dealer is required: enrollment from any other index is refused, and with no pin at
+        // all enrollment is refused entirely unless the holder explicitly opted into open
+        // enrollment. This stops a compromised-but-attested group member poisoning or overwriting
+        // this holder's share, and keeps the default secure rather than accepting from any peer.
+        match self.expected_oprf_dealer {
+            Some(expected) if payload.dealer_index != expected => {
                 return Err(FrostNetError::UntrustedPeer(format!(
                     "OPRF enrollment from share {} but the designated dealer is {expected}",
                     payload.dealer_index
                 )));
             }
+            None if !self.allow_unpinned_oprf_dealer => {
+                return Err(FrostNetError::UntrustedPeer(
+                    "OPRF enrollment refused: no designated dealer pinned and unpinned enrollment \
+                     not enabled"
+                        .into(),
+                ));
+            }
+            _ => {}
+        }
+
+        // 5c. Replay dedup: a relay redelivering the same OprfEnroll within the replay window
+        // re-passes every gate, so drop a repeat keyed on (dealer_index, session_id) before it can
+        // re-emit live key material on the broadcast bus or re-ack. The dealer_index is bound to
+        // `from` by step 5, so another peer cannot evict or forge this entry. A genuine retry uses
+        // a fresh random session_id and so is not deduped here.
+        if self
+            .seen_oprf_enrolls
+            .write()
+            .insert((payload.dealer_index, payload.session_id), payload.created_at)
+            .is_some()
+        {
+            debug!(
+                session_id = %hex::encode(payload.session_id),
+                dealer = payload.dealer_index,
+                "Dropping duplicate OPRF enrollment"
+            );
+            return Ok(());
         }
 
         // 6. Attestation gate: taking custody of a key share from an unattested
@@ -286,11 +320,17 @@ impl KfpNode {
             "Received OPRF enrollment share"
         );
 
-        // Hand the validated share to the node/app to seal (TPM or keystore); that
-        // is not this protocol's job. The Debug impl redacts the share. A broadcast
-        // send errors only when there are zero receivers: if nothing is subscribed
-        // to take custody, the share would be silently dropped, so refuse to ack
-        // rather than tell the dealer enrollment succeeded with no share sealed.
+        // Hand the validated share to the node/app to seal (TPM or keystore); that is not this
+        // protocol's job. The Debug impl redacts the share. Acking means DURABLE CUSTODY, not mere
+        // receipt: a non-empty subscriber count is not enough because an idle subscriber that
+        // ignores the event (e.g. desktop's `=> {}` arm) would let the ack fire while nothing
+        // sealed the share, leaving the dealer believing enrollment completed with no sealed share.
+        // So pass a one-shot ack-back and ack only on a confirmed seal. A broadcast send errors
+        // only with zero receivers; once delivered, the sealer takes the sender and reports the
+        // result, and if every subscriber ignores the event the sender is dropped and the receiver
+        // resolves Err, which we treat as custody failed.
+        let (seal_tx, seal_rx) = oneshot::channel::<bool>();
+        let seal_ack: OprfShareSealAck = Arc::new(Mutex::new(Some(seal_tx)));
         if self
             .event_tx
             .send(KfpNodeEvent::OprfShareReceived {
@@ -298,12 +338,32 @@ impl KfpNode {
                 threshold: payload.threshold,
                 total: payload.total,
                 share: Zeroizing::new(share_bytes.to_vec()),
+                seal_ack,
             })
             .is_err()
         {
             return Err(FrostNetError::Session(
                 "No subscriber to take custody of OPRF share; not acking".into(),
             ));
+        }
+
+        match tokio::time::timeout(self.dealer_wait_timeout(), seal_rx).await {
+            Ok(Ok(true)) => {}
+            Ok(Ok(false)) => {
+                return Err(FrostNetError::Session(
+                    "OPRF share sealing failed; not acking".into(),
+                ));
+            }
+            Ok(Err(_)) => {
+                return Err(FrostNetError::Session(
+                    "No subscriber sealed the OPRF share; not acking".into(),
+                ));
+            }
+            Err(_) => {
+                return Err(FrostNetError::Timeout(
+                    "OPRF share sealing confirmation timed out".into(),
+                ));
+            }
         }
 
         let ack = OprfEnrollAckPayload::new(payload.session_id, self.share.metadata.identifier);

--- a/keep-frost-net/src/node/enroll.rs
+++ b/keep-frost-net/src/node/enroll.rs
@@ -74,10 +74,21 @@ impl KfpNode {
                         "Dealer must not distribute its own OPRF share".into(),
                     ));
                 }
-                if share_bytes.len() != keep_core::oprf::threshold::KEY_SHARE_LEN {
-                    return Err(FrostNetError::Protocol(
-                        "OPRF enrollment share has wrong length".into(),
-                    ));
+                // Canonically validate every share (length, canonical scalars, non-zero id) by
+                // deserializing it before anything leaves the box, so a single malformed share
+                // aborts the whole round up front instead of being partially distributed and
+                // failing on a holder. Scrub the decoded live scalar immediately.
+                {
+                    use zeroize::Zeroize;
+                    let mut decoded =
+                        keep_core::oprf::threshold::deserialize_key_share(&share_bytes).map_err(
+                            |e| {
+                                FrostNetError::Protocol(format!(
+                                    "OPRF enrollment share {target_index} invalid: {e}"
+                                ))
+                            },
+                        )?;
+                    decoded.zeroize();
                 }
                 if target_indices.contains(&target_index) {
                     return Err(FrostNetError::Protocol(
@@ -276,13 +287,24 @@ impl KfpNode {
         );
 
         // Hand the validated share to the node/app to seal (TPM or keystore); that
-        // is not this protocol's job. The Debug impl redacts the share.
-        let _ = self.event_tx.send(KfpNodeEvent::OprfShareReceived {
-            dealer_index: payload.dealer_index,
-            threshold: payload.threshold,
-            total: payload.total,
-            share: Zeroizing::new(share_bytes.to_vec()),
-        });
+        // is not this protocol's job. The Debug impl redacts the share. A broadcast
+        // send errors only when there are zero receivers: if nothing is subscribed
+        // to take custody, the share would be silently dropped, so refuse to ack
+        // rather than tell the dealer enrollment succeeded with no share sealed.
+        if self
+            .event_tx
+            .send(KfpNodeEvent::OprfShareReceived {
+                dealer_index: payload.dealer_index,
+                threshold: payload.threshold,
+                total: payload.total,
+                share: Zeroizing::new(share_bytes.to_vec()),
+            })
+            .is_err()
+        {
+            return Err(FrostNetError::Session(
+                "No subscriber to take custody of OPRF share; not acking".into(),
+            ));
+        }
 
         let ack = OprfEnrollAckPayload::new(payload.session_id, self.share.metadata.identifier);
         let event = KfpEventBuilder::oprf_enroll_ack(&self.keys, &from, ack)?;

--- a/keep-frost-net/src/node/enroll.rs
+++ b/keep-frost-net/src/node/enroll.rs
@@ -266,25 +266,6 @@ impl KfpNode {
             _ => {}
         }
 
-        // 5c. Replay dedup: a relay redelivering the same OprfEnroll within the replay window
-        // re-passes every gate, so drop a repeat keyed on (dealer_index, session_id) before it can
-        // re-emit live key material on the broadcast bus or re-ack. The dealer_index is bound to
-        // `from` by step 5, so another peer cannot evict or forge this entry. A genuine retry uses
-        // a fresh random session_id and so is not deduped here.
-        if self
-            .seen_oprf_enrolls
-            .write()
-            .insert((payload.dealer_index, payload.session_id), payload.created_at)
-            .is_some()
-        {
-            debug!(
-                session_id = %hex::encode(payload.session_id),
-                dealer = payload.dealer_index,
-                "Dropping duplicate OPRF enrollment"
-            );
-            return Ok(());
-        }
-
         // 6. Attestation gate: taking custody of a key share from an unattested
         // dealer is unsafe, so require VERIFIED attestation (STRICT, like the eval
         // oracle), not merely `is_attested()`.
@@ -302,6 +283,28 @@ impl KfpNode {
                     payload.dealer_index, peer.attestation_status
                 )));
             }
+        }
+
+        // Replay dedup, placed after the attestation gate but before share deserialization: a relay
+        // redelivering the same OprfEnroll within the replay window re-passes every gate, so drop a
+        // repeat keyed on (dealer_index, session_id) before it can deserialize the secret again,
+        // re-emit live key material on the broadcast bus, or re-ack. Recording only after attestation
+        // means a delivery that failed that gate (e.g. dealer not yet Verified) does not poison the
+        // entry, so a later legitimate redelivery still proceeds. The dealer_index is bound to `from`
+        // by the pubkey↔index check above, so another peer cannot forge or evict this entry. A
+        // genuine dealer retry uses a fresh random session_id and so is never deduped here.
+        if self
+            .seen_oprf_enrolls
+            .write()
+            .insert((payload.dealer_index, payload.session_id), payload.created_at)
+            .is_some()
+        {
+            debug!(
+                session_id = %hex::encode(payload.session_id),
+                dealer = payload.dealer_index,
+                "Dropping duplicate OPRF enrollment"
+            );
+            return Ok(());
         }
 
         // 7. Validate the share itself (length / canonical scalars / non-zero id), then scrub the
@@ -347,7 +350,12 @@ impl KfpNode {
             ));
         }
 
-        match tokio::time::timeout(self.dealer_wait_timeout(), seal_rx).await {
+        // Bound the inline wait to the seal-confirm window (a fraction of the session/dealer wait),
+        // NOT the full session timeout: this caps how long the single inbound-message loop is
+        // blocked on the sealing subscriber, and keeps the ack inside the dealer's own ack-wait so
+        // completion can still fire. A subscriber that never seals is caught here by timeout and the
+        // ack is withheld (durable-custody, not mere receipt).
+        match tokio::time::timeout(self.seal_confirm_timeout(), seal_rx).await {
             Ok(Ok(true)) => {}
             Ok(Ok(false)) => {
                 return Err(FrostNetError::Session(

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 mod descriptor;
 mod ecdh;
+mod enroll;
 mod oprf;
 mod psbt;
 mod signing;
@@ -32,6 +33,7 @@ use crate::attestation::{verify_peer_attestation, ExpectedPcrs};
 use crate::audit::SigningAuditLog;
 use crate::descriptor_session::DescriptorSessionManager;
 use crate::ecdh::EcdhSessionManager;
+use crate::enroll_session::OprfEnrollSessionManager;
 use crate::error::{FrostNetError, Result};
 use crate::event::KfpEventBuilder;
 use crate::nonce_pool::{NonceId, NoncePool};
@@ -500,6 +502,26 @@ pub enum KfpNodeEvent {
         session_id: [u8; 32],
         error: String,
     },
+    /// A holder took custody of a validated OPRF secret key share from a trusted
+    /// dealer. The node/app must seal `share` (TPM or keystore).
+    ///
+    /// SECURITY: this carries live key material on the shared broadcast bus; the
+    /// `Debug` impl redacts it and it is never serialized to the wire. Prefer
+    /// sealing it immediately and do not log the event payload.
+    OprfShareReceived {
+        dealer_index: u16,
+        threshold: u16,
+        total: u16,
+        share: Zeroizing<Vec<u8>>,
+    },
+    /// The dealer collected an ack from every enrollment target.
+    OprfEnrollComplete {
+        session_id: [u8; 32],
+    },
+    OprfEnrollFailed {
+        session_id: [u8; 32],
+        error: String,
+    },
     DescriptorProposed {
         session_id: [u8; 32],
     },
@@ -653,6 +675,27 @@ impl std::fmt::Debug for KfpNodeEvent {
                 .field("session_id", &hex::encode(session_id))
                 .field("error", error)
                 .finish(),
+            Self::OprfShareReceived {
+                dealer_index,
+                threshold,
+                total,
+                ..
+            } => f
+                .debug_struct("OprfShareReceived")
+                .field("dealer_index", dealer_index)
+                .field("threshold", threshold)
+                .field("total", total)
+                .field("share", &"[REDACTED]")
+                .finish(),
+            Self::OprfEnrollComplete { session_id } => f
+                .debug_struct("OprfEnrollComplete")
+                .field("session_id", &hex::encode(session_id))
+                .finish(),
+            Self::OprfEnrollFailed { session_id, error } => f
+                .debug_struct("OprfEnrollFailed")
+                .field("session_id", &hex::encode(session_id))
+                .field("error", error)
+                .finish(),
             Self::DescriptorProposed { session_id } => f
                 .debug_struct("DescriptorProposed")
                 .field("session_id", &hex::encode(session_id))
@@ -799,6 +842,12 @@ pub struct KfpNode {
     pub(crate) oprf_sessions: Arc<RwLock<OprfUnlockSessionManager>>,
     /// Per-requester sliding-window limiter guarding the holder eval oracle.
     pub(crate) oprf_rate_limiter: Arc<RwLock<OprfEvalRateLimiter>>,
+    /// Dealer-side OPRF enrollment sessions (trusted-dealer share distribution).
+    pub(crate) enroll_sessions: Arc<RwLock<OprfEnrollSessionManager>>,
+    /// Holder-side pin of the only share index allowed to deal an OPRF enrollment to this node.
+    /// `None` accepts an enrollment from any attested, authorized group peer; setting it (to the
+    /// box's index) refuses a share from any peer other than the designated dealer.
+    pub(crate) expected_oprf_dealer: Option<u16>,
     pub(crate) descriptor_sessions: Arc<RwLock<DescriptorSessionManager>>,
     pub(crate) psbt_sessions: Arc<RwLock<PsbtSessionManager>>,
     pub(crate) peers: Arc<RwLock<PeerManager>>,
@@ -974,6 +1023,11 @@ impl KfpNode {
             None => OprfUnlockSessionManager::new(),
         };
 
+        let enroll_manager = match session_timeout {
+            Some(t) => OprfEnrollSessionManager::new().with_timeout(t),
+            None => OprfEnrollSessionManager::new(),
+        };
+
         let audit_hmac_key = derive_audit_hmac_key(&keys, &group_pubkey);
         let audit_log = Arc::new(SigningAuditLog::new(audit_hmac_key));
 
@@ -988,6 +1042,8 @@ impl KfpNode {
             oprf_key_share: None,
             oprf_sessions: Arc::new(RwLock::new(oprf_manager)),
             oprf_rate_limiter: Arc::new(RwLock::new(OprfEvalRateLimiter::new())),
+            enroll_sessions: Arc::new(RwLock::new(enroll_manager)),
+            expected_oprf_dealer: None,
             descriptor_sessions: Arc::new(RwLock::new(descriptor_manager)),
             psbt_sessions: Arc::new(RwLock::new(psbt_manager)),
             peers: Arc::new(RwLock::new(PeerManager::new(our_index))),
@@ -1142,6 +1198,19 @@ impl KfpNode {
         self.handle_oprf_eval_request(from, request).await
     }
 
+    /// Test-only: drive the holder-side OPRF enrollment handler directly. Lets the
+    /// gate tests assert on the returned `Result` (attestation, replay, policy)
+    /// without a full dealer round-trip.
+    #[doc(hidden)]
+    #[cfg(any(test, feature = "testing"))]
+    pub async fn test_handle_oprf_enroll(
+        &self,
+        from: PublicKey,
+        payload: OprfEnrollPayload,
+    ) -> Result<()> {
+        self.handle_oprf_enroll(from, payload).await
+    }
+
     pub fn set_replay_window(&mut self, secs: u64) {
         self.replay_window_secs = secs;
     }
@@ -1277,6 +1346,19 @@ impl KfpNode {
     pub fn with_oprf_key_share(mut self, share: keep_core::oprf::threshold::KeyShare) -> Self {
         self.oprf_key_share = Some(share);
         self
+    }
+
+    /// Pin the only share index permitted to deal an OPRF enrollment to this node (the box). When
+    /// set, `handle_oprf_enroll` refuses a share from any other peer, even an attested one, so a
+    /// compromised-but-attested group member cannot poison or overwrite this holder's share.
+    pub fn with_expected_oprf_dealer(mut self, dealer_index: u16) -> Self {
+        self.expected_oprf_dealer = Some(dealer_index);
+        self
+    }
+
+    /// Setter form of [`with_expected_oprf_dealer`](Self::with_expected_oprf_dealer).
+    pub fn set_expected_oprf_dealer(&mut self, dealer_index: u16) {
+        self.expected_oprf_dealer = Some(dealer_index);
     }
 
     pub fn set_descriptor_proposers(&self, indices: HashSet<u16>) {
@@ -1536,6 +1618,7 @@ impl KfpNode {
                     self.sessions.write().cleanup_expired();
                     self.ecdh_sessions.write().cleanup_expired();
                     self.oprf_sessions.write().cleanup_expired();
+                    self.enroll_sessions.write().cleanup_expired();
                     let expired = self.descriptor_sessions.write().cleanup_expired();
                     for (session_id, reason) in expired {
                         let _ = self.event_tx.send(KfpNodeEvent::DescriptorFailed {
@@ -1621,6 +1704,7 @@ impl KfpNode {
                 | KfpMessage::SignRequest(_)
                 | KfpMessage::EcdhRequest(_)
                 | KfpMessage::OprfEvalRequest(_)
+                | KfpMessage::OprfEnroll(_)
         ) && !self.peers.read().is_trusted_peer(&event.pubkey)
         {
             debug!(from = %event.pubkey, "Rejecting message from untrusted peer");
@@ -1661,6 +1745,12 @@ impl KfpNode {
             }
             KfpMessage::OprfEvalShare(payload) => {
                 self.handle_oprf_eval_share(event.pubkey, payload).await?;
+            }
+            KfpMessage::OprfEnroll(payload) => {
+                self.handle_oprf_enroll(event.pubkey, payload).await?;
+            }
+            KfpMessage::OprfEnrollAck(payload) => {
+                self.handle_oprf_enroll_ack(event.pubkey, payload).await?;
             }
             KfpMessage::RefreshRequest(_)
             | KfpMessage::RefreshRound1(_)

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -445,6 +445,13 @@ pub(crate) const ANNOUNCE_MAX_FUTURE_SECS: u64 = 30;
 /// How often the early-exit liveness ping re-checks for pongs while waiting.
 const LIVENESS_PING_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
+/// Durable-custody ack-back channel for [`KfpNodeEvent::OprfShareReceived`]. The
+/// subscriber that durably seals the share takes the sender and reports the seal
+/// result; the holder acks the dealer only on a confirmed `true`. Wrapped in
+/// `Arc<Mutex<Option<_>>>` so the broadcast event remains `Clone` while the
+/// single-shot sender can be taken by exactly one subscriber.
+pub type OprfShareSealAck = Arc<std::sync::Mutex<Option<tokio::sync::oneshot::Sender<bool>>>>;
+
 #[derive(Clone)]
 pub enum KfpNodeEvent {
     PeerDiscovered {
@@ -513,6 +520,15 @@ pub enum KfpNodeEvent {
         threshold: u16,
         total: u16,
         share: Zeroizing<Vec<u8>>,
+        /// Durable-custody ack-back. The consumer that seals `share` MUST take the
+        /// sender (`lock().take()`) and send `true` on a confirmed seal or `false`
+        /// on failure. The holder withholds its enrollment ack to the dealer until
+        /// it observes `true`: if every subscriber ignores the event the sender is
+        /// dropped and the receiver resolves `Err`, so custody is reported failed
+        /// rather than the dealer being told enrollment completed with nothing
+        /// sealed. Wrapped so the broadcast event stays `Clone`; only one
+        /// subscriber can take the single-shot sender.
+        seal_ack: OprfShareSealAck,
     },
     /// The dealer collected an ack from every enrollment target.
     OprfEnrollComplete {
@@ -845,9 +861,19 @@ pub struct KfpNode {
     /// Dealer-side OPRF enrollment sessions (trusted-dealer share distribution).
     pub(crate) enroll_sessions: Arc<RwLock<OprfEnrollSessionManager>>,
     /// Holder-side pin of the only share index allowed to deal an OPRF enrollment to this node.
-    /// `None` accepts an enrollment from any attested, authorized group peer; setting it (to the
-    /// box's index) refuses a share from any peer other than the designated dealer.
+    /// `None` requires an explicit opt-out (`allow_unpinned_oprf_dealer`) and otherwise refuses
+    /// enrollment fail-closed; setting it (to the box's index) refuses a share from any peer
+    /// other than the designated dealer.
     pub(crate) expected_oprf_dealer: Option<u16>,
+    /// Holder-side opt-out for the fail-closed dealer pin. In a trusted-dealer model only the box
+    /// should deal shares, so with no `expected_oprf_dealer` pinned enrollment is refused unless
+    /// this is explicitly set, which keeps the default secure while preserving open-enrollment
+    /// flows (e.g. tests) that knowingly accept a share from any attested, authorized peer.
+    pub(crate) allow_unpinned_oprf_dealer: bool,
+    /// Resolved session timeout (configured or default). The dealer derives its enrollment/unlock
+    /// ack wait from this so a short session timeout cannot expire the session before the wait,
+    /// stranding completion. See [`KfpNode::dealer_wait_timeout`].
+    pub(crate) session_timeout: Duration,
     pub(crate) descriptor_sessions: Arc<RwLock<DescriptorSessionManager>>,
     pub(crate) psbt_sessions: Arc<RwLock<PsbtSessionManager>>,
     pub(crate) peers: Arc<RwLock<PeerManager>>,
@@ -867,6 +893,13 @@ pub struct KfpNode {
     /// stops a peer forcing repeated secp256k1 deserialization by perturbing the
     /// timestamp. Value is `created_at` for time-based retention.
     pub(crate) seen_nonce_commitments: RwLock<HashMap<(u16, [u8; 32]), u64>>,
+    /// Holder-side de-duplication for `OprfEnroll` deliveries, keyed by
+    /// `(dealer_index, session_id)` so a relay redelivering the same enrollment
+    /// inside the replay window cannot re-emit live key material on the broadcast
+    /// bus or re-ack. The `dealer_index` is bound to the sender pubkey by
+    /// `verify_peer_share_index` before insertion. Value is `created_at` for
+    /// replay-window pruning.
+    pub(crate) seen_oprf_enrolls: RwLock<HashMap<(u16, [u8; 32]), u64>>,
     /// Per-session de-duplication for `DescriptorMigrate` link broadcasts.
     /// Keyed by `(session_id, new_descriptor_hash)` so an attacker cannot
     /// bypass dedupe by perturbing `created_at`. Value is `created_at` for
@@ -1027,6 +1060,9 @@ impl KfpNode {
             Some(t) => OprfEnrollSessionManager::new().with_timeout(t),
             None => OprfEnrollSessionManager::new(),
         };
+        // Mirror the managers' own default so the dealer ack wait tracks the
+        // configured session lifetime rather than a hardcoded constant.
+        let resolved_session_timeout = session_timeout.unwrap_or(Duration::from_secs(30));
 
         let audit_hmac_key = derive_audit_hmac_key(&keys, &group_pubkey);
         let audit_log = Arc::new(SigningAuditLog::new(audit_hmac_key));
@@ -1044,6 +1080,8 @@ impl KfpNode {
             oprf_rate_limiter: Arc::new(RwLock::new(OprfEvalRateLimiter::new())),
             enroll_sessions: Arc::new(RwLock::new(enroll_manager)),
             expected_oprf_dealer: None,
+            allow_unpinned_oprf_dealer: false,
+            session_timeout: resolved_session_timeout,
             descriptor_sessions: Arc::new(RwLock::new(descriptor_manager)),
             psbt_sessions: Arc::new(RwLock::new(psbt_manager)),
             peers: Arc::new(RwLock::new(PeerManager::new(our_index))),
@@ -1057,6 +1095,7 @@ impl KfpNode {
             expected_pcrs: None,
             seen_xpub_announces: RwLock::new(HashSet::new()),
             seen_nonce_commitments: RwLock::new(HashMap::new()),
+            seen_oprf_enrolls: RwLock::new(HashMap::new()),
             seen_descriptor_migrates: RwLock::new(HashMap::new()),
             descriptor_proposers: RwLock::new(HashSet::new()),
             psbt_proposers: RwLock::new(HashSet::new()),
@@ -1361,6 +1400,28 @@ impl KfpNode {
         self.expected_oprf_dealer = Some(dealer_index);
     }
 
+    /// Opt out of the fail-closed dealer pin: accept an OPRF enrollment share from any attested,
+    /// authorized peer when no `expected_oprf_dealer` is pinned. The default refuses unpinned
+    /// enrollment because in a trusted-dealer model only the box should deal shares; set this only
+    /// for deliberate open-enrollment flows that accept that weaker trust assumption.
+    pub fn allow_unpinned_oprf_dealer(mut self, allow: bool) -> Self {
+        self.allow_unpinned_oprf_dealer = allow;
+        self
+    }
+
+    /// Setter form of [`allow_unpinned_oprf_dealer`](Self::allow_unpinned_oprf_dealer).
+    pub fn set_allow_unpinned_oprf_dealer(&mut self, allow: bool) {
+        self.allow_unpinned_oprf_dealer = allow;
+    }
+
+    /// Dealer-side wait for enrollment/unlock acks, derived from the configured session timeout so
+    /// the wait and the session lifetime stay coupled: a short session timeout would otherwise
+    /// expire the session before a hardcoded 30s wait elapsed, so the final ack would be refused as
+    /// expired and completion would never fire.
+    pub(crate) fn dealer_wait_timeout(&self) -> Duration {
+        self.session_timeout
+    }
+
     pub fn set_descriptor_proposers(&self, indices: HashSet<u16>) {
         *self.descriptor_proposers.write() = indices;
     }
@@ -1644,6 +1705,9 @@ impl KfpNode {
                         self.seen_nonce_commitments.write().retain(|_, ts| {
                             now.saturating_sub(window) <= *ts
                         });
+                        self.seen_oprf_enrolls.write().retain(|_, ts| {
+                            now.saturating_sub(window) <= *ts
+                        });
                         self.seen_descriptor_migrates.write().retain(|_, ts| {
                             now.saturating_sub(window) <= *ts
                         });
@@ -1698,6 +1762,11 @@ impl KfpNode {
             }
         };
 
+        // Allowlist of initiating REQUESTS exempt from the trusted-peer requirement; each gates
+        // itself by attestation/policy inside its handler. Every response/share/ack message,
+        // including `OprfEnrollAck`, is deliberately absent so it still requires a trusted peer
+        // (defense in depth), matching `EcdhShare` / `SignatureShare` / `OprfEvalShare` /
+        // `DescriptorAck`. Do NOT add `OprfEnrollAck` here: that would exempt it from the gate.
         if !matches!(
             msg,
             KfpMessage::Announce(_)

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1747,6 +1747,21 @@ impl KfpNode {
                 self.handle_oprf_eval_share(event.pubkey, payload).await?;
             }
             KfpMessage::OprfEnroll(payload) => {
+                // Defense in depth: a share must arrive NIP-44 encrypted and directly addressed
+                // to us. decrypt_message treats a non-addressed event's content as plaintext, so
+                // require our `p` tag here; an addressed event that reached this point was
+                // necessarily decrypted (a forged plaintext payload would have failed decryption).
+                let addressed_to_us = event.tags.filter(TagKind::p()).any(|t| {
+                    matches!(
+                        t.as_standardized(),
+                        Some(TagStandard::PublicKey { public_key, .. })
+                            if public_key == &self.keys.public_key()
+                    )
+                });
+                if !addressed_to_us {
+                    debug!(from = %event.pubkey, "Rejecting OPRF enrollment: not directly addressed");
+                    return Ok(());
+                }
                 self.handle_oprf_enroll(event.pubkey, payload).await?;
             }
             KfpMessage::OprfEnrollAck(payload) => {

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -445,6 +445,13 @@ pub(crate) const ANNOUNCE_MAX_FUTURE_SECS: u64 = 30;
 /// How often the early-exit liveness ping re-checks for pongs while waiting.
 const LIVENESS_PING_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
+/// Upper bound on how long a holder blocks the inbound-message loop waiting for a subscriber to
+/// confirm it durably sealed an OPRF enrollment share. Kept well under the default session timeout
+/// so the loop is not deaf for a full session and the resulting ack still reaches the dealer inside
+/// its own ack-wait. A real TPM/keystore seal completes in well under this; the bound exists to
+/// catch a subscriber that never seals.
+pub(crate) const OPRF_SEAL_CONFIRM_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Durable-custody ack-back channel for [`KfpNodeEvent::OprfShareReceived`]. The
 /// subscriber that durably seals the share takes the sender and reports the seal
 /// result; the holder acks the dealer only on a confirmed `true`. Wrapped in
@@ -1420,6 +1427,14 @@ impl KfpNode {
     /// expired and completion would never fire.
     pub(crate) fn dealer_wait_timeout(&self) -> Duration {
         self.session_timeout
+    }
+
+    /// Holder-side bound on the inline wait for OPRF seal confirmation: the smaller of
+    /// [`OPRF_SEAL_CONFIRM_TIMEOUT`] and half the session timeout, so a very short configured
+    /// session timeout shrinks the wait too and the ack always lands inside the dealer's ack-wait
+    /// window rather than arriving after the session has already expired.
+    pub(crate) fn seal_confirm_timeout(&self) -> Duration {
+        OPRF_SEAL_CONFIRM_TIMEOUT.min(self.session_timeout / 2)
     }
 
     pub fn set_descriptor_proposers(&self, indices: HashSet<u16>) {

--- a/keep-frost-net/src/node/oprf.rs
+++ b/keep-frost-net/src/node/oprf.rs
@@ -10,8 +10,6 @@
 //! session in [`super::ecdh`], with the holder-side asymmetry and the #621
 //! ship-gate (attestation + rate limit + approval) on the eval oracle.
 
-use std::time::Duration;
-
 use nostr_sdk::prelude::*;
 use tracing::{debug, info, warn};
 use zeroize::Zeroizing;
@@ -349,7 +347,7 @@ impl KfpNode {
             }
         }
 
-        let timeout = Duration::from_secs(30);
+        let timeout = self.dealer_wait_timeout();
 
         let result = tokio::time::timeout(timeout, async {
             loop {

--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -104,6 +104,8 @@ pub enum KfpMessage {
     EcdhComplete(EcdhCompletePayload),
     OprfEvalRequest(OprfEvalRequestPayload),
     OprfEvalShare(OprfEvalSharePayload),
+    OprfEnroll(OprfEnrollPayload),
+    OprfEnrollAck(OprfEnrollAckPayload),
     RefreshRequest(RefreshRequestPayload),
     RefreshRound1(RefreshRound1Payload),
     RefreshRound2(RefreshRound2Payload),
@@ -138,6 +140,8 @@ impl KfpMessage {
             KfpMessage::EcdhComplete(_) => "ecdh_complete",
             KfpMessage::OprfEvalRequest(_) => "oprf_eval_request",
             KfpMessage::OprfEvalShare(_) => "oprf_eval_share",
+            KfpMessage::OprfEnroll(_) => "oprf_enroll",
+            KfpMessage::OprfEnrollAck(_) => "oprf_enroll_ack",
             KfpMessage::RefreshRequest(_) => "refresh_request",
             KfpMessage::RefreshRound1(_) => "refresh_round1",
             KfpMessage::RefreshRound2(_) => "refresh_round2",
@@ -170,6 +174,8 @@ impl KfpMessage {
             KfpMessage::EcdhComplete(p) => Some(&p.session_id),
             KfpMessage::OprfEvalRequest(p) => Some(&p.session_id),
             KfpMessage::OprfEvalShare(p) => Some(&p.session_id),
+            KfpMessage::OprfEnroll(p) => Some(&p.session_id),
+            KfpMessage::OprfEnrollAck(p) => Some(&p.session_id),
             KfpMessage::RefreshRequest(p) => Some(&p.session_id),
             KfpMessage::RefreshRound1(p) => Some(&p.session_id),
             KfpMessage::RefreshRound2(p) => Some(&p.session_id),
@@ -196,6 +202,7 @@ impl KfpMessage {
             KfpMessage::NonceCommitment(p) => Some(&p.group_pubkey),
             KfpMessage::EcdhRequest(p) => Some(&p.group_pubkey),
             KfpMessage::OprfEvalRequest(p) => Some(&p.group_pubkey),
+            KfpMessage::OprfEnroll(p) => Some(&p.group_pubkey),
             KfpMessage::RefreshRequest(p) => Some(&p.group_pubkey),
             KfpMessage::DescriptorPropose(p) => Some(&p.group_pubkey),
             KfpMessage::DescriptorContribute(p) => Some(&p.group_pubkey),
@@ -353,6 +360,32 @@ impl KfpMessage {
                 // 33-byte compressed point (see keep_core::oprf::threshold).
                 if p.partial.len() != OPRF_PARTIAL_LEN {
                     return Err("Invalid OPRF partial size");
+                }
+            }
+            KfpMessage::OprfEnroll(p) => {
+                // The secret share is exactly the serialized key-share length.
+                if p.share.len() != keep_core::oprf::threshold::KEY_SHARE_LEN {
+                    return Err("Invalid OPRF key share size");
+                }
+                if p.dealer_index == 0 {
+                    return Err("dealer_index must be non-zero");
+                }
+                if p.target_index == 0 {
+                    return Err("target_index must be non-zero");
+                }
+                if p.threshold < 2 {
+                    return Err("threshold must be at least 2");
+                }
+                if p.threshold > p.total {
+                    return Err("threshold must not exceed total");
+                }
+                if p.total as usize > MAX_PARTICIPANTS {
+                    return Err("total exceeds maximum participants");
+                }
+            }
+            KfpMessage::OprfEnrollAck(p) => {
+                if p.share_index == 0 {
+                    return Err("share_index must be non-zero");
                 }
             }
             KfpMessage::RefreshRequest(p) => {
@@ -1233,6 +1266,88 @@ impl OprfEvalSharePayload {
             session_id,
             share_index,
             partial,
+        }
+    }
+}
+
+/// Dealer (box) → holder: a trusted-dealer OPRF enrollment carrying the holder's
+/// dedicated OPRF secret key share. `share` is the 64-byte
+/// `keep_core::oprf::threshold::serialize_key_share` output and is the most
+/// sensitive payload in the protocol; it is delivered NIP-44 encrypted to the
+/// target peer's pubkey and REDACTED from `Debug` (mirrors [`EcdhCompletePayload`]).
+#[derive(Serialize, Deserialize, Clone)]
+pub struct OprfEnrollPayload {
+    #[serde(with = "hex_bytes")]
+    pub session_id: [u8; 32],
+    #[serde(with = "hex_bytes")]
+    pub group_pubkey: [u8; 32],
+    pub dealer_index: u16,
+    pub target_index: u16,
+    pub threshold: u16,
+    pub total: u16,
+    #[serde(with = "hex_vec_zeroizing")]
+    pub share: Zeroizing<Vec<u8>>,
+    pub created_at: u64,
+}
+
+impl OprfEnrollPayload {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        session_id: [u8; 32],
+        group_pubkey: [u8; 32],
+        dealer_index: u16,
+        target_index: u16,
+        threshold: u16,
+        total: u16,
+        share: Zeroizing<Vec<u8>>,
+    ) -> Self {
+        Self {
+            session_id,
+            group_pubkey,
+            dealer_index,
+            target_index,
+            threshold,
+            total,
+            share,
+            created_at: Timestamp::now().as_secs(),
+        }
+    }
+
+    pub fn is_within_replay_window(&self, window_secs: u64) -> bool {
+        within_replay_window(self.created_at, window_secs)
+    }
+}
+
+impl std::fmt::Debug for OprfEnrollPayload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OprfEnrollPayload")
+            .field("session_id", &hex::encode(self.session_id))
+            .field("group_pubkey", &hex::encode(self.group_pubkey))
+            .field("dealer_index", &self.dealer_index)
+            .field("target_index", &self.target_index)
+            .field("threshold", &self.threshold)
+            .field("total", &self.total)
+            .field("share", &"[REDACTED]")
+            .field("created_at", &self.created_at)
+            .finish()
+    }
+}
+
+/// Holder → dealer: acknowledgement that the enrollment share was received and
+/// validated. Carries the holder's own FROST share index so the dealer can bind
+/// the acking pubkey to a known peer.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct OprfEnrollAckPayload {
+    #[serde(with = "hex_bytes")]
+    pub session_id: [u8; 32],
+    pub share_index: u16,
+}
+
+impl OprfEnrollAckPayload {
+    pub fn new(session_id: [u8; 32], share_index: u16) -> Self {
+        Self {
+            session_id,
+            share_index,
         }
     }
 }

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -2679,6 +2679,8 @@ async fn test_oprf_enroll_distributes_share_and_completes() {
     let mut node2 = KfpNode::new(share2, vec![relay])
         .await
         .expect("holder node");
+    // Pin the box (FROST id 1) as the designated dealer (fail-closed default).
+    node2.set_expected_oprf_dealer(1);
 
     let mut rx1 = node1.subscribe();
     let mut rx2 = node2.subscribe();
@@ -2730,7 +2732,14 @@ async fn test_oprf_enroll_distributes_share_and_completes() {
                     threshold,
                     total,
                     share,
-                }) => return Some((dealer_index, threshold, total, share)),
+                    seal_ack,
+                }) => {
+                    // Confirm durable custody so the holder acks the dealer.
+                    if let Some(tx) = seal_ack.lock().unwrap().take() {
+                        let _ = tx.send(true);
+                    }
+                    return Some((dealer_index, threshold, total, share));
+                }
                 Ok(_) => {}
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
                 Err(_) => return None,
@@ -2803,9 +2812,11 @@ async fn test_oprf_enroll_rejects_unattested_dealer() {
     let _ = shares.remove(0); // id 1 (dealer is synthetic)
     let holder_share = shares.remove(0); // id 2 = holder
 
+    // Allow unpinned enrollment so the attestation gate (not the dealer pin) is what rejects.
     let holder = KfpNode::new(holder_share, vec![relay])
         .await
-        .expect("holder");
+        .expect("holder")
+        .allow_unpinned_oprf_dealer(true);
 
     let (dealer_pubkey, payload) = make_oprf_enroll(&holder);
     // Inject the dealer with the DEFAULT attestation status (NotProvided).
@@ -2856,4 +2867,157 @@ async fn test_oprf_enroll_rejects_non_designated_dealer() {
         rx.try_recv().is_err(),
         "no OprfShareReceived may be emitted for a non-designated dealer"
     );
+}
+
+/// Durable custody: with the share addressed, attested, and pinned but NO subscriber to take
+/// custody (seal) it, `handle_oprf_enroll` returns Err and sends no ack. A non-empty subscriber
+/// count is not enough; here there are zero receivers, so the broadcast send fails outright.
+#[tokio::test]
+async fn test_oprf_enroll_no_subscriber_refuses_ack() {
+    let mock_relay = MockRelay::run().await.expect("relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pkg) = dealer.generate("test-oprf-enroll-no-sub").unwrap();
+    let _ = shares.remove(0); // id 1
+    let holder_share = shares.remove(0); // id 2 = holder
+
+    let mut holder = KfpNode::new(holder_share, vec![relay])
+        .await
+        .expect("holder");
+    holder.set_expected_oprf_dealer(1);
+
+    let (dealer_pubkey, payload) = make_oprf_enroll(&holder);
+    holder.test_inject_peer(keep_frost_net::Peer::new(dealer_pubkey, 1));
+    holder.test_set_peer_attestation(1, keep_frost_net::AttestationStatus::Verified);
+
+    // Deliberately do NOT subscribe: nothing will take custody of the share.
+    let result = holder.test_handle_oprf_enroll(dealer_pubkey, payload).await;
+    assert!(
+        matches!(result, Err(keep_frost_net::FrostNetError::Session(_))),
+        "with no subscriber to seal the share the holder must refuse to ack, got {result:?}"
+    );
+}
+
+/// Replay window: an enrollment whose `created_at` is far in the past is rejected with
+/// `ReplayDetected` at the replay gate, before any custody is taken.
+#[tokio::test]
+async fn test_oprf_enroll_rejects_stale_created_at() {
+    let mock_relay = MockRelay::run().await.expect("relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pkg) = dealer.generate("test-oprf-enroll-stale").unwrap();
+    let _ = shares.remove(0); // id 1
+    let holder_share = shares.remove(0); // id 2 = holder
+
+    let holder = KfpNode::new(holder_share, vec![relay])
+        .await
+        .expect("holder");
+
+    let (dealer_pubkey, mut payload) = make_oprf_enroll(&holder);
+    payload.created_at = nostr_sdk::Timestamp::now().as_secs() - 400;
+
+    let mut rx = holder.subscribe();
+    let result = holder.test_handle_oprf_enroll(dealer_pubkey, payload).await;
+    assert!(
+        matches!(result, Err(keep_frost_net::FrostNetError::ReplayDetected(_))),
+        "a stale enrollment must be rejected with ReplayDetected, got {result:?}"
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "no OprfShareReceived may be emitted for a replayed enrollment"
+    );
+}
+
+/// Build a dealer node (FROST id 1) over a mock relay. The relay handle is returned so the caller
+/// keeps it alive for the node's lifetime.
+async fn make_dealer_node() -> (KfpNode, MockRelay) {
+    let mock_relay = MockRelay::run().await.expect("relay");
+    let relay = mock_relay.url().await.to_string();
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pkg) = dealer.generate("test-oprf-distribute").unwrap();
+    let share1 = shares.remove(0); // id 1 = dealer
+    let node = KfpNode::new(share1, vec![relay])
+        .await
+        .expect("dealer node");
+    (node, mock_relay)
+}
+
+/// Dealer-side `distribute_oprf_shares` rejects every malformed round up front, before any share
+/// leaves the box: bad threshold/total bounds, empty input, the dealer's own index, a zero index,
+/// a malformed share, and an unannounced target.
+#[tokio::test]
+async fn test_distribute_oprf_shares_early_validations() {
+    use zeroize::Zeroizing;
+
+    let (node, _relay) = make_dealer_node().await;
+    let valid =
+        || Zeroizing::new(keep_core::oprf::threshold::serialize_key_share(&split_oprf_key_2of3()[1]).to_vec());
+
+    // Empty input.
+    assert!(node.distribute_oprf_shares(vec![], 2, 3).await.is_err());
+
+    // threshold < 2.
+    assert!(node
+        .distribute_oprf_shares(vec![(2u16, valid())], 1, 3)
+        .await
+        .is_err());
+
+    // threshold > total.
+    assert!(node
+        .distribute_oprf_shares(vec![(2u16, valid())], 3, 2)
+        .await
+        .is_err());
+
+    // total exceeds MAX_PARTICIPANTS.
+    assert!(node
+        .distribute_oprf_shares(vec![(2u16, valid())], 2, 256)
+        .await
+        .is_err());
+
+    // Zero target index.
+    assert!(node
+        .distribute_oprf_shares(vec![(0u16, valid())], 2, 3)
+        .await
+        .is_err());
+
+    // The dealer's own index (1) must never be distributed.
+    assert!(node
+        .distribute_oprf_shares(vec![(1u16, valid())], 2, 3)
+        .await
+        .is_err());
+
+    // A malformed share aborts the whole round.
+    assert!(node
+        .distribute_oprf_shares(vec![(2u16, Zeroizing::new(vec![0u8; 8]))], 2, 3)
+        .await
+        .is_err());
+
+    // An unannounced target peer.
+    let result = node
+        .distribute_oprf_shares(vec![(2u16, valid())], 2, 3)
+        .await;
+    assert!(
+        matches!(result, Err(keep_frost_net::FrostNetError::UntrustedPeer(_))),
+        "an unannounced target must be rejected with UntrustedPeer, got {result:?}"
+    );
+}
+
+/// A duplicate target index is rejected even when the peer is announced and sendable.
+#[tokio::test]
+async fn test_distribute_oprf_shares_rejects_duplicate_target() {
+    use zeroize::Zeroizing;
+
+    let (node, _relay) = make_dealer_node().await;
+    let peer2 = nostr_sdk::Keys::generate().public_key();
+    node.test_inject_peer(keep_frost_net::Peer::new(peer2, 2));
+
+    let valid =
+        || Zeroizing::new(keep_core::oprf::threshold::serialize_key_share(&split_oprf_key_2of3()[1]).to_vec());
+
+    let result = node
+        .distribute_oprf_shares(vec![(2u16, valid()), (2u16, valid())], 2, 3)
+        .await;
+    assert!(result.is_err(), "a duplicate target index must be rejected");
 }

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -2869,6 +2869,76 @@ async fn test_oprf_enroll_rejects_non_designated_dealer() {
     );
 }
 
+/// Durable custody is fail-closed: if a subscriber takes the seal-ack sender but drops it without
+/// confirming a seal, the holder withholds the ack rather than confirm custody it did not take.
+/// This drives the `Ok(Err(_))` arm directly (the dropped sender resolves the receiver to Err),
+/// distinct from the timeout arm that fires when no subscriber touches the sender at all.
+#[tokio::test]
+async fn test_oprf_enroll_withholds_ack_when_seal_sender_dropped() {
+    let mock_relay = MockRelay::run().await.expect("relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pkg) = dealer.generate("test-oprf-enroll-seal-drop").unwrap();
+    let _ = shares.remove(0); // id 1 = dealer
+    let holder_share = shares.remove(0); // id 2 = holder
+
+    let holder = KfpNode::new(holder_share, vec![relay])
+        .await
+        .expect("holder");
+
+    let (dealer_pubkey, payload) = make_oprf_enroll(&holder); // dealer_index = 1
+                                                              // Pin the dealer (fail-closed default refuses enrollment with no pin), inject and attest it, so
+                                                              // every gate passes and the handler reaches the seal step.
+    let mut holder = holder;
+    holder.set_expected_oprf_dealer(1);
+    holder.test_inject_peer(keep_frost_net::Peer::new(dealer_pubkey, 1));
+    holder.test_set_peer_attestation(1, keep_frost_net::AttestationStatus::Verified);
+
+    let holder = std::sync::Arc::new(holder);
+    let mut rx = holder.subscribe();
+    let h = std::sync::Arc::clone(&holder);
+    let handle =
+        tokio::spawn(async move { h.test_handle_oprf_enroll(dealer_pubkey, payload).await });
+
+    // Take the seal sender out of the shared Option and drop it without confirming a seal. take()
+    // moves the sender out, so the broadcast ring buffer's retained clone no longer keeps it alive
+    // and the holder's receiver resolves to Err. Bounded so the test cannot hang.
+    let took = timeout(Duration::from_secs(10), async {
+        loop {
+            match rx.recv().await {
+                Ok(KfpNodeEvent::OprfShareReceived { seal_ack, .. }) => {
+                    let _ = seal_ack.lock().unwrap().take();
+                    return true;
+                }
+                Ok(_) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                Err(_) => return false,
+            }
+        }
+    })
+    .await
+    .unwrap_or(false);
+    assert!(
+        took,
+        "handler must emit OprfShareReceived so a subscriber can take custody"
+    );
+
+    let result = timeout(Duration::from_secs(20), handle)
+        .await
+        .expect("handler did not return in time")
+        .expect("handler task panicked");
+    match result {
+        Err(keep_frost_net::FrostNetError::Session(msg)) => {
+            assert!(
+                msg.contains("No subscriber sealed"),
+                "expected the dropped-seal failure, got: {msg}"
+            );
+        }
+        other => panic!("dropping the seal sender must withhold the ack, got {other:?}"),
+    }
+}
+
 /// Durable custody: with the share addressed, attested, and pinned but NO subscriber to take
 /// custody (seal) it, `handle_oprf_enroll` returns Err and sends no ack. A non-empty subscriber
 /// count is not enough; here there are zero receivers, so the broadcast send fails outright.
@@ -2921,7 +2991,10 @@ async fn test_oprf_enroll_rejects_stale_created_at() {
     let mut rx = holder.subscribe();
     let result = holder.test_handle_oprf_enroll(dealer_pubkey, payload).await;
     assert!(
-        matches!(result, Err(keep_frost_net::FrostNetError::ReplayDetected(_))),
+        matches!(
+            result,
+            Err(keep_frost_net::FrostNetError::ReplayDetected(_))
+        ),
         "a stale enrollment must be rejected with ReplayDetected, got {result:?}"
     );
     assert!(
@@ -2952,8 +3025,11 @@ async fn test_distribute_oprf_shares_early_validations() {
     use zeroize::Zeroizing;
 
     let (node, _relay) = make_dealer_node().await;
-    let valid =
-        || Zeroizing::new(keep_core::oprf::threshold::serialize_key_share(&split_oprf_key_2of3()[1]).to_vec());
+    let valid = || {
+        Zeroizing::new(
+            keep_core::oprf::threshold::serialize_key_share(&split_oprf_key_2of3()[1]).to_vec(),
+        )
+    };
 
     // Empty input.
     assert!(node.distribute_oprf_shares(vec![], 2, 3).await.is_err());
@@ -3013,8 +3089,11 @@ async fn test_distribute_oprf_shares_rejects_duplicate_target() {
     let peer2 = nostr_sdk::Keys::generate().public_key();
     node.test_inject_peer(keep_frost_net::Peer::new(peer2, 2));
 
-    let valid =
-        || Zeroizing::new(keep_core::oprf::threshold::serialize_key_share(&split_oprf_key_2of3()[1]).to_vec());
+    let valid = || {
+        Zeroizing::new(
+            keep_core::oprf::threshold::serialize_key_share(&split_oprf_key_2of3()[1]).to_vec(),
+        )
+    };
 
     let result = node
         .distribute_oprf_shares(vec![(2u16, valid()), (2u16, valid())], 2, 3)

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -2639,3 +2639,221 @@ async fn test_oprf_eval_rejects_replayed_request() {
         "a stale request must be rejected with ReplayDetected, got {result:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Trusted-dealer OPRF enrollment tests.
+//
+// The "box" (dealer) has already split an OPRF secret and now ships each remote
+// holder that holder's secret key share, collecting an ack from each. Like the
+// eval oracle, taking custody of a key share is gated on STRICT (`Verified`)
+// attestation of the dealer.
+// ---------------------------------------------------------------------------
+
+/// Happy path: a 2-of-3 group where the dealer (id 1) distributes the holder's
+/// (id 2) OPRF secret key share. The holder, seeing the dealer as `Verified`,
+/// takes custody (emits `OprfShareReceived` with a share that round-trips
+/// through `deserialize_key_share` and equals what was sent) and acks, so the
+/// dealer's `distribute_oprf_shares` completes.
+#[tokio::test]
+async fn test_oprf_enroll_distributes_share_and_completes() {
+    use std::sync::Arc;
+    use zeroize::Zeroizing;
+
+    let mock_relay = MockRelay::run().await.expect("Failed to start mock relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let config = ThresholdConfig::two_of_three();
+    let dealer = TrustedDealer::new(config);
+    let (mut shares, _pkg) = dealer.generate("test-oprf-enroll").unwrap();
+    let share1 = shares.remove(0); // FROST id 1 = dealer (box)
+    let share2 = shares.remove(0); // FROST id 2 = holder
+
+    let oprf = split_oprf_key_2of3();
+    // The remote target (holder id 2) gets the vsss share at index 2 (oprf[1]).
+    // The dealer keeps its own share (oprf[0]) sealed locally; it is NOT sent.
+    let target_bytes = keep_core::oprf::threshold::serialize_key_share(&oprf[1]).to_vec();
+
+    let mut node1 = KfpNode::new(share1, vec![relay.clone()])
+        .await
+        .expect("dealer node");
+    let mut node2 = KfpNode::new(share2, vec![relay])
+        .await
+        .expect("holder node");
+
+    let mut rx1 = node1.subscribe();
+    let mut rx2 = node2.subscribe();
+    let shutdown1 = node1.take_shutdown_handle();
+    let shutdown2 = node2.take_shutdown_handle();
+
+    let node1 = Arc::new(node1);
+    let node2 = Arc::new(node2);
+    let node1_run = Arc::clone(&node1);
+    let node2_run = Arc::clone(&node2);
+    let node1_handle = tokio::spawn(async move {
+        let _ = node1_run.run().await;
+    });
+    let node2_handle = tokio::spawn(async move {
+        let _ = node2_run.run().await;
+    });
+
+    let mut n1 = 0u32;
+    let mut n2 = 0u32;
+    let discovery = timeout(Duration::from_secs(45), async {
+        loop {
+            tokio::select! {
+                Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx1.recv() => n1 += 1,
+                Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx2.recv() => n2 += 1,
+            }
+            if n1 >= 1 && n2 >= 1 {
+                return;
+            }
+        }
+    })
+    .await;
+    if discovery.is_err() {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        panic!("Peer discovery timed out: node1={n1}, node2={n2}");
+    }
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    // The holder must see the dealer as Verified to take custody of a share.
+    node2.test_set_peer_attestation(1, keep_frost_net::AttestationStatus::Verified);
+
+    // Watch the holder for OprfShareReceived (rx2 already subscribed, so the
+    // event is buffered even if it arrives before we await).
+    let recv_task = tokio::spawn(async move {
+        loop {
+            match rx2.recv().await {
+                Ok(KfpNodeEvent::OprfShareReceived {
+                    dealer_index,
+                    threshold,
+                    total,
+                    share,
+                }) => return Some((dealer_index, threshold, total, share)),
+                Ok(_) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                Err(_) => return None,
+            }
+        }
+    });
+
+    let dist = timeout(
+        Duration::from_secs(45),
+        node1.distribute_oprf_shares(vec![(2u16, Zeroizing::new(target_bytes.clone()))], 2, 3),
+    )
+    .await;
+
+    let received = timeout(Duration::from_secs(5), recv_task).await;
+
+    graceful_shutdown(shutdown1, node1_handle).await;
+    graceful_shutdown(shutdown2, node2_handle).await;
+
+    match dist {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => panic!("distribute_oprf_shares failed: {e}"),
+        Err(_) => panic!("distribute_oprf_shares timed out (no ack)"),
+    }
+
+    let received = received
+        .expect("holder OprfShareReceived wait timed out")
+        .expect("holder recv task panicked")
+        .expect("holder must emit OprfShareReceived");
+    let (dealer_index, threshold, total, share) = received;
+    assert_eq!(dealer_index, 1, "share came from the dealer at index 1");
+    assert_eq!(threshold, 2);
+    assert_eq!(total, 3);
+    assert_eq!(
+        share.as_slice(),
+        target_bytes.as_slice(),
+        "the received share must equal exactly what the dealer sent"
+    );
+    keep_core::oprf::threshold::deserialize_key_share(&share)
+        .expect("the received share must be a valid OPRF key share");
+}
+
+/// Build a well-formed OPRF enrollment for `holder` (FROST id 2) from a synthetic
+/// dealer at share index 1, returning the dealer pubkey and the payload.
+fn make_oprf_enroll(holder: &KfpNode) -> (nostr_sdk::PublicKey, keep_frost_net::OprfEnrollPayload) {
+    let dealer_pubkey = nostr_sdk::Keys::generate().public_key();
+    let oprf = split_oprf_key_2of3();
+    let share = keep_core::oprf::threshold::serialize_key_share(&oprf[1]).to_vec();
+    let payload = keep_frost_net::OprfEnrollPayload::new(
+        [0x01u8; 32],
+        *holder.group_pubkey(),
+        1, // dealer_index
+        2, // target_index = holder FROST id 2
+        2, // threshold
+        3, // total
+        zeroize::Zeroizing::new(share),
+    );
+    (dealer_pubkey, payload)
+}
+
+/// Gate (attestation): a dealer whose peer is NOT `Verified` (default
+/// `NotProvided`) is rejected with `UntrustedPeer` before the share is taken
+/// into custody, and the holder emits no `OprfShareReceived` (and sends no ack).
+#[tokio::test]
+async fn test_oprf_enroll_rejects_unattested_dealer() {
+    let mock_relay = MockRelay::run().await.expect("relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pkg) = dealer.generate("test-oprf-enroll-unattested").unwrap();
+    let _ = shares.remove(0); // id 1 (dealer is synthetic)
+    let holder_share = shares.remove(0); // id 2 = holder
+
+    let holder = KfpNode::new(holder_share, vec![relay])
+        .await
+        .expect("holder");
+
+    let (dealer_pubkey, payload) = make_oprf_enroll(&holder);
+    // Inject the dealer with the DEFAULT attestation status (NotProvided).
+    holder.test_inject_peer(keep_frost_net::Peer::new(dealer_pubkey, 1));
+
+    let mut rx = holder.subscribe();
+    let result = holder.test_handle_oprf_enroll(dealer_pubkey, payload).await;
+    assert!(
+        matches!(result, Err(keep_frost_net::FrostNetError::UntrustedPeer(_))),
+        "an unattested dealer must be rejected with UntrustedPeer, got {result:?}"
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "no OprfShareReceived may be emitted for a rejected unattested dealer"
+    );
+}
+
+/// With a designated dealer pinned, an enrollment from a different index is refused even when the
+/// sender is attested (defense in depth against a compromised-but-attested group member).
+#[tokio::test]
+async fn test_oprf_enroll_rejects_non_designated_dealer() {
+    let mock_relay = MockRelay::run().await.expect("relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pkg) = dealer.generate("test-oprf-enroll-pin").unwrap();
+    let _ = shares.remove(0); // id 1
+    let holder_share = shares.remove(0); // id 2 = holder
+
+    let mut holder = KfpNode::new(holder_share, vec![relay])
+        .await
+        .expect("holder");
+    // Pin the designated dealer to index 2; the enrollment below arrives from index 1.
+    holder.set_expected_oprf_dealer(2);
+
+    let (dealer_pubkey, payload) = make_oprf_enroll(&holder); // dealer_index = 1
+    holder.test_inject_peer(keep_frost_net::Peer::new(dealer_pubkey, 1));
+    // Attest the sender, so the pin (not attestation) is what rejects it.
+    holder.test_set_peer_attestation(1, keep_frost_net::AttestationStatus::Verified);
+
+    let mut rx = holder.subscribe();
+    let result = holder.test_handle_oprf_enroll(dealer_pubkey, payload).await;
+    assert!(
+        matches!(result, Err(keep_frost_net::FrostNetError::UntrustedPeer(_))),
+        "a non-designated dealer must be rejected even when attested, got {result:?}"
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "no OprfShareReceived may be emitted for a non-designated dealer"
+    );
+}


### PR DESCRIPTION
Builds on the merged threshold-OPRF unlock primitive (#618, #620) and its evaluation session (#622). This adds the **enrollment** half: the box (acting as a trusted dealer) distributes to each FROST holder that holder's secret OPRF key share, so that a quorum exists to derive the volume key on later unlocks. No single party ever holds the whole OPRF key after enrollment.

## What

**keep-core** (`oprf::threshold`): `serialize_key_share`/`deserialize_key_share`, a 64-byte secret-share codec (32-byte identifier scalar + 32-byte value scalar) with zeroize discipline and rejection of bad-length, non-canonical, and zero-identifier encodings.

**keep-frost-net** (new `enroll_session.rs`, `node/enroll.rs`): a trusted-dealer, single-round share distribution modeled on the existing DKG round-2 pattern and the OPRF evaluation session.
- `OprfEnroll`/`OprfEnrollAck` messages. The `share` field is `Zeroizing`, redacted in `Debug`, and NIP-44-encrypted to the recipient, so a relay only ever sees ciphertext.
- `distribute_oprf_shares` (dealer): resolves and validates every target before any share leaves the box; subscribe-before-send, 30s timeout, session teardown on every exit.
- `handle_oprf_enroll` (holder custody): gates in order group -> addressed-to-us -> replay window -> receive policy -> sender/share-index binding -> designated-dealer pin -> strict `Verified` attestation -> replay dedup -> share validation.
- **Durable custody**: the holder acknowledges only after a subscriber confirms the share was sealed, via a one-shot ack-back channel. A subscriber that ignores the event, fails to seal, or drops the channel causes the ack to be withheld, so the dealer never believes enrollment completed with no sealed share.

## Security

The custody path (the most sensitive payload in the system, a raw key share crossing the network) was reviewed. No critical or high findings; confidentiality in transit, gate ordering, dealer-impersonation resistance, ack binding, session caps, and input validation were all confirmed correct. Findings addressed in this PR:
- Zeroize the decoded `KeyShare` after re-serialization (it is `Copy` + `Zeroize` but not `ZeroizeOnDrop`, so the live scalar was left resident).
- A designated-dealer pin (`with_expected_oprf_dealer`/`set_expected_oprf_dealer`), **fail-closed by default**: enrollment is refused unless the dealer is pinned, or unpinned enrollment is explicitly enabled. A compromised-but-attested group member cannot poison or overwrite a holder's share.
- Holder-side replay dedup: a redelivered `OprfEnroll` within the replay window is dropped on `(dealer_index, session_id)` before it can re-deserialize the secret or re-ack.

One low, systemic follow-up remains tracked: the plaintext JSON of secret-bearing messages is not zeroized before encryption (shared by all secret KFP messages, e.g. `EcdhComplete`/`RefreshRound2`, not specific to enrollment), so it is better fixed once at the message layer.

## Tests

`serialize_key_share` round-trip in keep-core; unit tests for `OprfEnrollSession`; and multinode tests covering the happy-path distribute/ack/durable-custody flow and each gate independently (unattested dealer rejected, non-designated dealer rejected, dropped-seal ack withheld, no-subscriber ack withheld). Full keep-frost-net suite green; `clippy -D warnings` and the whole-workspace `--all-targets --features testing` check are clean.
