### PR TITLE
keep-cli: add frost network attestation-provision (TOFU policy authoring)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4486,6 +4486,7 @@ dependencies = [
  "fs2",
  "hex",
  "indicatif",
+ "k256",
  "keep-agent",
  "keep-bitcoin",
  "keep-core",

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Keep runs as a CLI, a desktop app (Linux/macOS/Windows), a mobile library (Andro
 - **Remote signing**: NIP-46 bunker mode for any compatible Nostr client
 - **Threshold signatures**: FROST t-of-n key splitting with distributed key generation (DKG)
 - **Network signing**: Coordinate FROST signing across devices over Nostr relays
+- **Threshold vault unlock**: Reconstruct a disk-encryption key at boot from a t-of-n OPRF quorum across TPM-attested holders (powers [keep-node](https://github.com/privkeyio/keep-node))
 - **Bitcoin**: BIP-86 Taproot addresses, PSBT signing, wallet descriptor coordination
 - **Enclaves**: AWS Nitro Enclave signing with attestation-based KMS
 - **Agent SDK**: Constrained signing sessions for AI agents (Python, TypeScript, MCP)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -245,6 +245,60 @@ keep frost network sign --group npub1... --message "hello"
 keep frost network sign-event --group npub1... --kind 1 --content "Posted via FROST"
 ```
 
+### Threshold-OPRF Vault Unlock (advanced)
+
+Reconstruct a disk-encryption (LUKS) key at boot from a *t-of-n* Oblivious-PRF
+quorum across holders (for example an on-prem box, a phone, and a remote
+replica), so no single device can decrypt the volume. A holder answers an OPRF
+evaluation only after verifying the requester's measured-boot state by TPM
+attestation. These are the building blocks the
+[keep-node](https://github.com/privkeyio/keep-node) appliance drives at boot;
+they can also be run directly.
+
+```bash
+# 1. One-time provisioning by the dealer/box, with every holder online and
+#    serving (step 2) so they receive and seal their shares: generates the OPRF
+#    key, splits it t-of-n, distributes the remote shares, and writes the LUKS
+#    key plus this box's own share.
+keep frost network oprf-provision --group npub1... \
+  --threshold 2 --total 3 --volume-id vault0 \
+  --key-out luks.key --share-out box.share
+
+# 2. Each holder runs a node that seals its enrolled share, loads it on the next
+#    start, and answers evaluations, verifying the box's attestation first
+#    (see "Attestation policy" below):
+keep frost network serve --group npub1... \
+  --oprf-share-file holder.share --oprf-dealer 1 \
+  --attestation-config keep-attestation.toml
+
+# 3. The box requests an unlock at boot, attaching its own TPM quote:
+keep frost network oprf-unlock --group npub1... \
+  --volume-id vault0 --share-file box.share \
+  --tpm-tcti device:/dev/tpmrm0
+```
+
+#### Attestation policy
+
+A holder only answers an evaluation from a peer whose TPM quote matches a pinned
+policy (its attestation key and reference PCRs). Author that policy by observing
+the group's announces, then enforce it:
+
+```bash
+# Capture pins from online peers (trust-on-first-use; run on a trusted network):
+keep frost network attestation-provision --group npub1... --out keep-attestation.toml
+
+# Enforce it — holders refuse OPRF evaluations from unverified peers:
+keep frost network serve --group npub1... --attestation-config keep-attestation.toml
+
+# Test/dev only — run with no policy (the node then serves no OPRF evaluations,
+# only FROST coordination):
+keep frost network serve --group npub1... --insecure-no-attestation
+```
+
+The TPM quote producer (`--tpm-tcti`) requires a build with the
+`tpm-attestation` feature (`cargo build --features tpm-attestation`); it links
+the tpm2-tss stack and is off by default.
+
 ### Policy Enforcement (Warden)
 
 Integrate with [Warden](https://github.com/privkeyio/warden) for policy-based signing controls:

--- a/keep-cli/Cargo.toml
+++ b/keep-cli/Cargo.toml
@@ -87,3 +87,4 @@ bitcoin = { workspace = true }
 tempfile = "3.27"
 sha2 = "0.10"
 hex = "0.4"
+k256 = { version = "0.13.4", features = ["schnorr"] }

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -598,6 +598,25 @@ pub(crate) enum FrostNetworkCommands {
         #[arg(short, long)]
         relay: Option<String>,
     },
+    /// Author an attestation-config from observed announces (trust-on-first-use).
+    AttestationProvision {
+        #[arg(short, long, help = "FROST group npub")]
+        group: String,
+        #[arg(short, long, help = "Coordination relay URL")]
+        relay: Option<String>,
+        #[arg(
+            long,
+            value_name = "FILE",
+            help = "Write the attestation policy TOML here"
+        )]
+        out: PathBuf,
+        #[arg(
+            long,
+            default_value = "25",
+            help = "Seconds to listen for announces (>= one announce interval)"
+        )]
+        wait: u64,
+    },
     Dkg {
         #[arg(short, long, help = "Group name for the new keyset")]
         group: String,

--- a/keep-cli/src/commands/frost_network/attestation.rs
+++ b/keep-cli/src/commands/frost_network/attestation.rs
@@ -23,14 +23,14 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use p256::ecdsa::VerifyingKey;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use keep_core::error::{KeepError, Result};
 use keep_frost_net::TpmAttestationPolicy;
 
 use crate::output::Output;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 struct AttestationConfig {
     selection: String,
     reference_pcrs: Vec<String>,
@@ -38,7 +38,7 @@ struct AttestationConfig {
     peer: Vec<PeerPin>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 struct PeerPin {
     index: u16,
     ak: String,
@@ -208,6 +208,140 @@ pub fn build_announce_attestor(
     ))
 }
 
+/// Build an attestation policy from observed group announces (trust-on-first-use):
+/// pin each attested peer's AK, and take the shared PCR selection + reference
+/// values from the first attested announce. Warns (via `out`) if a later peer
+/// disagrees on the selection or reference PCRs, which means a heterogeneous
+/// group the single-reference policy cannot express. The captured pins are NOT
+/// verified here; the caller establishes trust by running this in a trusted moment.
+fn capture_policy_from_announces(
+    out: &Output,
+    events: &[nostr_sdk::Event],
+) -> Result<AttestationConfig> {
+    use std::collections::BTreeMap;
+
+    let mut selection: Option<String> = None;
+    let mut reference_pcrs: Option<Vec<String>> = None;
+    let mut peers: BTreeMap<u16, String> = BTreeMap::new();
+
+    for event in events {
+        let payload = match keep_frost_net::KfpMessage::from_json(&event.content) {
+            Ok(keep_frost_net::KfpMessage::Announce(p)) => p,
+            _ => continue,
+        };
+        let Some(tpm) = payload.tpm_attestation else {
+            continue;
+        };
+        // The selection a verifier pins lives only inside the signed quote.
+        let sel = match keep_frost_net::tpm_quote::pcr_selection_from_attest(&tpm.attest) {
+            Ok(s) => hex::encode(s),
+            Err(_) => continue, // malformed quote; ignore this announce
+        };
+
+        match &selection {
+            None => selection = Some(sel),
+            Some(s) if *s != sel => out.warn(&format!(
+                "peer {} announced a different PCR selection; keeping the first observed",
+                payload.share_index
+            )),
+            _ => {}
+        }
+        match &reference_pcrs {
+            None => reference_pcrs = Some(tpm.pcr_values.clone()),
+            Some(r) if *r != tpm.pcr_values => out.warn(&format!(
+                "peer {} announced different reference PCRs; keeping the first observed",
+                payload.share_index
+            )),
+            _ => {}
+        }
+        peers.insert(payload.share_index, hex::encode(&tpm.ak_sec1));
+    }
+
+    let selection =
+        selection.ok_or_else(|| err("no attested announce observed; are the holders online?"))?;
+    Ok(AttestationConfig {
+        selection,
+        reference_pcrs: reference_pcrs.unwrap_or_default(),
+        peer: peers
+            .into_iter()
+            .map(|(index, ak)| PeerPin { index, ak })
+            .collect(),
+    })
+}
+
+/// Serialize a captured policy to TOML and write it, after re-parsing it through
+/// the loader so a written file is guaranteed to load back into a valid policy.
+fn write_policy_toml(path: &Path, config: &AttestationConfig) -> Result<()> {
+    let text = toml::to_string_pretty(config).map_err(|e| err(format!("serialize policy: {e}")))?;
+    parse_tpm_policy(&text)?; // never write a file the loader would reject
+    std::fs::write(path, text).map_err(|e| err(format!("write {}: {e}", path.display())))
+}
+
+/// `keep frost network attestation-provision`: observe the group's announces over
+/// the relay for `wait_secs`, capture each attested peer's AK + reference PCRs
+/// (trust-on-first-use), and write an `--attestation-config` TOML file.
+pub fn cmd_frost_network_attestation_provision(
+    out: &Output,
+    group_npub: &str,
+    relay: &str,
+    out_path: &Path,
+    wait_secs: u64,
+) -> Result<()> {
+    use nostr_sdk::prelude::*;
+
+    let group_pubkey = keep_core::keys::npub_to_bytes(group_npub)?;
+    let wait = wait_secs.max(1);
+
+    out.newline();
+    out.header("Attestation Policy Provisioning");
+    out.field("Group", group_npub);
+    out.field("Relay", relay);
+    out.field("Output", &out_path.display().to_string());
+    out.warn(
+        "TRUST-ON-FIRST-USE: AK pins and reference PCRs are captured from observed announces \
+         WITHOUT verifying them. Run this only on a trusted network while your holders are online.",
+    );
+    out.newline();
+
+    let rt =
+        tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
+
+    let config = rt.block_on(async {
+        let client = Client::new(Keys::generate());
+        client
+            .add_relay(relay)
+            .await
+            .map_err(|e| err(format!("add relay {relay}: {e}")))?;
+        client.connect().await;
+
+        let filter = Filter::new()
+            .kind(Kind::Custom(keep_frost_net::KFP_EVENT_KIND))
+            .custom_tag(
+                SingleLetterTag::lowercase(Alphabet::G),
+                hex::encode(group_pubkey),
+            )
+            .since(Timestamp::now() - std::time::Duration::from_secs(wait));
+
+        let spinner = out.spinner(&format!("Listening {wait}s for attested announces..."));
+        let events = client
+            .fetch_events(filter, std::time::Duration::from_secs(wait))
+            .await
+            .map_err(|e| err(format!("fetch announces: {e}")))?;
+        spinner.finish();
+
+        capture_policy_from_announces(out, &events.into_iter().collect::<Vec<_>>())
+    })?;
+
+    let pinned = config.peer.len();
+    write_policy_toml(out_path, &config)?;
+    out.success(&format!(
+        "Wrote attestation policy pinning {pinned} peer(s) to {}",
+        out_path.display()
+    ));
+    out.info("Review it, then pass it to `keep frost network serve --attestation-config <FILE>`.");
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -349,5 +483,57 @@ mod tests {
             ak = "04f533789fb86ad512ca3e930df08cd16396d14c30c79c46a88839b574a3dfb3271b3db55b2abdc884e40898e95dfffd2c7e8554526d4e1f651779bab1f81300cb"
         "#;
         assert!(parse_tpm_policy(cfg).is_err());
+    }
+
+    #[test]
+    fn capture_policy_from_announce_round_trips_through_loader() {
+        use keep_frost_net::{AnnouncePayload, KfpMessage, TpmQuoteEvidence, KFP_EVENT_KIND};
+        use nostr_sdk::{EventBuilder, Keys, Kind};
+
+        // The real swtpm quote vector: selection {0,2,4,7,11,12}, a valid AK.
+        const ATTEST: &str = "ff54434780180022000bb9df3193fe4f66ac5a3ee8f8552e454d20bbae633354bcff12b65d581f9d38c7001000112233445566778899aabbccddeeff000000000000041f000000010000000001202401250012000000000001000b03951800002094d0f020a3c4d09b8b88e69e7a093a38ec0ff9715cfdc70285d99d236c52990a";
+        const AK: &str = "04f533789fb86ad512ca3e930df08cd16396d14c30c79c46a88839b574a3dfb3271b3db55b2abdc884e40898e95dfffd2c7e8554526d4e1f651779bab1f81300cb";
+        let zero = "00".repeat(32);
+        let pcr11 = "cf2b0db7514f320c315130275a960f6e6ed80744c754c687069d7a9f55d704f0".to_string();
+
+        let evidence = TpmQuoteEvidence {
+            attest: hex::decode(ATTEST).unwrap(),
+            signature: vec![0u8; 64],
+            ak_sec1: hex::decode(AK).unwrap(),
+            pcr_values: vec![
+                zero.clone(),
+                zero.clone(),
+                zero.clone(),
+                zero.clone(),
+                pcr11,
+                zero,
+            ],
+        };
+        let payload = AnnouncePayload::new([7u8; 32], 2, [2u8; 33], [0u8; 64], 1_700_000_000)
+            .with_tpm_attestation(evidence);
+        let content = KfpMessage::Announce(payload).to_json().unwrap();
+        let event = EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), content)
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+
+        let out = Output::new();
+        let config = capture_policy_from_announces(&out, &[event]).expect("capture");
+        assert_eq!(config.selection, "00000001000b03951800");
+        assert_eq!(config.peer.len(), 1);
+        assert_eq!(config.peer[0].index, 2);
+        assert_eq!(config.reference_pcrs.len(), 6);
+
+        // The written file must load back into a valid policy.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("policy.toml");
+        write_policy_toml(&path, &config).expect("write");
+        let pol = load_tpm_policy(&path).expect("written policy must load");
+        assert_eq!(pol.pinned_aks.len(), 1);
+    }
+
+    #[test]
+    fn capture_errors_without_an_attested_announce() {
+        let out = Output::new();
+        assert!(capture_policy_from_announces(&out, &[]).is_err());
     }
 }

--- a/keep-cli/src/commands/frost_network/attestation.rs
+++ b/keep-cli/src/commands/frost_network/attestation.rs
@@ -210,14 +210,22 @@ pub fn build_announce_attestor(
 
 /// Build an attestation policy from observed group announces (trust-on-first-use):
 /// pin each attested peer's AK, and take the shared PCR selection + reference
-/// values from the first attested announce. Warns (via `out`) if a later peer
-/// disagrees on the selection or reference PCRs, which means a heterogeneous
-/// group the single-reference policy cannot express. The captured pins are NOT
-/// verified here; the caller establishes trust by running this in a trusted moment.
+/// values from the first attested announce. A peer that disagrees on the selection
+/// or reference PCRs cannot be expressed by this single-reference policy (it would
+/// be rejected at serve time), so it is skipped with a warning rather than written
+/// into a policy guaranteed to lock it out.
+///
+/// Capture matches the runtime `handle_announce` admission bar: announces for a
+/// different group, or whose proof-of-share does not verify, are ignored, so this
+/// step never trusts the relay more than a running node does. The AK pins remain
+/// trust-on-first-use: the operator establishes trust by running this in a trusted
+/// moment while the genuine holders are online.
 fn capture_policy_from_announces(
     out: &Output,
+    group_pubkey: &[u8; 32],
     events: &[nostr_sdk::Event],
 ) -> Result<AttestationConfig> {
+    use std::collections::btree_map::Entry;
     use std::collections::BTreeMap;
 
     let mut selection: Option<String> = None;
@@ -229,6 +237,28 @@ fn capture_policy_from_announces(
             Ok(keep_frost_net::KfpMessage::Announce(p)) => p,
             _ => continue,
         };
+        // The relay's `g` filter is advisory; the signed payload is authoritative.
+        if payload.group_pubkey != *group_pubkey {
+            continue;
+        }
+        // Reject announces whose proof-of-share does not verify, matching the
+        // runtime `handle_announce` path so a forged or self-inconsistent announce
+        // on the relay is not pinned.
+        if keep_frost_net::proof::verify_proof(
+            &payload.verifying_share,
+            &payload.proof_signature,
+            &payload.group_pubkey,
+            payload.share_index,
+            payload.timestamp,
+        )
+        .is_err()
+        {
+            out.warn(&format!(
+                "peer {} proof-of-share did not verify; ignoring its announce",
+                payload.share_index
+            ));
+            continue;
+        }
         let Some(tpm) = payload.tpm_attestation else {
             continue;
         };
@@ -238,30 +268,51 @@ fn capture_policy_from_announces(
             Err(_) => continue, // malformed quote; ignore this announce
         };
 
+        // The first attested peer fixes the shared selection + reference PCRs; a
+        // later peer that disagrees is skipped (it cannot be admitted under a
+        // single-reference policy), so the pinned count reflects reality.
         match &selection {
-            None => selection = Some(sel),
-            Some(s) if *s != sel => out.warn(&format!(
-                "peer {} announced a different PCR selection; keeping the first observed",
-                payload.share_index
-            )),
+            None => selection = Some(sel.clone()),
+            Some(s) if *s != sel => {
+                out.warn(&format!(
+                    "peer {} announced a different PCR selection; not pinning it",
+                    payload.share_index
+                ));
+                continue;
+            }
             _ => {}
         }
         match &reference_pcrs {
             None => reference_pcrs = Some(tpm.pcr_values.clone()),
-            Some(r) if *r != tpm.pcr_values => out.warn(&format!(
-                "peer {} announced different reference PCRs; keeping the first observed",
-                payload.share_index
-            )),
+            Some(r) if *r != tpm.pcr_values => {
+                out.warn(&format!(
+                    "peer {} announced different reference PCRs; not pinning it",
+                    payload.share_index
+                ));
+                continue;
+            }
             _ => {}
         }
-        peers.insert(payload.share_index, hex::encode(&tpm.ak_sec1));
+        // First-wins on the AK pin, consistent with the selection/reference above:
+        // a later announce for an already-pinned index never silently replaces it.
+        match peers.entry(payload.share_index) {
+            Entry::Vacant(e) => {
+                e.insert(hex::encode(&tpm.ak_sec1));
+            }
+            Entry::Occupied(_) => out.warn(&format!(
+                "peer {} announced more than once; keeping the first AK pin",
+                payload.share_index
+            )),
+        }
     }
 
     let selection =
         selection.ok_or_else(|| err("no attested announce observed; are the holders online?"))?;
+    let reference_pcrs = reference_pcrs
+        .ok_or_else(|| err("no attested announce observed; are the holders online?"))?;
     Ok(AttestationConfig {
         selection,
-        reference_pcrs: reference_pcrs.unwrap_or_default(),
+        reference_pcrs,
         peer: peers
             .into_iter()
             .map(|(index, ak)| PeerPin { index, ak })
@@ -272,9 +323,24 @@ fn capture_policy_from_announces(
 /// Serialize a captured policy to TOML and write it, after re-parsing it through
 /// the loader so a written file is guaranteed to load back into a valid policy.
 fn write_policy_toml(path: &Path, config: &AttestationConfig) -> Result<()> {
+    use std::io::Write;
     let text = toml::to_string_pretty(config).map_err(|e| err(format!("serialize policy: {e}")))?;
     parse_tpm_policy(&text)?; // never write a file the loader would reject
-    std::fs::write(path, text).map_err(|e| err(format!("write {}: {e}", path.display())))
+                              // `create_new` fails closed if the path exists, so a re-run never
+                              // clobbers a hand-edited attestation policy.
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|e| match e.kind() {
+            std::io::ErrorKind::AlreadyExists => err(format!(
+                "refusing to overwrite existing policy {}; remove it or choose another --out",
+                path.display()
+            )),
+            _ => err(format!("write {}: {e}", path.display())),
+        })?;
+    f.write_all(text.as_bytes())
+        .map_err(|e| err(format!("write {}: {e}", path.display())))
 }
 
 /// `keep frost network attestation-provision`: observe the group's announces over
@@ -329,7 +395,7 @@ pub fn cmd_frost_network_attestation_provision(
             .map_err(|e| err(format!("fetch announces: {e}")))?;
         spinner.finish();
 
-        capture_policy_from_announces(out, &events.into_iter().collect::<Vec<_>>())
+        capture_policy_from_announces(out, &group_pubkey, &events.into_iter().collect::<Vec<_>>())
     })?;
 
     let pinned = config.peer.len();
@@ -485,39 +551,95 @@ mod tests {
         assert!(parse_tpm_policy(cfg).is_err());
     }
 
-    #[test]
-    fn capture_policy_from_announce_round_trips_through_loader() {
+    // The real swtpm quote vector: selection {0,2,4,7,11,12}, a valid AK.
+    const ATTEST: &str = "ff54434780180022000bb9df3193fe4f66ac5a3ee8f8552e454d20bbae633354bcff12b65d581f9d38c7001000112233445566778899aabbccddeeff000000000000041f000000010000000001202401250012000000000001000b03951800002094d0f020a3c4d09b8b88e69e7a093a38ec0ff9715cfdc70285d99d236c52990a";
+    const AK: &str = "04f533789fb86ad512ca3e930df08cd16396d14c30c79c46a88839b574a3dfb3271b3db55b2abdc884e40898e95dfffd2c7e8554526d4e1f651779bab1f81300cb";
+
+    // The 6 reference PCRs the canned ATTEST selection {0,2,4,7,11,12} picks.
+    fn default_pcrs() -> Vec<String> {
+        let zero = "00".repeat(32);
+        let pcr11 = "cf2b0db7514f320c315130275a960f6e6ed80744c754c687069d7a9f55d704f0".to_string();
+        vec![
+            zero.clone(),
+            zero.clone(),
+            zero.clone(),
+            zero.clone(),
+            pcr11,
+            zero,
+        ]
+    }
+
+    // A valid proof-of-share for the announce fields, so capture's verify_proof
+    // gate (matching the runtime admission path) accepts the announce.
+    fn signed_share(group: &[u8; 32], index: u16, timestamp: u64) -> ([u8; 33], [u8; 64]) {
+        use k256::schnorr::SigningKey;
+        let signing_share = [7u8; 32]; // any valid nonzero scalar
+        let sk = SigningKey::from_bytes(&signing_share).expect("valid scalar");
+        let mut verifying_share = [0u8; 33];
+        verifying_share[0] = 0x02;
+        verifying_share[1..].copy_from_slice(&sk.verifying_key().to_bytes());
+        let sig = keep_frost_net::proof::sign_proof(
+            &signing_share,
+            group,
+            index,
+            &verifying_share,
+            timestamp,
+        )
+        .expect("sign proof");
+        (verifying_share, sig)
+    }
+
+    // Build an attested announce event with a valid proof-of-share, given the
+    // captured-into-policy fields that the tests vary. Uses the canned ATTEST
+    // selection {0,2,4,7,11,12} unless `attest` overrides it.
+    fn attested_event(
+        group: &[u8; 32],
+        index: u16,
+        timestamp: u64,
+        pcr_values: Vec<String>,
+        proof: ([u8; 33], [u8; 64]),
+    ) -> nostr_sdk::Event {
+        attested_event_with_attest(group, index, timestamp, ATTEST, pcr_values, proof)
+    }
+
+    fn attested_event_with_attest(
+        group: &[u8; 32],
+        index: u16,
+        timestamp: u64,
+        attest: &str,
+        pcr_values: Vec<String>,
+        proof: ([u8; 33], [u8; 64]),
+    ) -> nostr_sdk::Event {
         use keep_frost_net::{AnnouncePayload, KfpMessage, TpmQuoteEvidence, KFP_EVENT_KIND};
         use nostr_sdk::{EventBuilder, Keys, Kind};
 
-        // The real swtpm quote vector: selection {0,2,4,7,11,12}, a valid AK.
-        const ATTEST: &str = "ff54434780180022000bb9df3193fe4f66ac5a3ee8f8552e454d20bbae633354bcff12b65d581f9d38c7001000112233445566778899aabbccddeeff000000000000041f000000010000000001202401250012000000000001000b03951800002094d0f020a3c4d09b8b88e69e7a093a38ec0ff9715cfdc70285d99d236c52990a";
-        const AK: &str = "04f533789fb86ad512ca3e930df08cd16396d14c30c79c46a88839b574a3dfb3271b3db55b2abdc884e40898e95dfffd2c7e8554526d4e1f651779bab1f81300cb";
-        let zero = "00".repeat(32);
-        let pcr11 = "cf2b0db7514f320c315130275a960f6e6ed80744c754c687069d7a9f55d704f0".to_string();
-
         let evidence = TpmQuoteEvidence {
-            attest: hex::decode(ATTEST).unwrap(),
+            attest: hex::decode(attest).unwrap(),
             signature: vec![0u8; 64],
             ak_sec1: hex::decode(AK).unwrap(),
-            pcr_values: vec![
-                zero.clone(),
-                zero.clone(),
-                zero.clone(),
-                zero.clone(),
-                pcr11,
-                zero,
-            ],
+            pcr_values,
         };
-        let payload = AnnouncePayload::new([7u8; 32], 2, [2u8; 33], [0u8; 64], 1_700_000_000)
+        let payload = AnnouncePayload::new(*group, index, proof.0, proof.1, timestamp)
             .with_tpm_attestation(evidence);
         let content = KfpMessage::Announce(payload).to_json().unwrap();
-        let event = EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), content)
+        EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), content)
             .sign_with_keys(&Keys::generate())
-            .unwrap();
+            .unwrap()
+    }
+
+    #[test]
+    fn capture_policy_from_announce_round_trips_through_loader() {
+        let group = [7u8; 32];
+        let event = attested_event(
+            &group,
+            2,
+            1_700_000_000,
+            default_pcrs(),
+            signed_share(&group, 2, 1_700_000_000),
+        );
 
         let out = Output::new();
-        let config = capture_policy_from_announces(&out, &[event]).expect("capture");
+        let config = capture_policy_from_announces(&out, &group, &[event]).expect("capture");
         assert_eq!(config.selection, "00000001000b03951800");
         assert_eq!(config.peer.len(), 1);
         assert_eq!(config.peer[0].index, 2);
@@ -534,6 +656,122 @@ mod tests {
     #[test]
     fn capture_errors_without_an_attested_announce() {
         let out = Output::new();
-        assert!(capture_policy_from_announces(&out, &[]).is_err());
+        assert!(capture_policy_from_announces(&out, &[7u8; 32], &[]).is_err());
+    }
+
+    #[test]
+    fn capture_ignores_announce_with_bad_proof() {
+        // A real announce body but a zero (invalid) proof-of-share: rejected like
+        // the runtime path, leaving nothing to capture.
+        let group = [7u8; 32];
+        let event = attested_event(
+            &group,
+            2,
+            1_700_000_000,
+            default_pcrs(),
+            ([2u8; 33], [0u8; 64]),
+        );
+        let out = Output::new();
+        assert!(capture_policy_from_announces(&out, &group, &[event]).is_err());
+    }
+
+    #[test]
+    fn capture_ignores_announce_for_other_group() {
+        let group = [7u8; 32];
+        let other = [9u8; 32];
+        let event = attested_event(
+            &other,
+            2,
+            1_700_000_000,
+            default_pcrs(),
+            signed_share(&other, 2, 1_700_000_000),
+        );
+        let out = Output::new();
+        assert!(capture_policy_from_announces(&out, &group, &[event]).is_err());
+    }
+
+    #[test]
+    fn capture_skips_peer_with_divergent_reference_pcrs() {
+        // Peer 2 fixes the reference; peer 3 announces different PCR values the
+        // single-reference policy cannot express, so only peer 2 is pinned.
+        let group = [7u8; 32];
+        let mut divergent = default_pcrs();
+        divergent[0] = "11".repeat(32);
+        let events = vec![
+            attested_event(
+                &group,
+                2,
+                1_700_000_000,
+                default_pcrs(),
+                signed_share(&group, 2, 1_700_000_000),
+            ),
+            attested_event(
+                &group,
+                3,
+                1_700_000_000,
+                divergent,
+                signed_share(&group, 3, 1_700_000_000),
+            ),
+        ];
+        let out = Output::new();
+        let config = capture_policy_from_announces(&out, &group, &events).expect("capture");
+        assert_eq!(config.peer.len(), 1);
+        assert_eq!(config.peer[0].index, 2);
+    }
+
+    #[test]
+    fn capture_skips_peer_with_divergent_selection() {
+        // Same canned quote but the PCR selection bitmap changed to {0} only, so
+        // peer 3's selection differs from peer 2's and it is skipped.
+        let attest_alt = ATTEST.replace("000b03951800", "000b03010000");
+        assert_ne!(attest_alt, ATTEST);
+        let group = [7u8; 32];
+        let events = vec![
+            attested_event(
+                &group,
+                2,
+                1_700_000_000,
+                default_pcrs(),
+                signed_share(&group, 2, 1_700_000_000),
+            ),
+            attested_event_with_attest(
+                &group,
+                3,
+                1_700_000_000,
+                &attest_alt,
+                vec!["00".repeat(32)],
+                signed_share(&group, 3, 1_700_000_000),
+            ),
+        ];
+        let out = Output::new();
+        let config = capture_policy_from_announces(&out, &group, &events).expect("capture");
+        assert_eq!(config.peer.len(), 1);
+        assert_eq!(config.peer[0].index, 2);
+    }
+
+    #[test]
+    fn capture_keeps_first_ak_on_repeat_announce() {
+        // The same index announcing twice keeps the first pin (first-wins),
+        // consistent with the selection/reference handling.
+        let group = [7u8; 32];
+        let events = vec![
+            attested_event(
+                &group,
+                2,
+                1_700_000_000,
+                default_pcrs(),
+                signed_share(&group, 2, 1_700_000_000),
+            ),
+            attested_event(
+                &group,
+                2,
+                1_700_000_001,
+                default_pcrs(),
+                signed_share(&group, 2, 1_700_000_001),
+            ),
+        ];
+        let out = Output::new();
+        let config = capture_policy_from_announces(&out, &group, &events).expect("capture");
+        assert_eq!(config.peer.len(), 1);
     }
 }

--- a/keep-cli/src/commands/frost_network/attestation.rs
+++ b/keep-cli/src/commands/frost_network/attestation.rs
@@ -208,6 +208,26 @@ pub fn build_announce_attestor(
     ))
 }
 
+/// Parse an announced AK exactly as the policy loader will (`parse_tpm_policy`):
+/// a 65-byte uncompressed SEC1 point on P-256. Returns `None` for anything the
+/// loader would later reject, so a bad AK is dropped at capture instead of
+/// poisoning the batch.
+fn validated_ak(ak_sec1: &[u8]) -> Option<VerifyingKey> {
+    if ak_sec1.len() != 65 || ak_sec1[0] != 0x04 {
+        return None;
+    }
+    VerifyingKey::from_sec1_bytes(ak_sec1).ok()
+}
+
+/// Decode announced PCR values into 32-byte digests, rejecting any entry that is
+/// not exactly 32 bytes of hex (the same shape `parse_tpm_policy` requires).
+fn decode_pcr_digests(values: &[String]) -> Option<Vec<[u8; 32]>> {
+    values
+        .iter()
+        .map(|v| hex::decode(v.trim()).ok()?.try_into().ok())
+        .collect()
+}
+
 /// Build an attestation policy from observed group announces (trust-on-first-use):
 /// pin each attested peer's AK, and take the shared PCR selection + reference
 /// values from the first attested announce. A peer that disagrees on the selection
@@ -263,10 +283,57 @@ fn capture_policy_from_announces(
             continue;
         };
         // The selection a verifier pins lives only inside the signed quote.
-        let sel = match keep_frost_net::tpm_quote::pcr_selection_from_attest(&tpm.attest) {
-            Ok(s) => hex::encode(s),
+        let sel_bytes = match keep_frost_net::tpm_quote::pcr_selection_from_attest(&tpm.attest) {
+            Ok(s) => s,
             Err(_) => continue, // malformed quote; ignore this announce
         };
+        // Authenticate the TPM evidence against THIS signed announce before any of
+        // it is trusted: run the same AK/PCR-shape checks the policy loader enforces,
+        // then verify the quote the way the runtime appraisal does (`verify_quote`):
+        // the nonce binds the quote to this announce, the AK signs the attest, and
+        // the PCR values recompute to the attested digest. A peer failing any check
+        // is skipped, so malformed or forged evidence can neither seed the capture
+        // baseline (selection/reference) nor be pinned.
+        let Some(ak) = validated_ak(&tpm.ak_sec1) else {
+            out.warn(&format!(
+                "peer {} announced an invalid attestation key; ignoring its announce",
+                payload.share_index
+            ));
+            continue;
+        };
+        let pcr_digests = match decode_pcr_digests(&tpm.pcr_values) {
+            Some(d) if d.len() == count_selected_pcrs(&sel_bytes).unwrap_or(0) => d,
+            _ => {
+                out.warn(&format!(
+                    "peer {} announced PCR values inconsistent with its selection; ignoring it",
+                    payload.share_index
+                ));
+                continue;
+            }
+        };
+        let nonce = keep_frost_net::derive_announce_attestation_nonce(
+            &payload.group_pubkey,
+            payload.share_index,
+            payload.timestamp,
+        );
+        if keep_frost_net::tpm_quote::verify_quote(
+            &tpm.attest,
+            &tpm.signature,
+            &ak,
+            &nonce,
+            &sel_bytes,
+            &pcr_digests,
+            &pcr_digests,
+        )
+        .is_err()
+        {
+            out.warn(&format!(
+                "peer {} TPM quote did not authenticate against its announce; ignoring it",
+                payload.share_index
+            ));
+            continue;
+        }
+        let sel = hex::encode(&sel_bytes);
 
         // The first attested peer fixes the shared selection + reference PCRs; a
         // later peer that disagrees is skipped (it cannot be admitted under a
@@ -551,11 +618,10 @@ mod tests {
         assert!(parse_tpm_policy(cfg).is_err());
     }
 
-    // The real swtpm quote vector: selection {0,2,4,7,11,12}, a valid AK.
-    const ATTEST: &str = "ff54434780180022000bb9df3193fe4f66ac5a3ee8f8552e454d20bbae633354bcff12b65d581f9d38c7001000112233445566778899aabbccddeeff000000000000041f000000010000000001202401250012000000000001000b03951800002094d0f020a3c4d09b8b88e69e7a093a38ec0ff9715cfdc70285d99d236c52990a";
-    const AK: &str = "04f533789fb86ad512ca3e930df08cd16396d14c30c79c46a88839b574a3dfb3271b3db55b2abdc884e40898e95dfffd2c7e8554526d4e1f651779bab1f81300cb";
+    // Marshalled TPML_PCR_SELECTION for {0,2,4,7,11,12} (6 PCRs).
+    const SELECTION: &str = "00000001000b03951800";
 
-    // The 6 reference PCRs the canned ATTEST selection {0,2,4,7,11,12} picks.
+    // The 6 reference PCRs the SELECTION picks.
     fn default_pcrs() -> Vec<String> {
         let zero = "00".repeat(32);
         let pcr11 = "cf2b0db7514f320c315130275a960f6e6ed80744c754c687069d7a9f55d704f0".to_string();
@@ -589,9 +655,83 @@ mod tests {
         (verifying_share, sig)
     }
 
-    // Build an attested announce event with a valid proof-of-share, given the
-    // captured-into-policy fields that the tests vary. Uses the canned ATTEST
-    // selection {0,2,4,7,11,12} unless `attest` overrides it.
+    // The test AK: a fixed P-256 key the synthetic quotes are signed under.
+    fn ak_signing_key() -> p256::ecdsa::SigningKey {
+        p256::ecdsa::SigningKey::from_slice(&[7u8; 32]).expect("valid AK scalar")
+    }
+
+    fn ak_sec1() -> Vec<u8> {
+        ak_signing_key()
+            .verifying_key()
+            .to_encoded_point(false)
+            .as_bytes()
+            .to_vec()
+    }
+
+    // Build a marshalled TPMS_ATTEST quote over the given nonce, selection, and
+    // PCR values (digest = SHA-256 of the concatenated values), matching what
+    // `verify_quote` parses and checks.
+    fn build_attest(nonce: &[u8], selection: &[u8], pcr_values: &[String]) -> Vec<u8> {
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        for v in pcr_values {
+            h.update(hex::decode(v.trim()).unwrap());
+        }
+        let pcr_digest = h.finalize();
+        let mut a = Vec::new();
+        a.extend_from_slice(&0xFF54_4347u32.to_be_bytes()); // TPM_GENERATED
+        a.extend_from_slice(&0x8018u16.to_be_bytes()); // TPM_ST_ATTEST_QUOTE
+        a.extend_from_slice(&0u16.to_be_bytes()); // TPM2B_NAME (empty)
+        a.extend_from_slice(&(nonce.len() as u16).to_be_bytes());
+        a.extend_from_slice(nonce); // extraData
+        a.extend_from_slice(&[0u8; 17]); // TPMS_CLOCK_INFO
+        a.extend_from_slice(&[0u8; 8]); // firmware version
+        a.extend_from_slice(selection); // TPML_PCR_SELECTION
+        a.extend_from_slice(&(pcr_digest.len() as u16).to_be_bytes());
+        a.extend_from_slice(&pcr_digest);
+        a
+    }
+
+    // A TPM evidence blob whose quote is signed under the test AK over `nonce`.
+    fn evidence(
+        nonce: &[u8],
+        selection: &[u8],
+        pcr_values: Vec<String>,
+    ) -> keep_frost_net::TpmQuoteEvidence {
+        use p256::ecdsa::{signature::hazmat::PrehashSigner, Signature};
+        use sha2::{Digest, Sha256};
+
+        let attest = build_attest(nonce, selection, &pcr_values);
+        let sig: Signature = ak_signing_key()
+            .sign_prehash(&Sha256::digest(&attest))
+            .expect("sign attest");
+        keep_frost_net::TpmQuoteEvidence {
+            attest,
+            signature: sig.to_bytes().to_vec(),
+            ak_sec1: ak_sec1(),
+            pcr_values,
+        }
+    }
+
+    fn announce_event(
+        group: &[u8; 32],
+        index: u16,
+        timestamp: u64,
+        evidence: keep_frost_net::TpmQuoteEvidence,
+        proof: ([u8; 33], [u8; 64]),
+    ) -> nostr_sdk::Event {
+        use keep_frost_net::{AnnouncePayload, KfpMessage, KFP_EVENT_KIND};
+        use nostr_sdk::{EventBuilder, Keys, Kind};
+
+        let payload = AnnouncePayload::new(*group, index, proof.0, proof.1, timestamp)
+            .with_tpm_attestation(evidence);
+        let content = KfpMessage::Announce(payload).to_json().unwrap();
+        EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), content)
+            .sign_with_keys(&Keys::generate())
+            .unwrap()
+    }
+
+    // An announce carrying a valid, announce-bound quote and proof-of-share.
     fn attested_event(
         group: &[u8; 32],
         index: u16,
@@ -599,32 +739,21 @@ mod tests {
         pcr_values: Vec<String>,
         proof: ([u8; 33], [u8; 64]),
     ) -> nostr_sdk::Event {
-        attested_event_with_attest(group, index, timestamp, ATTEST, pcr_values, proof)
+        attested_event_sel(group, index, timestamp, SELECTION, pcr_values, proof)
     }
 
-    fn attested_event_with_attest(
+    fn attested_event_sel(
         group: &[u8; 32],
         index: u16,
         timestamp: u64,
-        attest: &str,
+        selection_hex: &str,
         pcr_values: Vec<String>,
         proof: ([u8; 33], [u8; 64]),
     ) -> nostr_sdk::Event {
-        use keep_frost_net::{AnnouncePayload, KfpMessage, TpmQuoteEvidence, KFP_EVENT_KIND};
-        use nostr_sdk::{EventBuilder, Keys, Kind};
-
-        let evidence = TpmQuoteEvidence {
-            attest: hex::decode(attest).unwrap(),
-            signature: vec![0u8; 64],
-            ak_sec1: hex::decode(AK).unwrap(),
-            pcr_values,
-        };
-        let payload = AnnouncePayload::new(*group, index, proof.0, proof.1, timestamp)
-            .with_tpm_attestation(evidence);
-        let content = KfpMessage::Announce(payload).to_json().unwrap();
-        EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), content)
-            .sign_with_keys(&Keys::generate())
-            .unwrap()
+        let nonce = keep_frost_net::derive_announce_attestation_nonce(group, index, timestamp);
+        let selection = hex::decode(selection_hex).unwrap();
+        let ev = evidence(&nonce, &selection, pcr_values);
+        announce_event(group, index, timestamp, ev, proof)
     }
 
     #[test]
@@ -721,10 +850,8 @@ mod tests {
 
     #[test]
     fn capture_skips_peer_with_divergent_selection() {
-        // Same canned quote but the PCR selection bitmap changed to {0} only, so
-        // peer 3's selection differs from peer 2's and it is skipped.
-        let attest_alt = ATTEST.replace("000b03951800", "000b03010000");
-        assert_ne!(attest_alt, ATTEST);
+        // Peer 3 quotes a different selection ({0} only) the single-reference
+        // policy cannot express, so only peer 2 is pinned.
         let group = [7u8; 32];
         let events = vec![
             attested_event(
@@ -734,11 +861,11 @@ mod tests {
                 default_pcrs(),
                 signed_share(&group, 2, 1_700_000_000),
             ),
-            attested_event_with_attest(
+            attested_event_sel(
                 &group,
                 3,
                 1_700_000_000,
-                &attest_alt,
+                "00000001000b03010000",
                 vec!["00".repeat(32)],
                 signed_share(&group, 3, 1_700_000_000),
             ),
@@ -747,6 +874,60 @@ mod tests {
         let config = capture_policy_from_announces(&out, &group, &events).expect("capture");
         assert_eq!(config.peer.len(), 1);
         assert_eq!(config.peer[0].index, 2);
+    }
+
+    #[test]
+    fn capture_ignores_announce_with_unauthenticated_quote() {
+        // Valid proof-of-share, but the quote's nonce is bound to a different
+        // timestamp than the announce carries, so verify_quote rejects it and
+        // nothing is captured.
+        let group = [7u8; 32];
+        let selection = hex::decode(SELECTION).unwrap();
+        let wrong_nonce =
+            keep_frost_net::derive_announce_attestation_nonce(&group, 2, 1_700_000_999);
+        let ev = evidence(&wrong_nonce, &selection, default_pcrs());
+        let event = announce_event(
+            &group,
+            2,
+            1_700_000_000,
+            ev,
+            signed_share(&group, 2, 1_700_000_000),
+        );
+        let out = Output::new();
+        assert!(capture_policy_from_announces(&out, &group, &[event]).is_err());
+    }
+
+    #[test]
+    fn capture_bad_first_announce_does_not_poison_capture() {
+        // A malformed first announce (invalid AK) must be skipped before it can
+        // seed the baseline; a later valid peer is still captured.
+        let group = [7u8; 32];
+        let selection = hex::decode(SELECTION).unwrap();
+        let nonce2 = keep_frost_net::derive_announce_attestation_nonce(&group, 2, 1_700_000_000);
+        let mut bad = evidence(&nonce2, &selection, default_pcrs());
+        bad.ak_sec1 = vec![0u8; 10]; // not a 65-byte SEC1 point
+        let nonce3 = keep_frost_net::derive_announce_attestation_nonce(&group, 3, 1_700_000_000);
+        let good = evidence(&nonce3, &selection, default_pcrs());
+        let events = vec![
+            announce_event(
+                &group,
+                2,
+                1_700_000_000,
+                bad,
+                signed_share(&group, 2, 1_700_000_000),
+            ),
+            announce_event(
+                &group,
+                3,
+                1_700_000_000,
+                good,
+                signed_share(&group, 3, 1_700_000_000),
+            ),
+        ];
+        let out = Output::new();
+        let config = capture_policy_from_announces(&out, &group, &events).expect("capture");
+        assert_eq!(config.peer.len(), 1);
+        assert_eq!(config.peer[0].index, 3);
     }
 
     #[test]

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -22,6 +22,7 @@ mod attestation;
 mod dkg;
 mod hardware;
 
+pub use attestation::cmd_frost_network_attestation_provision;
 pub use dkg::{cmd_frost_network_dkg, cmd_frost_network_group_create};
 pub use hardware::{cmd_frost_network_nonce_precommit, cmd_frost_network_sign_hardware};
 

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -335,6 +335,17 @@ fn dispatch_frost_network(
             let relay = relay.as_deref().unwrap_or(default_relay);
             commands::frost_network::cmd_frost_network_peers(out, path, &group, relay)
         }
+        FrostNetworkCommands::AttestationProvision {
+            group,
+            relay,
+            out: out_path,
+            wait,
+        } => {
+            let relay = relay.as_deref().unwrap_or(default_relay);
+            commands::frost_network::cmd_frost_network_attestation_provision(
+                out, &group, relay, &out_path, wait,
+            )
+        }
         FrostNetworkCommands::Dkg {
             group,
             threshold,

--- a/keep-frost-net/src/tpm_quote.rs
+++ b/keep-frost-net/src/tpm_quote.rs
@@ -124,6 +124,15 @@ fn parse_quote(attest: &[u8]) -> Result<ParsedQuote<'_>> {
     })
 }
 
+/// Extract the marshaled `TPML_PCR_SELECTION` bytes from a quote's `TPMS_ATTEST`.
+/// The selection a verifier must pin lives only inside the signed quote, so
+/// trust-on-first-use provisioning reads it from an observed announce. This
+/// validates magic and type but performs NO signature or freshness check: the
+/// caller is establishing trust, not relying on it.
+pub fn pcr_selection_from_attest(attest: &[u8]) -> Result<Vec<u8>> {
+    Ok(parse_quote(attest)?.pcr_select.to_vec())
+}
+
 /// Verify a TPM2 quote against a pinned AK, expected nonce, pinned PCR selection,
 /// and pinned reference PCR values. `pcr_values` are the holder's claimed PCR
 /// digests in the SAME order as the selection; `attest` is the marshaled
@@ -260,6 +269,19 @@ pub(crate) mod test_vector {
 mod tests {
     use super::test_vector::*;
     use super::*;
+
+    #[test]
+    fn pcr_selection_from_attest_matches_pinned_selection() {
+        // The selection extracted from the real quote equals the pinned bytes
+        // the verifier checks (`PCR_SELECT`), so TOFU provisioning recovers it.
+        let sel = super::pcr_selection_from_attest(&h(ATTEST)).expect("extract selection");
+        assert_eq!(sel, h(PCR_SELECT));
+    }
+
+    #[test]
+    fn pcr_selection_from_attest_rejects_non_quote() {
+        assert!(super::pcr_selection_from_attest(&[0u8; 8]).is_err());
+    }
 
     #[test]
     fn verifies_real_swtpm_quote() {


### PR DESCRIPTION
## Summary

Adds `keep frost network attestation-provision`, which authors a `--attestation-config` policy file by observing the group's announces, instead of hand-copying AK and PCR hex. This removes the main rough edge in the attestation policy workflow added in #629.

## How it works

- Connects to the relay and fetches the group's recent announces over a window (`--wait`, default 25s).
- For each announce carrying a TPM quote, captures the peer's AK pin and the shared PCR selection + reference values. The selection is read from the signed quote via a new `keep_frost_net::tpm_quote::pcr_selection_from_attest` (the selection a verifier must pin lives only inside the attest).
- Writes the policy TOML, after re-parsing it through the existing loader so a written file is guaranteed to load back into a valid policy.

It is **trust-on-first-use**: the captured pins are not verified, so the command warns prominently that it must be run on a trusted network while the holders are online. It does not touch the vault (pure network observation).

## Usage

```
keep frost network attestation-provision \
  --group npub1... --relay wss://... --out keep-attestation.toml
# review, then:
keep frost network serve --attestation-config keep-attestation.toml
```

## Tests

- `keep-frost-net`: `pcr_selection_from_attest` extracts the pinned selection from the real swtpm quote vector and rejects non-quotes.
- `keep-cli`: the capture core is pure and unit-tested , a synthetic attested announce is captured into a config, written, and reloaded into a valid `TpmAttestationPolicy`; capturing zero attested announces errors. (The relay fetch is thin glue over the tested core.)

Build, fmt, and clippy are clean across both crates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advanced support for threshold-based vault unlock with TPM-backed attestation checks.
  * Introduced a new CLI flow to provision attestation settings and save them for later use.
  * Added a helper that extracts TPM PCR selection details from attestation data.

* **Documentation**
  * Expanded usage docs with step-by-step examples for provisioning, running holders, and requesting an unlock.
  * Added notes on attestation policy setup and TPM-related requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->