### PR TITLE
frost: clear pending sign requests when re-init replaces a live node

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,8 @@ all-features = true
 ignore = [
     { id = "RUSTSEC-2025-0141", reason = "bincode unmaintained but stable; used in keep-core" },
     { id = "RUSTSEC-2024-0415", reason = "gtk3 bindings unmaintained; no migration path for tray-icon ecosystem" },
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml XML DoS; only reached via wayland-scanner (build-time protocol XML) and tauri-winrt-notification (self-generated Windows toast XML), never untrusted input; fix requires 0.41.0, unavailable at the pinned transitive minors" },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml XML DoS; only reached via wayland-scanner (build-time protocol XML) and tauri-winrt-notification (self-generated Windows toast XML), never untrusted input; fix requires 0.41.0, unavailable at the pinned transitive minors" },
 ]
 unmaintained = "workspace"
 

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -3585,10 +3585,14 @@ mod import_teardown_tests {
         let prior_flag = AbortFlag(Arc::clone(&aborted));
         mobile.runtime.block_on(async {
             // Stand in for a prior node's still-running task.
-            mobile.node_tasks.lock().unwrap().push(tokio::spawn(async move {
-                let _flag = prior_flag;
-                std::future::pending::<()>().await;
-            }));
+            mobile
+                .node_tasks
+                .lock()
+                .unwrap()
+                .push(tokio::spawn(async move {
+                    let _flag = prior_flag;
+                    std::future::pending::<()>().await;
+                }));
             tokio::task::yield_now().await;
 
             let listener = tokio::spawn(async {});

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -2500,15 +2500,14 @@ impl KeepMobile {
         persistence::persist_relay_config(&self.storage, &key, &stored)
     }
 
-    /// Install a freshly spawned node's tasks, aborting any left running from a
-    /// prior initialize that skipped invalidate_live_node. When a prior node is
-    /// replaced its pending sign requests belong to the now-aborted sessions, so
-    /// mirror invalidate_live_node and drop them too, keeping a first init clean.
-    async fn swap_node_tasks(
-        &self,
-        listener_handle: tokio::task::JoinHandle<()>,
-        run_handle: tokio::task::JoinHandle<()>,
-    ) {
+    /// Abort any prior node's tasks and drop their pending sign requests before a
+    /// replacement node starts. Must run before the new node's listener/run tasks
+    /// spawn: clearing up front means the clear cannot race the fresh session,
+    /// whose requests can only be enqueued once those tasks are live, so a
+    /// replacement never loses the new session's requests. A first init has no
+    /// prior tasks, so pending is left untouched. Mirrors invalidate_live_node
+    /// minus nulling the node, which do_initialize overwrites immediately after.
+    async fn retire_prior_node_tasks(&self) {
         let replaced_prior_node = {
             let mut tasks = self
                 .node_tasks
@@ -2518,8 +2517,6 @@ impl KeepMobile {
             for handle in tasks.drain(..) {
                 handle.abort();
             }
-            tasks.push(listener_handle);
-            tasks.push(run_handle);
             had_prior
         };
 
@@ -2640,6 +2637,12 @@ impl KeepMobile {
                 callback: self.state_callback.clone(),
                 rev: self.state_rev.clone(),
             };
+            // Retire any prior node before starting the new one so its pending
+            // requests are cleared up front. Clearing before the tasks below
+            // spawn is what keeps the new session's requests: they can only be
+            // enqueued once its listener/run tasks are live.
+            self.retire_prior_node_tasks().await;
+
             let listener_handle = tokio::spawn(async move {
                 Self::event_listener(event_rx, request_rx, desc_ctx, state_ctx).await;
             });
@@ -2651,7 +2654,10 @@ impl KeepMobile {
                 }
             });
 
-            self.swap_node_tasks(listener_handle, run_handle).await;
+            self.node_tasks
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .extend([listener_handle, run_handle]);
 
             *self.node.write().await = Some(node);
             Ok(())
@@ -3565,7 +3571,7 @@ mod import_teardown_tests {
     // invalidate_live_node, must drop its pending requests so the fresh node does
     // not surface sign requests from the torn-down session.
     #[test]
-    fn swap_node_tasks_clears_pending_when_replacing() {
+    fn retire_prior_node_tasks_clears_pending_when_replacing() {
         let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
         let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
 
@@ -3595,9 +3601,7 @@ mod import_teardown_tests {
                 }));
             tokio::task::yield_now().await;
 
-            let listener = tokio::spawn(async {});
-            let run = tokio::spawn(async {});
-            mobile.swap_node_tasks(listener, run).await;
+            mobile.retire_prior_node_tasks().await;
 
             // abort() is asynchronous; let the runtime cancel and drop the future.
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -3605,7 +3609,8 @@ mod import_teardown_tests {
                 aborted.load(std::sync::atomic::Ordering::SeqCst),
                 "prior node task must be aborted, not detached and left signing"
             );
-            assert_eq!(mobile.node_tasks.lock().unwrap().len(), 2);
+            // Prior handles are drained; do_initialize installs the new ones next.
+            assert!(mobile.node_tasks.lock().unwrap().is_empty());
         });
         assert_pending_cleared(&mobile);
     }
@@ -3613,15 +3618,13 @@ mod import_teardown_tests {
     // A first initialize with no prior node must leave pending requests untouched:
     // there is no torn-down session whose requests need dropping.
     #[test]
-    fn swap_node_tasks_keeps_pending_on_first_init() {
+    fn retire_prior_node_tasks_keeps_pending_on_first_init() {
         let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
         let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
 
         seed_pending_request(&mobile);
         mobile.runtime.block_on(async {
-            let listener = tokio::spawn(async {});
-            let run = tokio::spawn(async {});
-            mobile.swap_node_tasks(listener, run).await;
+            mobile.retire_prior_node_tasks().await;
 
             assert_eq!(
                 mobile.pending_requests.lock().await.len(),

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -3569,19 +3569,38 @@ mod import_teardown_tests {
         let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
         let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
 
+        // A drop-guard whose Drop only runs if the task's future is dropped, i.e.
+        // the task was aborted. Detaching (dropping the JoinHandle without abort)
+        // leaves the future running and never fires Drop, so this distinguishes a
+        // real abort from a silently removed handle.abort().
+        struct AbortFlag(Arc<std::sync::atomic::AtomicBool>);
+        impl Drop for AbortFlag {
+            fn drop(&mut self) {
+                self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+
         seed_pending_request(&mobile);
+        let aborted = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let prior_flag = AbortFlag(Arc::clone(&aborted));
         mobile.runtime.block_on(async {
             // Stand in for a prior node's still-running task.
-            mobile
-                .node_tasks
-                .lock()
-                .unwrap()
-                .push(tokio::spawn(async { std::future::pending::<()>().await }));
+            mobile.node_tasks.lock().unwrap().push(tokio::spawn(async move {
+                let _flag = prior_flag;
+                std::future::pending::<()>().await;
+            }));
+            tokio::task::yield_now().await;
 
             let listener = tokio::spawn(async {});
             let run = tokio::spawn(async {});
             mobile.swap_node_tasks(listener, run).await;
 
+            // abort() is asynchronous; let the runtime cancel and drop the future.
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            assert!(
+                aborted.load(std::sync::atomic::Ordering::SeqCst),
+                "prior node task must be aborted, not detached and left signing"
+            );
             assert_eq!(mobile.node_tasks.lock().unwrap().len(), 2);
         });
         assert_pending_cleared(&mobile);

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -2623,18 +2623,27 @@ impl KeepMobile {
                 }
             });
 
-            {
+            let replaced_prior_node = {
                 let mut tasks = self
                     .node_tasks
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner());
                 // Abort any node whose tasks were left running from a prior
                 // initialize that skipped invalidate_live_node.
+                let had_prior = !tasks.is_empty();
                 for handle in tasks.drain(..) {
                     handle.abort();
                 }
                 tasks.push(listener_handle);
                 tasks.push(run_handle);
+                had_prior
+            };
+
+            // Mirror invalidate_live_node: a replaced node's pending sign
+            // requests belong to now-aborted sessions, so drop them here too so
+            // a re-init starts clean even when invalidate_live_node was skipped.
+            if replaced_prior_node {
+                self.pending_requests.lock().await.clear();
             }
 
             *self.node.write().await = Some(node);

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -2500,6 +2500,34 @@ impl KeepMobile {
         persistence::persist_relay_config(&self.storage, &key, &stored)
     }
 
+    /// Install a freshly spawned node's tasks, aborting any left running from a
+    /// prior initialize that skipped invalidate_live_node. When a prior node is
+    /// replaced its pending sign requests belong to the now-aborted sessions, so
+    /// mirror invalidate_live_node and drop them too, keeping a first init clean.
+    async fn swap_node_tasks(
+        &self,
+        listener_handle: tokio::task::JoinHandle<()>,
+        run_handle: tokio::task::JoinHandle<()>,
+    ) {
+        let replaced_prior_node = {
+            let mut tasks = self
+                .node_tasks
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let had_prior = !tasks.is_empty();
+            for handle in tasks.drain(..) {
+                handle.abort();
+            }
+            tasks.push(listener_handle);
+            tasks.push(run_handle);
+            had_prior
+        };
+
+        if replaced_prior_node {
+            self.pending_requests.lock().await.clear();
+        }
+    }
+
     fn do_initialize(
         &self,
         relays: Vec<String>,
@@ -2623,28 +2651,7 @@ impl KeepMobile {
                 }
             });
 
-            let replaced_prior_node = {
-                let mut tasks = self
-                    .node_tasks
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner());
-                // Abort any node whose tasks were left running from a prior
-                // initialize that skipped invalidate_live_node.
-                let had_prior = !tasks.is_empty();
-                for handle in tasks.drain(..) {
-                    handle.abort();
-                }
-                tasks.push(listener_handle);
-                tasks.push(run_handle);
-                had_prior
-            };
-
-            // Mirror invalidate_live_node: a replaced node's pending sign
-            // requests belong to now-aborted sessions, so drop them here too so
-            // a re-init starts clean even when invalidate_live_node was skipped.
-            if replaced_prior_node {
-                self.pending_requests.lock().await.clear();
-            }
+            self.swap_node_tasks(listener_handle, run_handle).await;
 
             *self.node.write().await = Some(node);
             Ok(())
@@ -3552,6 +3559,53 @@ mod import_teardown_tests {
             storage.get_active_share_key().as_deref(),
             Some(info.group_pubkey.as_str())
         );
+    }
+
+    // A re-initialize that replaces a live node aborts the prior tasks and, like
+    // invalidate_live_node, must drop its pending requests so the fresh node does
+    // not surface sign requests from the torn-down session.
+    #[test]
+    fn swap_node_tasks_clears_pending_when_replacing() {
+        let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
+        let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
+
+        seed_pending_request(&mobile);
+        mobile.runtime.block_on(async {
+            // Stand in for a prior node's still-running task.
+            mobile
+                .node_tasks
+                .lock()
+                .unwrap()
+                .push(tokio::spawn(async { std::future::pending::<()>().await }));
+
+            let listener = tokio::spawn(async {});
+            let run = tokio::spawn(async {});
+            mobile.swap_node_tasks(listener, run).await;
+
+            assert_eq!(mobile.node_tasks.lock().unwrap().len(), 2);
+        });
+        assert_pending_cleared(&mobile);
+    }
+
+    // A first initialize with no prior node must leave pending requests untouched:
+    // there is no torn-down session whose requests need dropping.
+    #[test]
+    fn swap_node_tasks_keeps_pending_on_first_init() {
+        let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
+        let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
+
+        seed_pending_request(&mobile);
+        mobile.runtime.block_on(async {
+            let listener = tokio::spawn(async {});
+            let run = tokio::spawn(async {});
+            mobile.swap_node_tasks(listener, run).await;
+
+            assert_eq!(
+                mobile.pending_requests.lock().await.len(),
+                1,
+                "first init must not drop pending requests"
+            );
+        });
     }
 
     // The import_share path lands in store_share_package, which got the same


### PR DESCRIPTION
When `initialize` re-initializes a node while a prior node's tasks are still running (a re-init that did not go through `invalidate_live_node`), it aborts the stale tasks but left the prior node's `pending_requests` in place. Those requests belong to the now-aborted sessions, so the fresh node would surface stale sign requests from a torn-down session.

This mirrors `invalidate_live_node`, which aborts the tasks *and* clears `pending_requests`. The re-init path now clears `pending_requests` too, but only when it actually replaced a prior node, so a clean first init is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app stability when reconnecting or reinitializing nodes, reducing the chance of stale background tasks affecting new sessions.
  * Preserved pending requests during the first initialization, while correctly clearing requests tied to aborted prior sessions.
* **Chores**
  * Updated security exception settings for two known Rust advisories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->