### PR TITLE
keep-cli: attach box TPM quote to oprf-unlock announces

### DIFF
--- a/keep-cli/Cargo.toml
+++ b/keep-cli/Cargo.toml
@@ -78,6 +78,9 @@ uuid = { version = "1.23", features = ["v4", "serde"], optional = true }
 default = []
 testing = ["keep-core/testing"]
 warden = ["dep:reqwest", "dep:uuid"]
+# TPM-side quote producer for the on-prem box (links the tpm2-tss C stack via
+# keep-frost-net). Off by default; only a node that attests via a TPM needs it.
+tpm-attestation = ["keep-frost-net/tpm-attestation"]
 
 [dev-dependencies]
 bitcoin = { workspace = true }

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -709,6 +709,14 @@ pub(crate) enum FrostNetworkCommands {
             help = "Path to this box's 64-byte OPRF key share (TPM-unsealed at boot)"
         )]
         share_file: PathBuf,
+        #[arg(
+            long,
+            value_name = "TCTI",
+            help = "Attest this box's measured boot to holders by attaching a TPM quote to its \
+                    announces. TCTI of the TPM (e.g. device:/dev/tpmrm0). Requires the \
+                    tpm-attestation build feature."
+        )]
+        tpm_tcti: Option<String>,
     },
     /// One-time setup: act as the trusted dealer, generate the OPRF key, split
     /// it, distribute the remote shares to online holders, and write the LUKS

--- a/keep-cli/src/commands/frost_network/attestation.rs
+++ b/keep-cli/src/commands/frost_network/attestation.rs
@@ -219,7 +219,10 @@ mod tests {
         let out = Output::new();
         let rejected = build_announce_attestor(&out, "device:/dev/tpmrm0")
             .is_err_and(|e| e.to_string().contains("tpm-attestation"));
-        assert!(rejected, "default build must reject --tpm-tcti via the feature flag");
+        assert!(
+            rejected,
+            "default build must reject --tpm-tcti via the feature flag"
+        );
     }
 
     // A valid config over the default selection {0,2,4,7,11,12} with one peer.

--- a/keep-cli/src/commands/frost_network/attestation.rs
+++ b/keep-cli/src/commands/frost_network/attestation.rs
@@ -180,6 +180,33 @@ pub fn resolve_serve_policy(
     }
 }
 
+/// Build the TPM-backed announce attestor for this box from a `--tpm-tcti`
+/// string, so its announces carry a fresh measured-boot quote peers can verify.
+/// Only available when built with the `tpm-attestation` feature.
+#[cfg(feature = "tpm-attestation")]
+pub fn build_announce_attestor(
+    out: &Output,
+    tcti: &str,
+) -> Result<std::sync::Arc<dyn keep_frost_net::AnnounceAttestor>> {
+    use keep_frost_net::AnnounceAttestor;
+    let service = keep_frost_net::TpmQuoteService::spawn_from_tcti(tcti)
+        .map_err(|e| err(format!("start TPM quote service: {e}")))?;
+    out.field("Attestation key", &hex::encode(service.ak_sec1()));
+    Ok(std::sync::Arc::new(service))
+}
+
+/// Without the `tpm-attestation` feature there is no TPM producer; `--tpm-tcti`
+/// is rejected so the build limitation is explicit rather than silently ignored.
+#[cfg(not(feature = "tpm-attestation"))]
+pub fn build_announce_attestor(
+    _out: &Output,
+    _tcti: &str,
+) -> Result<std::sync::Arc<dyn keep_frost_net::AnnounceAttestor>> {
+    Err(err(
+        "this build has no TPM support; rebuild with `--features tpm-attestation` to use --tpm-tcti",
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/keep-cli/src/commands/frost_network/attestation.rs
+++ b/keep-cli/src/commands/frost_network/attestation.rs
@@ -211,6 +211,17 @@ pub fn build_announce_attestor(
 mod tests {
     use super::*;
 
+    // A default build (no `tpm-attestation`) must reject `--tpm-tcti` with a
+    // message pointing at the feature flag, not silently ignore it.
+    #[cfg(not(feature = "tpm-attestation"))]
+    #[test]
+    fn rejects_tpm_tcti_without_feature() {
+        let out = Output::new();
+        let rejected = build_announce_attestor(&out, "device:/dev/tpmrm0")
+            .is_err_and(|e| e.to_string().contains("tpm-attestation"));
+        assert!(rejected, "default build must reject --tpm-tcti via the feature flag");
+    }
+
     // A valid config over the default selection {0,2,4,7,11,12} with one peer.
     const VALID: &str = r#"
         selection = "00000001000b03951800"

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -1021,6 +1021,7 @@ fn write_secret_file(path: &Path, bytes: &[u8]) -> Result<()> {
 /// `Output` (which is backed by `Term::stderr()`); the key is never logged.
 #[tracing::instrument(skip(out), fields(path = %path.display()))]
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 pub fn cmd_frost_network_oprf_unlock(
     out: &Output,
     path: &Path,
@@ -1030,6 +1031,7 @@ pub fn cmd_frost_network_oprf_unlock(
     volume_id: &str,
     epoch: u32,
     share_file: &Path,
+    tpm_tcti: Option<&str>,
 ) -> Result<()> {
     debug!(
         group = group_npub,
@@ -1097,6 +1099,13 @@ pub fn cmd_frost_network_oprf_unlock(
         // Install the OPRF key share BEFORE running so this box can answer its
         // own quorum's evaluate requests.
         node.set_oprf_key_share(oprf_share);
+
+        // If a TPM is configured, attach a fresh measured-boot quote to every
+        // announce so holders can verify this box before answering its evals.
+        if let Some(tcti) = tpm_tcti {
+            let attestor = attestation::build_announce_attestor(out, tcti)?;
+            node.set_announce_attestor(attestor);
+        }
 
         out.info("Starting FROST coordination node...");
         let shutdown_tx = node.take_shutdown_handle();

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -1021,7 +1021,6 @@ fn write_secret_file(path: &Path, bytes: &[u8]) -> Result<()> {
 /// `Output` (which is backed by `Term::stderr()`); the key is never logged.
 #[tracing::instrument(skip(out), fields(path = %path.display()))]
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_arguments)]
 pub fn cmd_frost_network_oprf_unlock(
     out: &Output,
     path: &Path,
@@ -1043,6 +1042,15 @@ pub fn cmd_frost_network_oprf_unlock(
     );
 
     let mut keep = Keep::open(path)?;
+
+    // Build the announce attestor BEFORE unlocking, so a config mistake (a build
+    // without `tpm-attestation`, or an unparseable/unreachable TPM) fails fast
+    // without prompting for the password or materializing the OPRF secret.
+    let attestor = match tpm_tcti {
+        Some(tcti) => Some(attestation::build_announce_attestor(out, tcti)?),
+        None => None,
+    };
+
     let password = get_password("Enter password")?;
 
     let spinner = out.spinner("Unlocking vault...");
@@ -1100,10 +1108,9 @@ pub fn cmd_frost_network_oprf_unlock(
         // own quorum's evaluate requests.
         node.set_oprf_key_share(oprf_share);
 
-        // If a TPM is configured, attach a fresh measured-boot quote to every
-        // announce so holders can verify this box before answering its evals.
-        if let Some(tcti) = tpm_tcti {
-            let attestor = attestation::build_announce_attestor(out, tcti)?;
+        // If a TPM is configured, attach the fresh measured-boot quote source to
+        // every announce so holders can verify this box before answering evals.
+        if let Some(attestor) = attestor {
             node.set_announce_attestor(attestor);
         }
 

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -444,6 +444,7 @@ fn dispatch_frost_network(
             volume_id,
             epoch,
             share_file,
+            tpm_tcti,
         } => {
             let relay = relay.as_deref().unwrap_or(default_relay);
             commands::frost_network::cmd_frost_network_oprf_unlock(
@@ -455,6 +456,7 @@ fn dispatch_frost_network(
                 &volume_id,
                 epoch,
                 &share_file,
+                tpm_tcti.as_deref(),
             )
         }
         FrostNetworkCommands::OprfProvision {

--- a/keep-frost-net/src/tpm_producer.rs
+++ b/keep-frost-net/src/tpm_producer.rs
@@ -371,6 +371,17 @@ impl TpmQuoteService {
     pub fn spawn_default(tcti: tss_esapi::TctiNameConf) -> Result<Self> {
         Self::spawn(tcti, DEFAULT_PCR_SLOTS.to_vec())
     }
+
+    /// Convenience constructor that parses a TCTI configuration string (e.g.
+    /// `device:/dev/tpmrm0` or `swtpm:host=localhost,port=2321`) and quotes over
+    /// [`DEFAULT_PCR_SLOTS`]. Lets callers configure the TPM source without
+    /// depending on `tss-esapi` directly.
+    pub fn spawn_from_tcti(tcti: &str) -> Result<Self> {
+        use std::str::FromStr;
+        let conf = tss_esapi::TctiNameConf::from_str(tcti)
+            .map_err(|e| att(format!("invalid TCTI '{tcti}': {e}")))?;
+        Self::spawn_default(conf)
+    }
 }
 
 impl crate::announce_attestor::AnnounceAttestor for TpmQuoteService {
@@ -572,6 +583,17 @@ mod tests {
             ),
             "the quote must not verify against a different announce"
         );
+    }
+
+    // The string-TCTI constructor the CLI uses must open the TPM and create the
+    // AK from a TCTI configuration string.
+    #[test]
+    #[ignore = "requires a TPM; run against swtpm with TPM2TOOLS_TCTI set"]
+    fn spawn_from_tcti_string_works() {
+        use crate::announce_attestor::AnnounceAttestor;
+        let tcti = std::env::var("TPM2TOOLS_TCTI").expect("set TPM2TOOLS_TCTI");
+        let service = TpmQuoteService::spawn_from_tcti(&tcti).expect("spawn from TCTI string");
+        assert_eq!(service.ak_sec1().len(), 65);
     }
 
     // The threaded TpmQuoteService (the AnnounceAttestor the node holds) must

--- a/keep-frost-net/src/tpm_producer.rs
+++ b/keep-frost-net/src/tpm_producer.rs
@@ -539,6 +539,16 @@ mod tests {
         Context::new(tcti).expect("open TPM context")
     }
 
+    // Resolve the TCTI configuration string with the same precedence
+    // `TctiNameConf::from_environment_variable` uses, so a string-TCTI test works
+    // whether the environment exports TPM2TOOLS_TCTI, TCTI, or TEST_TCTI.
+    fn tcti_env_string() -> String {
+        std::env::var("TPM2TOOLS_TCTI")
+            .or_else(|_| std::env::var("TCTI"))
+            .or_else(|_| std::env::var("TEST_TCTI"))
+            .expect("set TPM2TOOLS_TCTI / TCTI (e.g. swtpm:host=localhost,port=2321)")
+    }
+
     // End-to-end against a real (virtual) TPM: produce a quote with the producer,
     // then appraise it with the pure-Rust verifier. Ignored by default because it
     // needs a TPM; run with a swtpm and TPM2TOOLS_TCTI set.
@@ -591,7 +601,7 @@ mod tests {
     #[ignore = "requires a TPM; run against swtpm with TPM2TOOLS_TCTI set"]
     fn spawn_from_tcti_string_works() {
         use crate::announce_attestor::AnnounceAttestor;
-        let tcti = std::env::var("TPM2TOOLS_TCTI").expect("set TPM2TOOLS_TCTI");
+        let tcti = tcti_env_string();
         let service = TpmQuoteService::spawn_from_tcti(&tcti).expect("spawn from TCTI string");
         assert_eq!(service.ak_sec1().len(), 65);
     }


### PR DESCRIPTION
## Summary

Wires the TPM quote producer into the on-prem box's unlock path. With `--tpm-tcti`, `keep frost network oprf-unlock` attaches a fresh measured-boot quote to every announce, so holders running an attestation policy (#629) can verify the box before answering its OPRF evaluation requests. This is the producer-side counterpart to the holder verifier and completes the produce-to-verify loop end to end on the CLI.

## What's here

- `keep-frost-net`: a `TpmQuoteService::spawn_from_tcti(&str)` convenience that parses a TCTI configuration string, so callers configure the TPM source without depending on `tss-esapi` directly.
- `keep-cli`:
  - A `tpm-attestation` feature (off by default) that forwards to `keep-frost-net/tpm-attestation`. Only a node that attests via a TPM links the tpm2-tss C stack; default builds are unaffected.
  - `--tpm-tcti <TCTI>` on `oprf-unlock` (e.g. `device:/dev/tpmrm0`). When set, the box spawns the quote service and installs it as its announce attestor.
  - Built without the feature, `--tpm-tcti` fails with a clear "rebuild with `--features tpm-attestation`" error rather than being silently ignored.

## Threat model closed

A stolen, powered-on box with a reachable relay cannot self-decrypt: when it announces, holders verify its measured-boot quote against their pinned policy and refuse to answer evaluations from a box whose boot state does not match. The box proves its state with this quote.

## Tests

- `keep-frost-net` (swtpm, `#[ignore]`): `spawn_from_tcti_string_works` exercises the exact string-TCTI constructor the CLI uses; the existing produce/verify and threaded-service round-trips still pass.
- `keep-cli`: existing attestation tests pass; default build, fmt, and clippy are clean, and the feature build (`--features tpm-attestation`) is clippy-clean against the real tpm2-tss stack.

## Status

With the holder verifier (#629) and this box producer, keep-u6ne is functionally complete: the box attests, holders verify, and the OPRF gate enforces it. The natural next step is the 3-node swtpm VM test that exercises the whole quorum end to end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional TPM attestation support for the OPRF unlock flow.
  * Introduced a new command-line option to provide a TCTI value for TPM-based measured-boot quotes.
  * Enabled builds to include TPM attestation support through a new feature flag.

* **Bug Fixes**
  * Improved error handling and messaging when TPM attestation is unavailable or a TCTI value cannot be parsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->