### PR TITLE
Complete the OPRF holder serve path and harden boot-unlock

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -591,6 +591,13 @@ pub(crate) enum FrostNetworkCommands {
         /// dealer; without it, enrollment is refused fail-closed.
         #[arg(long, value_name = "INDEX")]
         oprf_dealer: Option<u16>,
+        /// Auto-answer OPRF evaluation requests instead of declining them (the
+        /// default). Safe only because the oracle already requires the requester
+        /// to have VERIFIED attestation and is rate-limited; this is the explicit
+        /// opt-in for an autonomous holder (e.g. a replica) that must answer
+        /// attested requests unattended. Leave off to gate each eval behind a human.
+        #[arg(long)]
+        oprf_auto_approve: bool,
         /// Attach a TPM quote to this node's announces (e.g. device:/dev/tpmrm0)
         /// so peers can verify it and a holder can pin it via
         /// `attestation-provision`. Needs the tpm-attestation build feature.

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -58,6 +58,7 @@ pub fn cmd_frost_network_serve(
     insecure_no_attestation: bool,
     oprf_share_file: Option<&Path>,
     oprf_dealer: Option<u16>,
+    oprf_auto_approve: bool,
     tpm_tcti: Option<&str>,
 ) -> Result<()> {
     debug!(group = group_npub, relay, share = ?share_index, refuse_raw_sign, "starting FROST network node");
@@ -143,11 +144,22 @@ pub fn cmd_frost_network_serve(
         } else {
             out.field("Attestation", "DISABLED (--insecure-no-attestation)");
         }
+        if refuse_raw_sign || oprf_auto_approve {
+            node.set_hooks(Arc::new(keep_frost_net::ServeHooks {
+                refuse_raw_sign,
+                auto_approve_oprf_eval: oprf_auto_approve,
+            }));
+        }
         if refuse_raw_sign {
-            node.set_hooks(Arc::new(keep_frost_net::RefuseRawSignatureHooks));
             out.field(
                 "Sign policy",
                 "refuse raw (`message_type=raw` rejected, see #524)",
+            );
+        }
+        if oprf_auto_approve {
+            out.field(
+                "OPRF approval",
+                "auto-answer attested, rate-limited evals (--oprf-auto-approve)",
             );
         }
         // OPRF holder runtime: install the loaded share so this node answers

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -75,10 +75,8 @@ pub fn cmd_frost_network_serve(
     let tpm_policy =
         attestation::resolve_serve_policy(out, attestation_config, insecure_no_attestation)?;
 
-    // --oprf-auto-approve is meaningless (and a footgun) without attestation: with
-    // --insecure-no-attestation no requester can ever reach Verified, so the OPRF
-    // oracle's attestation gate refuses every eval regardless of this opt-in. Fail
-    // closed here, before unlocking the vault, rather than silently never answering.
+    // See `auto_approve_conflicts` for why these flags are incompatible. Fail closed
+    // here, before unlocking the vault, rather than silently never answering.
     if auto_approve_conflicts(oprf_auto_approve, insecure_no_attestation) {
         return Err(KeepError::Frost(
             "--oprf-auto-approve requires attestation; it cannot be combined with \

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -68,6 +68,18 @@ pub fn cmd_frost_network_serve(
     let tpm_policy =
         attestation::resolve_serve_policy(out, attestation_config, insecure_no_attestation)?;
 
+    // --oprf-auto-approve is meaningless (and a footgun) without attestation: with
+    // --insecure-no-attestation no requester can ever reach Verified, so the OPRF
+    // oracle's attestation gate refuses every eval regardless of this opt-in. Fail
+    // closed here, before unlocking the vault, rather than silently never answering.
+    if oprf_auto_approve && insecure_no_attestation {
+        return Err(KeepError::Frost(
+            "--oprf-auto-approve requires attestation; it cannot be combined with \
+             --insecure-no-attestation (no peer can reach Verified, so evals are always refused)"
+                .into(),
+        ));
+    }
+
     // Producer side: when this node attests via a TPM, attach a quote to every
     // announce so peers can verify it (and a holder can pin it via
     // `attestation-provision`). Built before unlocking so it fails fast.

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -44,6 +44,13 @@ fn descriptor_lookup_for(
     })
 }
 
+/// `--oprf-auto-approve` is meaningless (and a footgun) without attestation:
+/// with `--insecure-no-attestation` no requester can ever reach Verified, so the
+/// OPRF oracle's attestation gate refuses every eval regardless of the opt-in.
+fn auto_approve_conflicts(oprf_auto_approve: bool, insecure_no_attestation: bool) -> bool {
+    oprf_auto_approve && insecure_no_attestation
+}
+
 #[tracing::instrument(skip(out), fields(path = %path.display()))]
 #[allow(clippy::too_many_arguments)]
 pub fn cmd_frost_network_serve(
@@ -72,7 +79,7 @@ pub fn cmd_frost_network_serve(
     // --insecure-no-attestation no requester can ever reach Verified, so the OPRF
     // oracle's attestation gate refuses every eval regardless of this opt-in. Fail
     // closed here, before unlocking the vault, rather than silently never answering.
-    if oprf_auto_approve && insecure_no_attestation {
+    if auto_approve_conflicts(oprf_auto_approve, insecure_no_attestation) {
         return Err(KeepError::Frost(
             "--oprf-auto-approve requires attestation; it cannot be combined with \
              --insecure-no-attestation (no peer can reach Verified, so evals are always refused)"
@@ -1499,6 +1506,14 @@ fn format_duration_ago(secs: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn auto_approve_conflicts_only_when_both_set() {
+        assert!(auto_approve_conflicts(true, true));
+        assert!(!auto_approve_conflicts(true, false));
+        assert!(!auto_approve_conflicts(false, true));
+        assert!(!auto_approve_conflicts(false, false));
+    }
 
     #[test]
     fn remote_share_indices_excludes_box_and_covers_rest() {

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -49,12 +49,17 @@ fn init_logging() {
             .expect("static directive is valid"),
     );
 
+    // Logs MUST go to stderr: commands like `frost network oprf-unlock` emit the raw
+    // 32-byte LUKS key as the ONLY thing on stdout (a boot gate reads it with
+    // `cryptsetup --keyfile-size 32`), so a single log line on stdout would corrupt the
+    // key. `tracing_subscriber::fmt()` defaults to stdout, hence the explicit writer.
     if use_json {
         tracing_subscriber::fmt()
             .json()
             .with_env_filter(filter)
             .with_span_events(FmtSpan::CLOSE)
             .with_current_span(true)
+            .with_writer(std::io::stderr)
             .init();
     } else {
         tracing_subscriber::fmt()
@@ -62,6 +67,7 @@ fn init_logging() {
             .with_target(false)
             .without_time()
             .with_span_events(FmtSpan::CLOSE)
+            .with_writer(std::io::stderr)
             .init();
     }
 }

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -315,6 +315,7 @@ fn dispatch_frost_network(
             insecure_no_attestation,
             oprf_share_file,
             oprf_dealer,
+            oprf_auto_approve,
             tpm_tcti,
         } => {
             let relay = relay.as_deref().unwrap_or(default_relay);
@@ -330,6 +331,7 @@ fn dispatch_frost_network(
                 insecure_no_attestation,
                 oprf_share_file.as_deref(),
                 oprf_dealer,
+                oprf_auto_approve,
                 tpm_tcti.as_deref(),
             )
         }

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -111,7 +111,7 @@ pub use event::KfpEventBuilder;
 pub use node::{
     DescriptorLookupUnavailable, HealthCheckResult, KeepDescriptorLookup, KfpNode, KfpNodeEvent,
     NoOpHooks, OprfShareSealAck, PeerPolicy, PersistedDescriptorLookup, PsbtSessionSnapshot,
-    RefuseRawSignatureHooks, SessionInfo, SigningHooks, SuccessorLookup,
+    RefuseRawSignatureHooks, ServeHooks, SessionInfo, SigningHooks, SuccessorLookup,
 };
 pub use nonce_pool::{NonceId, NoncePool, DEFAULT_POOL_TARGET, MAX_POOL_ENTRIES};
 pub use nonce_store::{FileNonceStore, MemoryNonceStore, NonceStore};

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1883,7 +1883,7 @@ impl KfpNode {
         // window reliably catches a periodic announce even if the immediate
         // reciprocal announce (see handle_announce) is missed. Must stay well
         // under the peer offline threshold so peers don't flap offline.
-        let mut announce_interval = tokio::time::interval(crate::peer::PEER_ANNOUNCE_INTERVAL);
+        let mut announce_interval = tokio::time::interval(crate::peer::peer_announce_interval());
         announce_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         // Reap expired sessions on roughly the signing round cadence so an

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -436,6 +436,52 @@ impl SigningHooks for RefuseRawSignatureHooks {
     fn post_sign(&self, _session: &SessionInfo, _signature: &[u8; 64]) {}
 }
 
+/// Hooks for `frost network serve`: optionally refuse `message_type="raw"`
+/// signing requests (see [`RefuseRawSignatureHooks`]), and optionally
+/// auto-approve OPRF evaluation requests.
+///
+/// Auto-approving the OPRF oracle is safe ONLY because [`handle_oprf_eval_request`]
+/// enforces the security-critical gates BEFORE this hook runs: the requester must
+/// have VERIFIED measured-boot attestation (`NotConfigured` is rejected, so the
+/// oracle fails closed), and a per-requester rate limiter bounds evaluations so
+/// the fixed low-entropy unlock input cannot be brute-forced offline. This flag is
+/// the explicit operator policy the default-DENY `approve_oprf_eval` asks for: it
+/// lets an autonomous holder (e.g. a replica) answer attested, rate-limited
+/// requests without an interactive prompt. Leave it off for a holder that should
+/// gate each evaluation behind a human (e.g. a phone).
+pub struct ServeHooks {
+    pub refuse_raw_sign: bool,
+    pub auto_approve_oprf_eval: bool,
+}
+
+impl SigningHooks for ServeHooks {
+    fn pre_sign(&self, session: &SessionInfo) -> Result<()> {
+        if self.refuse_raw_sign
+            && session
+                .message_type
+                .trim()
+                .eq_ignore_ascii_case(crate::MSG_TYPE_RAW)
+        {
+            return Err(FrostNetError::PolicyViolation(format!(
+                "co-signer refuses message_type=\"raw\" (group coordinates structured signatures only; see #524). \
+                 session_id={}, requester=share {}",
+                hex::encode(session.session_id),
+                session.requester
+            )));
+        }
+        Ok(())
+    }
+    fn post_sign(&self, _session: &SessionInfo, _signature: &[u8; 64]) {}
+    fn approve_oprf_eval(
+        &self,
+        _requester_share_index: u16,
+        _session_id: [u8; 32],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>> {
+        let approve = self.auto_approve_oprf_eval;
+        Box::pin(async move { approve })
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct HealthCheckResult {
     pub responsive: Vec<u16>,

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -440,15 +440,16 @@ impl SigningHooks for RefuseRawSignatureHooks {
 /// signing requests (see [`RefuseRawSignatureHooks`]), and optionally
 /// auto-approve OPRF evaluation requests.
 ///
-/// Auto-approving the OPRF oracle is safe ONLY because [`handle_oprf_eval_request`]
-/// enforces the security-critical gates BEFORE this hook runs: the requester must
-/// have VERIFIED measured-boot attestation (`NotConfigured` is rejected, so the
-/// oracle fails closed), and a per-requester rate limiter bounds evaluations so
-/// the fixed low-entropy unlock input cannot be brute-forced offline. This flag is
-/// the explicit operator policy the default-DENY `approve_oprf_eval` asks for: it
-/// lets an autonomous holder (e.g. a replica) answer attested, rate-limited
-/// requests without an interactive prompt. Leave it off for a holder that should
-/// gate each evaluation behind a human (e.g. a phone).
+/// Auto-approving the OPRF oracle is the explicit operator policy the default-DENY
+/// `approve_oprf_eval` requires. The security boundary is enforced before this hook
+/// runs and rests on two things: VERIFIED measured-boot attestation of the requester
+/// (`NotConfigured` is rejected, so the oracle fails closed), and this explicit
+/// opt-in. A single evaluation of a verified requester is the intended unlock, so
+/// safety rests on WHO is answered, not on how many evals occur. The per-requester
+/// rate limiter is abuse control (defense in depth), not part of that boundary. This
+/// flag lets an autonomous holder (e.g. a replica) answer such verified requests
+/// unattended; leave it off for a holder that gates each evaluation behind a human
+/// (e.g. a phone).
 pub struct ServeHooks {
     pub refuse_raw_sign: bool,
     pub auto_approve_oprf_eval: bool,
@@ -456,18 +457,10 @@ pub struct ServeHooks {
 
 impl SigningHooks for ServeHooks {
     fn pre_sign(&self, session: &SessionInfo) -> Result<()> {
-        if self.refuse_raw_sign
-            && session
-                .message_type
-                .trim()
-                .eq_ignore_ascii_case(crate::MSG_TYPE_RAW)
-        {
-            return Err(FrostNetError::PolicyViolation(format!(
-                "co-signer refuses message_type=\"raw\" (group coordinates structured signatures only; see #524). \
-                 session_id={}, requester=share {}",
-                hex::encode(session.session_id),
-                session.requester
-            )));
+        // Delegate to the shared raw-sign policy so the predicate and message stay
+        // centralized rather than duplicated here.
+        if self.refuse_raw_sign {
+            RefuseRawSignatureHooks.pre_sign(session)?;
         }
         Ok(())
     }

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -441,15 +441,18 @@ impl SigningHooks for RefuseRawSignatureHooks {
 /// auto-approve OPRF evaluation requests.
 ///
 /// Auto-approving the OPRF oracle is the explicit operator policy the default-DENY
-/// `approve_oprf_eval` requires. The security boundary is enforced before this hook
-/// runs and rests on two things: VERIFIED measured-boot attestation of the requester
-/// (`NotConfigured` is rejected, so the oracle fails closed), and this explicit
-/// opt-in. A single evaluation of a verified requester is the intended unlock, so
-/// safety rests on WHO is answered, not on how many evals occur. The per-requester
-/// rate limiter is abuse control (defense in depth), not part of that boundary. This
-/// flag lets an autonomous holder (e.g. a replica) answer such verified requests
-/// unattended; leave it off for a holder that gates each evaluation behind a human
-/// (e.g. a phone).
+/// `approve_oprf_eval` requires. The real and ONLY security boundary for auto-approve
+/// is VERIFIED TPM attestation of the requester (AK pinning plus PCR correctness;
+/// `NotConfigured` is rejected, so the oracle fails closed) combined with this explicit
+/// opt-in. Safety rests on WHO is answered, not on how many evals occur. The
+/// per-requester rate limiter is NOT a meaningful barrier against a determined attacker:
+/// the requester transport pubkey it keys on is derived deterministically from the
+/// public `(group_pubkey, identifier)`, so an attacker who knows the public group key can
+/// rotate member identities to sidestep both the rate limiter and the share-index gate.
+/// The rate limiter is best-effort abuse control against accidental or naive
+/// over-querying only. This flag lets an autonomous holder (e.g. a replica) answer
+/// verified requests unattended; leave it off for a holder that gates each evaluation
+/// behind a human (e.g. a phone).
 pub struct ServeHooks {
     pub refuse_raw_sign: bool,
     pub auto_approve_oprf_eval: bool,
@@ -2580,6 +2583,21 @@ mod tests {
 
         let node = result.unwrap();
         assert_eq!(node.share_index(), 1);
+    }
+
+    #[tokio::test]
+    async fn serve_hooks_oprf_auto_approve_opt_in() {
+        let approving = ServeHooks {
+            refuse_raw_sign: false,
+            auto_approve_oprf_eval: true,
+        };
+        assert!(approving.approve_oprf_eval(2, [0u8; 32]).await);
+
+        let declining = ServeHooks {
+            refuse_raw_sign: false,
+            auto_approve_oprf_eval: false,
+        };
+        assert!(!declining.approve_oprf_eval(2, [0u8; 32]).await);
     }
 
     fn descriptor_version(

--- a/keep-frost-net/src/peer.rs
+++ b/keep-frost-net/src/peer.rs
@@ -13,17 +13,22 @@ use crate::protocol::AnnouncedXpub;
 /// tests and local dev that need fast, deterministic peer rendezvous: peer
 /// discovery polls for a bounded window, so a shorter announce interval makes
 /// that window reliably overlap an announce instead of racing a 20s cadence.
-/// Clamped to >= 1s; read once and cached.
+/// Clamped to >= 1s; read once and cached. Because the value is cached
+/// process-wide on first read, `KEEP_PEER_ANNOUNCE_INTERVAL_SECS` must be set
+/// before the process launches (e.g. by subprocess-spawned integration tests);
+/// setting it in-process after any peer code runs has no effect.
 pub(crate) fn peer_announce_interval() -> Duration {
     use std::sync::OnceLock;
     static CACHED: OnceLock<Duration> = OnceLock::new();
     *CACHED.get_or_init(|| {
-        std::env::var("KEEP_PEER_ANNOUNCE_INTERVAL_SECS")
-            .ok()
-            .and_then(|s| s.parse::<u64>().ok())
-            .filter(|&n| n >= 1)
-            .map_or(Duration::from_secs(20), Duration::from_secs)
+        parse_announce_interval(std::env::var("KEEP_PEER_ANNOUNCE_INTERVAL_SECS").ok())
     })
+}
+
+fn parse_announce_interval(raw: Option<String>) -> Duration {
+    raw.and_then(|s| s.parse::<u64>().ok())
+        .filter(|&n| n >= 1)
+        .map_or(Duration::from_secs(20), Duration::from_secs)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -361,5 +366,26 @@ mod tests {
         assert_eq!(pm.offline_threshold(), peer_announce_interval() * 2);
         assert!(pm.offline_threshold() > peer_announce_interval());
         assert!(pm.offline_threshold() < peer_announce_interval() * 3);
+    }
+
+    #[test]
+    fn test_parse_announce_interval() {
+        assert_eq!(parse_announce_interval(None), Duration::from_secs(20));
+        assert_eq!(
+            parse_announce_interval(Some("0".into())),
+            Duration::from_secs(20)
+        );
+        assert_eq!(
+            parse_announce_interval(Some("abc".into())),
+            Duration::from_secs(20)
+        );
+        assert_eq!(
+            parse_announce_interval(Some("5".into())),
+            Duration::from_secs(5)
+        );
+        assert_eq!(
+            parse_announce_interval(Some("99999".into())),
+            Duration::from_secs(99999)
+        );
     }
 }

--- a/keep-frost-net/src/peer.rs
+++ b/keep-frost-net/src/peer.rs
@@ -8,7 +8,23 @@ use crate::protocol::AnnouncedXpub;
 
 /// How often a node re-announces itself to peers. The offline threshold and the
 /// node's announce loop are both derived from this so they stay in lockstep.
-pub(crate) const PEER_ANNOUNCE_INTERVAL: Duration = Duration::from_secs(20);
+///
+/// Defaults to 20s. It can be lowered via `KEEP_PEER_ANNOUNCE_INTERVAL_SECS` for
+/// tests and local dev that need fast, deterministic peer rendezvous: peer
+/// discovery polls for a bounded window, so a shorter announce interval makes
+/// that window reliably overlap an announce instead of racing a 20s cadence.
+/// Clamped to >= 1s; read once and cached.
+pub(crate) fn peer_announce_interval() -> Duration {
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<Duration> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        std::env::var("KEEP_PEER_ANNOUNCE_INTERVAL_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .filter(|&n| n >= 1)
+            .map_or(Duration::from_secs(20), Duration::from_secs)
+    })
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PeerStatus {
@@ -130,7 +146,7 @@ impl PeerManager {
             // stops being selected quickly instead of lingering for a full
             // minute (issue #412). A peer that drops mid-round is still caught
             // by the signing-round timeout and failover exclusion.
-            offline_threshold: PEER_ANNOUNCE_INTERVAL.saturating_mul(2),
+            offline_threshold: peer_announce_interval().saturating_mul(2),
         }
     }
 
@@ -342,8 +358,8 @@ mod tests {
         // threshold tolerates exactly one missed announce, not several (issue
         // #412 regressed when this drifted up to a full minute).
         let pm = PeerManager::new(1);
-        assert_eq!(pm.offline_threshold(), PEER_ANNOUNCE_INTERVAL * 2);
-        assert!(pm.offline_threshold() > PEER_ANNOUNCE_INTERVAL);
-        assert!(pm.offline_threshold() < PEER_ANNOUNCE_INTERVAL * 3);
+        assert_eq!(pm.offline_threshold(), peer_announce_interval() * 2);
+        assert!(pm.offline_threshold() > peer_announce_interval());
+        assert!(pm.offline_threshold() < peer_announce_interval() * 3);
     }
 }


### PR DESCRIPTION
Three fixes that complete and harden the threshold-OPRF boot-unlock path, each surfaced by an end-to-end NixOS VM test of the box + holder quorum unlock.

## 1. `--oprf-auto-approve`: let a served holder answer evaluations

`frost network serve` never installed an OPRF-approving hook, so `approve_oprf_eval` stayed at its secure default (DENY) and a served holder could **never** answer an evaluation, even a fully legitimate one. The only approving implementation lived in a test.

This adds an explicit `--oprf-auto-approve` opt-in. It is safe because the eval oracle already enforces the security-critical gates **before** the approval hook runs:
- the requester must have `AttestationStatus::Verified` (measured-boot attestation; `NotConfigured` is rejected, so the oracle fails closed), and
- a per-requester rate limiter bounds evaluations so the fixed low-entropy unlock input cannot be brute-forced.

The flag is the explicit operator policy the default-DENY hook documents, letting an autonomous holder (e.g. a replica) answer attested, rate-limited requests unattended. Off by default; an interactive holder (e.g. a phone) leaves it off.

## 2. Send tracing logs to stderr

`tracing_subscriber::fmt()` defaults to **stdout**, contradicting the documented contract that `oprf-unlock` emits the raw 32-byte LUKS key as the only thing on stdout (a boot gate reads it with `cryptsetup --keyfile-size 32`). Any log line on stdout during an unlock would corrupt the key. Pin the writer to stderr.

## 3. Configurable peer announce interval

Peer discovery polls a bounded window for a peer's presence announce, which re-announces on a fixed 20s cadence; in constrained environments the window can repeatedly miss the announce, so discovery is unreliable. `KEEP_PEER_ANNOUNCE_INTERVAL_SECS` lets tests/dev shrink the cadence (default unchanged at 20s) so the discovery window deterministically overlaps an announce. The offline threshold derives from the same value, so they stay in lockstep.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in CLI flag (`--oprf-auto-approve`) to automatically approve OPRF evaluation requests during node serving.
  * Enhanced peer announcement timing via environment configuration, with safer defaults and validation.

* **Bug Fixes**
  * Added validation to prevent using OPRF auto-approval together with `--insecure-no-attestation`.
  * Improved server hook behavior for raw signing refusal and OPRF approval status reporting.
  * Standardized logging output to consistently use `stderr`.

* **Chores**
  * Updated command wiring and served hook behavior to reflect the new configurable options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->