### PR TITLE
keep-frost-net: end-to-end threshold-OPRF unlock gated on real attestation

### DIFF
--- a/keep-frost-net/Cargo.toml
+++ b/keep-frost-net/Cargo.toml
@@ -59,6 +59,7 @@ tokio-test = "0.4"
 nostr-relay-builder = "0.44"
 chrono = "0.4"
 proptest = "1.11"
+p256 = { version = "0.13", features = ["ecdsa"] }
 keep-core = { path = "../keep-core", features = ["allow-ws", "allow-internal", "oprf"] }
 
 [[test]]

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -76,6 +76,8 @@ mod protocol;
 mod psbt_session;
 mod recovery_signers;
 mod session;
+#[cfg(any(test, feature = "testing"))]
+pub mod test_support;
 mod tpm_policy;
 #[cfg(feature = "tpm-attestation")]
 pub mod tpm_producer;

--- a/keep-frost-net/src/test_support.rs
+++ b/keep-frost-net/src/test_support.rs
@@ -1,0 +1,42 @@
+//! Shared test-support helpers for building synthetic TPM quote evidence.
+//!
+//! Gated behind `cfg(test)` for this crate's own unit tests and the `testing`
+//! feature for the integration-test binary, so the `TPMS_ATTEST` wire format
+//! lives in exactly one place. A divergence between the verifier's unit tests
+//! and the end-to-end attestation tests would otherwise let a quote builder
+//! drift silently, masking a real attestation regression.
+
+use p256::ecdsa::SigningKey;
+
+/// Marshalled `TPML_PCR_SELECTION` for the SHA-256 bank over a single PCR.
+pub fn one_pcr_selection() -> Vec<u8> {
+    hex::decode("00000001000b03800000").unwrap()
+}
+
+/// Build a self-consistent, signed `TPMS_ATTEST` quote over one PCR bound to
+/// `nonce`, signed with `sk`. Mirrors the producer's exact wire format.
+pub fn build_signed_quote(
+    nonce: &[u8],
+    pcr_select: &[u8],
+    pcr_value: &[u8; 32],
+    sk: &SigningKey,
+) -> (Vec<u8>, Vec<u8>) {
+    use p256::ecdsa::{signature::Signer, Signature};
+    use sha2::{Digest, Sha256};
+
+    let mut attest = Vec::new();
+    attest.extend_from_slice(&0xFF54_4347u32.to_be_bytes()); // TPM_GENERATED
+    attest.extend_from_slice(&0x8018u16.to_be_bytes()); // TPM_ST_ATTEST_QUOTE
+    attest.extend_from_slice(&0u16.to_be_bytes()); // TPM2B_NAME qualifiedSigner: empty
+    attest.extend_from_slice(&(nonce.len() as u16).to_be_bytes()); // TPM2B_DATA extraData
+    attest.extend_from_slice(nonce);
+    attest.extend_from_slice(&[0u8; 17]); // TPMS_CLOCK_INFO
+    attest.extend_from_slice(&[0u8; 8]); // firmwareVersion
+    attest.extend_from_slice(pcr_select); // TPML_PCR_SELECTION (== pinned selection)
+    let digest = Sha256::digest(pcr_value);
+    attest.extend_from_slice(&(digest.len() as u16).to_be_bytes()); // TPM2B_DIGEST pcrDigest
+    attest.extend_from_slice(&digest);
+
+    let sig: Signature = sk.sign(&attest); // ECDSA-P256 over SHA-256(attest)
+    (attest, sig.to_bytes().to_vec())
+}

--- a/keep-frost-net/src/tpm_policy.rs
+++ b/keep-frost-net/src/tpm_policy.rs
@@ -201,35 +201,12 @@ mod tests {
         assert!(matches!(status, AttestationStatus::Failed(_)));
     }
 
-    // Build a self-consistent, signed TPMS_ATTEST quote with the given qualifyingData (nonce),
-    // PCR selection, and single PCR value, signed with `sk`. This exercises the full
-    // nonce-derivation-to-verify wiring with a 32-byte announce-bound nonce, which the fixed
-    // test-vector quote (a 16-byte nonce) cannot.
-    fn build_signed_quote(
-        nonce: &[u8],
-        pcr_select: &[u8],
-        pcr_value: &[u8; 32],
-        sk: &p256::ecdsa::SigningKey,
-    ) -> (Vec<u8>, Vec<u8>) {
-        use p256::ecdsa::{signature::Signer, Signature};
-        use sha2::{Digest, Sha256};
-
-        let mut attest = Vec::new();
-        attest.extend_from_slice(&0xFF54_4347u32.to_be_bytes()); // TPM_GENERATED
-        attest.extend_from_slice(&0x8018u16.to_be_bytes()); // TPM_ST_ATTEST_QUOTE
-        attest.extend_from_slice(&0u16.to_be_bytes()); // TPM2B_NAME qualifiedSigner: empty
-        attest.extend_from_slice(&(nonce.len() as u16).to_be_bytes()); // TPM2B_DATA extraData
-        attest.extend_from_slice(nonce);
-        attest.extend_from_slice(&[0u8; 17]); // TPMS_CLOCK_INFO
-        attest.extend_from_slice(&[0u8; 8]); // firmwareVersion
-        attest.extend_from_slice(pcr_select); // TPML_PCR_SELECTION (== pinned selection)
-        let digest = Sha256::digest(pcr_value);
-        attest.extend_from_slice(&(digest.len() as u16).to_be_bytes()); // TPM2B_DIGEST pcrDigest
-        attest.extend_from_slice(&digest);
-
-        let sig: Signature = sk.sign(&attest); // ECDSA-P256 over SHA-256(attest)
-        (attest, sig.to_bytes().to_vec())
-    }
+    // The single-PCR `TPMS_ATTEST` builder lives in `crate::test_support` so the
+    // verifier's unit tests and the end-to-end attestation tests share one wire
+    // format. This case exercises the full nonce-derivation-to-verify wiring with
+    // a 32-byte announce-bound nonce, which the fixed test-vector quote (a 16-byte
+    // nonce) cannot.
+    use crate::test_support::build_signed_quote;
 
     #[test]
     fn tpm_appraise_verifies_announce_bound_derived_nonce() {
@@ -247,7 +224,7 @@ mod tests {
             .as_bytes()
             .to_vec();
 
-        let pcr_select = h("00000001000b03800000"); // sha256, one PCR
+        let pcr_select = crate::test_support::one_pcr_selection(); // sha256, one PCR
         let pcr_value = [0x11u8; 32];
         let (attest, signature) = build_signed_quote(&nonce, &pcr_select, &pcr_value, &sk);
 

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -3280,36 +3280,7 @@ async fn test_announce_fails_closed_when_quote_fails() {
 // reaching `Verified` on its own before answering the box's OPRF evaluation.
 // This is the protocol capstone for the 3-node deployment.
 
-/// Marshalled `TPML_PCR_SELECTION` for the SHA-256 bank over a single PCR.
-fn one_pcr_selection() -> Vec<u8> {
-    hex::decode("00000001000b03800000").unwrap()
-}
-
-/// Build a self-consistent, signed `TPMS_ATTEST` quote over one PCR bound to
-/// `nonce`, signed with `sk`. Mirrors the producer's exact wire format.
-fn build_signed_quote(
-    nonce: &[u8],
-    pcr_select: &[u8],
-    pcr_value: &[u8; 32],
-    sk: &p256::ecdsa::SigningKey,
-) -> (Vec<u8>, Vec<u8>) {
-    use p256::ecdsa::{signature::Signer, Signature};
-    use sha2::{Digest, Sha256};
-    let mut attest = Vec::new();
-    attest.extend_from_slice(&0xFF54_4347u32.to_be_bytes()); // TPM_GENERATED
-    attest.extend_from_slice(&0x8018u16.to_be_bytes()); // TPM_ST_ATTEST_QUOTE
-    attest.extend_from_slice(&0u16.to_be_bytes()); // qualifiedSigner: empty
-    attest.extend_from_slice(&(nonce.len() as u16).to_be_bytes()); // extraData len
-    attest.extend_from_slice(nonce);
-    attest.extend_from_slice(&[0u8; 17]); // TPMS_CLOCK_INFO
-    attest.extend_from_slice(&[0u8; 8]); // firmwareVersion
-    attest.extend_from_slice(pcr_select); // TPML_PCR_SELECTION
-    let digest = Sha256::digest(pcr_value);
-    attest.extend_from_slice(&(digest.len() as u16).to_be_bytes()); // pcrDigest len
-    attest.extend_from_slice(&digest);
-    let sig: Signature = sk.sign(&attest); // ECDSA-P256 over SHA-256(attest)
-    (attest, sig.to_bytes().to_vec())
-}
+use keep_frost_net::test_support::{build_signed_quote, one_pcr_selection};
 
 /// A test announce attestor that signs a valid quote for each announce nonce,
 /// the in-process stand-in for `TpmQuoteService` (proven against swtpm elsewhere).
@@ -3415,20 +3386,38 @@ async fn test_oprf_unlock_with_real_tpm_attestation_2of3() {
     let (mut n1, mut n2) = (0u32, 0u32);
     let discovery = timeout(Duration::from_secs(45), async {
         loop {
+            // Match the full `recv()` result: a closed stream (a crashed node)
+            // must surface as a legible error, not a `select!` "all branches
+            // disabled" panic that hides which node died. A lagged stream is
+            // transient and ignored, matching the original tolerant behaviour.
+            use tokio::sync::broadcast::error::RecvError;
             tokio::select! {
-                Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx1.recv() => n1 += 1,
-                Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx2.recv() => n2 += 1,
+                ev = rx1.recv() => match ev {
+                    Ok(KfpNodeEvent::PeerDiscovered { .. }) => n1 += 1,
+                    Ok(_) | Err(RecvError::Lagged(_)) => {}
+                    Err(RecvError::Closed) => return Err("box event stream closed".to_string()),
+                },
+                ev = rx2.recv() => match ev {
+                    Ok(KfpNodeEvent::PeerDiscovered { .. }) => n2 += 1,
+                    Ok(_) | Err(RecvError::Lagged(_)) => {}
+                    Err(RecvError::Closed) => return Err("holder event stream closed".to_string()),
+                },
             }
             if n1 >= 1 && n2 >= 1 {
-                return;
+                return Ok(());
             }
         }
     })
     .await;
-    if discovery.is_err() {
+    let discovery_failure = match discovery {
+        Ok(Ok(())) => None,
+        Ok(Err(msg)) => Some(msg),
+        Err(_) => Some(format!("discovery timed out: n1={n1}, n2={n2}")),
+    };
+    if let Some(msg) = discovery_failure {
         graceful_shutdown(shutdown1, h1).await;
         graceful_shutdown(shutdown2, h2).await;
-        panic!("discovery timed out: n1={n1}, n2={n2}");
+        panic!("{msg}");
     }
 
     let result = timeout(
@@ -3477,6 +3466,7 @@ async fn test_oprf_unlock_blocked_when_box_unattested() {
     node2.set_tpm_attestation_policy(policy);
 
     let mut rx1 = node1.subscribe();
+    let mut rx2 = node2.subscribe();
     let shutdown1 = node1.take_shutdown_handle();
     let shutdown2 = node2.take_shutdown_handle();
     let node1 = Arc::new(node1);
@@ -3506,6 +3496,31 @@ async fn test_oprf_unlock_blocked_when_box_unattested() {
         panic!("box never discovered the holder");
     }
 
+    // Watch the holder's stream: it must NEVER discover the unattested box
+    // (share index 1). That is the gate firing, and it attributes the blocked
+    // unlock to attestation rejection rather than to an incidental timeout or a
+    // dropped relay message. The flag is read after the unlock window closes.
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tokio::sync::broadcast::error::RecvError;
+    let holder_admitted_box = Arc::new(AtomicBool::new(false));
+    // A lagged stream means a dropped event could have hidden a bypass, so we
+    // fail safe rather than let the assertion pass on incomplete evidence.
+    let watcher_lagged = Arc::new(AtomicBool::new(false));
+    let admitted = Arc::clone(&holder_admitted_box);
+    let lagged = Arc::clone(&watcher_lagged);
+    let watcher = tokio::spawn(async move {
+        loop {
+            match rx2.recv().await {
+                Ok(KfpNodeEvent::PeerDiscovered { share_index: 1, .. }) => {
+                    admitted.store(true, Ordering::SeqCst);
+                }
+                Ok(_) => {}
+                Err(RecvError::Lagged(_)) => lagged.store(true, Ordering::SeqCst),
+                Err(RecvError::Closed) => break,
+            }
+        }
+    });
+
     // The holder never sends a partial, so the box stays below threshold; this
     // window only needs to be long enough to be sure it will not succeed.
     let result = timeout(
@@ -3513,8 +3528,18 @@ async fn test_oprf_unlock_blocked_when_box_unattested() {
         node1.request_oprf_unlock(OPRF_INPUT, "vault0", 1),
     )
     .await;
+    watcher.abort();
+    let _ = watcher.await; // join the aborted task so its flag write is visible
     graceful_shutdown(shutdown1, h1).await;
     graceful_shutdown(shutdown2, h2).await;
+    assert!(
+        !watcher_lagged.load(Ordering::SeqCst),
+        "holder event watcher lagged: cannot prove the attestation gate held"
+    );
+    assert!(
+        !holder_admitted_box.load(Ordering::SeqCst),
+        "holder must never discover the unattested box: the attestation gate was bypassed"
+    );
     assert!(
         !matches!(result, Ok(Ok(_))),
         "unlock must NOT succeed when the box is unattested (gate bypassed)"

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -3264,3 +3264,252 @@ async fn test_announce_fails_closed_when_quote_fails() {
         "the failure must be the attestation fail-closed path, got {err:?}"
     );
 }
+
+// ===== keep-4zhi: end-to-end threshold-OPRF unlock with REAL attestation =====
+//
+// The unlock/enroll tests above inject `Verified` via `test_set_peer_attestation`.
+// These instead drive attestation through the real path: the box attaches a TPM
+// quote to its announce, and the holder appraises it against a pinned policy,
+// reaching `Verified` on its own before answering the box's OPRF evaluation.
+// This is the protocol capstone for the 3-node deployment.
+
+/// Marshalled `TPML_PCR_SELECTION` for the SHA-256 bank over a single PCR.
+fn one_pcr_selection() -> Vec<u8> {
+    hex::decode("00000001000b03800000").unwrap()
+}
+
+/// Build a self-consistent, signed `TPMS_ATTEST` quote over one PCR bound to
+/// `nonce`, signed with `sk`. Mirrors the producer's exact wire format.
+fn build_signed_quote(
+    nonce: &[u8],
+    pcr_select: &[u8],
+    pcr_value: &[u8; 32],
+    sk: &p256::ecdsa::SigningKey,
+) -> (Vec<u8>, Vec<u8>) {
+    use p256::ecdsa::{signature::Signer, Signature};
+    use sha2::{Digest, Sha256};
+    let mut attest = Vec::new();
+    attest.extend_from_slice(&0xFF54_4347u32.to_be_bytes()); // TPM_GENERATED
+    attest.extend_from_slice(&0x8018u16.to_be_bytes()); // TPM_ST_ATTEST_QUOTE
+    attest.extend_from_slice(&0u16.to_be_bytes()); // qualifiedSigner: empty
+    attest.extend_from_slice(&(nonce.len() as u16).to_be_bytes()); // extraData len
+    attest.extend_from_slice(nonce);
+    attest.extend_from_slice(&[0u8; 17]); // TPMS_CLOCK_INFO
+    attest.extend_from_slice(&[0u8; 8]); // firmwareVersion
+    attest.extend_from_slice(pcr_select); // TPML_PCR_SELECTION
+    let digest = Sha256::digest(pcr_value);
+    attest.extend_from_slice(&(digest.len() as u16).to_be_bytes()); // pcrDigest len
+    attest.extend_from_slice(&digest);
+    let sig: Signature = sk.sign(&attest); // ECDSA-P256 over SHA-256(attest)
+    (attest, sig.to_bytes().to_vec())
+}
+
+/// A test announce attestor that signs a valid quote for each announce nonce,
+/// the in-process stand-in for `TpmQuoteService` (proven against swtpm elsewhere).
+struct ValidQuoteAttestor {
+    sk: p256::ecdsa::SigningKey,
+    ak_sec1: Vec<u8>,
+    pcr_value: [u8; 32],
+}
+
+impl ValidQuoteAttestor {
+    fn new() -> Self {
+        let sk = p256::ecdsa::SigningKey::from_slice(&[0x77u8; 32]).unwrap();
+        let ak_sec1 = sk
+            .verifying_key()
+            .to_encoded_point(false)
+            .as_bytes()
+            .to_vec();
+        Self {
+            sk,
+            ak_sec1,
+            pcr_value: [0x11u8; 32],
+        }
+    }
+
+    /// The verifier policy a peer pins to verify quotes from this attestor.
+    fn policy(&self, box_index: u16) -> keep_frost_net::TpmAttestationPolicy {
+        let mut pinned = std::collections::HashMap::new();
+        pinned.insert(box_index, self.ak_sec1.clone());
+        keep_frost_net::TpmAttestationPolicy::new(one_pcr_selection(), vec![self.pcr_value], pinned)
+    }
+}
+
+impl keep_frost_net::AnnounceAttestor for ValidQuoteAttestor {
+    fn ak_sec1(&self) -> Vec<u8> {
+        self.ak_sec1.clone()
+    }
+    fn request_quote(
+        &self,
+        nonce: [u8; 32],
+    ) -> tokio::sync::oneshot::Receiver<keep_frost_net::Result<keep_frost_net::TpmQuoteEvidence>>
+    {
+        let (attest, signature) =
+            build_signed_quote(&nonce, &one_pcr_selection(), &self.pcr_value, &self.sk);
+        let ev = keep_frost_net::TpmQuoteEvidence {
+            attest,
+            signature,
+            ak_sec1: self.ak_sec1.clone(),
+            pcr_values: vec![hex::encode(self.pcr_value)],
+        };
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let _ = tx.send(Ok(ev));
+        rx
+    }
+}
+
+/// Happy path: the box attaches a real TPM quote to its announce; the holder
+/// pins the box's AK and reaches `Verified` on its own (no injection), then
+/// answers the box's evaluation. A 2-of-3 unlock derives the 32-byte key.
+#[tokio::test]
+async fn test_oprf_unlock_with_real_tpm_attestation_2of3() {
+    use std::sync::Arc;
+
+    let mock_relay = MockRelay::run().await.expect("relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pkg) = dealer.generate("test-oprf-attest-ok").unwrap();
+    let share1 = shares.remove(0); // box id 1
+    let share2 = shares.remove(0); // holder id 2
+    let oprf = split_oprf_key_2of3();
+
+    let attestor = Arc::new(ValidQuoteAttestor::new());
+    let policy = attestor.policy(1);
+
+    let mut node1 = KfpNode::new(share1, vec![relay.clone()])
+        .await
+        .expect("box");
+    node1.set_oprf_key_share(oprf[0]);
+    node1.set_announce_attestor(attestor); // box self-attests on every announce
+
+    let mut node2 = KfpNode::new(share2, vec![relay]).await.expect("holder");
+    node2.set_oprf_key_share(oprf[1]);
+    node2.set_hooks(Arc::new(ApproveOprfHooks));
+    node2.set_tpm_attestation_policy(policy); // holder verifies the box
+
+    let mut rx1 = node1.subscribe();
+    let mut rx2 = node2.subscribe();
+    let shutdown1 = node1.take_shutdown_handle();
+    let shutdown2 = node2.take_shutdown_handle();
+    let node1 = Arc::new(node1);
+    let node2 = Arc::new(node2);
+    let r1 = Arc::clone(&node1);
+    let r2 = Arc::clone(&node2);
+    let h1 = tokio::spawn(async move {
+        let _ = r1.run().await;
+    });
+    let h2 = tokio::spawn(async move {
+        let _ = r2.run().await;
+    });
+
+    // Mutual discovery: the holder discovering the box means it processed AND
+    // verified the box's quote, so the box is `Verified` with no injection.
+    let (mut n1, mut n2) = (0u32, 0u32);
+    let discovery = timeout(Duration::from_secs(45), async {
+        loop {
+            tokio::select! {
+                Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx1.recv() => n1 += 1,
+                Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx2.recv() => n2 += 1,
+            }
+            if n1 >= 1 && n2 >= 1 {
+                return;
+            }
+        }
+    })
+    .await;
+    if discovery.is_err() {
+        graceful_shutdown(shutdown1, h1).await;
+        graceful_shutdown(shutdown2, h2).await;
+        panic!("discovery timed out: n1={n1}, n2={n2}");
+    }
+
+    let result = timeout(
+        Duration::from_secs(45),
+        node1.request_oprf_unlock(OPRF_INPUT, "vault0", 1),
+    )
+    .await;
+    graceful_shutdown(shutdown1, h1).await;
+    graceful_shutdown(shutdown2, h2).await;
+    match result {
+        Ok(Ok(key)) => assert_eq!(key.len(), 32, "derived LUKS key must be 32 bytes"),
+        Ok(Err(e)) => panic!("unlock failed despite valid attestation: {e}"),
+        Err(_) => panic!("unlock timed out despite valid attestation"),
+    }
+}
+
+/// Negative: the box attaches NO quote, so the holder (which requires
+/// attestation) refuses to answer. With the holder out, the box is alone below
+/// threshold and the unlock cannot complete: the gate, reached naturally,
+/// prevents a single share from opening the volume.
+#[tokio::test]
+async fn test_oprf_unlock_blocked_when_box_unattested() {
+    use std::sync::Arc;
+
+    let mock_relay = MockRelay::run().await.expect("relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pkg) = dealer.generate("test-oprf-attest-blocked").unwrap();
+    let share1 = shares.remove(0); // box id 1
+    let share2 = shares.remove(0); // holder id 2
+    let oprf = split_oprf_key_2of3();
+
+    // The holder pins a policy but the box presents NO attestor, so it never
+    // reaches Verified at the holder.
+    let policy = ValidQuoteAttestor::new().policy(1);
+
+    let mut node1 = KfpNode::new(share1, vec![relay.clone()])
+        .await
+        .expect("box");
+    node1.set_oprf_key_share(oprf[0]); // box: no announce attestor
+
+    let mut node2 = KfpNode::new(share2, vec![relay]).await.expect("holder");
+    node2.set_oprf_key_share(oprf[1]);
+    node2.set_hooks(Arc::new(ApproveOprfHooks));
+    node2.set_tpm_attestation_policy(policy);
+
+    let mut rx1 = node1.subscribe();
+    let shutdown1 = node1.take_shutdown_handle();
+    let shutdown2 = node2.take_shutdown_handle();
+    let node1 = Arc::new(node1);
+    let node2 = Arc::new(node2);
+    let r1 = Arc::clone(&node1);
+    let r2 = Arc::clone(&node2);
+    let h1 = tokio::spawn(async move {
+        let _ = r1.run().await;
+    });
+    let h2 = tokio::spawn(async move {
+        let _ = r2.run().await;
+    });
+
+    // The box (no policy) discovers the holder; the holder rejects the box's
+    // unattested announce, so we only wait on the box side.
+    let discovered = timeout(Duration::from_secs(45), async {
+        loop {
+            if let Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx1.recv().await {
+                return;
+            }
+        }
+    })
+    .await;
+    if discovered.is_err() {
+        graceful_shutdown(shutdown1, h1).await;
+        graceful_shutdown(shutdown2, h2).await;
+        panic!("box never discovered the holder");
+    }
+
+    // The holder never sends a partial, so the box stays below threshold; this
+    // window only needs to be long enough to be sure it will not succeed.
+    let result = timeout(
+        Duration::from_secs(12),
+        node1.request_oprf_unlock(OPRF_INPUT, "vault0", 1),
+    )
+    .await;
+    graceful_shutdown(shutdown1, h1).await;
+    graceful_shutdown(shutdown2, h2).await;
+    assert!(
+        !matches!(result, Ok(Ok(_))),
+        "unlock must NOT succeed when the box is unattested (gate bypassed)"
+    );
+}

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -444,10 +444,17 @@ async fn test_health_check_then_sign_no_deadlock() {
         panic!("Peer discovery timed out: only {peers_discovered} peers discovered");
     }
 
-    // The deadlock manifested here: before the fix this never returned.
+    // node3 having discovered both peers does not guarantee they have processed
+    // node3's announce yet; let the reciprocal announces flush so both are ready
+    // to answer node3's ping before we measure responsiveness.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // The deadlock manifested here: before the fix this never returned. The ping
+    // window is generous so a loaded (e.g. macOS CI) runner still collects both
+    // pongs; the point of the test is that health_check returns at all.
     let health = timeout(
-        Duration::from_secs(15),
-        node3.health_check(Duration::from_secs(2)),
+        Duration::from_secs(20),
+        node3.health_check(Duration::from_secs(8)),
     )
     .await;
 

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 mod api;
 mod auth;
 mod bunker;


### PR DESCRIPTION
## Summary

Adds the protocol-level end-to-end test for the threshold-OPRF unlock with TPM attestation enforced through the real path. The existing unlock/enroll tests inject `Verified` via `test_set_peer_attestation`; these instead drive attestation naturally: the box attaches a TPM quote to its announce, the holder appraises it against a pinned policy and reaches `Verified` on its own, and only then answers the box's evaluation.

This exercises the whole chain wired across #626 to #631 (produce a quote, attach it to the announce, verify it cross-node, gate OPRF eval on the result) in one flow, deterministically and without a TPM.

## Tests

- `test_oprf_unlock_with_real_tpm_attestation_2of3` (happy): the box self-attests on every announce; the holder pins the box's AK and reference PCR. Mutual discovery implies the holder verified the quote, so the box is `Verified` with no injection. The 2-of-3 unlock derives the 32-byte key.
- `test_oprf_unlock_blocked_when_box_unattested` (negative): the box presents no quote, so the holder (which requires attestation) rejects its announce and never answers. With the holder out, the box is alone below threshold and the unlock does not complete, proving the gate (reached naturally) stops a single share from opening the volume.

An in-process `ValidQuoteAttestor` signs a real ECDSA-P256 quote bound to each announce nonce (the stand-in for `TpmQuoteService`, which is itself proven against swtpm in keep-frost-net). `p256` is added as a dev-dependency; it is already in the normal dependency tree, so `deny` is unaffected. Build, fmt, and clippy are clean.

## Relation to keep-4zhi

This is the protocol capstone: it proves the quorum-only unlock and the attestation gate end to end at the library level. The remaining part of the bead is the boot-path realism (a NixOS VM running the CLI through cryptsetup), which can build on this.
