### PR TITLE
Build(deps): bump chacha20poly1305 and aes-gcm to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,13 +68,13 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
- "aead",
- "aes 0.8.4",
- "cipher 0.4.4",
+ "aead 0.6.1",
+ "aes 0.9.1",
+ "cipher 0.5.2",
  "ctr",
  "ghash",
  "subtle",
@@ -298,7 +308,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17453125d1e5c866b1f38bcccf7b9dd4a561f55930c68685ec8f188d01f71c8c"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "ascon-core",
  "subtle",
  "zeroize",
@@ -1347,11 +1357,23 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "chacha20 0.9.1",
  "cipher 0.4.4",
- "poly1305",
+ "poly1305 0.8.0",
  "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
+dependencies = [
+ "aead 0.6.1",
+ "chacha20 0.10.1",
+ "cipher 0.5.2",
+ "poly1305 0.9.0",
 ]
 
 [[package]]
@@ -2023,7 +2045,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2068,11 +2092,11 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
- "cipher 0.4.4",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -3169,11 +3193,10 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "opaque-debug",
  "polyval",
 ]
 
@@ -4561,7 +4584,7 @@ dependencies = [
  "blake2",
  "cbc 0.2.1",
  "chacha20 0.10.1",
- "chacha20poly1305",
+ "chacha20poly1305 0.11.0",
  "chrono",
  "criterion",
  "dirs",
@@ -5696,7 +5719,7 @@ dependencies = [
  "bitcoin_hashes",
  "cbc 0.1.2",
  "chacha20 0.9.1",
- "chacha20poly1305",
+ "chacha20poly1305 0.10.1",
  "getrandom 0.2.17",
  "hex",
  "instant",
@@ -6859,19 +6882,28 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00baa632505d05512f48a963e16051c54fda9a95cc9acea1a4e3c90991c4a2e"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
 name = "polyval"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
 dependencies = [
- "cfg-if 1.0.4",
- "cpufeatures 0.2.17",
- "opaque-debug",
- "universal-hash",
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -9739,6 +9771,16 @@ checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ keep-nip46 = { path = "keep-nip46" }
 
 # Crypto
 argon2 = "0.5"
-chacha20poly1305 = "0.10"
+chacha20poly1305 = "0.11"
 blake2 = "0.10"
 k256 = { version = "0.13", features = ["schnorr", "ecdh"] }
 rand = "0.10"

--- a/keep-core/Cargo.toml
+++ b/keep-core/Cargo.toml
@@ -19,7 +19,7 @@ oprf = ["dep:voprf", "dep:sha2_010", "dep:rand_core_06", "dep:vsss-rs", "k256/ha
 
 [dependencies]
 argon2 = "0.5"
-chacha20poly1305 = "0.10"
+chacha20poly1305 = "0.11"
 chacha20 = { version = "0.10", features = ["xchacha"] }
 aes = "0.9"
 cbc = { version = "0.2", features = ["alloc"] }

--- a/keep-core/src/crypto.rs
+++ b/keep-core/src/crypto.rs
@@ -14,8 +14,8 @@
 use argon2::{Algorithm, Argon2, Params, Version};
 use blake2::{Blake2b512, Digest};
 use chacha20poly1305::{
-    aead::{generic_array::GenericArray, Aead, KeyInit},
-    XChaCha20Poly1305,
+    aead::{Aead, KeyInit},
+    XChaCha20Poly1305, XNonce,
 };
 use memsecurity::EncryptedMem;
 use zeroize::{Zeroize, Zeroizing};
@@ -451,14 +451,14 @@ pub fn encrypt_with_aad(plaintext: &[u8], aad: &[u8], key: &SecretKey) -> Result
     use chacha20poly1305::aead::Payload;
 
     let decrypted = key.decrypt()?;
-    let cipher = XChaCha20Poly1305::new(GenericArray::from_slice(&*decrypted));
+    let cipher = XChaCha20Poly1305::new_from_slice(&*decrypted)
+        .map_err(|_| KeepError::Encryption("Encryption failed".into()))?;
 
     let nonce: [u8; NONCE_SIZE] = entropy::random_bytes();
-    let nonce_ga = GenericArray::from_slice(&nonce);
 
     let ciphertext = cipher
         .encrypt(
-            nonce_ga,
+            &XNonce::from(nonce),
             Payload {
                 msg: plaintext,
                 aad,
@@ -480,12 +480,12 @@ pub fn decrypt_with_aad(
     use chacha20poly1305::aead::Payload;
 
     let decrypted_key = key.decrypt()?;
-    let cipher = XChaCha20Poly1305::new(GenericArray::from_slice(&*decrypted_key));
-    let nonce = GenericArray::from_slice(&encrypted.nonce);
+    let cipher = XChaCha20Poly1305::new_from_slice(&*decrypted_key)
+        .map_err(|_| KeepError::DecryptionFailed)?;
 
     let plaintext = cipher
         .decrypt(
-            nonce,
+            &XNonce::from(encrypted.nonce),
             Payload {
                 msg: encrypted.ciphertext.as_ref(),
                 aad,

--- a/keep-core/src/keys.rs
+++ b/keep-core/src/keys.rs
@@ -279,9 +279,8 @@ pub fn bytes_to_npub(pubkey: &[u8; 32]) -> String {
 /// NIP-49 encrypted private key (ncryptsec) support.
 pub mod nip49 {
     use bech32::{Bech32, Hrp};
-    use chacha20poly1305::aead::generic_array::GenericArray;
     use chacha20poly1305::aead::{Aead, KeyInit, Payload};
-    use chacha20poly1305::XChaCha20Poly1305;
+    use chacha20poly1305::{XChaCha20Poly1305, XNonce};
     use unicode_normalization::UnicodeNormalization;
     use zeroize::{Zeroize, Zeroizing};
 
@@ -313,13 +312,14 @@ pub mod nip49 {
         let nonce: [u8; 24] = entropy::random_bytes();
         let key_security_byte: u8 = 0x01;
 
-        let cipher = XChaCha20Poly1305::new(GenericArray::from_slice(symmetric_key.as_ref()));
+        let cipher = XChaCha20Poly1305::new_from_slice(symmetric_key.as_ref())
+            .map_err(|_| CryptoError::encryption("NIP-49 key init failed"))?;
         let payload = Payload {
             msg: secret_key.as_slice(),
             aad: &[key_security_byte],
         };
         let ciphertext = cipher
-            .encrypt(GenericArray::from_slice(&nonce), payload)
+            .encrypt(&XNonce::from(nonce), payload)
             .map_err(|_| CryptoError::encryption("NIP-49 encryption failed"))?;
 
         let mut concat = Vec::with_capacity(91);
@@ -377,13 +377,14 @@ pub mod nip49 {
         let password_nfkc = Zeroizing::new(password.nfkc().collect::<String>());
         let symmetric_key = derive_key(&password_nfkc, &salt, log_n)?;
 
-        let cipher = XChaCha20Poly1305::new(GenericArray::from_slice(symmetric_key.as_ref()));
+        let cipher = XChaCha20Poly1305::new_from_slice(symmetric_key.as_ref())
+            .map_err(|_| KeepError::DecryptionFailed)?;
         let payload = Payload {
             msg: &ciphertext,
             aad: &[key_security_byte],
         };
         let mut plaintext = cipher
-            .decrypt(GenericArray::from_slice(&nonce), payload)
+            .decrypt(&XNonce::from(nonce), payload)
             .map_err(|_| KeepError::DecryptionFailed)?;
 
         if plaintext.len() != 32 {

--- a/keep-core/src/oprf.rs
+++ b/keep-core/src/oprf.rs
@@ -419,7 +419,7 @@ mod tests {
         let s = <Scalar as k256::elliptic_curve::Field>::random(&mut rng);
         let server = OprfServer::<Secp256k1Sha256>::new_with_key(s.to_bytes().as_slice())
             .expect("server from key");
-        let shares = threshold::split_key(&s, 2, 3, &mut rng).expect("split");
+        let shares = threshold::split_key(&s, 2, 3, rng).expect("split");
         (server, shares)
     }
 
@@ -524,11 +524,11 @@ mod tests {
         let input: &[u8] = b"keep-node-vault-v1";
 
         let s = <Scalar as k256::elliptic_curve::Field>::random(&mut rng);
-        let shares = threshold::split_key(&s, 2, 3, &mut rng).expect("split");
+        let shares = threshold::split_key(&s, 2, 3, rng).expect("split");
 
         // A second, independent key split with the SAME identifiers/threshold/n.
         let s_other = <Scalar as k256::elliptic_curve::Field>::random(&mut rng);
-        let shares_other = threshold::split_key(&s_other, 2, 3, &mut rng).expect("split other");
+        let shares_other = threshold::split_key(&s_other, 2, 3, rng).expect("split other");
 
         // One blind; evaluate the correct and the mixed quorum against the SAME blinded element
         // and finalize both with the same client state.
@@ -577,7 +577,7 @@ mod tests {
         let input: &[u8] = b"keep-node-vault-v1";
 
         let s = <Scalar as k256::elliptic_curve::Field>::random(&mut rng);
-        let shares = threshold::split_key(&s, 2, 3, &mut rng).expect("split");
+        let shares = threshold::split_key(&s, 2, 3, rng).expect("split");
         let b = OprfClient::<Secp256k1Sha256>::blind(input, &mut rng).expect("blind");
         let p0 = threshold::partial_eval(&shares[0], &b.message).expect("p0");
 
@@ -626,7 +626,7 @@ mod tests {
         use k256::Scalar;
         let mut rng = rand_core_06::OsRng;
         let s = <Scalar as k256::elliptic_curve::Field>::random(&mut rng);
-        let shares = threshold::split_key(&s, 2, 3, &mut rng).expect("split");
+        let shares = threshold::split_key(&s, 2, 3, rng).expect("split");
 
         assert!(
             unlock::evaluate(&shares[0], &[0u8; 10]).is_err(),
@@ -663,7 +663,7 @@ mod tests {
         use k256::Scalar;
         let mut rng = rand_core_06::OsRng;
         let s = <Scalar as k256::elliptic_curve::Field>::random(&mut rng);
-        let shares = threshold::split_key(&s, 2, 3, &mut rng).expect("split");
+        let shares = threshold::split_key(&s, 2, 3, rng).expect("split");
 
         let (client, wire) = unlock::blind(b"keep-node-vault-v1").expect("blind");
         let p0 = unlock::evaluate(&shares[0], &wire).expect("eval");
@@ -704,7 +704,7 @@ mod tests {
         let mut rng = rand_core_06::OsRng;
         let input: &[u8] = b"keep-node-vault-v1";
         let s = <Scalar as k256::elliptic_curve::Field>::random(&mut rng);
-        let shares = threshold::split_key(&s, 2, 3, &mut rng).expect("split");
+        let shares = threshold::split_key(&s, 2, 3, rng).expect("split");
         let b = OprfClient::<Secp256k1Sha256>::blind(input, &mut rng).expect("blind");
 
         for share in &shares {
@@ -740,11 +740,11 @@ mod tests {
         let s = <Scalar as k256::elliptic_curve::Field>::random(&mut rng);
 
         assert!(
-            threshold::split_key(&s, 4, 3, &mut rng).is_err(),
+            threshold::split_key(&s, 4, 3, rng).is_err(),
             "t > n must be rejected"
         );
         assert!(
-            threshold::split_key(&s, 1, 3, &mut rng).is_err(),
+            threshold::split_key(&s, 1, 3, rng).is_err(),
             "t < 2 must be rejected"
         );
     }
@@ -783,7 +783,7 @@ mod tests {
         use k256::Scalar;
         let mut rng = rand_core_06::OsRng;
         let s = <Scalar as k256::elliptic_curve::Field>::random(&mut rng);
-        let shares = threshold::split_key(&s, 2, 3, &mut rng).expect("split");
+        let shares = threshold::split_key(&s, 2, 3, rng).expect("split");
         let (_client, wire) = unlock::blind(b"keep-node-vault-v1").expect("blind");
         let mut bytes = unlock::evaluate(&shares[0], &wire).expect("eval");
         bytes[..threshold::ID_LEN].fill(0); // zero the identifier, keep the valid point

--- a/keep-enclave/enclave/Cargo.lock
+++ b/keep-enclave/enclave/Cargo.lock
@@ -4,30 +4,30 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common",
- "generic-array",
+ "crypto-common 0.2.2",
+ "inout",
 ]
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
  "aead",
  "aes",
@@ -176,6 +176,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,13 +241,20 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
  "inout",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -262,10 +278,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -305,12 +336,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctr"
-version = "0.9.2"
+name = "crypto-common"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -340,9 +389,9 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -494,11 +543,10 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "opaque-debug",
  "polyval",
 ]
 
@@ -584,12 +632,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.4"
+name = "hybrid-array"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
- "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -773,12 +830,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,13 +853,12 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
 dependencies = [
- "cfg-if",
- "cpufeatures",
- "opaque-debug",
+ "cpubits",
+ "cpufeatures 0.3.0",
  "universal-hash",
 ]
 
@@ -992,7 +1042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1177,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -1189,12 +1239,12 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]

--- a/keep-enclave/enclave/Cargo.toml
+++ b/keep-enclave/enclave/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 k256 = { version = "0.13.4", default-features = false, features = ["schnorr", "alloc"] }
 sha2 = { version = "0.10", default-features = false }
 hmac = { version = "0.12", default-features = false }
-aes-gcm = { version = "0.10.3", default-features = false, features = ["alloc", "aes"] }
+aes-gcm = { version = "0.11.0", default-features = false, features = ["alloc", "aes"] }
 signature = "2.2"
 
 frost-secp256k1-tr = { version = "3.0", default-features = false, features = ["serialization"] }

--- a/keep-enclave/enclave/src/kms.rs
+++ b/keep-enclave/enclave/src/kms.rs
@@ -42,7 +42,7 @@ impl EnclaveKms {
         let cipher = Aes256Gcm::new_from_slice(&data_key)
             .map_err(|e| EnclaveError::Kms(format!("Invalid data key: {}", e)))?;
 
-        let nonce = Nonce::from_slice(&encrypted.nonce);
+        let nonce = &Nonce::from(encrypted.nonce);
         let wallet_key = cipher
             .decrypt(nonce, encrypted.encrypted_wallet_key.as_ref())
             .map_err(|e| EnclaveError::Kms(format!("Decryption failed: {}", e)))?;
@@ -106,7 +106,7 @@ impl EnclaveKms {
             return Err(EnclaveError::Kms("Invalid encrypted key format".into()));
         }
 
-        let nonce = Nonce::from_slice(&encrypted_key[..12]);
+        let nonce = &Nonce::try_from(&encrypted_key[..12]).expect("slice is exactly 12 bytes");
         let ciphertext = &encrypted_key[12..];
 
         let cipher = Aes256Gcm::new_from_slice(&*self.ephemeral_secret)
@@ -126,7 +126,7 @@ mod tests {
     fn encrypt_data_key(master_key: &[u8; 32], plaintext: &[u8]) -> Vec<u8> {
         let nonce_bytes: [u8; 12] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
         let cipher = Aes256Gcm::new_from_slice(master_key).unwrap();
-        let nonce = Nonce::from_slice(&nonce_bytes);
+        let nonce = &Nonce::from(nonce_bytes);
         let mut ciphertext = cipher.encrypt(nonce, plaintext).unwrap();
         let mut result = nonce_bytes.to_vec();
         result.append(&mut ciphertext);
@@ -135,7 +135,7 @@ mod tests {
 
     fn encrypt_wallet_key(data_key: &[u8], wallet_key: &[u8], nonce: &[u8; 12]) -> Vec<u8> {
         let cipher = Aes256Gcm::new_from_slice(data_key).unwrap();
-        let n = Nonce::from_slice(nonce);
+        let n = &Nonce::from(*nonce);
         cipher.encrypt(n, wallet_key).unwrap()
     }
 

--- a/keep-enclave/host/Cargo.toml
+++ b/keep-enclave/host/Cargo.toml
@@ -27,7 +27,7 @@ const-oid = "0.10"
 k256 = { version = "0.13.4", features = ["schnorr"] }
 signature = "3.0"
 getrandom = "0.4"
-aes-gcm = "0.10.3"
+aes-gcm = "0.11.0"
 base64 = "0.22"
 redb.workspace = true
 rand_core = "0.10"

--- a/keep-enclave/host/src/kms.rs
+++ b/keep-enclave/host/src/kms.rs
@@ -48,7 +48,7 @@ impl<K: KmsProvider> EnvelopeEncryption<K> {
         let cipher = Aes256Gcm::new_from_slice(&data_key_result.plaintext)
             .map_err(|e| EnclaveError::Kms(format!("Invalid key: {e}")))?;
 
-        let nonce = Nonce::from_slice(&nonce_bytes);
+        let nonce = &Nonce::from(nonce_bytes);
         let encrypted_wallet_key = cipher
             .encrypt(nonce, wallet_key)
             .map_err(|e| EnclaveError::Kms(format!("Encryption failed: {e}")))?;
@@ -75,7 +75,7 @@ impl<K: KmsProvider> EnvelopeEncryption<K> {
         let cipher = Aes256Gcm::new_from_slice(&data_key)
             .map_err(|e| EnclaveError::Kms(format!("Invalid key: {e}")))?;
 
-        let nonce = Nonce::from_slice(&encrypted.nonce);
+        let nonce = &Nonce::from(encrypted.nonce);
         let wallet_key = cipher
             .decrypt(nonce, encrypted.encrypted_wallet_key.as_ref())
             .map_err(|e| EnclaveError::Kms(format!("Decryption failed: {e}")))?;
@@ -121,7 +121,7 @@ impl KmsProvider for MockKmsProvider {
         let cipher = Aes256Gcm::new_from_slice(&self.master_key)
             .map_err(|e| EnclaveError::Kms(format!("Invalid master key: {e}")))?;
 
-        let nonce = Nonce::from_slice(&nonce_bytes);
+        let nonce = &Nonce::from(nonce_bytes);
         let mut ciphertext = cipher
             .encrypt(nonce, plaintext.as_ref())
             .map_err(|e| EnclaveError::Kms(format!("Failed to encrypt data key: {e}")))?;
@@ -143,7 +143,7 @@ impl KmsProvider for MockKmsProvider {
             return Err(EnclaveError::Kms("Invalid encrypted key".into()));
         }
 
-        let nonce = Nonce::from_slice(&encrypted_key[..12]);
+        let nonce = &Nonce::try_from(&encrypted_key[..12]).expect("slice is exactly 12 bytes");
         let ciphertext = &encrypted_key[12..];
 
         let cipher = Aes256Gcm::new_from_slice(&self.master_key)


### PR DESCRIPTION
Bumps the RustCrypto AEAD crates to 0.11.0, combining the two Dependabot updates (#639, #640) into one change so the shared API migration lands together.

- `chacha20poly1305` 0.10 -> 0.11 (workspace + keep-core)
- `aes-gcm` 0.10.3 -> 0.11.0 (keep-enclave host and enclave)

0.11 drops the `generic_array` re-export in favor of `hybrid-array` and deprecates `Array::from_slice`. Code changes:

- keep-core `crypto.rs` / `keys.rs`: replace `GenericArray::from_slice`/`Key::from_slice` with `XChaCha20Poly1305::new_from_slice` for key init and `XNonce::from(..)` for nonces.
- keep-enclave `kms.rs` (host + enclave): replace deprecated `Nonce::from_slice` with `Nonce::from(..)` for owned 12-byte arrays and `Nonce::try_from(..)` for slices.
- keep-core `oprf.rs` tests: drop a now-needless `&mut` borrow on the `OsRng` argument to `split_key` (the updated dependency tree surfaces `clippy::needless_borrows_for_generic_args`).

`nostr` still pins `chacha20poly1305` 0.10, so both versions coexist in the tree; `multiple-versions` is already `warn` in `deny.toml`.

Verified locally: `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace --lib --bins`, `cargo check --all-targets --features testing` (1.89 MSRV), and the excluded fuzz and enclave crates all pass.

Closes #639
Closes #640


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated encryption and decryption flows to use newer crypto library APIs, improving compatibility with current releases.
  * Adjusted nonce handling across wallet and key encryption paths for more reliable processing.
  * Refined internal test coverage to match the updated key-splitting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->