### PR TITLE
deps: bump quinn-proto past RUSTSEC-2026-0037

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7106,9 +7106,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
Bumps `quinn-proto` to 0.11.15. RUSTSEC-2026-0037 (DoS, severity 8.7) was fixed in 0.11.14, which the lockfile already carried, so this is hygiene that keeps the dependency current and past the advisory. quinn-proto is a transitive dep via reqwest/quinn (the `warden` feature). Closes keep-iylw.