### PR TITLE
keep-cli: add --tpm-tcti to frost network serve (attest for policy bootstrap)

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -286,7 +286,9 @@ policy (its attestation key and reference PCRs). Author that policy by observing
 the group's announces, then enforce it:
 
 ```bash
-# Capture pins from online peers (trust-on-first-use; run on a trusted network):
+# The peer to be pinned must be online and attesting (running with `--tpm-tcti`,
+# e.g. `keep frost network serve --tpm-tcti device:/dev/tpmrm0`) so its announce
+# carries a quote. Then capture the pins (trust-on-first-use; trusted network):
 keep frost network attestation-provision --group npub1... --out keep-attestation.toml
 
 # Enforce it — holders refuse OPRF evaluations from unverified peers:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -303,6 +303,11 @@ The TPM quote producer (`--tpm-tcti`) requires a build with the
 `tpm-attestation` feature (`cargo build --features tpm-attestation`); it links
 the tpm2-tss stack and is off by default.
 
+Point `--tpm-tcti` at a LOCAL TPM device (e.g. `device:/dev/tpmrm0`) for a
+meaningful measured-boot guarantee. A remote or virtual TCTI (e.g.
+`swtpm:host=...`) lets an operator self-attest from a TPM they do not physically
+control, which defeats the purpose of pinning the quote.
+
 ### Policy Enforcement (Warden)
 
 Integrate with [Warden](https://github.com/privkeyio/warden) for policy-based signing controls:

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -591,6 +591,11 @@ pub(crate) enum FrostNetworkCommands {
         /// dealer; without it, enrollment is refused fail-closed.
         #[arg(long, value_name = "INDEX")]
         oprf_dealer: Option<u16>,
+        /// Attach a TPM quote to this node's announces (e.g. device:/dev/tpmrm0)
+        /// so peers can verify it and a holder can pin it via
+        /// `attestation-provision`. Needs the tpm-attestation build feature.
+        #[arg(long, value_name = "TCTI")]
+        tpm_tcti: Option<String>,
     },
     Peers {
         #[arg(short, long)]

--- a/keep-cli/src/commands/frost_network/attestation.rs
+++ b/keep-cli/src/commands/frost_network/attestation.rs
@@ -208,6 +208,31 @@ pub fn build_announce_attestor(
     ))
 }
 
+/// Build the announce attestor only when `--tpm-tcti` is set, returning `Ok(None)`
+/// otherwise. Built before unlocking so a config mistake fails fast.
+pub fn optional_announce_attestor(
+    out: &Output,
+    tpm_tcti: Option<&str>,
+) -> Result<Option<std::sync::Arc<dyn keep_frost_net::AnnounceAttestor>>> {
+    match tpm_tcti {
+        Some(tcti) => Ok(Some(build_announce_attestor(out, tcti)?)),
+        None => Ok(None),
+    }
+}
+
+/// Install an announce attestor on `node` and report it, so every node that
+/// attaches a TPM quote to its announces surfaces the same status field.
+pub fn set_optional_announce_attestor(
+    out: &Output,
+    node: &mut keep_frost_net::KfpNode,
+    attestor: Option<std::sync::Arc<dyn keep_frost_net::AnnounceAttestor>>,
+) {
+    if let Some(attestor) = attestor {
+        node.set_announce_attestor(attestor);
+        out.field("Self-attestation", "attaching a TPM quote to announces");
+    }
+}
+
 /// Parse an announced AK exactly as the policy loader will (`parse_tpm_policy`):
 /// a 65-byte uncompressed SEC1 point on P-256. Returns `None` for anything the
 /// loader would later reject, so a bad AK is dropped at capture instead of

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -70,10 +70,7 @@ pub fn cmd_frost_network_serve(
     // Producer side: when this node attests via a TPM, attach a quote to every
     // announce so peers can verify it (and a holder can pin it via
     // `attestation-provision`). Built before unlocking so it fails fast.
-    let attestor = match tpm_tcti {
-        Some(tcti) => Some(attestation::build_announce_attestor(out, tcti)?),
-        None => None,
-    };
+    let attestor = attestation::optional_announce_attestor(out, tpm_tcti)?;
 
     let mut keep = Keep::open(path)?;
     let password = get_password("Enter password")?;
@@ -165,10 +162,7 @@ pub fn cmd_frost_network_serve(
             node.set_expected_oprf_dealer(dealer);
             out.field("OPRF dealer", &format!("pinned to share {dealer}"));
         }
-        if let Some(attestor) = attestor {
-            node.set_announce_attestor(attestor);
-            out.field("Self-attestation", "attaching a TPM quote to announces");
-        }
+        attestation::set_optional_announce_attestor(out, &mut node, attestor);
         let node = std::sync::Arc::new(node);
 
         let pk = node.pubkey();
@@ -1165,10 +1159,7 @@ pub fn cmd_frost_network_oprf_unlock(
     // Build the announce attestor BEFORE unlocking, so a config mistake (a build
     // without `tpm-attestation`, or an unparseable/unreachable TPM) fails fast
     // without prompting for the password or materializing the OPRF secret.
-    let attestor = match tpm_tcti {
-        Some(tcti) => Some(attestation::build_announce_attestor(out, tcti)?),
-        None => None,
-    };
+    let attestor = attestation::optional_announce_attestor(out, tpm_tcti)?;
 
     let password = get_password("Enter password")?;
 
@@ -1229,9 +1220,7 @@ pub fn cmd_frost_network_oprf_unlock(
 
         // If a TPM is configured, attach the fresh measured-boot quote source to
         // every announce so holders can verify this box before answering evals.
-        if let Some(attestor) = attestor {
-            node.set_announce_attestor(attestor);
-        }
+        attestation::set_optional_announce_attestor(out, &mut node, attestor);
 
         out.info("Starting FROST coordination node...");
         let shutdown_tx = node.take_shutdown_handle();
@@ -1324,10 +1313,7 @@ pub fn cmd_frost_network_oprf_provision(
     // without `tpm-attestation`, or an unparseable/unreachable TPM) fails fast.
     // The dealer MUST attest: holders gate enrollment on a Verified dealer, so a
     // box that does not attach a quote here cannot distribute any share.
-    let attestor = match tpm_tcti {
-        Some(tcti) => Some(attestation::build_announce_attestor(out, tcti)?),
-        None => None,
-    };
+    let attestor = attestation::optional_announce_attestor(out, tpm_tcti)?;
 
     let password = get_password("Enter password")?;
 
@@ -1405,9 +1391,7 @@ pub fn cmd_frost_network_oprf_provision(
         let mut node = keep_frost_net::KfpNode::new(share, vec![relay.to_string()])
             .await
             .map_err(|e| KeepError::Frost(e.to_string()))?;
-        if let Some(attestor) = attestor {
-            node.set_announce_attestor(attestor);
-        }
+        attestation::set_optional_announce_attestor(out, &mut node, attestor);
 
         out.info("Starting FROST coordination node...");
         let shutdown_tx = node.take_shutdown_handle();

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -58,6 +58,7 @@ pub fn cmd_frost_network_serve(
     insecure_no_attestation: bool,
     oprf_share_file: Option<&Path>,
     oprf_dealer: Option<u16>,
+    tpm_tcti: Option<&str>,
 ) -> Result<()> {
     debug!(group = group_npub, relay, share = ?share_index, refuse_raw_sign, "starting FROST network node");
 
@@ -65,6 +66,14 @@ pub fn cmd_frost_network_serve(
     // invalid one fails before we prompt for the password or touch the vault.
     let tpm_policy =
         attestation::resolve_serve_policy(out, attestation_config, insecure_no_attestation)?;
+
+    // Producer side: when this node attests via a TPM, attach a quote to every
+    // announce so peers can verify it (and a holder can pin it via
+    // `attestation-provision`). Built before unlocking so it fails fast.
+    let attestor = match tpm_tcti {
+        Some(tcti) => Some(attestation::build_announce_attestor(out, tcti)?),
+        None => None,
+    };
 
     let mut keep = Keep::open(path)?;
     let password = get_password("Enter password")?;
@@ -155,6 +164,10 @@ pub fn cmd_frost_network_serve(
         if let Some(dealer) = oprf_dealer {
             node.set_expected_oprf_dealer(dealer);
             out.field("OPRF dealer", &format!("pinned to share {dealer}"));
+        }
+        if let Some(attestor) = attestor {
+            node.set_announce_attestor(attestor);
+            out.field("Attestation", "attaching a TPM quote to announces");
         }
         let node = std::sync::Arc::new(node);
 

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -167,7 +167,7 @@ pub fn cmd_frost_network_serve(
         }
         if let Some(attestor) = attestor {
             node.set_announce_attestor(attestor);
-            out.field("Attestation", "attaching a TPM quote to announces");
+            out.field("Self-attestation", "attaching a TPM quote to announces");
         }
         let node = std::sync::Arc::new(node);
 

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -315,6 +315,7 @@ fn dispatch_frost_network(
             insecure_no_attestation,
             oprf_share_file,
             oprf_dealer,
+            tpm_tcti,
         } => {
             let relay = relay.as_deref().unwrap_or(default_relay);
             commands::frost_network::cmd_frost_network_serve(
@@ -329,6 +330,7 @@ fn dispatch_frost_network(
                 insecure_no_attestation,
                 oprf_share_file.as_deref(),
                 oprf_dealer,
+                tpm_tcti.as_deref(),
             )
         }
         FrostNetworkCommands::Peers { group, relay } => {


### PR DESCRIPTION
## Summary

Adds `--tpm-tcti` to `frost network serve`, completing the producer side of the attestation flow so a node can attach a TPM quote to its announces. This is the missing piece for **bootstrapping an attestation policy**: a holder authors its policy with `attestation-provision`, which captures a peer's AK and reference PCRs from the peer's announced quote, but `serve` (the natural "be online and announce" command) previously attached no quote, so a peer running it could not be pinned.

Without this, the policy could only be captured from a peer mid-`oprf-provision`/`oprf-unlock` (which themselves require the policy to already exist on the holder), a chicken-and-egg. `serve --tpm-tcti` breaks it: the box announces a quote, the holder captures it, then enforces the resulting policy.

## Change

`serve` gains `--tpm-tcti <TCTI>` (same wiring as `oprf-unlock`/`oprf-provision`): when set, the node spawns its `TpmQuoteService` and attaches a quote to every announce. Built before the vault unlock so a misconfiguration fails fast; without the `tpm-attestation` build feature it errors clearly. `docs/USAGE.md` notes that the peer to be pinned must be attesting.

## Tests

Build, fmt, and clippy clean; existing keep-cli attestation tests pass. End-to-end exercise is the in-progress multi-node OPRF nixosTest in keep-node.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to attach a TPM quote to FROST network node announces when starting the server.
  * Updated the server startup flow to support TPM-based announce attestation.
* **Documentation**
  * Expanded the advanced Threshold-OPRF attestation guidance to explain when and how to capture pins with TPM quote pinning.
  * Clarified that the peer must be online and producing a quote before pinning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->