### PR TITLE
keep-frost-net: TPM2 quote producer (feature tpm-attestation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,6 +878,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitfield"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ba6517c6b0f2bf08be60e187ab64b038438f22dd755614d8fe4d4098c46419"
+dependencies = [
+ "bitfield-macros",
+]
+
+[[package]]
+name = "bitfield-macros"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f48d6ace212fdf1b45fd6b566bb40808415344642b76c3224c07c8df9da81e97"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3630,6 +3650,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname-validator"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
+
+[[package]]
 name = "http"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4642,6 +4668,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-test",
  "tracing",
+ "tss-esapi",
  "url",
  "webpki-roots 1.0.8",
  "zeroize",
@@ -5124,6 +5151,16 @@ checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
  "cfg-if 1.0.4",
  "rayon",
+]
+
+[[package]]
+name = "mbox"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d142aeadbc4e8c679fc6d93fbe7efe1c021fa7d80629e615915b519e3bc6de"
+dependencies = [
+ "libc",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -6228,6 +6265,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c19903c598813dba001b53beeae59bb77ad4892c5c1b9b3500ce4293a0d06c2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6609,6 +6655,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "picky-asn1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ff038f9360b934342fb3c0a1d6e82c438a2624b51c3c6e3e6d7cf252b6f3ee3"
+dependencies = [
+ "oid",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "picky-asn1-der"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d413165e4bf7f808b9a27cbaba657657a2921f0965db833f488c4d4be96dcd2e"
+dependencies = [
+ "picky-asn1",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "picky-asn1-x509"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d4117bd1b1dc5646359ee7243c50c5000c0920ea2d1fb120335a2f4c684b8"
+dependencies = [
+ "base64 0.22.1",
+ "oid",
+ "picky-asn1",
+ "picky-asn1-der",
+ "serde",
 ]
 
 [[package]]
@@ -9300,6 +9381,39 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tss-esapi"
+version = "7.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f10b25a84912b894d0e6d68f4a3771c923e9c44ddaaed7920cde92ed28aa84e"
+dependencies = [
+ "bitfield",
+ "enumflags2",
+ "getrandom 0.4.3",
+ "hostname-validator",
+ "log",
+ "mbox",
+ "num-derive",
+ "num-traits",
+ "oid",
+ "picky-asn1",
+ "picky-asn1-x509",
+ "regex",
+ "serde",
+ "tss-esapi-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "tss-esapi-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f972672926a3d3d18ecc04524720e4d20b7d1664a3fb73dbf7d4274196dbd9"
+dependencies = [
+ "pkg-config",
+ "target-lexicon",
+]
 
 [[package]]
 name = "ttf-parser"

--- a/keep-frost-net/Cargo.toml
+++ b/keep-frost-net/Cargo.toml
@@ -9,6 +9,10 @@ license = "MIT"
 [features]
 default = ["nitro-attestation"]
 nitro-attestation = ["dep:keep-enclave-host"]
+# TPM-side quote PRODUCER (links tpm2-tss C stack). Off by default: only TPM
+# nodes producing their own measured-boot quote need it; the pure-Rust verifier
+# (tpm_quote.rs) requires no TPM and is always built.
+tpm-attestation = ["dep:tss-esapi"]
 testing = ["keep-core/allow-ws"]
 
 [dependencies]
@@ -23,6 +27,8 @@ k256 = { version = "0.13.4", features = ["schnorr"] }
 # NIST P-256 ECDSA, for verifying TPM2 quote signatures (the AK is a P-256 key).
 # Verifier-side only: pure Rust, no TPM / libtss2 (see tpm_quote.rs).
 p256 = { version = "0.13", features = ["ecdsa"] }
+# TPM-side quote producer only (feature `tpm-attestation`); links libtss2.
+tss-esapi = { version = "7.7", optional = true }
 
 tokio = { version = "1", features = ["full", "sync"] }
 parking_lot = "0.12"

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -76,6 +76,8 @@ mod psbt_session;
 mod recovery_signers;
 mod session;
 mod tpm_policy;
+#[cfg(feature = "tpm-attestation")]
+pub mod tpm_producer;
 pub mod tpm_quote;
 
 pub use attestation::{derive_attestation_nonce, verify_peer_attestation, ExpectedPcrs};
@@ -145,6 +147,8 @@ pub use session::{
     derive_session_id, derive_session_id_salted, NetworkSession, SessionManager, SessionState,
 };
 pub use tpm_policy::TpmAttestationPolicy;
+#[cfg(feature = "tpm-attestation")]
+pub use tpm_producer::{TpmQuoter, DEFAULT_PCR_SLOTS};
 
 pub fn install_default_crypto_provider() {
     rustls::crypto::ring::default_provider()

--- a/keep-frost-net/src/tpm_producer.rs
+++ b/keep-frost-net/src/tpm_producer.rs
@@ -345,6 +345,39 @@ mod tests {
         }
     }
 
+    // The producer ships `attest.marshall()` (see `quote`), and the verifier's
+    // `parse_quote` consumes the inner TPMS_ATTEST with no outer size prefix. This
+    // round-trips a real swtpm quote through the exact type and trait the producer
+    // uses, proving `marshall()` reproduces that byte-exact framing and that the
+    // result verifies end-to-end, with no TPM. It catches a tss-esapi re-marshal
+    // drift in CI that the TPM-gated roundtrip below cannot.
+    #[test]
+    fn marshalled_attest_matches_verifier_wire_format() {
+        use crate::tpm_quote::{test_vector as v, verify_quote};
+        use tss_esapi::structures::Attest;
+        use tss_esapi::traits::UnMarshall;
+
+        let wire = v::h(v::ATTEST);
+        let attest = Attest::unmarshall(&wire).expect("real swtpm attest must unmarshall");
+        let remarshalled = attest.marshall().expect("attest must re-marshall");
+        assert_eq!(
+            remarshalled, wire,
+            "Attest::marshall() must reproduce the byte-exact TPMS_ATTEST the verifier parses"
+        );
+
+        let pcrs = v::pcrs();
+        verify_quote(
+            &remarshalled,
+            &v::sig_rs(),
+            &v::ak(),
+            &v::h(v::NONCE),
+            &v::h(v::PCR_SELECT),
+            &pcrs,
+            &pcrs,
+        )
+        .expect("marshalled producer bytes must verify against the pinned AK");
+    }
+
     // Marshalled TPML_PCR_SELECTION for the SHA-256 bank over DEFAULT_PCR_SLOTS
     // {0,2,4,7,11,12}: count=1, alg=0x000b, sizeofSelect=3, bitmap 0x95 0x18 0x00.
     // The verifier pins exactly these bytes (check 4).

--- a/keep-frost-net/src/tpm_producer.rs
+++ b/keep-frost-net/src/tpm_producer.rs
@@ -1,0 +1,295 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+//! TPM-side quote PRODUCER (feature `tpm-attestation`): the counterpart to the
+//! always-built pure-Rust verifier in [`crate::tpm_quote`]. A node with a real
+//! TPM 2.0 uses this to produce the [`TpmQuoteEvidence`] it attaches to its
+//! announce; peers appraise it with [`crate::tpm_policy::appraise_tpm_quote`].
+//!
+//! This module links the tpm2-tss C stack (via `tss-esapi`) and so is gated
+//! behind the `tpm-attestation` feature. Nodes that only VERIFY peers do not
+//! need it, and default builds do not compile it.
+//!
+//! Trust model: the attestation key (AK) is a restricted ECDSA-P256 signing key
+//! created as a primary in the Endorsement hierarchy. Being a primary, it is
+//! derived deterministically from the TPM's endorsement seed, so it is stable
+//! across reboots without persistent-handle management, and being restricted it
+//! can only sign TPM-internal structures (quotes), never attacker-chosen data.
+//! Its public key is pinned out of band at provisioning (TOFU); this module does
+//! not perform EK credential activation (there is no manufacturer IDevID to
+//! anchor for a self-hosted box, per ATTESTATION-DESIGN.md).
+
+use tss_esapi::abstraction::pcr;
+use tss_esapi::handles::KeyHandle;
+use tss_esapi::interface_types::algorithm::{HashingAlgorithm, PublicAlgorithm};
+use tss_esapi::interface_types::ecc::EccCurve;
+use tss_esapi::interface_types::resource_handles::Hierarchy;
+use tss_esapi::structures::{
+    Data, EccScheme, HashScheme, KeyDerivationFunctionScheme, PcrSelectionList,
+    PcrSelectionListBuilder, PcrSlot, Public, PublicBuilder, PublicEccParametersBuilder, Signature,
+    SignatureScheme,
+};
+use tss_esapi::traits::Marshall;
+use tss_esapi::utils::PublicKey;
+use tss_esapi::Context;
+
+use crate::error::{FrostNetError, Result};
+use crate::protocol::TpmQuoteEvidence;
+
+/// Measured-boot PCRs quoted by default: firmware/config (0), extended firmware
+/// (2), boot loader (4), Secure Boot policy (7), and the systemd-stub/UKI kernel
+/// + OS measurements (11, 12). Matches the selection the verifier pins.
+pub const DEFAULT_PCR_SLOTS: [PcrSlot; 6] = [
+    PcrSlot::Slot0,
+    PcrSlot::Slot2,
+    PcrSlot::Slot4,
+    PcrSlot::Slot7,
+    PcrSlot::Slot11,
+    PcrSlot::Slot12,
+];
+
+fn tpm_err(e: tss_esapi::Error) -> FrostNetError {
+    FrostNetError::Attestation(format!("TPM error: {e}"))
+}
+
+fn att(msg: impl Into<String>) -> FrostNetError {
+    FrostNetError::Attestation(msg.into())
+}
+
+/// Left-pad a big-endian ECC parameter to a fixed 32 bytes. The TPM may return r,
+/// s, x, or y with leading zero bytes trimmed; P-256 fields are 32 bytes wide.
+fn pad32(bytes: &[u8]) -> Result<[u8; 32]> {
+    if bytes.len() > 32 {
+        return Err(att("TPM ECC parameter longer than 32 bytes"));
+    }
+    let mut out = [0u8; 32];
+    out[32 - bytes.len()..].copy_from_slice(bytes);
+    Ok(out)
+}
+
+/// Template for the restricted ECDSA-P256 signing AK.
+fn ak_template() -> Result<Public> {
+    let object_attributes = tss_esapi::attributes::ObjectAttributesBuilder::new()
+        .with_fixed_tpm(true)
+        .with_fixed_parent(true)
+        .with_sensitive_data_origin(true)
+        .with_user_with_auth(true)
+        .with_decrypt(false)
+        .with_sign_encrypt(true)
+        .with_restricted(true)
+        .build()
+        .map_err(tpm_err)?;
+
+    let ecc_params = PublicEccParametersBuilder::new()
+        .with_ecc_scheme(EccScheme::EcDsa(HashScheme::new(HashingAlgorithm::Sha256)))
+        .with_curve(EccCurve::NistP256)
+        .with_is_signing_key(true)
+        .with_is_decryption_key(false)
+        .with_restricted(true)
+        .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+        .build()
+        .map_err(tpm_err)?;
+
+    PublicBuilder::new()
+        .with_public_algorithm(PublicAlgorithm::Ecc)
+        .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+        .with_object_attributes(object_attributes)
+        .with_ecc_parameters(ecc_params)
+        .with_ecc_unique_identifier(Default::default())
+        .build()
+        .map_err(tpm_err)
+}
+
+/// The uncompressed SEC1 point `0x04 || x || y` of an ECC public key.
+fn ecc_sec1(public: &Public) -> Result<Vec<u8>> {
+    let key = PublicKey::try_from(public.clone()).map_err(tpm_err)?;
+    let (x, y) = match key {
+        PublicKey::Ecc { x, y } => (x, y),
+        _ => return Err(att("AK is not an ECC key")),
+    };
+    let mut out = Vec::with_capacity(65);
+    out.push(0x04);
+    out.extend_from_slice(&pad32(&x)?);
+    out.extend_from_slice(&pad32(&y)?);
+    Ok(out)
+}
+
+/// The 64-byte `r || s` of an ECDSA signature.
+fn ecdsa_rs(signature: &Signature) -> Result<Vec<u8>> {
+    let ecc = match signature {
+        Signature::EcDsa(ecc) => ecc,
+        _ => return Err(att("AK quote signature is not ECDSA")),
+    };
+    let mut out = Vec::with_capacity(64);
+    out.extend_from_slice(&pad32(ecc.signature_r().value())?);
+    out.extend_from_slice(&pad32(ecc.signature_s().value())?);
+    Ok(out)
+}
+
+/// Produces TPM2 quotes over a fixed PCR selection, signed by a restricted AK.
+/// Holds the open [`Context`] and the AK handle for the node's lifetime.
+pub struct TpmQuoter {
+    context: Context,
+    ak_handle: KeyHandle,
+    ak_sec1: Vec<u8>,
+    pcr_selection: PcrSelectionList,
+    ordered_slots: Vec<PcrSlot>,
+}
+
+impl TpmQuoter {
+    /// Create the AK (restricted ECDSA-P256 Endorsement-hierarchy primary) and
+    /// fix the PCR selection this quoter will attest over. `slots` are quoted
+    /// from the SHA-256 bank in ascending PCR order, which is the order the
+    /// verifier recomputes the composite digest in.
+    pub fn create(mut context: Context, slots: &[PcrSlot]) -> Result<Self> {
+        if slots.is_empty() {
+            return Err(att("TPM quoter needs at least one PCR slot"));
+        }
+        let mut ordered_slots = slots.to_vec();
+        ordered_slots.sort_by_key(|s| u32::from(*s));
+        ordered_slots.dedup();
+
+        let pcr_selection = PcrSelectionListBuilder::new()
+            .with_selection(HashingAlgorithm::Sha256, &ordered_slots)
+            .build()
+            .map_err(tpm_err)?;
+
+        let template = ak_template()?;
+        let primary = context
+            .execute_with_nullauth_session(|ctx| {
+                ctx.create_primary(Hierarchy::Endorsement, template, None, None, None, None)
+            })
+            .map_err(tpm_err)?;
+
+        let ak_sec1 = ecc_sec1(&primary.out_public)?;
+
+        Ok(Self {
+            context,
+            ak_handle: primary.key_handle,
+            ak_sec1,
+            pcr_selection,
+            ordered_slots,
+        })
+    }
+
+    /// Convenience constructor over [`DEFAULT_PCR_SLOTS`].
+    pub fn create_default(context: Context) -> Result<Self> {
+        Self::create(context, &DEFAULT_PCR_SLOTS)
+    }
+
+    /// The pinned AK identity (65-byte uncompressed SEC1 point). The verifier
+    /// pins this at provisioning.
+    pub fn ak_sec1(&self) -> &[u8] {
+        &self.ak_sec1
+    }
+
+    /// Produce a fresh quote over the configured PCRs, bound to `nonce` (the
+    /// announce-bound value from [`crate::attestation::derive_announce_attestation_nonce`]).
+    /// The returned evidence is ready to attach to an announce.
+    pub fn quote(&mut self, nonce: &[u8]) -> Result<TpmQuoteEvidence> {
+        let qualifying_data = Data::try_from(nonce.to_vec())
+            .map_err(|_| att("quote nonce too long for TPM2B_DATA"))?;
+        let selection = self.pcr_selection.clone();
+        let ak_handle = self.ak_handle;
+
+        // Restricted key: scheme must be Null so the key's own scheme is used.
+        let (attest, signature) = self
+            .context
+            .execute_with_nullauth_session(|ctx| {
+                ctx.quote(ak_handle, qualifying_data, SignatureScheme::Null, selection)
+            })
+            .map_err(tpm_err)?;
+
+        let attest_bytes = attest.marshall().map_err(tpm_err)?;
+        let signature = ecdsa_rs(&signature)?;
+
+        // Read the live PCR values to report alongside the quote, in the same
+        // ascending order the verifier recomputes the composite digest in.
+        let pcr_data =
+            pcr::read_all(&mut self.context, self.pcr_selection.clone()).map_err(tpm_err)?;
+        let bank = pcr_data
+            .pcr_bank(HashingAlgorithm::Sha256)
+            .ok_or_else(|| att("TPM returned no SHA-256 PCR bank"))?;
+        let mut pcr_values = Vec::with_capacity(self.ordered_slots.len());
+        for slot in &self.ordered_slots {
+            let digest = bank
+                .get_digest(*slot)
+                .ok_or_else(|| att("TPM did not return a value for a selected PCR"))?;
+            pcr_values.push(hex::encode(digest.value()));
+        }
+
+        Ok(TpmQuoteEvidence {
+            attest: attest_bytes,
+            signature,
+            ak_sec1: self.ak_sec1.clone(),
+            pcr_values,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::attestation::derive_announce_attestation_nonce;
+    use crate::peer::AttestationStatus;
+    use crate::tpm_policy::{appraise_tpm_quote, TpmAttestationPolicy};
+    use std::collections::HashMap;
+    use tss_esapi::{Context, TctiNameConf};
+
+    // Marshalled TPML_PCR_SELECTION for the SHA-256 bank over DEFAULT_PCR_SLOTS
+    // {0,2,4,7,11,12}: count=1, alg=0x000b, sizeofSelect=3, bitmap 0x95 0x18 0x00.
+    // The verifier pins exactly these bytes (check 4).
+    const DEFAULT_SELECTION: &str = "00000001000b03951800";
+
+    fn tcti_context() -> Context {
+        let tcti = TctiNameConf::from_environment_variable()
+            .expect("set TPM2TOOLS_TCTI / TCTI (e.g. swtpm:host=localhost,port=2321)");
+        Context::new(tcti).expect("open TPM context")
+    }
+
+    // End-to-end against a real (virtual) TPM: produce a quote with the producer,
+    // then appraise it with the pure-Rust verifier. Ignored by default because it
+    // needs a TPM; run with a swtpm and TPM2TOOLS_TCTI set.
+    #[test]
+    #[ignore = "requires a TPM; run against swtpm with TPM2TOOLS_TCTI set"]
+    fn produce_then_verify_roundtrip() {
+        let mut quoter = TpmQuoter::create_default(tcti_context()).expect("create quoter");
+        let ak_sec1 = quoter.ak_sec1().to_vec();
+        assert_eq!(ak_sec1.len(), 65, "AK SEC1 must be 65 bytes");
+        assert_eq!(ak_sec1[0], 0x04, "AK SEC1 must be uncompressed");
+
+        let group = [9u8; 32];
+        let share_index: u16 = 2;
+        let timestamp: u64 = 1_700_000_000;
+        let nonce = derive_announce_attestation_nonce(&group, share_index, timestamp);
+
+        let ev = quoter.quote(&nonce).expect("produce quote");
+        assert_eq!(ev.signature.len(), 64, "signature must be r||s");
+        assert_eq!(ev.ak_sec1, ak_sec1);
+        assert_eq!(ev.pcr_values.len(), DEFAULT_PCR_SLOTS.len());
+
+        // Verifier pins the AK, the agreed selection, and the reported PCRs as
+        // the reference (TOFU at provisioning), then appraises the SAME announce.
+        let pcr_values = crate::tpm_quote::decode_pcr_values(&ev.pcr_values).unwrap();
+        let mut pinned = HashMap::new();
+        pinned.insert(share_index, ak_sec1.clone());
+        let pol =
+            TpmAttestationPolicy::new(hex::decode(DEFAULT_SELECTION).unwrap(), pcr_values, pinned);
+        assert_eq!(
+            appraise_tpm_quote(share_index, &ev, &pol, &nonce),
+            AttestationStatus::Verified,
+            "a freshly produced quote must verify against the verifier"
+        );
+
+        // A different announce (one tick later) must fail: the qualifyingData no
+        // longer matches, so a captured quote cannot be replayed across announces.
+        let other = derive_announce_attestation_nonce(&group, share_index, timestamp + 1);
+        assert!(
+            matches!(
+                appraise_tpm_quote(share_index, &ev, &pol, &other),
+                AttestationStatus::Failed(_)
+            ),
+            "the quote must not verify against a different announce"
+        );
+    }
+}

--- a/keep-frost-net/src/tpm_producer.rs
+++ b/keep-frost-net/src/tpm_producer.rs
@@ -60,8 +60,8 @@ fn att(msg: impl Into<String>) -> FrostNetError {
 /// Left-pad a big-endian ECC parameter to a fixed 32 bytes. The TPM may return r,
 /// s, x, or y with leading zero bytes trimmed; P-256 fields are 32 bytes wide.
 fn pad32(bytes: &[u8]) -> Result<[u8; 32]> {
-    if bytes.len() > 32 {
-        return Err(att("TPM ECC parameter longer than 32 bytes"));
+    if bytes.is_empty() || bytes.len() > 32 {
+        return Err(att("TPM ECC parameter not in 1..=32 bytes"));
     }
     let mut out = [0u8; 32];
     out[32 - bytes.len()..].copy_from_slice(bytes);
@@ -196,6 +196,9 @@ impl TpmQuoter {
     /// announce-bound value from [`crate::attestation::derive_announce_attestation_nonce`]).
     /// The returned evidence is ready to attach to an announce.
     pub fn quote(&mut self, nonce: &[u8]) -> Result<TpmQuoteEvidence> {
+        if nonce.len() != 32 {
+            return Err(att("quote nonce must be exactly 32 bytes"));
+        }
         let qualifying_data = Data::try_from(nonce.to_vec())
             .map_err(|_| att("quote nonce too long for TPM2B_DATA"))?;
 
@@ -282,7 +285,65 @@ mod tests {
     use crate::peer::AttestationStatus;
     use crate::tpm_policy::{appraise_tpm_quote, TpmAttestationPolicy};
     use std::collections::HashMap;
+    use tss_esapi::attributes::ObjectAttributesBuilder;
+    use tss_esapi::interface_types::key_bits::RsaKeyBits;
+    use tss_esapi::structures::{PublicKeyRsa, PublicRsaParametersBuilder, RsaScheme};
     use tss_esapi::{Context, TctiNameConf};
+
+    #[test]
+    fn pad32_rejects_empty() {
+        assert!(pad32(&[]).is_err());
+    }
+
+    #[test]
+    fn pad32_full_width_roundtrips() {
+        let input = [7u8; 32];
+        assert_eq!(pad32(&input).unwrap(), input);
+    }
+
+    #[test]
+    fn pad32_left_pads_short_input() {
+        let out = pad32(&[0xaa, 0xbb]).unwrap();
+        let mut expected = [0u8; 32];
+        expected[30] = 0xaa;
+        expected[31] = 0xbb;
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn pad32_rejects_oversized_input() {
+        assert!(pad32(&[0u8; 33]).is_err());
+    }
+
+    #[test]
+    fn ecc_sec1_rejects_non_ecc_key() {
+        let object_attributes = ObjectAttributesBuilder::new().build().unwrap();
+        let rsa_params = PublicRsaParametersBuilder::new()
+            .with_scheme(RsaScheme::Null)
+            .with_key_bits(RsaKeyBits::Rsa2048)
+            .build()
+            .unwrap();
+        let public = PublicBuilder::new()
+            .with_public_algorithm(PublicAlgorithm::Rsa)
+            .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+            .with_object_attributes(object_attributes)
+            .with_rsa_parameters(rsa_params)
+            .with_rsa_unique_identifier(PublicKeyRsa::default())
+            .build()
+            .unwrap();
+        match ecc_sec1(&public) {
+            Err(FrostNetError::Attestation(m)) => assert_eq!(m, "AK is not an ECC key"),
+            other => panic!("expected non-ECC attestation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ecdsa_rs_rejects_non_ecdsa_signature() {
+        match ecdsa_rs(&Signature::Null) {
+            Err(FrostNetError::Attestation(m)) => assert_eq!(m, "AK quote signature is not ECDSA"),
+            other => panic!("expected non-ECDSA attestation error, got {other:?}"),
+        }
+    }
 
     // Marshalled TPML_PCR_SELECTION for the SHA-256 bank over DEFAULT_PCR_SLOTS
     // {0,2,4,7,11,12}: count=1, alg=0x000b, sizeofSelect=3, bitmap 0x95 0x18 0x00.

--- a/keep-frost-net/src/tpm_producer.rs
+++ b/keep-frost-net/src/tpm_producer.rs
@@ -19,13 +19,14 @@
 //! not perform EK credential activation (there is no manufacturer IDevID to
 //! anchor for a self-hosted box, per ATTESTATION-DESIGN.md).
 
+use sha2::{Digest, Sha256};
 use tss_esapi::abstraction::pcr;
-use tss_esapi::handles::KeyHandle;
+use tss_esapi::handles::{KeyHandle, ObjectHandle};
 use tss_esapi::interface_types::algorithm::{HashingAlgorithm, PublicAlgorithm};
 use tss_esapi::interface_types::ecc::EccCurve;
 use tss_esapi::interface_types::resource_handles::Hierarchy;
 use tss_esapi::structures::{
-    Data, EccScheme, HashScheme, KeyDerivationFunctionScheme, PcrSelectionList,
+    AttestInfo, Data, EccScheme, HashScheme, KeyDerivationFunctionScheme, PcrSelectionList,
     PcrSelectionListBuilder, PcrSlot, Public, PublicBuilder, PublicEccParametersBuilder, Signature,
     SignatureScheme,
 };
@@ -161,7 +162,15 @@ impl TpmQuoter {
             })
             .map_err(tpm_err)?;
 
-        let ak_sec1 = ecc_sec1(&primary.out_public)?;
+        // From here the AK is allocated in the TPM; flush it on any error so a
+        // transient handle does not leak. Once the struct is built, Drop owns it.
+        let ak_sec1 = match ecc_sec1(&primary.out_public) {
+            Ok(sec1) => sec1,
+            Err(e) => {
+                let _ = context.flush_context(ObjectHandle::from(primary.key_handle));
+                return Err(e);
+            }
+        };
 
         Ok(Self {
             context,
@@ -189,41 +198,80 @@ impl TpmQuoter {
     pub fn quote(&mut self, nonce: &[u8]) -> Result<TpmQuoteEvidence> {
         let qualifying_data = Data::try_from(nonce.to_vec())
             .map_err(|_| att("quote nonce too long for TPM2B_DATA"))?;
-        let selection = self.pcr_selection.clone();
-        let ak_handle = self.ak_handle;
 
-        // Restricted key: scheme must be Null so the key's own scheme is used.
-        let (attest, signature) = self
-            .context
-            .execute_with_nullauth_session(|ctx| {
-                ctx.quote(ak_handle, qualifying_data, SignatureScheme::Null, selection)
-            })
-            .map_err(tpm_err)?;
+        // The quote attests a PCR composite captured at quote time; the reported
+        // PCR values are read separately, right after. If a selected PCR changes
+        // in between, the values would no longer reproduce the attested digest and
+        // the verifier (which recomputes the composite, check 5) would reject an
+        // otherwise-honest quote. Re-quote a bounded number of times until the
+        // read reproduces the attested digest, so the evidence is self-consistent.
+        const MAX_ATTEMPTS: usize = 3;
+        for _ in 0..MAX_ATTEMPTS {
+            let selection = self.pcr_selection.clone();
+            let ak_handle = self.ak_handle;
+            // Restricted key: scheme must be Null so the key's own scheme is used.
+            let (attest, signature) = self
+                .context
+                .execute_with_nullauth_session(|ctx| {
+                    ctx.quote(
+                        ak_handle,
+                        qualifying_data.clone(),
+                        SignatureScheme::Null,
+                        selection,
+                    )
+                })
+                .map_err(tpm_err)?;
 
-        let attest_bytes = attest.marshall().map_err(tpm_err)?;
-        let signature = ecdsa_rs(&signature)?;
+            let attested_digest = match attest.attested() {
+                AttestInfo::Quote { info } => info.pcr_digest().value().to_vec(),
+                _ => return Err(att("TPM returned a non-quote attestation")),
+            };
 
-        // Read the live PCR values to report alongside the quote, in the same
-        // ascending order the verifier recomputes the composite digest in.
-        let pcr_data =
-            pcr::read_all(&mut self.context, self.pcr_selection.clone()).map_err(tpm_err)?;
-        let bank = pcr_data
-            .pcr_bank(HashingAlgorithm::Sha256)
-            .ok_or_else(|| att("TPM returned no SHA-256 PCR bank"))?;
-        let mut pcr_values = Vec::with_capacity(self.ordered_slots.len());
-        for slot in &self.ordered_slots {
-            let digest = bank
-                .get_digest(*slot)
-                .ok_or_else(|| att("TPM did not return a value for a selected PCR"))?;
-            pcr_values.push(hex::encode(digest.value()));
+            // Read the live PCR values in the same ascending order the verifier
+            // recomputes the composite digest in, accumulating that composite.
+            let pcr_data =
+                pcr::read_all(&mut self.context, self.pcr_selection.clone()).map_err(tpm_err)?;
+            let bank = pcr_data
+                .pcr_bank(HashingAlgorithm::Sha256)
+                .ok_or_else(|| att("TPM returned no SHA-256 PCR bank"))?;
+            let mut pcr_values = Vec::with_capacity(self.ordered_slots.len());
+            let mut composite = Sha256::new();
+            for slot in &self.ordered_slots {
+                let digest = bank
+                    .get_digest(*slot)
+                    .ok_or_else(|| att("TPM did not return a value for a selected PCR"))?;
+                composite.update(digest.value());
+                pcr_values.push(hex::encode(digest.value()));
+            }
+
+            // A selected PCR changed between the quote and the read; discard this
+            // inconsistent pair and re-quote.
+            if composite.finalize().as_slice() != attested_digest.as_slice() {
+                continue;
+            }
+
+            return Ok(TpmQuoteEvidence {
+                attest: attest.marshall().map_err(tpm_err)?,
+                signature: ecdsa_rs(&signature)?,
+                ak_sec1: self.ak_sec1.clone(),
+                pcr_values,
+            });
         }
 
-        Ok(TpmQuoteEvidence {
-            attest: attest_bytes,
-            signature,
-            ak_sec1: self.ak_sec1.clone(),
-            pcr_values,
-        })
+        Err(att(
+            "PCR state changed during quoting; no consistent quote after retries",
+        ))
+    }
+}
+
+impl Drop for TpmQuoter {
+    /// Flush the transient AK so it does not linger in the TPM's limited object
+    /// memory after the quoter is dropped (a direct swtpm/`/dev/tpm0` connection,
+    /// unlike a resource manager, does not auto-flush on close).
+    fn drop(&mut self) {
+        let _ = self
+            .context
+            .flush_context(ObjectHandle::from(self.ak_handle));
     }
 }
 

--- a/keep-frost-net/src/tpm_quote.rs
+++ b/keep-frost-net/src/tpm_quote.rs
@@ -207,30 +207,36 @@ pub(crate) fn decode_pcr_values(
     Ok(out)
 }
 
+/// Canonical real-swtpm quote vector (swtpm 0.10.1 + tpm2-tools 5.7, ECDSA-P256/
+/// SHA-256 AK over sha256:0,2,4,7,11,12, verified by tpm2_checkquote). Shared by
+/// the verifier tests below and the producer's marshal-contract test, so both
+/// sides are pinned to the same wire bytes.
 #[cfg(test)]
-mod tests {
+pub(crate) mod test_vector {
     use super::*;
     use p256::{EncodedPoint, FieldBytes};
 
-    fn h(s: &str) -> Vec<u8> {
+    pub(crate) const ATTEST: &str = "ff54434780180022000bb9df3193fe4f66ac5a3ee8f8552e454d20bbae633354bcff12b65d581f9d38c7001000112233445566778899aabbccddeeff000000000000041f000000010000000001202401250012000000000001000b03951800002094d0f020a3c4d09b8b88e69e7a093a38ec0ff9715cfdc70285d99d236c52990a";
+    pub(crate) const SIG_R: &str =
+        "0408dac9c80e649049e75fc74d6e1634fa4922066ce488b49b5110e7125b172b";
+    pub(crate) const SIG_S: &str =
+        "124fd1dc171546bde98f4409ad002fa7ccad75a65374ea7ee96381de337b34f0";
+    pub(crate) const AK_X: &str =
+        "f533789fb86ad512ca3e930df08cd16396d14c30c79c46a88839b574a3dfb327";
+    pub(crate) const AK_Y: &str =
+        "1b3db55b2abdc884e40898e95dfffd2c7e8554526d4e1f651779bab1f81300cb";
+    pub(crate) const NONCE: &str = "00112233445566778899aabbccddeeff";
+    pub(crate) const PCR_SELECT: &str = "00000001000b03951800";
+    pub(crate) const PCR11: &str =
+        "cf2b0db7514f320c315130275a960f6e6ed80744c754c687069d7a9f55d704f0";
+
+    pub(crate) fn h(s: &str) -> Vec<u8> {
         hex::decode(s).unwrap()
     }
-    fn h32(s: &str) -> [u8; 32] {
+    pub(crate) fn h32(s: &str) -> [u8; 32] {
         h(s).try_into().unwrap()
     }
-
-    // Real TPM2 quote: swtpm 0.10.1 + tpm2-tools 5.7, ECDSA-P256/SHA256 AK, over
-    // sha256:0,2,4,7,11,12; verified by tpm2_checkquote. (keep-node/tpm-quote-test-vector.json)
-    const ATTEST: &str = "ff54434780180022000bb9df3193fe4f66ac5a3ee8f8552e454d20bbae633354bcff12b65d581f9d38c7001000112233445566778899aabbccddeeff000000000000041f000000010000000001202401250012000000000001000b03951800002094d0f020a3c4d09b8b88e69e7a093a38ec0ff9715cfdc70285d99d236c52990a";
-    const SIG_R: &str = "0408dac9c80e649049e75fc74d6e1634fa4922066ce488b49b5110e7125b172b";
-    const SIG_S: &str = "124fd1dc171546bde98f4409ad002fa7ccad75a65374ea7ee96381de337b34f0";
-    const AK_X: &str = "f533789fb86ad512ca3e930df08cd16396d14c30c79c46a88839b574a3dfb327";
-    const AK_Y: &str = "1b3db55b2abdc884e40898e95dfffd2c7e8554526d4e1f651779bab1f81300cb";
-    const NONCE: &str = "00112233445566778899aabbccddeeff";
-    const PCR_SELECT: &str = "00000001000b03951800";
-    const PCR11: &str = "cf2b0db7514f320c315130275a960f6e6ed80744c754c687069d7a9f55d704f0";
-
-    fn ak() -> VerifyingKey {
+    pub(crate) fn ak() -> VerifyingKey {
         let x = h(AK_X);
         let y = h(AK_Y);
         let point = EncodedPoint::from_affine_coordinates(
@@ -240,16 +246,20 @@ mod tests {
         );
         VerifyingKey::from_encoded_point(&point).unwrap()
     }
-
-    fn sig_rs() -> Vec<u8> {
+    pub(crate) fn sig_rs() -> Vec<u8> {
         [h(SIG_R), h(SIG_S)].concat()
     }
-
-    fn pcrs() -> [[u8; 32]; 6] {
+    pub(crate) fn pcrs() -> [[u8; 32]; 6] {
         let z = [0u8; 32];
         // selection order: PCR 0, 2, 4, 7, 11, 12
         [z, z, z, z, h32(PCR11), z]
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_vector::*;
+    use super::*;
 
     #[test]
     fn verifies_real_swtpm_quote() {


### PR DESCRIPTION
## Summary

Adds the TPM-side **quote producer**, the counterpart to the pure-Rust quote verifier merged in #626. A node with a real TPM 2.0 can now produce the `TpmQuoteEvidence` it attaches to its announce; peers appraise it with the existing verifier and policy, yielding the normalized `AttestationStatus::Verified` the OPRF oracle gates on.

## What's here

- New `tpm_producer` module behind a non-default `tpm-attestation` feature. It links the tpm2-tss C stack (via `tss-esapi`); nodes that only verify peers do not need it, and default builds do not compile it.
- `TpmQuoter` creates the attestation key as a restricted ECDSA-P256 signing primary in the Endorsement hierarchy (deterministic from the endorsement seed, so it is stable across reboots without persistent-handle management; restricted, so it can only sign TPM-internal structures, never attacker-chosen data) and produces quotes over a fixed PCR selection.
- `quote(nonce)` binds the quote to the announce-derived nonce (`qualifyingData`), marshals the inner `TPMS_ATTEST`, extracts the 64-byte `r||s` signature, and reports the live PCR values in the order the verifier recomputes the composite digest.

## Trust model

The AK public key is pinned out of band at provisioning (TOFU). There is no EK credential activation: a self-hosted box has no manufacturer IDevID to anchor, so the AK is pinned directly (per the attestation design).

## Verification

End-to-end against swtpm (a real virtual TPM): the producer creates the AK, produces a quote bound to an announce-derived nonce, and the verifier appraises it `Verified`, then rejects the same quote against a different announce (cross-announce replay). Test is `#[ignore]` (needs a TPM) and runs with `TPM2TOOLS_TCTI` set.

Default build, clippy, and the full suite are unaffected (feature off). With the feature on, `cargo clippy --all-targets -D warnings` is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional TPM attestation capability behind a feature flag.
  * When enabled, the library exposes a TPM-backed quote producer, including a default PCR slot set and the generated attestation evidence for verification.

* **Tests**
  * Added an end-to-end TPM quote roundtrip test that uses a real (virtual) TPM.
  * The test is ignored by default and includes a negative check to ensure nonce-bound evidence fails when reused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->