### PR TITLE
agent: honor loopback proxy for relay connections

### DIFF
--- a/keep-agent-py/src/lib.rs
+++ b/keep-agent-py/src/lib.rs
@@ -23,6 +23,13 @@ fn to_py_value_err(e: impl std::fmt::Display) -> PyErr {
     PyValueError::new_err(e.to_string())
 }
 
+fn resolve_proxy(proxy_port: Option<u16>) -> PyResult<Option<std::net::SocketAddr>> {
+    match proxy_port {
+        Some(port) => Ok(Some(loopback_proxy(port).map_err(to_py_value_err)?)),
+        None => Ok(None),
+    }
+}
+
 fn create_runtime() -> PyResult<tokio::runtime::Runtime> {
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -478,10 +485,7 @@ impl PyRemoteSession {
         let rt = create_runtime()?;
         let timeout = std::time::Duration::from_secs(timeout_secs);
 
-        let proxy = match proxy_port {
-            Some(port) => Some(loopback_proxy(port).map_err(to_py_err)?),
-            None => None,
-        };
+        let proxy = resolve_proxy(proxy_port)?;
 
         let client = rt.block_on(AgentClient::connect_with_proxy(bunker_url, timeout, proxy))
             .map_err(|e| PyConnectionError::new_err(e.to_string()))?;
@@ -581,10 +585,7 @@ impl PyPendingSession {
         let rt = create_runtime()?;
         let timeout = std::time::Duration::from_secs(timeout_secs);
 
-        let proxy = match proxy_port {
-            Some(port) => Some(loopback_proxy(port).map_err(to_py_err)?),
-            None => None,
-        };
+        let proxy = resolve_proxy(proxy_port)?;
 
         let pending = rt.block_on(PendingSession::new_with_proxy(bunker_url, timeout, proxy))
             .map_err(|e| PyConnectionError::new_err(e.to_string()))?;

--- a/keep-agent-py/src/lib.rs
+++ b/keep-agent-py/src/lib.rs
@@ -12,6 +12,7 @@ use zeroize::Zeroizing;
 use ::keep_agent::{
     RateLimitConfig, SessionConfig, SessionManager, SessionMetadata,
     SessionScope, SessionToken, Operation, AgentClient, ApprovalStatus, PendingSession,
+    loopback_proxy,
 };
 
 fn to_py_err(e: impl std::fmt::Display) -> PyErr {
@@ -472,12 +473,17 @@ pub struct PyRemoteSession {
 #[pymethods]
 impl PyRemoteSession {
     #[staticmethod]
-    #[pyo3(signature = (bunker_url, timeout_secs=30))]
-    fn connect(bunker_url: &str, timeout_secs: u64) -> PyResult<Self> {
+    #[pyo3(signature = (bunker_url, timeout_secs=30, proxy_port=None))]
+    fn connect(bunker_url: &str, timeout_secs: u64, proxy_port: Option<u16>) -> PyResult<Self> {
         let rt = create_runtime()?;
         let timeout = std::time::Duration::from_secs(timeout_secs);
 
-        let client = rt.block_on(AgentClient::connect(bunker_url, timeout))
+        let proxy = match proxy_port {
+            Some(port) => Some(loopback_proxy(port).map_err(to_py_err)?),
+            None => None,
+        };
+
+        let client = rt.block_on(AgentClient::connect_with_proxy(bunker_url, timeout, proxy))
             .map_err(|e| PyConnectionError::new_err(e.to_string()))?;
 
         Ok(Self {
@@ -570,12 +576,17 @@ pub struct PyPendingSession {
 #[pymethods]
 impl PyPendingSession {
     #[staticmethod]
-    #[pyo3(signature = (bunker_url, timeout_secs=30))]
-    fn create(bunker_url: &str, timeout_secs: u64) -> PyResult<Self> {
+    #[pyo3(signature = (bunker_url, timeout_secs=30, proxy_port=None))]
+    fn create(bunker_url: &str, timeout_secs: u64, proxy_port: Option<u16>) -> PyResult<Self> {
         let rt = create_runtime()?;
         let timeout = std::time::Duration::from_secs(timeout_secs);
 
-        let pending = rt.block_on(PendingSession::new(bunker_url, timeout))
+        let proxy = match proxy_port {
+            Some(port) => Some(loopback_proxy(port).map_err(to_py_err)?),
+            None => None,
+        };
+
+        let pending = rt.block_on(PendingSession::new_with_proxy(bunker_url, timeout, proxy))
             .map_err(|e| PyConnectionError::new_err(e.to_string()))?;
 
         let request_id = pending.request_id().to_string();

--- a/keep-agent-ts/index.d.ts
+++ b/keep-agent-ts/index.d.ts
@@ -16,7 +16,7 @@ export declare class KeepAgentSession {
 }
 
 export declare class RemoteSession {
-  static connect(bunkerUrl: string, timeoutSeconds?: number | undefined | null): Promise<RemoteSession>
+  static connect(bunkerUrl: string, timeoutSeconds?: number | undefined | null, proxyPort?: number | undefined | null): Promise<RemoteSession>
   signEvent(eventJson: string): Promise<string>
   getPublicKey(): Promise<string>
   nip44Encrypt(pubkey: string, plaintext: string): Promise<string>

--- a/keep-agent-ts/src/lib.rs
+++ b/keep-agent-ts/src/lib.rs
@@ -14,6 +14,22 @@ use keep_agent::{
     RateLimitConfig, SessionConfig, SessionManager, SessionMetadata, SessionScope, SessionToken,
 };
 
+// napi maps JS numbers to u16 via a uint32 cast, silently wrapping out-of-range
+// values (70000 -> 4464). Take u32 and reject anything outside 1..=65535 so a bad
+// port fails loudly instead of routing traffic to the wrong loopback port.
+fn resolve_proxy(proxy_port: Option<u32>) -> Result<Option<std::net::SocketAddr>> {
+    match proxy_port {
+        Some(port) => {
+            let port = u16::try_from(port)
+                .map_err(|_| Error::from_reason(format!("Invalid proxy port: {port}")))?;
+            Ok(Some(
+                loopback_proxy(port).map_err(|e| Error::from_reason(e.to_string()))?,
+            ))
+        }
+        None => Ok(None),
+    }
+}
+
 #[napi(object)]
 pub struct SessionScopeConfig {
     pub operations: Option<Vec<String>>,
@@ -483,14 +499,11 @@ impl RemoteSession {
     pub async fn connect(
         bunker_url: String,
         timeout_seconds: Option<u32>,
-        proxy_port: Option<u16>,
+        proxy_port: Option<u32>,
     ) -> Result<Self> {
         let timeout = std::time::Duration::from_secs(timeout_seconds.unwrap_or(30) as u64);
 
-        let proxy = match proxy_port {
-            Some(port) => Some(loopback_proxy(port).map_err(|e| Error::from_reason(e.to_string()))?),
-            None => None,
-        };
+        let proxy = resolve_proxy(proxy_port)?;
 
         let client = AgentClient::connect_with_proxy(&bunker_url, timeout, proxy)
             .await
@@ -576,14 +589,11 @@ impl PendingSession {
     pub async fn create(
         bunker_url: String,
         timeout_seconds: Option<u32>,
-        proxy_port: Option<u16>,
+        proxy_port: Option<u32>,
     ) -> Result<Self> {
         let timeout = std::time::Duration::from_secs(timeout_seconds.unwrap_or(30) as u64);
 
-        let proxy = match proxy_port {
-            Some(port) => Some(loopback_proxy(port).map_err(|e| Error::from_reason(e.to_string()))?),
-            None => None,
-        };
+        let proxy = resolve_proxy(proxy_port)?;
 
         let pending = RustPendingSession::new_with_proxy(&bunker_url, timeout, proxy)
             .await

--- a/keep-agent-ts/src/lib.rs
+++ b/keep-agent-ts/src/lib.rs
@@ -10,7 +10,7 @@ use tokio::sync::Mutex;
 use zeroize::Zeroizing;
 
 use keep_agent::{
-    AgentClient, ApprovalStatus, Operation, PendingSession as RustPendingSession,
+    loopback_proxy, AgentClient, ApprovalStatus, Operation, PendingSession as RustPendingSession,
     RateLimitConfig, SessionConfig, SessionManager, SessionMetadata, SessionScope, SessionToken,
 };
 
@@ -480,10 +480,19 @@ pub struct RemoteSession {
 #[napi]
 impl RemoteSession {
     #[napi(factory)]
-    pub async fn connect(bunker_url: String, timeout_seconds: Option<u32>) -> Result<Self> {
+    pub async fn connect(
+        bunker_url: String,
+        timeout_seconds: Option<u32>,
+        proxy_port: Option<u16>,
+    ) -> Result<Self> {
         let timeout = std::time::Duration::from_secs(timeout_seconds.unwrap_or(30) as u64);
 
-        let client = AgentClient::connect(&bunker_url, timeout)
+        let proxy = match proxy_port {
+            Some(port) => Some(loopback_proxy(port).map_err(|e| Error::from_reason(e.to_string()))?),
+            None => None,
+        };
+
+        let client = AgentClient::connect_with_proxy(&bunker_url, timeout, proxy)
             .await
             .map_err(|e| Error::from_reason(format!("Connection failed: {}", e)))?;
 
@@ -564,10 +573,19 @@ pub struct PendingSession {
 #[napi]
 impl PendingSession {
     #[napi(factory)]
-    pub async fn create(bunker_url: String, timeout_seconds: Option<u32>) -> Result<Self> {
+    pub async fn create(
+        bunker_url: String,
+        timeout_seconds: Option<u32>,
+        proxy_port: Option<u16>,
+    ) -> Result<Self> {
         let timeout = std::time::Duration::from_secs(timeout_seconds.unwrap_or(30) as u64);
 
-        let pending = RustPendingSession::new(&bunker_url, timeout)
+        let proxy = match proxy_port {
+            Some(port) => Some(loopback_proxy(port).map_err(|e| Error::from_reason(e.to_string()))?),
+            None => None,
+        };
+
+        let pending = RustPendingSession::new_with_proxy(&bunker_url, timeout, proxy)
             .await
             .map_err(|e| Error::from_reason(format!("Connection failed: {}", e)))?;
 

--- a/keep-agent/src/client.rs
+++ b/keep-agent/src/client.rs
@@ -438,19 +438,7 @@ impl AgentClient {
 
         self.client.disconnect().await;
         self.client.remove_all_relays().await;
-        let relay_opts = relay_opts(self.proxy);
-        let mut added = Vec::new();
-        for relay in &valid_relays {
-            if self
-                .client
-                .pool()
-                .add_relay(relay, relay_opts.clone())
-                .await
-                .is_ok()
-            {
-                added.push(relay.clone());
-            }
-        }
+        let added = add_proxied_relays(&self.client, &valid_relays, self.proxy).await;
         if added.is_empty() {
             return Err(AgentError::Connection(
                 "Failed to add any relay during switch".into(),
@@ -645,6 +633,25 @@ fn relay_opts(proxy: Option<SocketAddr>) -> RelayOptions {
     }
 }
 
+/// Re-add `relays` to `client`'s pool with `proxy` applied, returning those that
+/// were added. Isolated from `switch_relays` so the proxy-preservation invariant
+/// (a signer-driven relay switch must never fall back to a direct connection and
+/// deanonymize traffic) stays unit-testable without a live signer.
+async fn add_proxied_relays(
+    client: &Client,
+    relays: &[String],
+    proxy: Option<SocketAddr>,
+) -> Vec<String> {
+    let opts = relay_opts(proxy);
+    let mut added = Vec::new();
+    for relay in relays {
+        if client.pool().add_relay(relay, opts.clone()).await.is_ok() {
+            added.push(relay.clone());
+        }
+    }
+    added
+}
+
 fn generate_uuid() -> String {
     uuid::Uuid::new_v4().to_string()
 }
@@ -696,6 +703,24 @@ mod tests {
             .unwrap();
         let relay = client.relay("wss://relay.example.com").await.unwrap();
         assert_eq!(*relay.connection_mode(), ConnectionMode::Direct);
+    }
+
+    #[tokio::test]
+    async fn test_switch_relays_reconnect_preserves_proxy() {
+        // Guards the switch_relays re-add path: a signer-driven relay switch must
+        // re-add relays through the proxy, never fall back to a direct connection.
+        let proxy = loopback_proxy(9050).unwrap();
+        let client = Client::new(Keys::generate());
+        let relays = vec![
+            "wss://relay-a.example.com".to_string(),
+            "wss://relay-b.example.com".to_string(),
+        ];
+        let added = add_proxied_relays(&client, &relays, Some(proxy)).await;
+        assert_eq!(added, relays);
+        for url in &relays {
+            let relay = client.relay(url).await.unwrap();
+            assert_eq!(*relay.connection_mode(), ConnectionMode::Proxy(proxy));
+        }
     }
 
     #[test]

--- a/keep-agent/src/client.rs
+++ b/keep-agent/src/client.rs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: © 2026 PrivKey LLC
 // SPDX-License-Identifier: MIT
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
@@ -27,10 +28,18 @@ pub struct PendingSession {
 
 impl PendingSession {
     pub async fn new(bunker_url: &str, timeout: Duration) -> Result<Self> {
+        Self::new_with_proxy(bunker_url, timeout, None).await
+    }
+
+    pub async fn new_with_proxy(
+        bunker_url: &str,
+        timeout: Duration,
+        proxy: Option<SocketAddr>,
+    ) -> Result<Self> {
         let (signer_pubkey, relay_url, _) = AgentClient::parse_bunker_url(bunker_url)?;
 
         let client_keys = Keys::generate();
-        let client = Client::new(client_keys.clone());
+        let client = build_client(&client_keys, proxy);
 
         client
             .pool()
@@ -203,10 +212,18 @@ pub struct AgentClient {
 
 impl AgentClient {
     pub async fn connect(bunker_url: &str, timeout: Duration) -> Result<Self> {
+        Self::connect_with_proxy(bunker_url, timeout, None).await
+    }
+
+    pub async fn connect_with_proxy(
+        bunker_url: &str,
+        timeout: Duration,
+        proxy: Option<SocketAddr>,
+    ) -> Result<Self> {
         let (signer_pubkey, relay_url, secret) = Self::parse_bunker_url(bunker_url)?;
 
         let client_keys = Keys::generate();
-        let client = Client::new(client_keys.clone());
+        let client = build_client(&client_keys, proxy);
 
         client
             .pool()
@@ -601,6 +618,24 @@ async fn wait_for_any_relay_connection(
     .map_err(|_| AgentError::Connection("Relay connection timeout".into()))
 }
 
+fn build_client(keys: &Keys, proxy: Option<SocketAddr>) -> Client {
+    match proxy {
+        Some(addr) => {
+            let connection = Connection::new().proxy(addr).target(ConnectionTarget::All);
+            let opts = ClientOptions::new().connection(connection);
+            Client::builder().signer(keys.clone()).opts(opts).build()
+        }
+        None => Client::new(keys.clone()),
+    }
+}
+
+pub fn loopback_proxy(port: u16) -> Result<SocketAddr> {
+    if port == 0 {
+        return Err(AgentError::Connection("Invalid proxy port".into()));
+    }
+    Ok(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port))
+}
+
 fn default_relay_opts() -> RelayOptions {
     RelayOptions::default()
         .reconnect(true)
@@ -625,6 +660,18 @@ mod tests {
         let uuid2 = generate_uuid();
         assert_ne!(uuid1, uuid2);
         assert_eq!(uuid1.len(), 36);
+    }
+
+    #[test]
+    fn test_loopback_proxy_rejects_port_zero() {
+        assert!(loopback_proxy(0).is_err());
+    }
+
+    #[test]
+    fn test_loopback_proxy_builds_localhost() {
+        let addr = loopback_proxy(9050).unwrap();
+        assert!(addr.ip().is_loopback());
+        assert_eq!(addr.to_string(), "127.0.0.1:9050");
     }
 
     #[test]

--- a/keep-agent/src/client.rs
+++ b/keep-agent/src/client.rs
@@ -23,6 +23,7 @@ pub struct PendingSession {
     relay_url: String,
     client_keys: Keys,
     client: Client,
+    proxy: Option<SocketAddr>,
     connect_sent: AtomicBool,
 }
 
@@ -39,11 +40,11 @@ impl PendingSession {
         let (signer_pubkey, relay_url, _) = AgentClient::parse_bunker_url(bunker_url)?;
 
         let client_keys = Keys::generate();
-        let client = build_client(&client_keys, proxy);
+        let client = Client::new(client_keys.clone());
 
         client
             .pool()
-            .add_relay(&relay_url, default_relay_opts())
+            .add_relay(&relay_url, relay_opts(proxy))
             .await
             .map_err(|e| AgentError::Connection(e.to_string()))?;
 
@@ -58,6 +59,7 @@ impl PendingSession {
             relay_url,
             client_keys,
             client,
+            proxy,
             connect_sent: AtomicBool::new(false),
         })
     }
@@ -184,6 +186,7 @@ impl PendingSession {
                         relay_url: self.relay_url.clone(),
                         client_keys: self.client_keys.clone(),
                         client: self.client.clone(),
+                        proxy: self.proxy,
                     };
                     let _ = client.switch_relays().await;
                     return Ok(client);
@@ -208,6 +211,7 @@ pub struct AgentClient {
     relay_url: String,
     client_keys: Keys,
     client: Client,
+    proxy: Option<SocketAddr>,
 }
 
 impl AgentClient {
@@ -223,11 +227,11 @@ impl AgentClient {
         let (signer_pubkey, relay_url, secret) = Self::parse_bunker_url(bunker_url)?;
 
         let client_keys = Keys::generate();
-        let client = build_client(&client_keys, proxy);
+        let client = Client::new(client_keys.clone());
 
         client
             .pool()
-            .add_relay(&relay_url, default_relay_opts())
+            .add_relay(&relay_url, relay_opts(proxy))
             .await
             .map_err(|e| AgentError::Connection(e.to_string()))?;
 
@@ -239,6 +243,7 @@ impl AgentClient {
             relay_url,
             client_keys,
             client,
+            proxy,
         };
 
         agent_client.send_connect(secret.as_deref()).await?;
@@ -433,7 +438,7 @@ impl AgentClient {
 
         self.client.disconnect().await;
         self.client.remove_all_relays().await;
-        let relay_opts = default_relay_opts();
+        let relay_opts = relay_opts(self.proxy);
         let mut added = Vec::new();
         for relay in &valid_relays {
             if self
@@ -618,17 +623,6 @@ async fn wait_for_any_relay_connection(
     .map_err(|_| AgentError::Connection("Relay connection timeout".into()))
 }
 
-fn build_client(keys: &Keys, proxy: Option<SocketAddr>) -> Client {
-    match proxy {
-        Some(addr) => {
-            let connection = Connection::new().proxy(addr).target(ConnectionTarget::All);
-            let opts = ClientOptions::new().connection(connection);
-            Client::builder().signer(keys.clone()).opts(opts).build()
-        }
-        None => Client::new(keys.clone()),
-    }
-}
-
 pub fn loopback_proxy(port: u16) -> Result<SocketAddr> {
     if port == 0 {
         return Err(AgentError::Connection("Invalid proxy port".into()));
@@ -636,14 +630,19 @@ pub fn loopback_proxy(port: u16) -> Result<SocketAddr> {
     Ok(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port))
 }
 
-fn default_relay_opts() -> RelayOptions {
-    RelayOptions::default()
+fn relay_opts(proxy: Option<SocketAddr>) -> RelayOptions {
+    let opts = RelayOptions::default()
         .reconnect(true)
         .ping(true)
         .retry_interval(Duration::from_secs(10))
         .adjust_retry_interval(true)
         .ban_relay_on_mismatch(true)
-        .max_avg_latency(Some(Duration::from_secs(3)))
+        .max_avg_latency(Some(Duration::from_secs(3)));
+
+    match proxy {
+        Some(addr) => opts.connection_mode(ConnectionMode::Proxy(addr)),
+        None => opts,
+    }
 }
 
 fn generate_uuid() -> String {
@@ -672,6 +671,31 @@ mod tests {
         let addr = loopback_proxy(9050).unwrap();
         assert!(addr.ip().is_loopback());
         assert_eq!(addr.to_string(), "127.0.0.1:9050");
+    }
+
+    #[tokio::test]
+    async fn test_relay_opts_applies_proxy_to_pool_relay() {
+        let proxy = loopback_proxy(9050).unwrap();
+        let client = Client::new(Keys::generate());
+        client
+            .pool()
+            .add_relay("wss://relay.example.com", relay_opts(Some(proxy)))
+            .await
+            .unwrap();
+        let relay = client.relay("wss://relay.example.com").await.unwrap();
+        assert_eq!(*relay.connection_mode(), ConnectionMode::Proxy(proxy));
+    }
+
+    #[tokio::test]
+    async fn test_relay_opts_none_yields_direct() {
+        let client = Client::new(Keys::generate());
+        client
+            .pool()
+            .add_relay("wss://relay.example.com", relay_opts(None))
+            .await
+            .unwrap();
+        let relay = client.relay("wss://relay.example.com").await.unwrap();
+        assert_eq!(*relay.connection_mode(), ConnectionMode::Direct);
     }
 
     #[test]

--- a/keep-agent/src/lib.rs
+++ b/keep-agent/src/lib.rs
@@ -17,7 +17,7 @@ pub mod session;
 pub mod mcp;
 
 pub use attestation::{verify_peer_attestation, ExpectedPcrs, PeerAttestation, VerificationConfig};
-pub use client::{AgentClient, ApprovalStatus, PendingSession};
+pub use client::{loopback_proxy, AgentClient, ApprovalStatus, PendingSession};
 pub use entropy::{get_entropy, is_nitro_enclave};
 pub use error::{AgentError, Result};
 pub use frost::{FrostCommitment, FrostCoordinator, FrostParticipant, FrostSignatureShare};


### PR DESCRIPTION
Closes #649.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional local proxy support when starting or connecting to remote sessions in both Python and TypeScript APIs.
  * Session creation and connection calls can now take an optional proxy port, enabling routed connections through `127.0.0.1`.

* **Bug Fixes**
  * Invalid proxy ports now return clear errors instead of being accepted unexpectedly.
  * Proxy routing is preserved when sessions switch or reconnect relays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->