### PR TITLE
test: cover refuse_raw_sign pre-sign gate; trim announce-interval env input

### DIFF
--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -2600,6 +2600,26 @@ mod tests {
         assert!(!declining.approve_oprf_eval(2, [0u8; 32]).await);
     }
 
+    #[test]
+    fn serve_hooks_refuse_raw_sign_gates_pre_sign() {
+        let hooks = ServeHooks {
+            refuse_raw_sign: true,
+            auto_approve_oprf_eval: false,
+        };
+
+        let raw = raw_session();
+        assert!(
+            hooks.pre_sign(&raw).is_err(),
+            "refuse_raw_sign must reject message_type=\"raw\""
+        );
+
+        let mut structured = raw_session();
+        structured.message_type = "nostr-event".to_string();
+        hooks
+            .pre_sign(&structured)
+            .expect("non-raw session must pass pre_sign");
+    }
+
     fn descriptor_version(
         group: [u8; 32],
         external: &str,

--- a/keep-frost-net/src/peer.rs
+++ b/keep-frost-net/src/peer.rs
@@ -26,7 +26,7 @@ pub(crate) fn peer_announce_interval() -> Duration {
 }
 
 fn parse_announce_interval(raw: Option<String>) -> Duration {
-    raw.and_then(|s| s.parse::<u64>().ok())
+    raw.and_then(|s| s.trim().parse::<u64>().ok())
         .filter(|&n| n >= 1)
         .map_or(Duration::from_secs(20), Duration::from_secs)
 }
@@ -381,6 +381,10 @@ mod tests {
         );
         assert_eq!(
             parse_announce_interval(Some("5".into())),
+            Duration::from_secs(5)
+        );
+        assert_eq!(
+            parse_announce_interval(Some(" 5 ".into())),
             Duration::from_secs(5)
         );
         assert_eq!(


### PR DESCRIPTION
Two follow-up test/robustness improvements for the OPRF holder serve path landed in #643. The feature itself is already on main; these were surfaced by a post-merge review and are not yet upstream.

## Changes

- **Cover the `refuse_raw_sign` pre-sign gate.** `ServeHooks::pre_sign` delegates to the shared raw-sign policy when `refuse_raw_sign` is set, but that branch had no test. Adds `serve_hooks_refuse_raw_sign_gates_pre_sign`, which asserts a `message_type="raw"` session is rejected and a non-raw session passes, pinning the dedup refactor's behavior-preservation claim.
- **Trim whitespace in `KEEP_PEER_ANNOUNCE_INTERVAL_SECS`.** `parse_announce_interval` now trims before parsing, so a padded value like `" 5 "` parses to 5 instead of silently falling back to the 20s default. Adds a test case.

## Verification

- `cargo test -p keep-frost-net --lib` — 292 passed, 0 failed
- `cargo build` and `cargo clippy -p keep-frost-net` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of announce interval values so inputs with extra whitespace are parsed correctly.
  * Added a safeguard that blocks raw-sign sessions during pre-sign checks while still allowing structured messages.

* **Tests**
  * Expanded test coverage for whitespace-tolerant parsing.
  * Added a test to confirm raw-sign sessions are rejected and structured sessions continue to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->