### PR TITLE
keep-cli: attest the dealer in oprf-provision (--tpm-tcti)

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -259,10 +259,12 @@ they can also be run directly.
 # 1. One-time provisioning by the dealer/box, with every holder online and
 #    serving (step 2) so they receive and seal their shares: generates the OPRF
 #    key, splits it t-of-n, distributes the remote shares, and writes the LUKS
-#    key plus this box's own share.
+#    key plus this box's own share. `--tpm-tcti` is required — holders refuse a
+#    share from a dealer they cannot attest.
 keep frost network oprf-provision --group npub1... \
   --threshold 2 --total 3 --volume-id vault0 \
-  --key-out luks.key --share-out box.share
+  --key-out luks.key --share-out box.share \
+  --tpm-tcti device:/dev/tpmrm0
 
 # 2. Each holder runs a node that seals its enrolled share, loads it on the next
 #    start, and answers evaluations, verifying the box's attestation first

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -782,6 +782,7 @@ pub(crate) enum FrostNetworkCommands {
         share_out: PathBuf,
         #[arg(
             long,
+            required = true,
             value_name = "TCTI",
             help = "Attest this box to the holders by attaching a TPM quote to its announces \
                     (e.g. device:/dev/tpmrm0). Required: holders refuse a share from an \

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -780,6 +780,14 @@ pub(crate) enum FrostNetworkCommands {
             help = "Write this box's own 64-byte OPRF share here (mode 0600)"
         )]
         share_out: PathBuf,
+        #[arg(
+            long,
+            value_name = "TCTI",
+            help = "Attest this box to the holders by attaching a TPM quote to its announces \
+                    (e.g. device:/dev/tpmrm0). Required: holders refuse a share from an \
+                    unattested dealer. Needs the tpm-attestation build feature."
+        )]
+        tpm_tcti: Option<String>,
     },
 }
 

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -1292,6 +1292,7 @@ pub fn cmd_frost_network_oprf_provision(
     total: u16,
     key_out: &Path,
     share_out: &Path,
+    tpm_tcti: Option<&str>,
 ) -> Result<()> {
     debug!(
         group = group_npub,
@@ -1305,6 +1306,16 @@ pub fn cmd_frost_network_oprf_provision(
     );
 
     let mut keep = Keep::open(path)?;
+
+    // Build the announce attestor BEFORE unlocking, so a config mistake (a build
+    // without `tpm-attestation`, or an unparseable/unreachable TPM) fails fast.
+    // The dealer MUST attest: holders gate enrollment on a Verified dealer, so a
+    // box that does not attach a quote here cannot distribute any share.
+    let attestor = match tpm_tcti {
+        Some(tcti) => Some(attestation::build_announce_attestor(out, tcti)?),
+        None => None,
+    };
+
     let password = get_password("Enter password")?;
 
     let spinner = out.spinner("Unlocking vault...");
@@ -1381,6 +1392,9 @@ pub fn cmd_frost_network_oprf_provision(
         let mut node = keep_frost_net::KfpNode::new(share, vec![relay.to_string()])
             .await
             .map_err(|e| KeepError::Frost(e.to_string()))?;
+        if let Some(attestor) = attestor {
+            node.set_announce_attestor(attestor);
+        }
 
         out.info("Starting FROST coordination node...");
         let shutdown_tx = node.take_shutdown_handle();

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -484,11 +484,22 @@ fn dispatch_frost_network(
             total,
             key_out,
             share_out,
+            tpm_tcti,
         } => {
             let relay = relay.as_deref().unwrap_or(default_relay);
             commands::frost_network::cmd_frost_network_oprf_provision(
-                out, path, &group, relay, share, &volume_id, epoch, threshold, total, &key_out,
+                out,
+                path,
+                &group,
+                relay,
+                share,
+                &volume_id,
+                epoch,
+                threshold,
+                total,
+                &key_out,
                 &share_out,
+                tpm_tcti.as_deref(),
             )
         }
     }


### PR DESCRIPTION
## Summary

Fixes a provisioning gap found while scoping the end-to-end OPRF unlock test: the box dealer could not attest during `oprf-provision`, so holders refused to take custody of their shares.

The enrollment attestation gate (`enroll.rs`) **unconditionally** requires the dealer to be `Verified` before a holder seals an OPRF share. But `oprf-provision` wired no announce attestor, so the box's announces carried no TPM quote, the holders saw the dealer as `NotProvided`, and enrollment failed closed , over-the-wire provisioning could never complete.

## Change

Add `--tpm-tcti` to `frost network oprf-provision`, mirroring `oprf-unlock`: when set, the box spawns its `TpmQuoteService` and attaches a quote to every announce, so holders can verify it and accept the share. Built without the `tpm-attestation` feature, `--tpm-tcti` fails with a clear error.

The attestor is built before the vault is unlocked, so a misconfiguration fails fast.

`docs/USAGE.md` is updated: the provisioning step now shows `--tpm-tcti` and notes that holders refuse a share from a dealer they cannot attest.

## Tests

Builds, fmt, and clippy clean; the keep-cli attestation tests (20) pass. The end-to-end exercise of this path is the in-progress multi-node OPRF nixosTest in keep-node.
