### PR TITLE
keep-cli: fix Windows build of OPRF secret-file write

### DIFF
--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -959,17 +959,22 @@ fn remote_share_indices(box_id: u16, total: u16) -> Vec<u16> {
 /// full protection. Used for the LUKS key and the box's own OPRF share.
 fn write_secret_file(path: &Path, bytes: &[u8]) -> Result<()> {
     use std::io::Write;
-    use std::os::unix::fs::OpenOptionsExt;
     let mut tmp = path.as_os_str().to_owned();
     tmp.push(".tmp");
     let tmp = std::path::PathBuf::from(tmp);
     // Clear any stale temp from a crashed run; create_new below still fails closed if an attacker
     // races to recreate it, so this never writes through someone else's file.
     let _ = std::fs::remove_file(&tmp);
-    let mut f = std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .mode(0o600)
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    // 0600 at creation is the Unix appliance's protection; the mode bit is Unix-only, so gate it
+    // (create_new still gives O_EXCL everywhere). This feature targets the NixOS boot gate.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let mut f = opts
         .open(&tmp)
         .map_err(|e| KeepError::Runtime(format!("create {}: {e}", tmp.display())))?;
     f.write_all(bytes)


### PR DESCRIPTION
The OPRF subcommands' `write_secret_file` used `std::os::unix::fs::OpenOptionsExt::mode(0o600)`, which does not exist on Windows. The `build-windows` job runs only on `push` (not on PRs), so this compiled on the PR but broke the main build after merge.

Gate the Unix-only mode bit behind `#[cfg(unix)]`. `create_new` (O_EXCL semantics) still applies on every platform; the 0600 permission is the Unix appliance's protection and is the only part that is platform-specific. The rest of the atomic-write path (`create_new` + `sync_all` + parent-dir fsync + `rename`) is portable.

Verified with `cargo check -p keep-cli --target x86_64-pc-windows-gnu` (Finished, exit 0) in addition to the native clippy `-D warnings`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary file handling when saving secrets, including safer creation and cleanup behavior.
  * Tightened file permission handling on Unix-like systems to better protect sensitive files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->