### PR TITLE
keep-cli: enforce TPM attestation policy in frost network serve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4493,6 +4493,7 @@ dependencies = [
  "keep-frost-net",
  "keep-nip46",
  "nostr-sdk",
+ "p256",
  "rand 0.10.1",
  "ratatui",
  "reqwest",

--- a/keep-cli/Cargo.toml
+++ b/keep-cli/Cargo.toml
@@ -39,6 +39,7 @@ url = "2.5"
 base64 = "0.22"
 
 frost-secp256k1-tr = "3.0.0"
+p256 = { version = "0.13", features = ["ecdsa"] }
 sha2 = "0.10.9"
 rand = "0.10"
 

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -567,6 +567,17 @@ pub(crate) enum FrostNetworkCommands {
         /// See #524 for the deeper protocol-level fix.
         #[arg(long)]
         refuse_raw_sign: bool,
+        /// TOML file pinning each peer's TPM attestation key and the reference
+        /// PCRs they must quote. The node verifies a peer's measured-boot state
+        /// against this before answering its OPRF evaluation requests. Required
+        /// unless `--insecure-no-attestation` is set.
+        #[arg(long, value_name = "FILE")]
+        attestation_config: Option<PathBuf>,
+        /// Run WITHOUT verifying peer TPM attestation. Test/dev only: an
+        /// unattested holder answers OPRF evaluations from any peer, which can
+        /// leak the unlock key. Mutually exclusive with `--attestation-config`.
+        #[arg(long)]
+        insecure_no_attestation: bool,
     },
     Peers {
         #[arg(short, long)]

--- a/keep-cli/src/commands/frost_network/attestation.rs
+++ b/keep-cli/src/commands/frost_network/attestation.rs
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+//! Loading the TPM attestation policy a FROST node uses to verify a peer's
+//! measured-boot state before answering its OPRF evaluation requests.
+//!
+//! The policy is provisioned out of band (trust-on-first-use) and pinned in a
+//! TOML file: a shared PCR selection and reference digest set, plus one AK pin
+//! per peer. See `keep frost network serve --attestation-config`.
+//!
+//! ```toml
+//! # Marshalled TPML_PCR_SELECTION the peer quote must match (hex).
+//! selection = "00000001000b03951800"
+//! # Reference PCR digests in selection order (hex, 32 bytes each).
+//! reference_pcrs = ["0000…", "0000…", "0000…", "0000…", "cf2b…", "0000…"]
+//!
+//! [[peer]]
+//! index = 2
+//! ak = "04f533…b327…"   # 65-byte uncompressed SEC1 point
+//! ```
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use keep_core::error::{KeepError, Result};
+use keep_frost_net::TpmAttestationPolicy;
+
+use crate::output::Output;
+
+#[derive(Deserialize)]
+struct AttestationConfig {
+    selection: String,
+    reference_pcrs: Vec<String>,
+    #[serde(default)]
+    peer: Vec<PeerPin>,
+}
+
+#[derive(Deserialize)]
+struct PeerPin {
+    index: u16,
+    ak: String,
+}
+
+fn err(msg: impl Into<String>) -> KeepError {
+    KeepError::Frost(msg.into())
+}
+
+/// Read and parse a TOML attestation policy file.
+pub fn load_tpm_policy(path: &Path) -> Result<TpmAttestationPolicy> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| err(format!("read attestation config {}: {e}", path.display())))?;
+    parse_tpm_policy(&text)
+}
+
+fn parse_tpm_policy(text: &str) -> Result<TpmAttestationPolicy> {
+    let cfg: AttestationConfig =
+        toml::from_str(text).map_err(|e| err(format!("invalid attestation config: {e}")))?;
+
+    let selection = hex::decode(cfg.selection.trim())
+        .map_err(|_| err("attestation `selection` is not valid hex"))?;
+    if selection.is_empty() {
+        return Err(err("attestation `selection` must not be empty"));
+    }
+
+    if cfg.reference_pcrs.is_empty() {
+        return Err(err(
+            "attestation `reference_pcrs` must list at least one PCR",
+        ));
+    }
+    let mut reference_pcrs = Vec::with_capacity(cfg.reference_pcrs.len());
+    for (i, p) in cfg.reference_pcrs.iter().enumerate() {
+        let bytes = hex::decode(p.trim())
+            .map_err(|_| err(format!("`reference_pcrs[{i}]` is not valid hex")))?;
+        let digest: [u8; 32] = bytes
+            .try_into()
+            .map_err(|_| err(format!("`reference_pcrs[{i}]` must be 32 bytes")))?;
+        reference_pcrs.push(digest);
+    }
+
+    if cfg.peer.is_empty() {
+        return Err(err(
+            "attestation config pins no peers (add a `[[peer]]` entry)",
+        ));
+    }
+    let mut pinned_aks = HashMap::new();
+    for p in &cfg.peer {
+        let ak = hex::decode(p.ak.trim())
+            .map_err(|_| err(format!("peer {} `ak` is not valid hex", p.index)))?;
+        if ak.len() != 65 || ak[0] != 0x04 {
+            return Err(err(format!(
+                "peer {} `ak` must be a 65-byte uncompressed SEC1 point (starts with 0x04)",
+                p.index
+            )));
+        }
+        if pinned_aks.insert(p.index, ak).is_some() {
+            return Err(err(format!(
+                "peer index {} is pinned more than once",
+                p.index
+            )));
+        }
+    }
+
+    Ok(TpmAttestationPolicy::new(
+        selection,
+        reference_pcrs,
+        pinned_aks,
+    ))
+}
+
+/// Resolve the serve-time attestation policy from the CLI flags, fail-closed: a
+/// node must either pin a policy or explicitly opt out of attestation, and it
+/// cannot do both.
+pub fn resolve_serve_policy(
+    out: &Output,
+    attestation_config: Option<&Path>,
+    insecure_no_attestation: bool,
+) -> Result<Option<TpmAttestationPolicy>> {
+    match (attestation_config, insecure_no_attestation) {
+        (Some(_), true) => Err(err(
+            "--attestation-config conflicts with --insecure-no-attestation",
+        )),
+        (Some(path), false) => Ok(Some(load_tpm_policy(path)?)),
+        (None, true) => {
+            out.warn(
+                "INSECURE: --insecure-no-attestation set; this node will NOT verify peer TPM \
+                 attestation before answering OPRF evaluations.",
+            );
+            Ok(None)
+        }
+        (None, false) => Err(err(
+            "attestation required: pass --attestation-config <FILE>, or \
+             --insecure-no-attestation for test/dev only",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A valid config over the default selection {0,2,4,7,11,12} with one peer.
+    const VALID: &str = r#"
+        selection = "00000001000b03951800"
+        reference_pcrs = [
+          "0000000000000000000000000000000000000000000000000000000000000000",
+          "0000000000000000000000000000000000000000000000000000000000000000",
+          "0000000000000000000000000000000000000000000000000000000000000000",
+          "0000000000000000000000000000000000000000000000000000000000000000",
+          "cf2b0db7514f320c315130275a960f6e6ed80744c754c687069d7a9f55d704f0",
+          "0000000000000000000000000000000000000000000000000000000000000000",
+        ]
+        [[peer]]
+        index = 2
+        ak = "04f533789fb86ad512ca3e930df08cd16396d14c30c79c46a88839b574a3dfb3271b3db55b2abdc884e40898e95dfffd2c7e8554526d4e1f651779bab1f81300cb"
+    "#;
+
+    #[test]
+    fn parses_valid_config() {
+        let pol = parse_tpm_policy(VALID).expect("valid config");
+        assert_eq!(pol.pinned_aks.len(), 1);
+        assert_eq!(pol.reference_pcrs.len(), 6);
+        assert_eq!(pol.pinned_aks.get(&2).unwrap().len(), 65);
+    }
+
+    #[test]
+    fn rejects_no_peers() {
+        let cfg = r#"
+            selection = "00000001000b03951800"
+            reference_pcrs = ["0000000000000000000000000000000000000000000000000000000000000000"]
+        "#;
+        assert!(parse_tpm_policy(cfg).is_err());
+    }
+
+    #[test]
+    fn rejects_bad_ak() {
+        let cfg = r#"
+            selection = "00000001000b03951800"
+            reference_pcrs = ["0000000000000000000000000000000000000000000000000000000000000000"]
+            [[peer]]
+            index = 2
+            ak = "0400"
+        "#;
+        assert!(parse_tpm_policy(cfg).is_err());
+    }
+
+    #[test]
+    fn rejects_short_reference_pcr() {
+        let cfg = r#"
+            selection = "00000001000b03951800"
+            reference_pcrs = ["00ff"]
+            [[peer]]
+            index = 2
+            ak = "04f533789fb86ad512ca3e930df08cd16396d14c30c79c46a88839b574a3dfb3271b3db55b2abdc884e40898e95dfffd2c7e8554526d4e1f651779bab1f81300cb"
+        "#;
+        assert!(parse_tpm_policy(cfg).is_err());
+    }
+
+    #[test]
+    fn resolve_requires_a_choice() {
+        let out = Output::new();
+        // Neither flag: fail closed.
+        assert!(resolve_serve_policy(&out, None, false).is_err());
+    }
+
+    #[test]
+    fn resolve_rejects_both() {
+        let out = Output::new();
+        let path = Path::new("/nonexistent.toml");
+        assert!(resolve_serve_policy(&out, Some(path), true).is_err());
+    }
+
+    #[test]
+    fn resolve_insecure_opts_out() {
+        let out = Output::new();
+        assert!(matches!(resolve_serve_policy(&out, None, true), Ok(None)));
+    }
+
+    #[test]
+    fn rejects_duplicate_peer() {
+        let cfg = r#"
+            selection = "00000001000b03951800"
+            reference_pcrs = ["0000000000000000000000000000000000000000000000000000000000000000"]
+            [[peer]]
+            index = 2
+            ak = "04f533789fb86ad512ca3e930df08cd16396d14c30c79c46a88839b574a3dfb3271b3db55b2abdc884e40898e95dfffd2c7e8554526d4e1f651779bab1f81300cb"
+            [[peer]]
+            index = 2
+            ak = "04f533789fb86ad512ca3e930df08cd16396d14c30c79c46a88839b574a3dfb3271b3db55b2abdc884e40898e95dfffd2c7e8554526d4e1f651779bab1f81300cb"
+        "#;
+        assert!(parse_tpm_policy(cfg).is_err());
+    }
+}

--- a/keep-cli/src/commands/frost_network/attestation.rs
+++ b/keep-cli/src/commands/frost_network/attestation.rs
@@ -22,6 +22,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use p256::ecdsa::VerifyingKey;
 use serde::Deserialize;
 
 use keep_core::error::{KeepError, Result};
@@ -47,6 +48,34 @@ fn err(msg: impl Into<String>) -> KeepError {
     KeepError::Frost(msg.into())
 }
 
+/// Count the PCRs selected by a marshalled `TPML_PCR_SELECTION`:
+/// `count: u32`, then `count` * `{ hash: u16, sizeofSelect: u8, select[sizeofSelect] }`,
+/// summing the set bits across every selection bitmap. Mirrors the parse in
+/// `keep_frost_net::tpm_quote`, so the reference count can be reconciled at load.
+fn count_selected_pcrs(selection: &[u8]) -> Result<usize> {
+    let bad = || err("attestation `selection` is not a valid TPML_PCR_SELECTION");
+    let mut pos = 0usize;
+    let take = |pos: &mut usize, n: usize| -> Result<&[u8]> {
+        let end = pos.checked_add(n).ok_or_else(bad)?;
+        let slice = selection.get(*pos..end).ok_or_else(bad)?;
+        *pos = end;
+        Ok(slice)
+    };
+    let count = u32::from_be_bytes(take(&mut pos, 4)?.try_into().map_err(|_| bad())?);
+    let mut selected = 0usize;
+    for _ in 0..count {
+        take(&mut pos, 2)?; // hash alg
+        let size = take(&mut pos, 1)?[0] as usize;
+        for &b in take(&mut pos, size)? {
+            selected += b.count_ones() as usize;
+        }
+    }
+    if pos != selection.len() {
+        return Err(bad());
+    }
+    Ok(selected)
+}
+
 /// Read and parse a TOML attestation policy file.
 pub fn load_tpm_policy(path: &Path) -> Result<TpmAttestationPolicy> {
     let text = std::fs::read_to_string(path)
@@ -63,6 +92,7 @@ fn parse_tpm_policy(text: &str) -> Result<TpmAttestationPolicy> {
     if selection.is_empty() {
         return Err(err("attestation `selection` must not be empty"));
     }
+    let selected = count_selected_pcrs(&selection)?;
 
     if cfg.reference_pcrs.is_empty() {
         return Err(err(
@@ -77,6 +107,15 @@ fn parse_tpm_policy(text: &str) -> Result<TpmAttestationPolicy> {
             .try_into()
             .map_err(|_| err(format!("`reference_pcrs[{i}]` must be 32 bytes")))?;
         reference_pcrs.push(digest);
+    }
+    // The reference count must equal the PCRs the selection actually picks, or
+    // the policy would look "enforced" yet reject every peer on the count check
+    // in `verify_quote`.
+    if reference_pcrs.len() != selected {
+        return Err(err(format!(
+            "attestation `selection` picks {selected} PCR(s) but `reference_pcrs` lists {}",
+            reference_pcrs.len()
+        )));
     }
 
     if cfg.peer.is_empty() {
@@ -94,6 +133,11 @@ fn parse_tpm_policy(text: &str) -> Result<TpmAttestationPolicy> {
                 p.index
             )));
         }
+        // Reject a pin that is not a valid P-256 point at load time, so a typo'd
+        // AK is a clear config error here rather than every peer silently failing
+        // attestation later (`appraise_tpm_quote` parses the pin the same way).
+        VerifyingKey::from_sec1_bytes(&ak)
+            .map_err(|_| err(format!("peer {} `ak` is not a valid P-256 point", p.index)))?;
         if pinned_aks.insert(p.index, ak).is_some() {
             return Err(err(format!(
                 "peer index {} is pinned more than once",
@@ -164,10 +208,14 @@ mod tests {
         assert_eq!(pol.pinned_aks.get(&2).unwrap().len(), 65);
     }
 
+    // A 1-PCR selection (picks PCR 0 only) so single-`reference_pcrs` fixtures
+    // pass the count cross-check and exercise their intended validation.
+    const ONE_PCR_SELECTION: &str = "00000001000b03010000";
+
     #[test]
     fn rejects_no_peers() {
         let cfg = r#"
-            selection = "00000001000b03951800"
+            selection = "00000001000b03010000"
             reference_pcrs = ["0000000000000000000000000000000000000000000000000000000000000000"]
         "#;
         assert!(parse_tpm_policy(cfg).is_err());
@@ -176,11 +224,40 @@ mod tests {
     #[test]
     fn rejects_bad_ak() {
         let cfg = r#"
-            selection = "00000001000b03951800"
+            selection = "00000001000b03010000"
             reference_pcrs = ["0000000000000000000000000000000000000000000000000000000000000000"]
             [[peer]]
             index = 2
             ak = "0400"
+        "#;
+        assert!(parse_tpm_policy(cfg).is_err());
+    }
+
+    #[test]
+    fn rejects_off_curve_ak() {
+        // 65 bytes, 0x04 prefix, but not a valid P-256 point.
+        let cfg = format!(
+            r#"
+            selection = "{ONE_PCR_SELECTION}"
+            reference_pcrs = ["0000000000000000000000000000000000000000000000000000000000000000"]
+            [[peer]]
+            index = 2
+            ak = "04{}"
+        "#,
+            "ff".repeat(64)
+        );
+        assert!(parse_tpm_policy(&cfg).is_err());
+    }
+
+    #[test]
+    fn rejects_reference_count_mismatch() {
+        // selection picks 6 PCRs but only one reference value is listed.
+        let cfg = r#"
+            selection = "00000001000b03951800"
+            reference_pcrs = ["0000000000000000000000000000000000000000000000000000000000000000"]
+            [[peer]]
+            index = 2
+            ak = "04f533789fb86ad512ca3e930df08cd16396d14c30c79c46a88839b574a3dfb3271b3db55b2abdc884e40898e95dfffd2c7e8554526d4e1f651779bab1f81300cb"
         "#;
         assert!(parse_tpm_policy(cfg).is_err());
     }
@@ -220,7 +297,7 @@ mod tests {
     #[test]
     fn rejects_duplicate_peer() {
         let cfg = r#"
-            selection = "00000001000b03951800"
+            selection = "00000001000b03010000"
             reference_pcrs = ["0000000000000000000000000000000000000000000000000000000000000000"]
             [[peer]]
             index = 2

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -18,6 +18,7 @@ use crate::signer::HardwareSigner;
 
 use super::get_password;
 
+mod attestation;
 mod dkg;
 mod hardware;
 
@@ -43,6 +44,7 @@ fn descriptor_lookup_for(
 }
 
 #[tracing::instrument(skip(out), fields(path = %path.display()))]
+#[allow(clippy::too_many_arguments)]
 pub fn cmd_frost_network_serve(
     out: &Output,
     path: &Path,
@@ -51,8 +53,15 @@ pub fn cmd_frost_network_serve(
     share_index: Option<u16>,
     auto_contribute_descriptor: bool,
     refuse_raw_sign: bool,
+    attestation_config: Option<&Path>,
+    insecure_no_attestation: bool,
 ) -> Result<()> {
     debug!(group = group_npub, relay, share = ?share_index, refuse_raw_sign, "starting FROST network node");
+
+    // Resolve the attestation policy up front (fail-closed) so a missing or
+    // invalid one fails before we prompt for the password or touch the vault.
+    let tpm_policy =
+        attestation::resolve_serve_policy(out, attestation_config, insecure_no_attestation)?;
 
     let mut keep = Keep::open(path)?;
     let password = get_password("Enter password")?;
@@ -84,14 +93,24 @@ pub fn cmd_frost_network_serve(
 
     let keep = std::sync::Arc::new(std::sync::Mutex::new(keep));
 
-    rt.block_on(async {
+    rt.block_on(async move {
         out.info("Starting FROST coordination node...");
 
         let node = keep_frost_net::KfpNode::new(share, vec![relay.to_string()])
             .await
             .map_err(|e| KeepError::Frost(e.to_string()))?;
-        let node =
+        let mut node =
             node.with_descriptor_lookup(Arc::new(descriptor_lookup_for(keep.clone())));
+        if let Some(policy) = tpm_policy {
+            let pinned = policy.pinned_aks.len();
+            node.set_tpm_attestation_policy(policy);
+            out.field(
+                "Attestation",
+                &format!("TPM policy enforced ({pinned} peer(s) pinned)"),
+            );
+        } else {
+            out.field("Attestation", "DISABLED (--insecure-no-attestation)");
+        }
         if refuse_raw_sign {
             node.set_hooks(Arc::new(keep_frost_net::RefuseRawSignatureHooks));
             out.field(

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -311,6 +311,8 @@ fn dispatch_frost_network(
             share,
             auto_contribute_descriptor,
             refuse_raw_sign,
+            attestation_config,
+            insecure_no_attestation,
         } => {
             let relay = relay.as_deref().unwrap_or(default_relay);
             commands::frost_network::cmd_frost_network_serve(
@@ -321,6 +323,8 @@ fn dispatch_frost_network(
                 share,
                 auto_contribute_descriptor,
                 refuse_raw_sign,
+                attestation_config.as_deref(),
+                insecure_no_attestation,
             )
         }
         FrostNetworkCommands::Peers { group, relay } => {


### PR DESCRIPTION
## Summary

Wires the TPM attestation verifier into the persistent holder runtime. `keep frost network serve` now pins each peer's attestation key and the reference PCRs they must quote, and verifies a peer's measured-boot state (via the verifier from #626) before answering its OPRF evaluation requests. This is the deployment-side counterpart to the library work in #626/#627/#628.

## What's here

- A TOML attestation policy file: a shared PCR `selection` and `reference_pcrs`, plus one `[[peer]]` AK pin per holder. Pins are provisioned out of band (trust-on-first-use). Parsed into the existing `TpmAttestationPolicy`.
- Two flags on `frost network serve`:
  - `--attestation-config <FILE>`: load and enforce the policy.
  - `--insecure-no-attestation`: explicit, loud opt-out for test/dev.
- Fail-closed gate: the node refuses to start unless exactly one of the two is given (neither is rejected, and they are mutually exclusive). The policy is resolved before the password prompt so a bad or missing config fails fast.

Once a policy is set, the node's existing admission path requires `AttestationStatus::Verified` before it will answer evaluations, so an unattested or mismatched peer is refused.

## Trust model

AK pins and reference PCRs are pinned out of band at provisioning (TOFU); there is no manufacturer root of trust for a self-hosted box. A future `attestation provision` command could capture first-seen values to write this file; for now it is authored from the values a peer reports at provisioning.

## Tests

Config parsing (valid; rejects no-peers, malformed AK, short PCR, duplicate peer index) and the fail-closed resolver (requires a choice, rejects both flags, honors the insecure opt-out). Build, fmt, and clippy are clean.

## Follow-up

The producer side (the on-prem box attaching its own TPM quote via `TpmQuoteService`) lands next on the `oprf-unlock` path, behind the `tpm-attestation` feature, so peers running this policy can verify it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring peer TPM attestation when starting the FROST network service.
  * New command-line options let you provide an attestation policy file or explicitly start without attestation.

* **Bug Fixes**
  * Service startup now checks attestation settings early and fails fast if the configuration is missing, invalid, or conflicting.
  * Status output now clearly shows whether attestation is enabled and how many peers are pinned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->