### PR TITLE
keep-frost-net: attach a fresh TPM quote to each announce

### DIFF
--- a/keep-frost-net/src/announce_attestor.rs
+++ b/keep-frost-net/src/announce_attestor.rs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+//! The seam between the announce path and a TPM quote producer.
+//!
+//! A node that holds its measured-boot attestation in a TPM produces a fresh
+//! quote for every announce (each announce carries a fresh timestamp, and the
+//! quote is bound to it). The producer links the tpm2-tss C stack and its
+//! `tss-esapi` context is `!Send`, so it cannot live inside the spawned async
+//! node; the concrete implementation (`TpmQuoteService`, feature
+//! `tpm-attestation`) owns the producer on a dedicated thread and is reached
+//! over a channel.
+//!
+//! This trait is the feature-agnostic, `dyn`-safe handle the node holds. The
+//! async boundary is the returned [`oneshot::Receiver`] rather than an `async
+//! fn`, so the trait stays object-safe without an `async-trait` dependency, and
+//! it is trivially mockable in tests that do not have a TPM.
+
+use tokio::sync::oneshot;
+
+use crate::error::Result;
+use crate::protocol::TpmQuoteEvidence;
+
+/// Supplies a TPM quote bound to a specific announce.
+pub trait AnnounceAttestor: Send + Sync {
+    /// The 65-byte uncompressed SEC1 AK identity this attestor signs with. The
+    /// verifier pins this out of band; exposed here for provisioning/diagnostics.
+    fn ak_sec1(&self) -> Vec<u8>;
+
+    /// Request a quote whose `qualifyingData` is `nonce` (the announce-bound
+    /// value from [`crate::attestation::derive_announce_attestation_nonce`]).
+    /// Returns immediately; await the receiver for the evidence. A dropped
+    /// (cancelled) sender surfaces as a `RecvError` on the receiver.
+    fn request_quote(&self, nonce: [u8; 32]) -> oneshot::Receiver<Result<TpmQuoteEvidence>>;
+}

--- a/keep-frost-net/src/event.rs
+++ b/keep-frost-net/src/event.rs
@@ -11,6 +11,7 @@ use crate::protocol::*;
 pub struct KfpEventBuilder;
 
 impl KfpEventBuilder {
+    #[allow(clippy::too_many_arguments)]
     pub fn announcement(
         keys: &Keys,
         group_pubkey: &[u8; 32],
@@ -18,8 +19,9 @@ impl KfpEventBuilder {
         signing_share: &[u8; 32],
         verifying_share: &[u8; 33],
         name: Option<&str>,
+        timestamp: u64,
+        tpm_attestation: Option<TpmQuoteEvidence>,
     ) -> Result<Event> {
-        let timestamp = Timestamp::now().as_secs();
         let proof_signature = proof::sign_proof(
             signing_share,
             group_pubkey,
@@ -37,6 +39,9 @@ impl KfpEventBuilder {
         );
         if let Some(n) = name {
             payload = payload.with_name(n);
+        }
+        if let Some(ev) = tpm_attestation {
+            payload = payload.with_tpm_attestation(ev);
         }
 
         let msg = KfpMessage::Announce(payload);
@@ -573,6 +578,8 @@ mod tests {
             &signing_share,
             &verifying_share,
             Some("test"),
+            Timestamp::now().as_secs(),
+            None,
         )
         .unwrap();
 
@@ -594,9 +601,56 @@ mod tests {
                 payload.timestamp,
             )
             .expect("proof verification should succeed");
+            assert!(payload.tpm_attestation.is_none());
         } else {
             panic!("expected Announce message");
         }
+    }
+
+    #[test]
+    fn test_announcement_attaches_tpm_evidence() {
+        let keys = Keys::generate();
+        let group_pubkey = [2u8; 32];
+        let signing_key = SigningKey::random(&mut k256::elliptic_curve::rand_core::OsRng);
+        let verifying_key = signing_key.verifying_key();
+        let mut signing_share = [0u8; 32];
+        signing_share.copy_from_slice(&signing_key.to_bytes());
+        let mut verifying_share = [0u8; 33];
+        verifying_share[0] = 0x02;
+        verifying_share[1..33].copy_from_slice(&verifying_key.to_bytes());
+
+        let evidence = TpmQuoteEvidence {
+            attest: vec![0xff; 16],
+            signature: vec![7u8; 64],
+            ak_sec1: {
+                let mut v = vec![0u8; 65];
+                v[0] = 0x04;
+                v
+            },
+            pcr_values: vec!["00".repeat(32)],
+        };
+
+        let event = KfpEventBuilder::announcement(
+            &keys,
+            &group_pubkey,
+            1,
+            &signing_share,
+            &verifying_share,
+            None,
+            Timestamp::now().as_secs(),
+            Some(evidence.clone()),
+        )
+        .unwrap();
+
+        let parsed = KfpMessage::from_json(&event.content).unwrap();
+        let KfpMessage::Announce(payload) = parsed else {
+            panic!("expected Announce message");
+        };
+        let attached = payload.tpm_attestation.expect("evidence must be attached");
+        assert_eq!(attached.attest, evidence.attest);
+        assert_eq!(attached.signature, evidence.signature);
+        assert_eq!(attached.ak_sec1, evidence.ak_sec1);
+        assert_eq!(attached.pcr_values, evidence.pcr_values);
     }
 
     #[test]

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -56,6 +56,7 @@
 
 #![forbid(unsafe_code)]
 
+mod announce_attestor;
 mod attestation;
 mod audit;
 mod cert_pin;
@@ -80,7 +81,11 @@ mod tpm_policy;
 pub mod tpm_producer;
 pub mod tpm_quote;
 
-pub use attestation::{derive_attestation_nonce, verify_peer_attestation, ExpectedPcrs};
+pub use announce_attestor::AnnounceAttestor;
+pub use attestation::{
+    derive_announce_attestation_nonce, derive_attestation_nonce, verify_peer_attestation,
+    ExpectedPcrs,
+};
 pub use audit::{SigningAuditEntry, SigningAuditLog, SigningOperation};
 pub use cert_pin::{verify_relay_certificate, CertificatePinSet, SpkiHash};
 pub use descriptor_session::{
@@ -148,7 +153,7 @@ pub use session::{
 };
 pub use tpm_policy::TpmAttestationPolicy;
 #[cfg(feature = "tpm-attestation")]
-pub use tpm_producer::{TpmQuoter, DEFAULT_PCR_SLOTS};
+pub use tpm_producer::{TpmQuoteService, TpmQuoter, DEFAULT_PCR_SLOTS};
 
 pub fn install_default_crypto_provider() {
     rustls::crypto::ring::default_provider()

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1587,27 +1587,14 @@ impl KfpNode {
     }
 
     pub async fn announce(&self) -> Result<()> {
-        let key_package = self
-            .share
-            .key_package()
-            .map_err(|e| FrostNetError::Crypto(format!("Failed to get key package: {e}")))?;
-
-        let verifying_share = key_package.verifying_share();
-        let verifying_share_serialized = verifying_share.serialize().map_err(|e| {
-            FrostNetError::Crypto(format!("Failed to serialize verifying share: {e}"))
-        })?;
-        let verifying_share_bytes: [u8; 33] = verifying_share_serialized
-            .as_slice()
-            .try_into()
-            .map_err(|_| FrostNetError::Crypto("Invalid verifying share length".into()))?;
-
         let share_index = self.share.metadata.identifier;
         let timestamp = Timestamp::now().as_secs();
 
         // If this node attests via a TPM, bind a fresh quote to THIS announce
         // (group, share, timestamp) and attach it. Fail-closed: if quoting fails
         // we do not announce, since a configured-but-unattested announce would be
-        // rejected by any peer that pins a policy.
+        // rejected by any peer that pins a policy. Done BEFORE deserializing the
+        // share so no signing-key material is resident during the quote wait.
         let tpm_attestation = match &self.announce_attestor {
             Some(attestor) => {
                 let nonce =
@@ -1626,12 +1613,26 @@ impl KfpNode {
             None => None,
         };
 
-        // Derive the FROST signing share only after the quote round-trip, keeping
-        // the secret's in-memory residency window as small as possible.
+        // Deserialize the share and its key material only after attestation has
+        // succeeded, minimizing the secret's in-memory residency window.
+        let key_package = self
+            .share
+            .key_package()
+            .map_err(|e| FrostNetError::Crypto(format!("Failed to get key package: {e}")))?;
+
+        let verifying_share = key_package.verifying_share();
+        let verifying_share_serialized = verifying_share.serialize().map_err(|e| {
+            FrostNetError::Crypto(format!("Failed to serialize verifying share: {e}"))
+        })?;
+        let verifying_share_bytes: [u8; 33] = verifying_share_serialized
+            .as_slice()
+            .try_into()
+            .map_err(|_| FrostNetError::Crypto("Invalid verifying share length".into()))?;
+
         let signing_share = key_package.signing_share();
+        let signing_share_serialized = Zeroizing::new(signing_share.serialize());
         let signing_share_bytes: Zeroizing<[u8; 32]> = Zeroizing::new(
-            signing_share
-                .serialize()
+            signing_share_serialized
                 .as_slice()
                 .try_into()
                 .map_err(|_| FrostNetError::Crypto("Invalid signing share length".into()))?,

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1610,11 +1610,8 @@ impl KfpNode {
         // rejected by any peer that pins a policy.
         let tpm_attestation = match &self.announce_attestor {
             Some(attestor) => {
-                let nonce = derive_announce_attestation_nonce(
-                    &self.group_pubkey,
-                    share_index,
-                    timestamp,
-                );
+                let nonce =
+                    derive_announce_attestation_nonce(&self.group_pubkey, share_index, timestamp);
                 let evidence =
                     tokio::time::timeout(ANNOUNCE_QUOTE_TIMEOUT, attestor.request_quote(nonce))
                         .await

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -446,6 +446,10 @@ pub struct HealthCheckResult {
 pub(crate) const ANNOUNCE_MAX_AGE_SECS: u64 = 300;
 /// Maximum clock skew tolerance for future timestamps (30 seconds)
 pub(crate) const ANNOUNCE_MAX_FUTURE_SECS: u64 = 30;
+/// Maximum time to wait for a TPM quote during announce before failing closed.
+/// The TPM `quote()` is a blocking hardware call; bounding it keeps a wedged or
+/// slow TPM from stalling the inbound message-processing loop.
+const ANNOUNCE_QUOTE_TIMEOUT: Duration = Duration::from_secs(5);
 /// How often the early-exit liveness ping re-checks for pongs while waiting.
 const LIVENESS_PING_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
@@ -1588,15 +1592,6 @@ impl KfpNode {
             .key_package()
             .map_err(|e| FrostNetError::Crypto(format!("Failed to get key package: {e}")))?;
 
-        let signing_share = key_package.signing_share();
-        let signing_share_bytes: Zeroizing<[u8; 32]> = Zeroizing::new(
-            signing_share
-                .serialize()
-                .as_slice()
-                .try_into()
-                .map_err(|_| FrostNetError::Crypto("Invalid signing share length".into()))?,
-        );
-
         let verifying_share = key_package.verifying_share();
         let verifying_share_serialized = verifying_share.serialize().map_err(|e| {
             FrostNetError::Crypto(format!("Failed to serialize verifying share: {e}"))
@@ -1620,13 +1615,30 @@ impl KfpNode {
                     share_index,
                     timestamp,
                 );
-                let evidence = attestor.request_quote(nonce).await.map_err(|_| {
-                    FrostNetError::Attestation("TPM quote service is unavailable".into())
-                })??;
+                let evidence =
+                    tokio::time::timeout(ANNOUNCE_QUOTE_TIMEOUT, attestor.request_quote(nonce))
+                        .await
+                        .map_err(|_| {
+                            FrostNetError::Attestation("TPM quote service timed out".into())
+                        })?
+                        .map_err(|_| {
+                            FrostNetError::Attestation("TPM quote service is unavailable".into())
+                        })??;
                 Some(evidence)
             }
             None => None,
         };
+
+        // Derive the FROST signing share only after the quote round-trip, keeping
+        // the secret's in-memory residency window as small as possible.
+        let signing_share = key_package.signing_share();
+        let signing_share_bytes: Zeroizing<[u8; 32]> = Zeroizing::new(
+            signing_share
+                .serialize()
+                .as_slice()
+                .try_into()
+                .map_err(|_| FrostNetError::Crypto("Invalid signing share length".into()))?,
+        );
 
         let event = KfpEventBuilder::announcement(
             &self.keys,

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1610,7 +1610,7 @@ impl KfpNode {
         // rejected by any peer that pins a policy.
         let tpm_attestation = match &self.announce_attestor {
             Some(attestor) => {
-                let nonce = crate::attestation::derive_announce_attestation_nonce(
+                let nonce = derive_announce_attestation_nonce(
                     &self.group_pubkey,
                     share_index,
                     timestamp,

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -29,6 +29,7 @@ use keep_core::relay::{
     validate_relay_url, validate_relay_url_allow_internal, ALLOW_INTERNAL_HOSTS,
 };
 
+use crate::announce_attestor::AnnounceAttestor;
 use crate::attestation::{
     derive_announce_attestation_nonce, verify_peer_attestation, ExpectedPcrs,
 };
@@ -899,6 +900,9 @@ pub struct KfpNode {
     /// parallel to `expected_pcrs` for the Nitro path; `None` means TPM quotes
     /// are not configured and appraise to `NotConfigured`.
     tpm_attestation_policy: Option<TpmAttestationPolicy>,
+    /// Producer side: when set, every announce carries a fresh TPM quote bound to
+    /// it. `None` means this node attaches no TPM attestation to its announces.
+    announce_attestor: Option<Arc<dyn AnnounceAttestor>>,
     pub(crate) seen_xpub_announces: RwLock<HashSet<(u16, u64, [u8; 32])>>,
     /// Per-peer de-duplication for `NonceCommitment` broadcasts, keyed by
     /// `(share_index, content_hash)` where `content_hash` covers the sorted
@@ -1119,6 +1123,7 @@ impl KfpNode {
             audit_log,
             expected_pcrs: None,
             tpm_attestation_policy: None,
+            announce_attestor: None,
             seen_xpub_announces: RwLock::new(HashSet::new()),
             seen_nonce_commitments: RwLock::new(HashMap::new()),
             seen_oprf_enrolls: RwLock::new(HashMap::new()),
@@ -1196,6 +1201,18 @@ impl KfpNode {
 
     pub fn set_tpm_attestation_policy(&mut self, policy: TpmAttestationPolicy) {
         self.tpm_attestation_policy = Some(policy);
+    }
+
+    /// Attach a TPM quote, produced by `attestor`, to every announce this node
+    /// makes. The producer side of [`with_tpm_attestation_policy`]; see
+    /// [`AnnounceAttestor`].
+    pub fn with_announce_attestor(mut self, attestor: Arc<dyn AnnounceAttestor>) -> Self {
+        self.announce_attestor = Some(attestor);
+        self
+    }
+
+    pub fn set_announce_attestor(&mut self, attestor: Arc<dyn AnnounceAttestor>) {
+        self.announce_attestor = Some(attestor);
     }
 
     pub fn require_attestation(&self) -> bool {
@@ -1589,13 +1606,37 @@ impl KfpNode {
             .try_into()
             .map_err(|_| FrostNetError::Crypto("Invalid verifying share length".into()))?;
 
+        let share_index = self.share.metadata.identifier;
+        let timestamp = Timestamp::now().as_secs();
+
+        // If this node attests via a TPM, bind a fresh quote to THIS announce
+        // (group, share, timestamp) and attach it. Fail-closed: if quoting fails
+        // we do not announce, since a configured-but-unattested announce would be
+        // rejected by any peer that pins a policy.
+        let tpm_attestation = match &self.announce_attestor {
+            Some(attestor) => {
+                let nonce = crate::attestation::derive_announce_attestation_nonce(
+                    &self.group_pubkey,
+                    share_index,
+                    timestamp,
+                );
+                let evidence = attestor.request_quote(nonce).await.map_err(|_| {
+                    FrostNetError::Attestation("TPM quote service is unavailable".into())
+                })??;
+                Some(evidence)
+            }
+            None => None,
+        };
+
         let event = KfpEventBuilder::announcement(
             &self.keys,
             &self.group_pubkey,
-            self.share.metadata.identifier,
+            share_index,
             &signing_share_bytes,
             &verifying_share_bytes,
             Some(&self.share.metadata.name),
+            timestamp,
+            tpm_attestation,
         )?;
 
         self.client

--- a/keep-frost-net/src/tpm_producer.rs
+++ b/keep-frost-net/src/tpm_producer.rs
@@ -278,6 +278,118 @@ impl Drop for TpmQuoter {
     }
 }
 
+type QuoteRequest = (
+    [u8; 32],
+    tokio::sync::oneshot::Sender<Result<TpmQuoteEvidence>>,
+);
+
+/// A [`crate::announce_attestor::AnnounceAttestor`] backed by a real TPM.
+///
+/// The [`TpmQuoter`] (and its `!Send` `tss-esapi` context) lives on a dedicated
+/// thread; this handle forwards quote requests to it over a channel and is
+/// `Send + Sync`, so it can be held by the async node as `Arc<dyn AnnounceAttestor>`.
+/// Quoting is serialized on the worker thread, which is correct: a TPM processes
+/// one command at a time.
+pub struct TpmQuoteService {
+    tx: Option<tokio::sync::mpsc::UnboundedSender<QuoteRequest>>,
+    ak_sec1: Vec<u8>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+impl TpmQuoteService {
+    /// Open a TPM context over `tcti` on a dedicated thread, create the AK, and
+    /// return a handle once it is ready. Blocks briefly while the worker creates
+    /// the AK; returns the worker's error if that fails.
+    pub fn spawn(tcti: tss_esapi::TctiNameConf, slots: Vec<PcrSlot>) -> Result<Self> {
+        let (setup_tx, setup_rx) = std::sync::mpsc::channel::<Result<Vec<u8>>>();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<QuoteRequest>();
+
+        let worker = std::thread::Builder::new()
+            .name("tpm-quote-service".into())
+            .spawn(move || {
+                let mut quoter = match Context::new(tcti).map_err(tpm_err).and_then(|ctx| {
+                    let slots = slots; // moved in
+                    TpmQuoter::create(ctx, &slots)
+                }) {
+                    Ok(q) => q,
+                    Err(e) => {
+                        let _ = setup_tx.send(Err(e));
+                        return;
+                    }
+                };
+                if setup_tx.send(Ok(quoter.ak_sec1().to_vec())).is_err() {
+                    return; // spawner gave up
+                }
+                drop(setup_tx);
+                // Serve quote requests until every sender is dropped.
+                while let Some((nonce, reply)) = rx.blocking_recv() {
+                    let _ = reply.send(quoter.quote(&nonce));
+                }
+                // `quoter` drops here, flushing the AK.
+            })
+            .map_err(|e| att(format!("failed to spawn TPM quote thread: {e}")))?;
+
+        match setup_rx.recv() {
+            Ok(Ok(ak_sec1)) => Ok(Self {
+                tx: Some(tx),
+                ak_sec1,
+                worker: Some(worker),
+            }),
+            Ok(Err(e)) => {
+                let _ = worker.join();
+                Err(e)
+            }
+            Err(_) => {
+                let _ = worker.join();
+                Err(att("TPM quote thread exited before reporting readiness"))
+            }
+        }
+    }
+
+    /// Convenience constructor over [`DEFAULT_PCR_SLOTS`].
+    pub fn spawn_default(tcti: tss_esapi::TctiNameConf) -> Result<Self> {
+        Self::spawn(tcti, DEFAULT_PCR_SLOTS.to_vec())
+    }
+}
+
+impl crate::announce_attestor::AnnounceAttestor for TpmQuoteService {
+    fn ak_sec1(&self) -> Vec<u8> {
+        self.ak_sec1.clone()
+    }
+
+    fn request_quote(
+        &self,
+        nonce: [u8; 32],
+    ) -> tokio::sync::oneshot::Receiver<Result<TpmQuoteEvidence>> {
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        match &self.tx {
+            Some(tx) => {
+                if let Err(tokio::sync::mpsc::error::SendError((_, reply_tx))) =
+                    tx.send((nonce, reply_tx))
+                {
+                    let _ = reply_tx.send(Err(att("TPM quote service has stopped")));
+                }
+            }
+            None => {
+                let _ = reply_tx.send(Err(att("TPM quote service has stopped")));
+            }
+        }
+        reply_rx
+    }
+}
+
+impl Drop for TpmQuoteService {
+    fn drop(&mut self) {
+        // Drop the sender first so the worker's `blocking_recv` returns `None` and
+        // it exits its loop (flushing the AK as the quoter drops); then join so the
+        // TPM context is finalized before we return.
+        self.tx.take();
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -432,6 +544,42 @@ mod tests {
                 AttestationStatus::Failed(_)
             ),
             "the quote must not verify against a different announce"
+        );
+    }
+
+    // The threaded TpmQuoteService (the AnnounceAttestor the node holds) must
+    // produce, over its worker thread + channel, a quote that verifies. Exercises
+    // the spawn/request/Drop path against a real TPM.
+    #[test]
+    #[ignore = "requires a TPM; run against swtpm with TPM2TOOLS_TCTI set"]
+    fn service_quote_via_trait_verifies() {
+        use crate::announce_attestor::AnnounceAttestor;
+
+        let tcti = TctiNameConf::from_environment_variable().expect("set TPM2TOOLS_TCTI / TCTI");
+        let service = TpmQuoteService::spawn_default(tcti).expect("spawn TPM quote service");
+        let ak_sec1 = service.ak_sec1();
+        assert_eq!(ak_sec1.len(), 65);
+
+        let group = [4u8; 32];
+        let share_index: u16 = 3;
+        let timestamp: u64 = 1_700_000_500;
+        let nonce = derive_announce_attestation_nonce(&group, share_index, timestamp);
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let ev = rt
+            .block_on(service.request_quote(nonce))
+            .expect("worker replied")
+            .expect("quote produced");
+
+        let pcr_values = crate::tpm_quote::decode_pcr_values(&ev.pcr_values).unwrap();
+        let mut pinned = HashMap::new();
+        pinned.insert(share_index, ak_sec1);
+        let pol =
+            TpmAttestationPolicy::new(hex::decode(DEFAULT_SELECTION).unwrap(), pcr_values, pinned);
+        assert_eq!(
+            appraise_tpm_quote(share_index, &ev, &pol, &nonce),
+            AttestationStatus::Verified,
+            "a quote from the threaded service must verify"
         );
     }
 }

--- a/keep-frost-net/src/tpm_producer.rs
+++ b/keep-frost-net/src/tpm_producer.rs
@@ -290,8 +290,16 @@ type QuoteRequest = (
 /// `Send + Sync`, so it can be held by the async node as `Arc<dyn AnnounceAttestor>`.
 /// Quoting is serialized on the worker thread, which is correct: a TPM processes
 /// one command at a time.
+/// Bound on in-flight quote requests. Announces are periodic and serialized per
+/// node, so this is generous; if it is ever exceeded the request is rejected
+/// (backpressure) rather than queued without limit.
+const QUOTE_QUEUE_BOUND: usize = 16;
+/// How long [`TpmQuoteService::spawn`] waits for the worker to report readiness
+/// before failing startup, so a hung TCTI connection cannot block forever.
+const WORKER_SETUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 pub struct TpmQuoteService {
-    tx: Option<tokio::sync::mpsc::UnboundedSender<QuoteRequest>>,
+    tx: Option<tokio::sync::mpsc::Sender<QuoteRequest>>,
     ak_sec1: Vec<u8>,
     worker: Option<std::thread::JoinHandle<()>>,
 }
@@ -299,10 +307,11 @@ pub struct TpmQuoteService {
 impl TpmQuoteService {
     /// Open a TPM context over `tcti` on a dedicated thread, create the AK, and
     /// return a handle once it is ready. Blocks briefly while the worker creates
-    /// the AK; returns the worker's error if that fails.
+    /// the AK; returns the worker's error if that fails, or a timeout error if it
+    /// does not report readiness within [`WORKER_SETUP_TIMEOUT`].
     pub fn spawn(tcti: tss_esapi::TctiNameConf, slots: Vec<PcrSlot>) -> Result<Self> {
         let (setup_tx, setup_rx) = std::sync::mpsc::channel::<Result<Vec<u8>>>();
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<QuoteRequest>();
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<QuoteRequest>(QUOTE_QUEUE_BOUND);
 
         let worker = std::thread::Builder::new()
             .name("tpm-quote-service".into())
@@ -323,13 +332,19 @@ impl TpmQuoteService {
                 drop(setup_tx);
                 // Serve quote requests until every sender is dropped.
                 while let Some((nonce, reply)) = rx.blocking_recv() {
+                    // Skip work whose caller already gave up (announce timed out
+                    // and dropped the receiver), so a backlog drains without
+                    // spending scarce TPM time on stale requests.
+                    if reply.is_closed() {
+                        continue;
+                    }
                     let _ = reply.send(quoter.quote(&nonce));
                 }
                 // `quoter` drops here, flushing the AK.
             })
             .map_err(|e| att(format!("failed to spawn TPM quote thread: {e}")))?;
 
-        match setup_rx.recv() {
+        match setup_rx.recv_timeout(WORKER_SETUP_TIMEOUT) {
             Ok(Ok(ak_sec1)) => Ok(Self {
                 tx: Some(tx),
                 ak_sec1,
@@ -339,9 +354,15 @@ impl TpmQuoteService {
                 let _ = worker.join();
                 Err(e)
             }
-            Err(_) => {
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
                 let _ = worker.join();
                 Err(att("TPM quote thread exited before reporting readiness"))
+            }
+            // The worker is stuck (e.g. a hung TCTI connect). Do NOT join, which
+            // would hang too; drop the handle and fail startup. The detached
+            // thread unwinds if and when the blocking call returns.
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                Err(att("TPM quote service did not become ready in time"))
             }
         }
     }
@@ -361,15 +382,21 @@ impl crate::announce_attestor::AnnounceAttestor for TpmQuoteService {
         &self,
         nonce: [u8; 32],
     ) -> tokio::sync::oneshot::Receiver<Result<TpmQuoteEvidence>> {
+        use tokio::sync::mpsc::error::TrySendError;
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
         match &self.tx {
-            Some(tx) => {
-                if let Err(tokio::sync::mpsc::error::SendError((_, reply_tx))) =
-                    tx.send((nonce, reply_tx))
-                {
+            // Non-blocking send: this is a sync method and must not stall the
+            // caller. A full queue means too many quotes are already in flight, so
+            // reject with backpressure rather than block.
+            Some(tx) => match tx.try_send((nonce, reply_tx)) {
+                Ok(()) => {}
+                Err(TrySendError::Full((_, reply_tx))) => {
+                    let _ = reply_tx.send(Err(att("TPM quote service queue is full")));
+                }
+                Err(TrySendError::Closed((_, reply_tx))) => {
                     let _ = reply_tx.send(Err(att("TPM quote service has stopped")));
                 }
-            }
+            },
             None => {
                 let _ = reply_tx.send(Err(att("TPM quote service has stopped")));
             }

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -3255,8 +3255,12 @@ async fn test_announce_fails_closed_when_quote_fails() {
         succeed: false,
     }));
 
+    let err = node
+        .announce()
+        .await
+        .expect_err("announce must fail closed when the configured attestor cannot quote");
     assert!(
-        node.announce().await.is_err(),
-        "announce must fail closed when the configured attestor cannot quote"
+        matches!(err, keep_frost_net::FrostNetError::Attestation(_)),
+        "the failure must be the attestation fail-closed path, got {err:?}"
     );
 }

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -3154,3 +3154,109 @@ async fn test_unappraisable_tpm_evidence_is_failed_not_downgraded() {
         "a node enforcing no attestation must report NotConfigured, not reject"
     );
 }
+
+/// A test [`AnnounceAttestor`] that records the nonces it is asked to quote and
+/// returns either canned evidence or a failure, without needing a TPM.
+struct RecordingAttestor {
+    nonces: std::sync::Arc<std::sync::Mutex<Vec<[u8; 32]>>>,
+    succeed: bool,
+}
+
+impl keep_frost_net::AnnounceAttestor for RecordingAttestor {
+    fn ak_sec1(&self) -> Vec<u8> {
+        let mut v = vec![0u8; 65];
+        v[0] = 0x04;
+        v
+    }
+
+    fn request_quote(
+        &self,
+        nonce: [u8; 32],
+    ) -> tokio::sync::oneshot::Receiver<keep_frost_net::Result<keep_frost_net::TpmQuoteEvidence>>
+    {
+        self.nonces.lock().unwrap().push(nonce);
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let result = if self.succeed {
+            Ok(keep_frost_net::TpmQuoteEvidence {
+                attest: vec![0xff; 16],
+                signature: vec![0u8; 64],
+                ak_sec1: self.ak_sec1(),
+                pcr_values: vec!["00".repeat(32)],
+            })
+        } else {
+            Err(keep_frost_net::FrostNetError::Attestation(
+                "mock quote failure".into(),
+            ))
+        };
+        let _ = tx.send(result);
+        rx
+    }
+}
+
+/// The announce path must bind the TPM quote's nonce to THIS announce: the nonce
+/// the attestor is asked to quote must be `derive_announce_attestation_nonce`
+/// over the node's group, share index, and the announce's own timestamp.
+#[tokio::test]
+async fn test_announce_binds_tpm_quote_nonce_to_announce() {
+    let mock_relay = MockRelay::run().await.expect("relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pkg) = dealer.generate("test-announce-quote").unwrap();
+    let share = shares.remove(0);
+
+    let nonces = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mut node = KfpNode::new(share, vec![relay]).await.expect("node");
+    node.set_announce_attestor(std::sync::Arc::new(RecordingAttestor {
+        nonces: nonces.clone(),
+        succeed: true,
+    }));
+
+    let group = *node.group_pubkey();
+    let idx = node.share_index();
+
+    let t0 = chrono::Utc::now().timestamp() as u64;
+    node.announce().await.expect("announce");
+    let t1 = chrono::Utc::now().timestamp() as u64;
+
+    let recorded = nonces.lock().unwrap().clone();
+    assert_eq!(
+        recorded.len(),
+        1,
+        "the attestor must be asked for exactly one quote per announce"
+    );
+    // The exact second is the node's own `Timestamp::now()`; it lies within the
+    // bracket we measured around the call.
+    let candidates: Vec<[u8; 32]> = (t0..=t1 + 1)
+        .map(|ts| keep_frost_net::derive_announce_attestation_nonce(&group, idx, ts))
+        .collect();
+    assert!(
+        candidates.contains(&recorded[0]),
+        "the quote nonce must be bound to the announce's group, share, and timestamp"
+    );
+}
+
+/// If a node is configured to attest but quoting fails, the announce must fail
+/// closed (a configured-but-unattested announce would be rejected by any peer
+/// that pins a policy, so emitting it is pointless and masks the failure).
+#[tokio::test]
+async fn test_announce_fails_closed_when_quote_fails() {
+    let mock_relay = MockRelay::run().await.expect("relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pkg) = dealer.generate("test-announce-quote-fail").unwrap();
+    let share = shares.remove(0);
+
+    let nonces = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mut node = KfpNode::new(share, vec![relay]).await.expect("node");
+    node.set_announce_attestor(std::sync::Arc::new(RecordingAttestor {
+        nonces,
+        succeed: false,
+    }));
+
+    assert!(
+        node.announce().await.is_err(),
+        "announce must fail closed when the configured attestor cannot quote"
+    );
+}


### PR DESCRIPTION
## Summary

Connects the TPM quote producer (#627) to the protocol: a node that attests via a TPM now attaches a fresh quote to every announce, bound to that announce. Peers appraise it with the verifier and policy from #626, completing the produce-to-verify path over the wire.

## What's here

- `AnnounceAttestor`: a feature-agnostic, `dyn`-safe trait the node holds (`Option<Arc<dyn AnnounceAttestor>>`). The async boundary is a returned `oneshot::Receiver` rather than an `async fn`, so it stays object-safe with no `async-trait` dependency and is trivially mockable in tests.
- `TpmQuoteService` (feature `tpm-attestation`): the real implementation. The `tss-esapi` context is `!Send`, so the producer lives on a dedicated thread and is reached over a channel; the handle is `Send + Sync` and quoting is serialized (a TPM runs one command at a time). On drop it closes the channel and joins, so the worker flushes the AK.
- Announce wiring: `announcement()` now takes the announce timestamp and an optional quote. `announce()` derives the announce-bound nonce (group, share index, this announce's timestamp), requests a quote, and attaches it. Fail-closed: if a node is configured to attest and quoting fails, it does not announce, since a configured-but-unattested announce would be rejected by any peer that pins a policy.

## Why per-announce

Announces repeat (periodic re-announce and on new-peer discovery), each with a fresh timestamp, and the quote's `qualifyingData` is bound to that timestamp. So a fresh quote is produced for each announce, which is what stops a captured quote from being replayed onto a different announce.

## Tests

- Builder: an announce carries the evidence when supplied, and none otherwise.
- Wiring (no TPM, runs in CI): a recording mock attestor proves `announce()` binds the quote nonce to its own group/share/timestamp, and that a quote failure makes the announce fail closed.
- End-to-end against swtpm (`#[ignore]`): the threaded `TpmQuoteService` produces, over its worker thread and channel, a quote that the verifier appraises `Verified`.

No new dependencies. Default build, clippy, and the full suite are unaffected (feature off); with the feature on, `clippy --all-targets -D warnings` is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching TPM quote evidence to node announcements.
  * Introduced a pluggable attestation interface and a TPM quote service for producing quotes asynchronously.
  * Exposed additional attestation helpers for generating announce-specific nonces.

* **Bug Fixes**
  * Announce timestamps can now be provided explicitly, ensuring consistent signing and payload contents.
  * Quote requests now fail safely on timeout or service unavailability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->