### PR TITLE
keep-frost-net: produce announce TPM quote off the event loop

### DIFF
--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -907,6 +907,12 @@ pub struct KfpNode {
     /// Producer side: when set, every announce carries a fresh TPM quote bound to
     /// it. `None` means this node attaches no TPM attestation to its announces.
     announce_attestor: Option<Arc<dyn AnnounceAttestor>>,
+    /// In-flight background re-announce, if any. Holds at most one task: a new
+    /// `spawn_announce` is suppressed while this one is unfinished, so a slow TPM
+    /// quote cannot pile up concurrent quotes, concurrent signing-share copies,
+    /// or emit duplicate same-second announces. Aborted when `run` exits so a
+    /// queued announce cannot fire (or hold share material) after shutdown.
+    announce_task: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
     pub(crate) seen_xpub_announces: RwLock<HashSet<(u16, u64, [u8; 32])>>,
     /// Per-peer de-duplication for `NonceCommitment` broadcasts, keyed by
     /// `(share_index, content_hash)` where `content_hash` covers the sorted
@@ -968,8 +974,12 @@ pub(crate) fn sanitize_reason(reason: &str) -> String {
 /// `&KfpNode` so the slow part (TPM quote + relay send) can run off the node's
 /// event loop without borrowing it. The `SharePackage` is `ZeroizeOnDrop` and
 /// not `Clone`, so its signing share is serialized here into a `Zeroizing`
-/// buffer; that copy lives only for the announce and is wiped on drop (the
-/// original is resident in `self.share` for the node's lifetime regardless).
+/// buffer wiped on drop. Running off-loop trades away the old ordering that
+/// produced the quote *before* materializing the share: this copy is now
+/// resident for the full quote round-trip (up to `ANNOUNCE_QUOTE_TIMEOUT`).
+/// The marginal exposure is bounded: the original share is resident in
+/// `self.share` for the node's lifetime regardless, and `spawn_announce`'s
+/// single-flight guard keeps at most one such copy alive at a time.
 struct AnnounceJob {
     keys: Keys,
     client: Client,
@@ -1145,6 +1155,7 @@ impl KfpNode {
             expected_pcrs: None,
             tpm_attestation_policy: None,
             announce_attestor: None,
+            announce_task: std::sync::Mutex::new(None),
             seen_xpub_announces: RwLock::new(HashSet::new()),
             seen_nonce_commitments: RwLock::new(HashMap::new()),
             seen_oprf_enrolls: RwLock::new(HashMap::new()),
@@ -1698,15 +1709,29 @@ impl KfpNode {
     /// periodic and reciprocal re-announces so a slow TPM quote cannot stall the
     /// event loop (and with it every other inbound protocol message).
     fn spawn_announce(&self) {
+        // Single-flight: while one background announce is still running, skip
+        // spawning another. Both call sites (the periodic tick and the inbound
+        // reciprocal-announce path) run on the node's `run` task, so this lock is
+        // uncontended; it exists for interior mutability and the shutdown abort.
+        // Without this, a burst of new-peer discoveries (or a tick overlapping a
+        // slow quote) would spawn concurrent TPM quotes, hold several signing-
+        // share copies at once, and emit duplicate same-second announces.
+        let mut slot = self.announce_task.lock().unwrap();
+        if slot.as_ref().is_some_and(|h| !h.is_finished()) {
+            return;
+        }
         match self.announce_job() {
             Ok(job) => {
-                tokio::spawn(async move {
+                *slot = Some(tokio::spawn(async move {
                     if let Err(e) = Self::run_announce_job(job).await {
                         warn!(error = %e, "Background re-announce failed");
                     }
-                });
+                }));
             }
-            Err(e) => warn!(error = %e, "Failed to prepare re-announce"),
+            Err(e) => {
+                *slot = None;
+                warn!(error = %e, "Failed to prepare re-announce");
+            }
         }
     }
 
@@ -1882,6 +1907,12 @@ impl KfpNode {
                     }
                 }
             }
+        }
+
+        // Abort any in-flight background re-announce so it cannot emit a stale
+        // announce, or hold the signing-share copy, past the node's run loop.
+        if let Some(handle) = self.announce_task.lock().unwrap().take() {
+            handle.abort();
         }
 
         Ok(())

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -964,6 +964,23 @@ pub(crate) fn sanitize_reason(reason: &str) -> String {
     }
 }
 
+/// Owned inputs for building and sending one announce, extracted from a
+/// `&KfpNode` so the slow part (TPM quote + relay send) can run off the node's
+/// event loop without borrowing it. The `SharePackage` is `ZeroizeOnDrop` and
+/// not `Clone`, so its signing share is serialized here into a `Zeroizing`
+/// buffer; that copy lives only for the announce and is wiped on drop (the
+/// original is resident in `self.share` for the node's lifetime regardless).
+struct AnnounceJob {
+    keys: Keys,
+    client: Client,
+    group_pubkey: [u8; 32],
+    share_index: u16,
+    name: String,
+    signing_share: Zeroizing<[u8; 32]>,
+    verifying_share: [u8; 33],
+    attestor: Option<Arc<dyn AnnounceAttestor>>,
+}
+
 impl KfpNode {
     pub async fn new(share: SharePackage, relays: Vec<String>) -> Result<Self> {
         Self::with_nonce_store(share, relays, None, None, None).await
@@ -1586,19 +1603,57 @@ impl KfpNode {
         Ok((participants, participant_peers))
     }
 
-    pub async fn announce(&self) -> Result<()> {
-        let share_index = self.share.metadata.identifier;
-        let timestamp = Timestamp::now().as_secs();
+    /// Extract everything needed to send one announce. Fast and synchronous (no
+    /// TPM, no network), so it can run on the event loop without blocking it.
+    fn announce_job(&self) -> Result<AnnounceJob> {
+        let key_package = self
+            .share
+            .key_package()
+            .map_err(|e| FrostNetError::Crypto(format!("Failed to get key package: {e}")))?;
 
-        // If this node attests via a TPM, bind a fresh quote to THIS announce
-        // (group, share, timestamp) and attach it. Fail-closed: if quoting fails
-        // we do not announce, since a configured-but-unattested announce would be
-        // rejected by any peer that pins a policy. Done BEFORE deserializing the
-        // share so no signing-key material is resident during the quote wait.
-        let tpm_attestation = match &self.announce_attestor {
+        let verifying_share = key_package.verifying_share();
+        let verifying_share_serialized = verifying_share.serialize().map_err(|e| {
+            FrostNetError::Crypto(format!("Failed to serialize verifying share: {e}"))
+        })?;
+        let verifying_share: [u8; 33] = verifying_share_serialized
+            .as_slice()
+            .try_into()
+            .map_err(|_| FrostNetError::Crypto("Invalid verifying share length".into()))?;
+
+        let signing_share_serialized = Zeroizing::new(key_package.signing_share().serialize());
+        let signing_share: Zeroizing<[u8; 32]> = Zeroizing::new(
+            signing_share_serialized
+                .as_slice()
+                .try_into()
+                .map_err(|_| FrostNetError::Crypto("Invalid signing share length".into()))?,
+        );
+
+        Ok(AnnounceJob {
+            keys: self.keys.clone(),
+            client: self.client.clone(),
+            group_pubkey: self.group_pubkey,
+            share_index: self.share.metadata.identifier,
+            name: self.share.metadata.name.clone(),
+            signing_share,
+            verifying_share,
+            attestor: self.announce_attestor.clone(),
+        })
+    }
+
+    /// Produce the (optional) TPM quote bound to this announce, build the event,
+    /// and send it. This is the slow part (the quote round-trips to a TPM), and
+    /// it takes owned data so it can run in a spawned task off the event loop.
+    /// Fail-closed: if quoting fails, no announce is sent (a configured-but-
+    /// unattested announce would be rejected by any peer that pins a policy).
+    async fn run_announce_job(job: AnnounceJob) -> Result<()> {
+        let timestamp = Timestamp::now().as_secs();
+        let tpm_attestation = match &job.attestor {
             Some(attestor) => {
-                let nonce =
-                    derive_announce_attestation_nonce(&self.group_pubkey, share_index, timestamp);
+                let nonce = derive_announce_attestation_nonce(
+                    &job.group_pubkey,
+                    job.share_index,
+                    timestamp,
+                );
                 let evidence =
                     tokio::time::timeout(ANNOUNCE_QUOTE_TIMEOUT, attestor.request_quote(nonce))
                         .await
@@ -1613,52 +1668,46 @@ impl KfpNode {
             None => None,
         };
 
-        // Deserialize the share and its key material only after attestation has
-        // succeeded, minimizing the secret's in-memory residency window.
-        let key_package = self
-            .share
-            .key_package()
-            .map_err(|e| FrostNetError::Crypto(format!("Failed to get key package: {e}")))?;
-
-        let verifying_share = key_package.verifying_share();
-        let verifying_share_serialized = verifying_share.serialize().map_err(|e| {
-            FrostNetError::Crypto(format!("Failed to serialize verifying share: {e}"))
-        })?;
-        let verifying_share_bytes: [u8; 33] = verifying_share_serialized
-            .as_slice()
-            .try_into()
-            .map_err(|_| FrostNetError::Crypto("Invalid verifying share length".into()))?;
-
-        let signing_share = key_package.signing_share();
-        let signing_share_serialized = Zeroizing::new(signing_share.serialize());
-        let signing_share_bytes: Zeroizing<[u8; 32]> = Zeroizing::new(
-            signing_share_serialized
-                .as_slice()
-                .try_into()
-                .map_err(|_| FrostNetError::Crypto("Invalid signing share length".into()))?,
-        );
-
         let event = KfpEventBuilder::announcement(
-            &self.keys,
-            &self.group_pubkey,
-            share_index,
-            &signing_share_bytes,
-            &verifying_share_bytes,
-            Some(&self.share.metadata.name),
+            &job.keys,
+            &job.group_pubkey,
+            job.share_index,
+            &job.signing_share,
+            &job.verifying_share,
+            Some(&job.name),
             timestamp,
             tpm_attestation,
         )?;
 
-        self.client
+        job.client
             .send_event(&event)
             .await
             .map_err(|e| FrostNetError::Transport(e.to_string()))?;
 
-        info!(
-            share_index = self.share.metadata.identifier,
-            "Announced presence"
-        );
+        info!(share_index = job.share_index, "Announced presence");
         Ok(())
+    }
+
+    /// Send one announce, awaiting completion. Used at startup so a quote failure
+    /// fails the node fast (fail-closed) before it begins serving.
+    pub async fn announce(&self) -> Result<()> {
+        Self::run_announce_job(self.announce_job()?).await
+    }
+
+    /// Send one announce in the background, returning immediately. Used for the
+    /// periodic and reciprocal re-announces so a slow TPM quote cannot stall the
+    /// event loop (and with it every other inbound protocol message).
+    fn spawn_announce(&self) {
+        match self.announce_job() {
+            Ok(job) => {
+                tokio::spawn(async move {
+                    if let Err(e) = Self::run_announce_job(job).await {
+                        warn!(error = %e, "Background re-announce failed");
+                    }
+                });
+            }
+            Err(e) => warn!(error = %e, "Failed to prepare re-announce"),
+        }
     }
 
     pub async fn run(&self) -> Result<()> {
@@ -1767,9 +1816,8 @@ impl KfpNode {
                     break;
                 }
                 _ = announce_interval.tick() => {
-                    if let Err(e) = self.announce().await {
-                        warn!(error = %e, "Failed to re-announce");
-                    }
+                    // Spawn so a slow TPM quote cannot stall the select loop.
+                    self.spawn_announce();
                 }
                 _ = replenish_interval.tick() => {
                     if self.nonce_pool.own_deficit() > 0 {
@@ -2134,10 +2182,9 @@ impl KfpNode {
             // Without this, an initiator's short discovery window can miss an
             // already-online co-signer. Gated on `is_new_peer` so the exchange
             // terminates: once a peer knows us, our announce no longer looks
-            // new to it and it won't reciprocate again.
-            if let Err(e) = self.announce().await {
-                warn!(peer = %pubkey, error = %e, "Failed to reciprocate announce to new peer");
-            }
+            // new to it and it won't reciprocate again. Spawned so a slow TPM
+            // quote cannot stall this inbound-event handler.
+            self.spawn_announce();
 
             // A newly discovered peer may have come online after we last
             // replenished (whose broadcast only carries freshly generated

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1733,10 +1733,7 @@ impl KfpNode {
         // Without this, a burst of new-peer discoveries (or a tick overlapping a
         // slow quote) would spawn concurrent TPM quotes, hold several signing-
         // share copies at once, and emit duplicate same-second announces.
-        let mut slot = self
-            .announce_task
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let mut slot = self.announce_task.lock().unwrap_or_else(|e| e.into_inner());
         if slot.as_ref().is_some_and(|h| !h.is_finished()) {
             return;
         }
@@ -1929,18 +1926,19 @@ impl KfpNode {
             }
         }
 
-        // Request cancellation of any in-flight background re-announce so a queued
-        // announce stops promptly and drops its share copy. abort() is best-effort
-        // (the task ends on its next poll; an announce already mid-`send_event` may
-        // still reach the relay), so this bounds residency rather than guaranteeing
-        // no further send.
-        if let Some(handle) = self
+        // Cancel any in-flight background re-announce and await it, so its
+        // `Zeroizing` share copy is dropped and wiped before `run` returns.
+        // abort() takes effect at the task's next await point (an announce already
+        // mid-`send_event` may still reach the relay); awaiting the handle bounds
+        // that to completion rather than leaving the task running past `run`.
+        let handle = self
             .announce_task
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .take()
-        {
+            .take();
+        if let Some(handle) = handle {
             handle.abort();
+            let _ = handle.await;
         }
 
         Ok(())

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -910,8 +910,10 @@ pub struct KfpNode {
     /// In-flight background re-announce, if any. Holds at most one task: a new
     /// `spawn_announce` is suppressed while this one is unfinished, so a slow TPM
     /// quote cannot pile up concurrent quotes, concurrent signing-share copies,
-    /// or emit duplicate same-second announces. Aborted when `run` exits so a
-    /// queued announce cannot fire (or hold share material) after shutdown.
+    /// or emit duplicate same-second announces. Aborted both when `run` exits and
+    /// on drop; the abort is best-effort cancellation (the task ends on its next
+    /// poll, so an announce already mid-send may still reach the relay) that bounds
+    /// how long a queued announce keeps its share copy alive after shutdown.
     announce_task: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
     pub(crate) seen_xpub_announces: RwLock<HashSet<(u16, u64, [u8; 32])>>,
     /// Per-peer de-duplication for `NonceCommitment` broadcasts, keyed by
@@ -949,6 +951,17 @@ impl Drop for KfpNode {
             use zeroize::Zeroize;
             share.zeroize();
         }
+        // If `run` was cancelled (its future dropped) rather than shutdown-signalled,
+        // its run-exit abort never ran; cancel any orphaned announce task here so it
+        // stops holding its `Zeroizing` signing-share copy.
+        if let Some(handle) = self
+            .announce_task
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take()
+        {
+            handle.abort();
+        }
     }
 }
 
@@ -980,6 +993,10 @@ pub(crate) fn sanitize_reason(reason: &str) -> String {
 /// The marginal exposure is bounded: the original share is resident in
 /// `self.share` for the node's lifetime regardless, and `spawn_announce`'s
 /// single-flight guard keeps at most one such copy alive at a time.
+/// The same bounded-exposure argument covers the `keys` clone: it carries the
+/// Nostr identity secret and is resident for the same quote round-trip, but the
+/// original is held in `self.keys` for the node's lifetime regardless and the
+/// single-flight guard bounds it to one copy at a time.
 struct AnnounceJob {
     keys: Keys,
     client: Client,
@@ -1716,7 +1733,10 @@ impl KfpNode {
         // Without this, a burst of new-peer discoveries (or a tick overlapping a
         // slow quote) would spawn concurrent TPM quotes, hold several signing-
         // share copies at once, and emit duplicate same-second announces.
-        let mut slot = self.announce_task.lock().unwrap();
+        let mut slot = self
+            .announce_task
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         if slot.as_ref().is_some_and(|h| !h.is_finished()) {
             return;
         }
@@ -1909,9 +1929,17 @@ impl KfpNode {
             }
         }
 
-        // Abort any in-flight background re-announce so it cannot emit a stale
-        // announce, or hold the signing-share copy, past the node's run loop.
-        if let Some(handle) = self.announce_task.lock().unwrap().take() {
+        // Request cancellation of any in-flight background re-announce so a queued
+        // announce stops promptly and drops its share copy. abort() is best-effort
+        // (the task ends on its next poll; an announce already mid-`send_event` may
+        // still reach the relay), so this bounds residency rather than guaranteeing
+        // no further send.
+        if let Some(handle) = self
+            .announce_task
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take()
+        {
             handle.abort();
         }
 

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -3547,10 +3547,13 @@ async fn test_oprf_unlock_blocked_when_box_unattested() {
 }
 
 /// A valid attestor whose quote arrives after a delay (still within the
-/// announce timeout), to exercise the slow-quote path.
+/// announce timeout), to exercise the slow-quote path. `quote_starts` counts
+/// each `request_quote` so a test can wait until a particular quote (e.g. the
+/// reciprocal one) is genuinely in flight before probing.
 struct SlowQuoteAttestor {
     inner: ValidQuoteAttestor,
     delay: Duration,
+    quote_starts: std::sync::Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl keep_frost_net::AnnounceAttestor for SlowQuoteAttestor {
@@ -3562,6 +3565,8 @@ impl keep_frost_net::AnnounceAttestor for SlowQuoteAttestor {
         nonce: [u8; 32],
     ) -> tokio::sync::oneshot::Receiver<keep_frost_net::Result<keep_frost_net::TpmQuoteEvidence>>
     {
+        self.quote_starts
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let (attest, signature) = build_signed_quote(
             &nonce,
             &one_pcr_selection(),
@@ -3592,6 +3597,7 @@ impl keep_frost_net::AnnounceAttestor for SlowQuoteAttestor {
 /// inline-await code would leave node1 unresponsive for the whole quote.)
 #[tokio::test]
 async fn test_slow_announce_quote_does_not_block_event_loop() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
     let mock_relay = MockRelay::run().await.expect("relay");
@@ -3602,12 +3608,14 @@ async fn test_slow_announce_quote_does_not_block_event_loop() {
     let share1 = shares.remove(0); // node1: slow attestor
     let share2 = shares.remove(0); // node2: normal
 
+    let quote_starts = Arc::new(AtomicUsize::new(0));
     let mut node1 = KfpNode::new(share1, vec![relay.clone()])
         .await
         .expect("node1");
     node1.set_announce_attestor(Arc::new(SlowQuoteAttestor {
         inner: ValidQuoteAttestor::new(),
         delay: Duration::from_millis(4500),
+        quote_starts: Arc::clone(&quote_starts),
     }));
     let mut node2 = KfpNode::new(share2, vec![relay]).await.expect("node2");
 
@@ -3644,6 +3652,23 @@ async fn test_slow_announce_quote_does_not_block_event_loop() {
         panic!("node2 never discovered node1");
     }
 
+    // Wait until node1's RECIPROCAL quote is actually in flight before probing:
+    // the first quote is its startup announce; the second is the reciprocal it
+    // spawns on seeing node2. Probing only after `quote_starts >= 2` guarantees a
+    // slow announce is genuinely outstanding (otherwise the ping could race ahead
+    // of the reciprocal and pass even on the old blocking code).
+    let reciprocal_started = timeout(Duration::from_secs(10), async {
+        while quote_starts.load(Ordering::SeqCst) < 2 {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await;
+    if reciprocal_started.is_err() {
+        graceful_shutdown(shutdown1, h1).await;
+        graceful_shutdown(shutdown2, h2).await;
+        panic!("node1's reciprocal announce quote never started");
+    }
+
     // node1 is mid slow reciprocal announce now; its loop must still pong within
     // a window shorter than the 4.5s quote, proving it is not blocked on it.
     let health = timeout(
@@ -3664,15 +3689,17 @@ async fn test_slow_announce_quote_does_not_block_event_loop() {
     );
 }
 
-/// A valid attestor with a configurable quote delay that records the peak number
-/// of quote requests in flight at once. The single-flight test asserts on that
-/// peak: a second background announce that lands while a first is still awaiting
-/// its quote must be suppressed rather than starting a concurrent quote.
+/// A valid attestor with a configurable quote delay that records both the peak
+/// number of concurrent quotes and the TOTAL number of quotes started. The
+/// single-flight test asserts on the total: while one background announce is
+/// awaiting its quote, further reciprocal announces must be suppressed (not
+/// merely serialized), so exactly one reciprocal quote is issued.
 struct ConcurrentQuoteProbe {
     inner: ValidQuoteAttestor,
     delay: Duration,
     in_flight: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     max_in_flight: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    total_starts: std::sync::Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl keep_frost_net::AnnounceAttestor for ConcurrentQuoteProbe {
@@ -3685,6 +3712,7 @@ impl keep_frost_net::AnnounceAttestor for ConcurrentQuoteProbe {
     ) -> tokio::sync::oneshot::Receiver<keep_frost_net::Result<keep_frost_net::TpmQuoteEvidence>>
     {
         use std::sync::atomic::Ordering;
+        self.total_starts.fetch_add(1, Ordering::SeqCst);
         let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
         self.max_in_flight.fetch_max(now, Ordering::SeqCst);
         let (attest, signature) = build_signed_quote(
@@ -3733,6 +3761,7 @@ async fn test_single_flight_suppresses_concurrent_announce_quotes() {
 
     let in_flight = Arc::new(AtomicUsize::new(0));
     let max_in_flight = Arc::new(AtomicUsize::new(0));
+    let total_starts = Arc::new(AtomicUsize::new(0));
 
     let mut node1 = KfpNode::new(share1, vec![relay.clone()])
         .await
@@ -3742,6 +3771,7 @@ async fn test_single_flight_suppresses_concurrent_announce_quotes() {
         delay: Duration::from_millis(4500),
         in_flight: Arc::clone(&in_flight),
         max_in_flight: Arc::clone(&max_in_flight),
+        total_starts: Arc::clone(&total_starts),
     }));
 
     let mut rx1 = node1.subscribe();
@@ -3800,6 +3830,7 @@ async fn test_single_flight_suppresses_concurrent_announce_quotes() {
     // Give the reciprocal spawns time to reach request_quote before sampling.
     tokio::time::sleep(Duration::from_millis(500)).await;
     let peak = max_in_flight.load(Ordering::SeqCst);
+    let total = total_starts.load(Ordering::SeqCst);
 
     graceful_shutdown(shutdown1, h1).await;
     graceful_shutdown(shutdown2, h2).await;
@@ -3812,5 +3843,13 @@ async fn test_single_flight_suppresses_concurrent_announce_quotes() {
     assert!(
         peak <= 1,
         "single-flight must keep at most one background announce quote in flight (peak={peak})"
+    );
+    // The startup announce issues exactly one quote; discovering two peers within
+    // one slow-quote window must add exactly one reciprocal quote (the second is
+    // suppressed, not serialized). Total == 2 verifies suppression, which `peak`
+    // alone cannot (two sequential reciprocal quotes would also keep peak at 1).
+    assert_eq!(
+        total, 2,
+        "expected 1 startup + 1 reciprocal quote (second reciprocal suppressed), got {total}"
     );
 }

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -3663,3 +3663,154 @@ async fn test_slow_announce_quote_does_not_block_event_loop() {
         health.responsive
     );
 }
+
+/// A valid attestor with a configurable quote delay that records the peak number
+/// of quote requests in flight at once. The single-flight test asserts on that
+/// peak: a second background announce that lands while a first is still awaiting
+/// its quote must be suppressed rather than starting a concurrent quote.
+struct ConcurrentQuoteProbe {
+    inner: ValidQuoteAttestor,
+    delay: Duration,
+    in_flight: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    max_in_flight: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl keep_frost_net::AnnounceAttestor for ConcurrentQuoteProbe {
+    fn ak_sec1(&self) -> Vec<u8> {
+        self.inner.ak_sec1.clone()
+    }
+    fn request_quote(
+        &self,
+        nonce: [u8; 32],
+    ) -> tokio::sync::oneshot::Receiver<keep_frost_net::Result<keep_frost_net::TpmQuoteEvidence>>
+    {
+        use std::sync::atomic::Ordering;
+        let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max_in_flight.fetch_max(now, Ordering::SeqCst);
+        let (attest, signature) = build_signed_quote(
+            &nonce,
+            &one_pcr_selection(),
+            &self.inner.pcr_value,
+            &self.inner.sk,
+        );
+        let ev = keep_frost_net::TpmQuoteEvidence {
+            attest,
+            signature,
+            ak_sec1: self.inner.ak_sec1.clone(),
+            pcr_values: vec![hex::encode(self.inner.pcr_value)],
+        };
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let delay = self.delay;
+        let in_flight = std::sync::Arc::clone(&self.in_flight);
+        tokio::spawn(async move {
+            tokio::time::sleep(delay).await;
+            let _ = tx.send(Ok(ev));
+            in_flight.fetch_sub(1, Ordering::SeqCst);
+        });
+        rx
+    }
+}
+
+/// Single-flight regression: while one slow background announce is in flight, a
+/// second `spawn_announce` must be skipped rather than starting a concurrent
+/// quote. node1 carries a slow attestor that records the peak number of in-flight
+/// quotes; node2 and node3 come online only after node1 is past its synchronous
+/// startup announce, so the reciprocal announces node1 attempts on discovering
+/// them fall inside one slow-quote window. The recorded peak must stay at one.
+#[tokio::test]
+async fn test_single_flight_suppresses_concurrent_announce_quotes() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    let mock_relay = MockRelay::run().await.expect("relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pkg) = dealer.generate("test-single-flight").unwrap();
+    let share1 = shares.remove(0);
+    let share2 = shares.remove(0);
+    let share3 = shares.remove(0);
+
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let max_in_flight = Arc::new(AtomicUsize::new(0));
+
+    let mut node1 = KfpNode::new(share1, vec![relay.clone()])
+        .await
+        .expect("node1");
+    node1.set_announce_attestor(Arc::new(ConcurrentQuoteProbe {
+        inner: ValidQuoteAttestor::new(),
+        delay: Duration::from_millis(4500),
+        in_flight: Arc::clone(&in_flight),
+        max_in_flight: Arc::clone(&max_in_flight),
+    }));
+
+    let mut rx1 = node1.subscribe();
+    let shutdown1 = node1.take_shutdown_handle();
+    let node1 = Arc::new(node1);
+    let r1 = Arc::clone(&node1);
+    let h1 = tokio::spawn(async move {
+        let _ = r1.run().await;
+    });
+
+    // Hold node2/node3 back until node1 is past its ~4.5s synchronous startup
+    // announce and into its loop, so the peers are discovered (and reciprocated)
+    // only while a single slow background announce can already be in flight. This
+    // keeps the startup announce from overlapping a reciprocal spawn, isolating
+    // the single-flight guard as the only thing bounding concurrency.
+    tokio::time::sleep(Duration::from_secs(7)).await;
+
+    let mut node2 = KfpNode::new(share2, vec![relay.clone()])
+        .await
+        .expect("node2");
+    let mut node3 = KfpNode::new(share3, vec![relay]).await.expect("node3");
+    let shutdown2 = node2.take_shutdown_handle();
+    let shutdown3 = node3.take_shutdown_handle();
+    let node2 = Arc::new(node2);
+    let node3 = Arc::new(node3);
+    let r2 = Arc::clone(&node2);
+    let r3 = Arc::clone(&node3);
+    let h2 = tokio::spawn(async move {
+        let _ = r2.run().await;
+    });
+    let h3 = tokio::spawn(async move {
+        let _ = r3.run().await;
+    });
+
+    // Wait until node1 has discovered both peers; each new-peer discovery drives a
+    // reciprocal spawn_announce, so this guarantees the suppression path is hit.
+    let mut seen2 = false;
+    let mut seen3 = false;
+    let discovered = timeout(Duration::from_secs(30), async {
+        loop {
+            if let Ok(KfpNodeEvent::PeerDiscovered { share_index, .. }) = rx1.recv().await {
+                if share_index == 2 {
+                    seen2 = true;
+                }
+                if share_index == 3 {
+                    seen3 = true;
+                }
+                if seen2 && seen3 {
+                    return;
+                }
+            }
+        }
+    })
+    .await;
+
+    // Give the reciprocal spawns time to reach request_quote before sampling.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let peak = max_in_flight.load(Ordering::SeqCst);
+
+    graceful_shutdown(shutdown1, h1).await;
+    graceful_shutdown(shutdown2, h2).await;
+    graceful_shutdown(shutdown3, h3).await;
+
+    assert!(
+        discovered.is_ok(),
+        "node1 must discover both peers to exercise the suppression path"
+    );
+    assert!(
+        peak <= 1,
+        "single-flight must keep at most one background announce quote in flight (peak={peak})"
+    );
+}

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -3545,3 +3545,121 @@ async fn test_oprf_unlock_blocked_when_box_unattested() {
         "unlock must NOT succeed when the box is unattested (gate bypassed)"
     );
 }
+
+/// A valid attestor whose quote arrives after a delay (still within the
+/// announce timeout), to exercise the slow-quote path.
+struct SlowQuoteAttestor {
+    inner: ValidQuoteAttestor,
+    delay: Duration,
+}
+
+impl keep_frost_net::AnnounceAttestor for SlowQuoteAttestor {
+    fn ak_sec1(&self) -> Vec<u8> {
+        self.inner.ak_sec1.clone()
+    }
+    fn request_quote(
+        &self,
+        nonce: [u8; 32],
+    ) -> tokio::sync::oneshot::Receiver<keep_frost_net::Result<keep_frost_net::TpmQuoteEvidence>>
+    {
+        let (attest, signature) = build_signed_quote(
+            &nonce,
+            &one_pcr_selection(),
+            &self.inner.pcr_value,
+            &self.inner.sk,
+        );
+        let ev = keep_frost_net::TpmQuoteEvidence {
+            attest,
+            signature,
+            ak_sec1: self.inner.ak_sec1.clone(),
+            pcr_values: vec![hex::encode(self.inner.pcr_value)],
+        };
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let delay = self.delay;
+        tokio::spawn(async move {
+            tokio::time::sleep(delay).await;
+            let _ = tx.send(Ok(ev));
+        });
+        rx
+    }
+}
+
+/// Regression test for keep-w7t2: a slow TPM quote must not stall the node's
+/// event loop. node1 has a valid but slow (4.5s, under the 5s announce timeout)
+/// attestor; after it discovers node2 it spawns a slow reciprocal announce. Its
+/// loop must keep serving, so a liveness ping still gets a prompt pong well
+/// inside the quote window. (Passes for the spawned-announce fix; the old
+/// inline-await code would leave node1 unresponsive for the whole quote.)
+#[tokio::test]
+async fn test_slow_announce_quote_does_not_block_event_loop() {
+    use std::sync::Arc;
+
+    let mock_relay = MockRelay::run().await.expect("relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pkg) = dealer.generate("test-slow-announce").unwrap();
+    let share1 = shares.remove(0); // node1: slow attestor
+    let share2 = shares.remove(0); // node2: normal
+
+    let mut node1 = KfpNode::new(share1, vec![relay.clone()])
+        .await
+        .expect("node1");
+    node1.set_announce_attestor(Arc::new(SlowQuoteAttestor {
+        inner: ValidQuoteAttestor::new(),
+        delay: Duration::from_millis(4500),
+    }));
+    let mut node2 = KfpNode::new(share2, vec![relay]).await.expect("node2");
+
+    let mut rx2 = node2.subscribe();
+    let shutdown1 = node1.take_shutdown_handle();
+    let shutdown2 = node2.take_shutdown_handle();
+    let node1 = Arc::new(node1);
+    let node2 = Arc::new(node2);
+    let r1 = Arc::clone(&node1);
+    let r2 = Arc::clone(&node2);
+    let h1 = tokio::spawn(async move {
+        let _ = r1.run().await;
+    });
+    let h2 = tokio::spawn(async move {
+        let _ = r2.run().await;
+    });
+
+    // node1's startup announce is sync and waits for its slow quote, so node2
+    // discovers it only after that; node1 then spawns a slow reciprocal announce
+    // on seeing node2. The generous timeout covers the ~4.5s startup quote.
+    let discovered = timeout(Duration::from_secs(45), async {
+        loop {
+            if let Ok(KfpNodeEvent::PeerDiscovered { share_index, .. }) = rx2.recv().await {
+                if share_index == 1 {
+                    return;
+                }
+            }
+        }
+    })
+    .await;
+    if discovered.is_err() {
+        graceful_shutdown(shutdown1, h1).await;
+        graceful_shutdown(shutdown2, h2).await;
+        panic!("node2 never discovered node1");
+    }
+
+    // node1 is mid slow reciprocal announce now; its loop must still pong within
+    // a window shorter than the 4.5s quote, proving it is not blocked on it.
+    let health = timeout(
+        Duration::from_secs(10),
+        node2.health_check(Duration::from_secs(3)),
+    )
+    .await
+    .expect("health_check did not return")
+    .expect("health_check error");
+
+    graceful_shutdown(shutdown1, h1).await;
+    graceful_shutdown(shutdown2, h2).await;
+
+    assert!(
+        health.responsive.contains(&1),
+        "node1 must answer a ping while a slow announce is in flight (responsive={:?})",
+        health.responsive
+    );
+}


### PR DESCRIPTION
## Summary

Fixes keep-w7t2 (the Medium availability finding from the attestation review pass): a slow or wedged TPM could stall the node's event loop. `announce()` awaited the TPM quote inline (up to the 5s `ANNOUNCE_QUOTE_TIMEOUT`) on the single inbound-event task, so a slow quote blocked processing of every other protocol message (SignRequest, OprfEvalRequest, PSBT) for that window. It only affects a node that both produces a TPM quote and serves as a signer/holder, but it degrades co-signer availability.

## Change

`announce()` is split so the slow part runs off the event loop:

- `announce_job(&self)` extracts everything an announce needs (keys, client, group key, share index/name, serialized shares, attestor) into an owned `AnnounceJob`. Fast and synchronous, safe to run on the loop.
- `run_announce_job(job)` produces the quote, builds the event, and sends it. Takes owned data, so it can run in a spawned task. Still fail-closed (no quote -> no announce).
- `announce()` (startup) awaits `run_announce_job` so a quote failure still fails the node fast.
- The periodic and reciprocal re-announces now call `spawn_announce()`, which runs `run_announce_job` in a detached task and returns immediately, so a slow quote can never block the loop.

`SharePackage` is `ZeroizeOnDrop` and not `Clone`, so the signing share is serialized into a `Zeroizing` buffer carried by the job and wiped on drop; the original is resident in `self.share` for the node's lifetime regardless, so this is a negligible residency change for a non-blocking loop. The public `run()`/`announce()` signatures are unchanged.

## Tests

- New `test_slow_announce_quote_does_not_block_event_loop`: node1 has a valid-but-slow (4.5s) attestor; after it discovers node2 it spawns a slow reciprocal announce, and a liveness ping must still get a prompt pong inside the quote window. Verified it is a real regression guard, it fails against the old inline-await code and passes with this fix.
- Full keep-frost-net suite green (287 lib + 35 multinode + the rest), including the real-attestation e2e and peer-discovery (which rely on the now-spawned reciprocal announce). fmt + clippy clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node responsiveness during announcements by preventing slow quote generation from blocking other activity.
  * Reduced the chance of overlapping announcement work, helping avoid duplicate or delayed background sends.
  * Added regression coverage for slow-quote handling and single-flight announcement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->