### PR TITLE
Fix attestation-provision to listen continuously for ephemeral announces

### DIFF
--- a/keep-cli/src/commands/frost_network/attestation.rs
+++ b/keep-cli/src/commands/frost_network/attestation.rs
@@ -472,6 +472,13 @@ pub fn cmd_frost_network_attestation_provision(
             .map_err(|e| err(format!("add relay {relay}: {e}")))?;
         client.connect().await;
 
+        // Announces are ephemeral (KFP_EVENT_KIND is in the NIP-16 ephemeral range), so relays
+        // do not store them: a point-in-time fetch (which returns on EOSE) only catches one if a
+        // peer happens to broadcast in the brief window before EOSE, making capture a race.
+        // Peers re-announce on a fixed interval, so hold a live subscription open for the full
+        // `wait` and collect every announce that arrives instead, guaranteeing we observe at
+        // least one periodic re-announce from each online peer (pick `wait` >= that interval).
+        let mut notifications = client.notifications();
         let filter = Filter::new()
             .kind(Kind::Custom(keep_frost_net::KFP_EVENT_KIND))
             .custom_tag(
@@ -479,15 +486,30 @@ pub fn cmd_frost_network_attestation_provision(
                 hex::encode(group_pubkey),
             )
             .since(Timestamp::now() - std::time::Duration::from_secs(wait));
+        client
+            .subscribe(filter, None)
+            .await
+            .map_err(|e| err(format!("subscribe announces: {e}")))?;
 
         let spinner = out.spinner(&format!("Listening {wait}s for attested announces..."));
-        let events = client
-            .fetch_events(filter, std::time::Duration::from_secs(wait))
-            .await
-            .map_err(|e| err(format!("fetch announces: {e}")))?;
+        let mut events: Vec<Event> = Vec::new();
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(wait);
+        loop {
+            match tokio::time::timeout_at(deadline, notifications.recv()).await {
+                Err(_) => break, // the full wait window elapsed: the normal success path
+                Ok(Ok(RelayPoolNotification::Event { event, .. })) => events.push(*event),
+                Ok(Ok(_)) => {} // non-event notifications: ignore
+                // Fell behind the broadcast buffer: some notifications were dropped, but peers
+                // re-announce on their interval, so keep listening rather than aborting.
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                // The stream closed before the window elapsed (relay pool shut down): surface a
+                // clear failure instead of silently capturing a partial/empty set.
+                Ok(Err(e)) => return Err(err(format!("announce subscription ended early: {e}"))),
+            }
+        }
         spinner.finish();
 
-        capture_policy_from_announces(out, &group_pubkey, &events.into_iter().collect::<Vec<_>>())
+        capture_policy_from_announces(out, &group_pubkey, &events)
     })?;
 
     let pinned = config.peer.len();


### PR DESCRIPTION
## Problem

`attestation-provision` captures peer attestation announces by calling `fetch_events`, which returns as soon as the relay sends EOSE (end of stored events). Announces are **ephemeral** events (`KFP_EVENT_KIND` is in the NIP-16 ephemeral range), so relays do not store them. That makes capture a race: the only way `fetch_events` returns an announce is if a peer happens to broadcast in the brief window between the subscription opening and EOSE arriving. With peers re-announcing on a fixed interval, the call frequently returns "no attested announce observed; are the holders online?" even though the holders *are* online.

This contradicts the documented design intent in `keep-frost-net` (`node/mod.rs`): *"Re-announce often enough that an initiator with a short discovery window reliably catches a periodic announce"* , which assumes the initiator **listens continuously**, not that it does a point-in-time fetch.

## Fix

Hold a live subscription open for the full `--wait` duration and collect every announce that arrives (via the relay notification stream), instead of `fetch_events`. As long as `--wait` is at least one re-announce interval, the capture deterministically observes at least one announce from each online peer. The downstream TOFU validation (`capture_policy_from_announces`) is unchanged.

Mirrors the subscription + `RelayPoolNotification::Event` pattern already used by the node's run loop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved attestation provisioning to continuously collect relevant peer announcements until the wait period ends.
  - This makes event capture more reliable and reduces the chance of missing announcements during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->