### PR TITLE
frost: invalidate live node on share import so imported group announces

### DIFF
--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -877,16 +877,22 @@ impl KeepMobile {
         Some((&metadata).into())
     }
 
+    /// Drop pending sign requests and null the live node so the next active
+    /// share re-initializes a fresh node instead of reusing the stale one.
+    fn invalidate_live_node(&self) {
+        self.runtime.block_on(async {
+            self.pending_requests.lock().await.clear();
+            *self.node.write().await = None;
+        });
+    }
+
     pub fn set_active_share(&self, group_pubkey: String) -> Result<(), KeepMobileError> {
         validate_hex_pubkey(&group_pubkey)?;
 
         self.storage.load_share_by_key(group_pubkey.clone())?;
         self.storage.set_active_share_key(Some(group_pubkey))?;
 
-        self.runtime.block_on(async {
-            self.pending_requests.lock().await.clear();
-            *self.node.write().await = None;
-        });
+        self.invalidate_live_node();
 
         Ok(())
     }
@@ -2657,10 +2663,7 @@ impl KeepMobile {
         self.storage
             .set_active_share_key(Some(group_pubkey_hex.clone()))?;
 
-        self.runtime.block_on(async {
-            self.pending_requests.lock().await.clear();
-            *self.node.write().await = None;
-        });
+        self.invalidate_live_node();
 
         Ok(ShareInfo {
             name: metadata_info.name,
@@ -2885,10 +2888,7 @@ impl KeepMobile {
         self.storage
             .set_active_share_key(Some(group_pubkey_hex.clone()))?;
 
-        self.runtime.block_on(async {
-            self.pending_requests.lock().await.clear();
-            *self.node.write().await = None;
-        });
+        self.invalidate_live_node();
 
         Ok(ShareInfo {
             name: metadata.name,
@@ -3464,12 +3464,14 @@ mod import_teardown_tests {
         }
     }
 
-    // A successful import must run the same teardown set_active_share does:
-    // clear pending requests and null the live node so the imported group can
-    // announce without a restart. Seeding a pending request lets us observe the
-    // teardown block executed (before the fix it never ran on the import path).
+    // A successful import must run invalidate_live_node, the same teardown
+    // set_active_share does, so the imported group can announce without a
+    // restart. The node starts None in this harness (a real KfpNode needs a
+    // live network), so we observe the teardown via the pending request it
+    // clears: seeding one lets us prove the block ran (before the fix it never
+    // ran on the import path).
     #[test]
-    fn import_nsec_invalidates_live_node() {
+    fn import_nsec_runs_node_teardown() {
         let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
         let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
 
@@ -3497,10 +3499,6 @@ mod import_teardown_tests {
             assert!(
                 mobile.pending_requests.lock().await.is_empty(),
                 "import must clear pending requests via node teardown"
-            );
-            assert!(
-                mobile.node.read().await.is_none(),
-                "import must invalidate the live node"
             );
         });
         assert_eq!(

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -420,6 +420,11 @@ impl SigningHooks for MobileSigningHooks {
 #[derive(uniffi::Object)]
 pub struct KeepMobile {
     pub(crate) node: Arc<RwLock<Option<Arc<KfpNode>>>>,
+    /// Handles for the node's spawned run + event-listener tasks. Nulling the
+    /// `node` Arc alone does not stop them: each task holds its own Arc clone,
+    /// so the node never drops and keeps signing on the relays. Held here so
+    /// invalidate_live_node can abort them.
+    node_tasks: Arc<std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>>,
     storage: Arc<dyn SecureStorage>,
     pending_requests: Arc<Mutex<Vec<PendingRequest>>>,
     dkg_session: DkgSession,
@@ -564,6 +569,7 @@ impl KeepMobile {
 
         Ok(Self {
             node: Arc::new(RwLock::new(None)),
+            node_tasks: Arc::new(std::sync::Mutex::new(Vec::new())),
             storage,
             pending_requests: Arc::new(Mutex::new(Vec::new())),
             dkg_session: DkgSession::new(),
@@ -877,9 +883,20 @@ impl KeepMobile {
         Some((&metadata).into())
     }
 
-    /// Drop pending sign requests and null the live node so the next active
-    /// share re-initializes a fresh node instead of reusing the stale one.
+    /// Abort the running node's tasks, drop pending sign requests, and null the
+    /// live node so the next active share re-initializes a fresh node instead of
+    /// leaving the stale one signing on the relays. Aborting the tasks lets them
+    /// release their Arc clones, so the node drops and its share material
+    /// zeroizes once the runtime finishes cancelling them.
     fn invalidate_live_node(&self) {
+        for handle in self
+            .node_tasks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .drain(..)
+        {
+            handle.abort();
+        }
         self.runtime.block_on(async {
             self.pending_requests.lock().await.clear();
             *self.node.write().await = None;
@@ -907,9 +924,7 @@ impl KeepMobile {
 
         if is_active {
             self.storage.set_active_share_key(None)?;
-            self.runtime.block_on(async {
-                *self.node.write().await = None;
-            });
+            self.invalidate_live_node();
         }
 
         self.storage.delete_share_by_key(group_pubkey)?;
@@ -2597,16 +2612,30 @@ impl KeepMobile {
                 callback: self.state_callback.clone(),
                 rev: self.state_rev.clone(),
             };
-            tokio::spawn(async move {
+            let listener_handle = tokio::spawn(async move {
                 Self::event_listener(event_rx, request_rx, desc_ctx, state_ctx).await;
             });
 
             let run_node = node.clone();
-            tokio::spawn(async move {
+            let run_handle = tokio::spawn(async move {
                 if let Err(e) = run_node.run().await {
                     tracing::error!("Node run failed: {e}");
                 }
             });
+
+            {
+                let mut tasks = self
+                    .node_tasks
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                // Abort any node whose tasks were left running from a prior
+                // initialize that skipped invalidate_live_node.
+                for handle in tasks.drain(..) {
+                    handle.abort();
+                }
+                tasks.push(listener_handle);
+                tasks.push(run_handle);
+            }
 
             *self.node.write().await = Some(node);
             Ok(())
@@ -3464,17 +3493,11 @@ mod import_teardown_tests {
         }
     }
 
-    // A successful import must run invalidate_live_node, the same teardown
-    // set_active_share does, so the imported group can announce without a
-    // restart. The node starts None in this harness (a real KfpNode needs a
-    // live network), so we observe the teardown via the pending request it
-    // clears: seeding one lets us prove the block ran (before the fix it never
-    // ran on the import path).
-    #[test]
-    fn import_nsec_runs_node_teardown() {
-        let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
-        let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
-
+    // Seed one pending request so we can observe invalidate_live_node running:
+    // the node starts None in this harness (a real KfpNode needs a live
+    // network), so the pending request it clears is the observable proof the
+    // teardown block ran on the import path.
+    fn seed_pending_request(mobile: &KeepMobile) {
         let (tx, _rx) = mpsc::channel::<bool>(1);
         mobile.runtime.block_on(async {
             mobile.pending_requests.lock().await.push(PendingRequest {
@@ -3490,17 +3513,57 @@ mod import_teardown_tests {
                 response_tx: tx,
             });
         });
+    }
 
-        let info = mobile
-            .import_nsec("01".repeat(32), "imported".into())
-            .unwrap();
-
+    fn assert_pending_cleared(mobile: &KeepMobile) {
         mobile.runtime.block_on(async {
             assert!(
                 mobile.pending_requests.lock().await.is_empty(),
                 "import must clear pending requests via node teardown"
             );
         });
+    }
+
+    // A successful import must run invalidate_live_node, the same teardown
+    // set_active_share does, so the imported group can announce without a
+    // restart. Before the fix it never ran on the import path.
+    #[test]
+    fn import_nsec_runs_node_teardown() {
+        let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
+        let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
+
+        seed_pending_request(&mobile);
+
+        let info = mobile
+            .import_nsec("01".repeat(32), "imported".into())
+            .unwrap();
+
+        assert_pending_cleared(&mobile);
+        assert_eq!(
+            storage.get_active_share_key().as_deref(),
+            Some(info.group_pubkey.as_str())
+        );
+    }
+
+    // The import_share path lands in store_share_package, which got the same
+    // invalidate_live_node() call; guard it so a future removal is caught.
+    #[test]
+    fn store_share_package_runs_node_teardown() {
+        let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
+        let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
+
+        seed_pending_request(&mobile);
+
+        let key_bytes = Zeroizing::new(hex::decode("02".repeat(32)).unwrap());
+        let (key_package, pubkey_package, vk_bytes) =
+            KeepMobile::build_nsec_packages(&key_bytes).unwrap();
+        let group_pubkey: [u8; 32] = vk_bytes[1..33].try_into().unwrap();
+        let metadata = ShareMetadata::new(1, 1, 1, group_pubkey, "imported-share".into());
+        let share = SharePackage::new(metadata, &key_package, &pubkey_package).unwrap();
+
+        let info = mobile.store_share_package(&share).unwrap();
+
+        assert_pending_cleared(&mobile);
         assert_eq!(
             storage.get_active_share_key().as_deref(),
             Some(info.group_pubkey.as_str())

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -2657,6 +2657,11 @@ impl KeepMobile {
         self.storage
             .set_active_share_key(Some(group_pubkey_hex.clone()))?;
 
+        self.runtime.block_on(async {
+            self.pending_requests.lock().await.clear();
+            *self.node.write().await = None;
+        });
+
         Ok(ShareInfo {
             name: metadata_info.name,
             share_index: metadata_info.identifier,
@@ -2879,6 +2884,11 @@ impl KeepMobile {
             .store_share_by_key(group_pubkey_hex.clone(), serialized, metadata.clone())?;
         self.storage
             .set_active_share_key(Some(group_pubkey_hex.clone()))?;
+
+        self.runtime.block_on(async {
+            self.pending_requests.lock().await.clear();
+            *self.node.write().await = None;
+        });
 
         Ok(ShareInfo {
             name: metadata.name,
@@ -3389,5 +3399,113 @@ impl KeepMobile {
         self.storage.set_active_share_key(Some(key.clone()))?;
 
         Ok(key)
+    }
+}
+
+#[cfg(test)]
+mod import_teardown_tests {
+    use super::*;
+    use crate::storage::{SecureStorage, ShareMetadataInfo};
+    use std::collections::HashMap;
+    use std::sync::Mutex as StdMutex;
+
+    #[derive(Default)]
+    struct MemStorage {
+        data: StdMutex<HashMap<String, Vec<u8>>>,
+        active: StdMutex<Option<String>>,
+    }
+
+    impl SecureStorage for MemStorage {
+        fn store_share(&self, _: Vec<u8>, _: ShareMetadataInfo) -> Result<(), KeepMobileError> {
+            Ok(())
+        }
+        fn load_share(&self) -> Result<Vec<u8>, KeepMobileError> {
+            Err(KeepMobileError::StorageNotFound)
+        }
+        fn has_share(&self) -> bool {
+            false
+        }
+        fn get_share_metadata(&self) -> Option<ShareMetadataInfo> {
+            None
+        }
+        fn delete_share(&self) -> Result<(), KeepMobileError> {
+            Ok(())
+        }
+        fn store_share_by_key(
+            &self,
+            key: String,
+            data: Vec<u8>,
+            _: ShareMetadataInfo,
+        ) -> Result<(), KeepMobileError> {
+            self.data.lock().unwrap().insert(key, data);
+            Ok(())
+        }
+        fn load_share_by_key(&self, key: String) -> Result<Vec<u8>, KeepMobileError> {
+            self.data
+                .lock()
+                .unwrap()
+                .get(&key)
+                .cloned()
+                .ok_or(KeepMobileError::StorageNotFound)
+        }
+        fn list_all_shares(&self) -> Vec<ShareMetadataInfo> {
+            Vec::new()
+        }
+        fn delete_share_by_key(&self, key: String) -> Result<(), KeepMobileError> {
+            self.data.lock().unwrap().remove(&key);
+            Ok(())
+        }
+        fn get_active_share_key(&self) -> Option<String> {
+            self.active.lock().unwrap().clone()
+        }
+        fn set_active_share_key(&self, key: Option<String>) -> Result<(), KeepMobileError> {
+            *self.active.lock().unwrap() = key;
+            Ok(())
+        }
+    }
+
+    // A successful import must run the same teardown set_active_share does:
+    // clear pending requests and null the live node so the imported group can
+    // announce without a restart. Seeding a pending request lets us observe the
+    // teardown block executed (before the fix it never ran on the import path).
+    #[test]
+    fn import_nsec_invalidates_live_node() {
+        let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
+        let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
+
+        let (tx, _rx) = mpsc::channel::<bool>(1);
+        mobile.runtime.block_on(async {
+            mobile.pending_requests.lock().await.push(PendingRequest {
+                info: SignRequest {
+                    id: "seed".into(),
+                    session_id: vec![0u8; 32],
+                    message_type: String::new(),
+                    message_preview: String::new(),
+                    from_peer: 0,
+                    timestamp: 0,
+                    metadata: None,
+                },
+                response_tx: tx,
+            });
+        });
+
+        let info = mobile
+            .import_nsec("01".repeat(32), "imported".into())
+            .unwrap();
+
+        mobile.runtime.block_on(async {
+            assert!(
+                mobile.pending_requests.lock().await.is_empty(),
+                "import must clear pending requests via node teardown"
+            );
+            assert!(
+                mobile.node.read().await.is_none(),
+                "import must invalidate the live node"
+            );
+        });
+        assert_eq!(
+            storage.get_active_share_key().as_deref(),
+            Some(info.group_pubkey.as_str())
+        );
     }
 }


### PR DESCRIPTION
`import_share`/`store_share_package` and `do_import_nsec` changed the active share but never tore down the running FROST node, unlike `set_active_share`/`delete_share_by_key`. So an imported group never announced until keep restarted (fixes the keep-android import-restart bug).

Both import paths now run the same teardown after the share is persisted and the active key is set, so a failed import never nulls a valid node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Importing or storing a share now reliably resets active session state.
  * Pending requests are cleared and the active live session/node is stopped when switching to an imported share.
  * The active share key now updates consistently after importing via NSEC or saving a share package.
* **Tests**
  * Added/expanded coverage to verify that share import and share-package storage trigger proper teardown behavior and state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->