### PR TITLE
keep-cli: OPRF holder runtime in frost network serve

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -578,6 +578,17 @@ pub(crate) enum FrostNetworkCommands {
         /// leak the unlock key. Mutually exclusive with `--attestation-config`.
         #[arg(long)]
         insecure_no_attestation: bool,
+        /// Act as an OPRF holder: load this 64-byte OPRF key share at boot so the
+        /// node answers evaluation requests, and seal a freshly enrolled share
+        /// here. If the file is absent the node serves without a share until one
+        /// is enrolled (see --oprf-dealer).
+        #[arg(long, value_name = "FILE")]
+        oprf_share_file: Option<PathBuf>,
+        /// Pin the share index allowed to deal this node an OPRF enrollment. Set
+        /// it to the box's index to accept a share only from the designated
+        /// dealer; without it, enrollment is refused fail-closed.
+        #[arg(long, value_name = "INDEX")]
+        oprf_dealer: Option<u16>,
     },
     Peers {
         #[arg(short, long)]

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -388,20 +388,36 @@ pub fn cmd_frost_network_serve(
                         // ack only on a confirmed write so the dealer is never told
                         // enrollment completed with nothing sealed.
                         let sealed = match &event_seal_path {
-                            Some(path) => match write_secret_file(path, share.as_slice()) {
-                                Ok(()) => {
-                                    tracing::info!(
-                                        dealer_index,
-                                        path = %path.display(),
-                                        "sealed enrolled OPRF share; restart serve with --oprf-share-file to answer evaluations"
-                                    );
-                                    true
+                            Some(path) => {
+                                // The seal write fsyncs the file and its parent dir;
+                                // keep those blocking syscalls off the executor.
+                                let bytes =
+                                    zeroize::Zeroizing::new(share.as_slice().to_vec());
+                                let path = path.clone();
+                                let log_path = path.clone();
+                                let write = tokio::task::spawn_blocking(move || {
+                                    write_secret_file(&path, bytes.as_slice())
+                                })
+                                .await;
+                                match write {
+                                    Ok(Ok(())) => {
+                                        tracing::info!(
+                                            dealer_index,
+                                            path = %log_path.display(),
+                                            "sealed enrolled OPRF share; restart serve with --oprf-share-file to answer evaluations"
+                                        );
+                                        true
+                                    }
+                                    Ok(Err(e)) => {
+                                        tracing::error!(error = %e, "failed to seal enrolled OPRF share");
+                                        false
+                                    }
+                                    Err(e) => {
+                                        tracing::error!(error = %e, "seal write task failed");
+                                        false
+                                    }
                                 }
-                                Err(e) => {
-                                    tracing::error!(error = %e, "failed to seal enrolled OPRF share");
-                                    false
-                                }
-                            },
+                            }
                             None => {
                                 tracing::error!(
                                     "received an OPRF enrollment but --oprf-share-file is not set; cannot seal"
@@ -409,8 +425,17 @@ pub fn cmd_frost_network_serve(
                                 false
                             }
                         };
-                        if let Some(tx) = seal_ack.lock().ok().and_then(|mut g| g.take()) {
-                            let _ = tx.send(sealed);
+                        match seal_ack.lock() {
+                            Ok(mut g) => {
+                                if let Some(tx) = g.take() {
+                                    let _ = tx.send(sealed);
+                                }
+                            }
+                            Err(_) => {
+                                tracing::error!(
+                                    "seal_ack mutex poisoned; cannot ack OPRF enrollment, dealer will time out"
+                                );
+                            }
                         }
                     }
                     Err(_) => break,
@@ -427,8 +452,9 @@ pub fn cmd_frost_network_serve(
         Ok::<_, KeepError>(())
     });
 
-    // `KeyShare` is `Copy` + `Zeroize` but not `ZeroizeOnDrop`: the copy installed
-    // on the node is gone with it, but our local copy must be wiped by hand.
+    // The sealed file bytes are wiped via `Zeroizing`, and the node-resident copy is
+    // wiped by `KfpNode`'s `Drop`. `KeyShare` is `Copy` + `Zeroize` but not
+    // `ZeroizeOnDrop`, so this wipes our remaining local copy by hand.
     if let Some(mut share) = oprf_share {
         share.zeroize();
     }

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -55,6 +55,8 @@ pub fn cmd_frost_network_serve(
     refuse_raw_sign: bool,
     attestation_config: Option<&Path>,
     insecure_no_attestation: bool,
+    oprf_share_file: Option<&Path>,
+    oprf_dealer: Option<u16>,
 ) -> Result<()> {
     debug!(group = group_npub, relay, share = ?share_index, refuse_raw_sign, "starting FROST network node");
 
@@ -88,12 +90,31 @@ pub fn cmd_frost_network_serve(
     out.field("Relay", relay);
     out.newline();
 
+    // Load this holder's OPRF key share if the file is present, so the node can
+    // answer evaluation requests. An absent file means the node serves without a
+    // share (e.g. awaiting its first enrollment); the share is sealed into this
+    // same path on enrollment and takes effect on the next start.
+    let oprf_share: Option<keep_core::oprf::threshold::KeyShare> = match oprf_share_file {
+        Some(p) if p.exists() => {
+            let bytes = zeroize::Zeroizing::new(
+                std::fs::read(p)
+                    .map_err(|e| KeepError::Runtime(format!("read OPRF share file: {e}")))?,
+            );
+            let share = keep_core::oprf::threshold::deserialize_key_share(&bytes)
+                .map_err(|e| KeepError::Frost(format!("invalid OPRF key share: {e}")))?;
+            Some(share)
+        }
+        _ => None,
+    };
+    // Where an enrolled share is sealed, owned so the event loop can move it.
+    let oprf_seal_path = oprf_share_file.map(|p| p.to_path_buf());
+
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
 
     let keep = std::sync::Arc::new(std::sync::Mutex::new(keep));
 
-    rt.block_on(async move {
+    let unlock_result = rt.block_on(async move {
         out.info("Starting FROST coordination node...");
 
         let node = keep_frost_net::KfpNode::new(share, vec![relay.to_string()])
@@ -118,6 +139,18 @@ pub fn cmd_frost_network_serve(
                 "refuse raw (`message_type=raw` rejected, see #524)",
             );
         }
+        // OPRF holder runtime: install the loaded share so this node answers
+        // evaluation requests, and pin the dealer that may enroll it.
+        if let Some(share) = oprf_share {
+            node = node.with_oprf_key_share(share);
+            out.field("OPRF holder", "share loaded (answering evaluations)");
+        } else if oprf_share_file.is_some() {
+            out.field("OPRF holder", "no share yet (awaiting enrollment)");
+        }
+        if let Some(dealer) = oprf_dealer {
+            node.set_expected_oprf_dealer(dealer);
+            out.field("OPRF dealer", &format!("pinned to share {dealer}"));
+        }
         let node = std::sync::Arc::new(node);
 
         let pk = node.pubkey();
@@ -129,6 +162,7 @@ pub fn cmd_frost_network_serve(
         let mut event_rx = node.subscribe();
         let event_node = node.clone();
         let event_keep = keep.clone();
+        let event_seal_path = oprf_seal_path.clone();
         let event_task = tokio::spawn(async move {
             loop {
                 match event_rx.recv().await {
@@ -344,6 +378,41 @@ pub fn cmd_frost_network_serve(
                         let session = hex::encode(&session_id[..8]);
                         tracing::error!(session, error, "descriptor session failed");
                     }
+                    Ok(keep_frost_net::KfpNodeEvent::OprfShareReceived {
+                        dealer_index,
+                        share,
+                        seal_ack,
+                        ..
+                    }) => {
+                        // Durable custody: seal the enrolled share to disk, then
+                        // ack only on a confirmed write so the dealer is never told
+                        // enrollment completed with nothing sealed.
+                        let sealed = match &event_seal_path {
+                            Some(path) => match write_secret_file(path, share.as_slice()) {
+                                Ok(()) => {
+                                    tracing::info!(
+                                        dealer_index,
+                                        path = %path.display(),
+                                        "sealed enrolled OPRF share; restart serve with --oprf-share-file to answer evaluations"
+                                    );
+                                    true
+                                }
+                                Err(e) => {
+                                    tracing::error!(error = %e, "failed to seal enrolled OPRF share");
+                                    false
+                                }
+                            },
+                            None => {
+                                tracing::error!(
+                                    "received an OPRF enrollment but --oprf-share-file is not set; cannot seal"
+                                );
+                                false
+                            }
+                        };
+                        if let Some(tx) = seal_ack.lock().ok().and_then(|mut g| g.take()) {
+                            let _ = tx.send(sealed);
+                        }
+                    }
                     Err(_) => break,
                     _ => {}
                 }
@@ -356,7 +425,14 @@ pub fn cmd_frost_network_serve(
         event_task.abort();
 
         Ok::<_, KeepError>(())
-    })?;
+    });
+
+    // `KeyShare` is `Copy` + `Zeroize` but not `ZeroizeOnDrop`: the copy installed
+    // on the node is gone with it, but our local copy must be wiped by hand.
+    if let Some(mut share) = oprf_share {
+        share.zeroize();
+    }
+    unlock_result?;
 
     Ok(())
 }

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -95,16 +95,20 @@ pub fn cmd_frost_network_serve(
     // share (e.g. awaiting its first enrollment); the share is sealed into this
     // same path on enrollment and takes effect on the next start.
     let oprf_share: Option<keep_core::oprf::threshold::KeyShare> = match oprf_share_file {
-        Some(p) if p.exists() => {
-            let bytes = zeroize::Zeroizing::new(
-                std::fs::read(p)
-                    .map_err(|e| KeepError::Runtime(format!("read OPRF share file: {e}")))?,
-            );
-            let share = keep_core::oprf::threshold::deserialize_key_share(&bytes)
-                .map_err(|e| KeepError::Frost(format!("invalid OPRF key share: {e}")))?;
-            Some(share)
-        }
-        _ => None,
+        Some(p) => match std::fs::read(p) {
+            Ok(raw) => {
+                let bytes = zeroize::Zeroizing::new(raw);
+                let share = keep_core::oprf::threshold::deserialize_key_share(&bytes)
+                    .map_err(|e| KeepError::Frost(format!("invalid OPRF key share: {e}")))?;
+                Some(share)
+            }
+            // Absent file: serve without a share (e.g. awaiting first enrollment).
+            // Any other failure (permissions, I/O) on a configured path is fatal,
+            // not silently ignored.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+            Err(e) => return Err(KeepError::Runtime(format!("read OPRF share file: {e}"))),
+        },
+        None => None,
     };
     // Where an enrolled share is sealed, owned so the event loop can move it.
     let oprf_seal_path = oprf_share_file.map(|p| p.to_path_buf());

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -162,7 +162,7 @@ pub fn cmd_frost_network_serve(
         let mut event_rx = node.subscribe();
         let event_node = node.clone();
         let event_keep = keep.clone();
-        let event_seal_path = oprf_seal_path.clone();
+        let event_seal_path = oprf_seal_path;
         let event_task = tokio::spawn(async move {
             loop {
                 match event_rx.recv().await {
@@ -393,17 +393,16 @@ pub fn cmd_frost_network_serve(
                                 // keep those blocking syscalls off the executor.
                                 let bytes =
                                     zeroize::Zeroizing::new(share.as_slice().to_vec());
-                                let path = path.clone();
-                                let log_path = path.clone();
+                                let owned_path = path.clone();
                                 let write = tokio::task::spawn_blocking(move || {
-                                    write_secret_file(&path, bytes.as_slice())
+                                    write_secret_file(&owned_path, bytes.as_slice())
                                 })
                                 .await;
                                 match write {
                                     Ok(Ok(())) => {
                                         tracing::info!(
                                             dealer_index,
-                                            path = %log_path.display(),
+                                            path = %path.display(),
                                             "sealed enrolled OPRF share; restart serve with --oprf-share-file to answer evaluations"
                                         );
                                         true

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -313,6 +313,8 @@ fn dispatch_frost_network(
             refuse_raw_sign,
             attestation_config,
             insecure_no_attestation,
+            oprf_share_file,
+            oprf_dealer,
         } => {
             let relay = relay.as_deref().unwrap_or(default_relay);
             commands::frost_network::cmd_frost_network_serve(
@@ -325,6 +327,8 @@ fn dispatch_frost_network(
                 refuse_raw_sign,
                 attestation_config.as_deref(),
                 insecure_no_attestation,
+                oprf_share_file.as_deref(),
+                oprf_dealer,
             )
         }
         FrostNetworkCommands::Peers { group, relay } => {


### PR DESCRIPTION
## Summary

Makes `keep frost network serve` a functional OPRF holder. Until now only the box (`oprf-unlock`) loaded an OPRF share; a phone/replica holder running `serve` had no share, so it could not answer evaluation requests and a 2-of-3 unlock could never reach threshold. This wires the holder side of the OPRF runtime.

## What's here

Two flags on `frost network serve`:

- `--oprf-share-file <FILE>`: the holder's 64-byte OPRF key share. If present at startup it is loaded and the node answers evaluation requests; it is also the destination where a freshly enrolled share is sealed.
- `--oprf-dealer <INDEX>`: pin the share index allowed to deal an enrollment to this node. Without it, enrollment is refused fail-closed (the node's existing default), so accepting a share is an explicit opt-in to the designated dealer.

Behavior:
- At boot, an existing share file is loaded (`deserialize_key_share`) and installed, so the holder answers evals immediately.
- On enrollment, the `OprfShareReceived` event is handled with durable custody: the share is sealed to the share file via the existing atomic 0600 `write_secret_file`, and the holder acks only on a confirmed write (a failed or unconfigured seal acks failure, so the dealer is never told enrollment completed with nothing sealed). The sealed share takes effect on the next start, mirroring the box's TPM-unsealed-at-boot model.
- The loaded `KeyShare` (Copy + Zeroize, not ZeroizeOnDrop) is wiped by hand after the runtime exits.

## Why this completes the holder runtime

With the box producer (#630) and holder verifier (#629) already in, this is the last missing deployable piece: phone/replica holders can now receive their shares during provisioning and answer evaluations during unlock, gated by the attestation policy. That unblocks the 3-node end-to-end VM test.

## Tests

The OPRF protocol (eval-with-share, enrollment, durable-custody seal/ack, rate limiting) is covered by the existing keep-frost-net multinode tests (13 passing). This PR is thin CLI glue over those tested primitives plus the atomic share-file writer; build, fmt, and clippy are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional OPRF startup settings for server mode, including loading a share from disk and specifying a dealer index.
  * Servers can now persist newly enrolled OPRF shares and report their OPRF status during startup.

* **Bug Fixes**
  * Improved handling of OPRF share enrollment so shares are written safely before being acknowledged.
  * Added better failure handling when share persistence is unavailable or misconfigured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->