### PR TITLE
attestation: review-pass fixes + add keep-node to ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Keep runs as a CLI, a desktop app (Linux/macOS/Windows), a mobile library (Andro
 | this repo | Rust | Encrypted vault, CLI, desktop app, Nitro Enclave signing, and [`keep-web`](keep-web) headless co-signer |
 | [keep-android](https://github.com/privkeyio/keep-android) | Kotlin | FROST mobile signer with NIP-55 and NIP-46 |
 | [keep-esp32](https://github.com/privkeyio/keep-esp32) | C | Air-gapped ESP32-S3 hardware signer |
+| [keep-node](https://github.com/privkeyio/keep-node) | Nix | Self-sovereign NixOS security appliance with threshold-OPRF boot unlock |
 | [keep-startos](https://github.com/start9-community/keep-startos) | TypeScript | Always-on FROST co-signer node packaging |
 
 ## Features

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -573,9 +573,11 @@ pub(crate) enum FrostNetworkCommands {
         /// unless `--insecure-no-attestation` is set.
         #[arg(long, value_name = "FILE")]
         attestation_config: Option<PathBuf>,
-        /// Run WITHOUT verifying peer TPM attestation. Test/dev only: an
-        /// unattested holder answers OPRF evaluations from any peer, which can
-        /// leak the unlock key. Mutually exclusive with `--attestation-config`.
+        /// Run without a peer-attestation policy (test/dev only). The OPRF
+        /// oracle independently requires a `Verified` peer, so with no policy no
+        /// peer is ever verified and the node serves NO OPRF evaluations; it
+        /// still participates in FROST coordination. Mutually exclusive with
+        /// `--attestation-config`.
         #[arg(long)]
         insecure_no_attestation: bool,
         /// Act as an OPRF holder: load this 64-byte OPRF key share at boot so the

--- a/keep-cli/src/commands/frost_network/attestation.rs
+++ b/keep-cli/src/commands/frost_network/attestation.rs
@@ -168,8 +168,9 @@ pub fn resolve_serve_policy(
         (Some(path), false) => Ok(Some(load_tpm_policy(path)?)),
         (None, true) => {
             out.warn(
-                "INSECURE: --insecure-no-attestation set; this node will NOT verify peer TPM \
-                 attestation before answering OPRF evaluations.",
+                "INSECURE: --insecure-no-attestation set; this node configures no peer-attestation \
+                 policy. The OPRF oracle still requires a Verified peer, so without a policy it \
+                 serves NO OPRF evaluations; the node participates only in FROST coordination.",
             );
             Ok(None)
         }

--- a/keep-frost-net/src/tpm_policy.rs
+++ b/keep-frost-net/src/tpm_policy.rs
@@ -51,16 +51,12 @@ pub(crate) fn appraise_tpm_quote(
     pol: &TpmAttestationPolicy,
     nonce: &[u8],
 ) -> AttestationStatus {
-    // TOFU: the AK must be pinned for this share and match exactly.
-    let pinned = match pol.pinned_aks.get(&share_index) {
-        Some(ak) => ak,
-        None => {
-            return AttestationStatus::Failed(format!(
-                "AK not pinned or changed for share {share_index}"
-            ))
-        }
-    };
-    if pinned.as_slice().ct_eq(ev.ak_sec1.as_slice()).unwrap_u8() != 1 {
+    // TOFU: the AK must be pinned for this share and match exactly (constant-time).
+    let pinned_ok = pol
+        .pinned_aks
+        .get(&share_index)
+        .is_some_and(|ak| ak.as_slice().ct_eq(ev.ak_sec1.as_slice()).unwrap_u8() == 1);
+    if !pinned_ok {
         return AttestationStatus::Failed(format!(
             "AK not pinned or changed for share {share_index}"
         ));
@@ -94,25 +90,12 @@ pub(crate) fn appraise_tpm_quote(
 mod tests {
     use super::*;
 
-    // Real swtpm quote (keep-node/tpm-quote-test-vector.json), tpm2_checkquote-verified.
-    const ATTEST: &str = "ff54434780180022000bb9df3193fe4f66ac5a3ee8f8552e454d20bbae633354bcff12b65d581f9d38c7001000112233445566778899aabbccddeeff000000000000041f000000010000000001202401250012000000000001000b03951800002094d0f020a3c4d09b8b88e69e7a093a38ec0ff9715cfdc70285d99d236c52990a";
-    const SIG_R: &str = "0408dac9c80e649049e75fc74d6e1634fa4922066ce488b49b5110e7125b172b";
-    const SIG_S: &str = "124fd1dc171546bde98f4409ad002fa7ccad75a65374ea7ee96381de337b34f0";
-    const AK_X: &str = "f533789fb86ad512ca3e930df08cd16396d14c30c79c46a88839b574a3dfb327";
-    const AK_Y: &str = "1b3db55b2abdc884e40898e95dfffd2c7e8554526d4e1f651779bab1f81300cb";
-    const NONCE: &str = "00112233445566778899aabbccddeeff";
-    const PCR_SELECT: &str = "00000001000b03951800";
-    const PCR11: &str = "cf2b0db7514f320c315130275a960f6e6ed80744c754c687069d7a9f55d704f0";
+    // The real swtpm quote vector (ATTEST/SIG_*/AK_*/NONCE/PCR_SELECT/PCR11 and
+    // h/h32) is the single source of truth in `tpm_quote::test_vector`.
+    use crate::tpm_quote::test_vector::*;
+
     const ZERO_PCR: &str = "0000000000000000000000000000000000000000000000000000000000000000";
     const SHARE_INDEX: u16 = 2;
-
-    fn h(s: &str) -> Vec<u8> {
-        hex::decode(s).unwrap()
-    }
-
-    fn h32(s: &str) -> [u8; 32] {
-        h(s).try_into().unwrap()
-    }
 
     fn ak_sec1() -> Vec<u8> {
         let mut v = vec![0x04u8];


### PR DESCRIPTION
## Summary

Two post-merge housekeeping changes following a security + over-engineering review pass across the TPM-attestation / threshold-OPRF work (#626-#632).

### Attestation review-pass fixes (`a20282e`)

A read-only security review found no Blocker/High issues (the verify path and fail-closed gate hold up against forged/replayed/cross-type/unattested peers). It surfaced one doc inaccuracy and an over-engineering pass found two small simplifications:

- **Correct the `--insecure-no-attestation` docs** (cli.rs + attestation.rs). The help and warning claimed an unattested holder "answers OPRF evaluations from any peer." That's backwards: the OPRF eval/enroll oracle independently requires a `Verified` peer, so with no policy no peer is ever verified and the node serves *no* OPRF evaluations (it still participates in FROST coordination). Reworded to say so.
- **Simplify the AK pin check** (tpm_policy.rs): two branches returning an identical error collapse to one constant-time `is_some_and` check (behavior and constant-time compare preserved).
- **Dedup the test vector** (tpm_policy.rs): the test re-declared the swtpm quote constants and `h`/`h32` that already live in `tpm_quote::test_vector`; import them instead.

The one Medium availability finding (a slow TPM quote can stall the inbound-event task for up to 5s on a node that is both producer and signer) is tracked separately as keep-w7t2, since the fix is an async refactor that deserves its own PR.

### README (`cc0f68c`)

Add keep-node to the ecosystem table.

## Validation

fmt + clippy clean; tpm_policy (7) and tpm_quote (6) tests pass. No behavior change beyond the doc wording.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new ecosystem entry in the README for the `keep-node` project.
  * Clarified command-line help and warning text for the no-attestation mode.

* **Bug Fixes**
  * Improved how TPM quote verification handles missing or mismatched pinned keys.
  * Kept the existing behavior for secure verification while making failure handling more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->