### PR TITLE
deps: bump memmap2 to 0.9.11, ignore unbumpable glib advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5227,9 +5227,9 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,7 @@ all-features = true
 ignore = [
     { id = "RUSTSEC-2025-0141", reason = "bincode unmaintained but stable; used in keep-core" },
     { id = "RUSTSEC-2024-0415", reason = "gtk3 bindings unmaintained; no migration path for tray-icon ecosystem" },
+    { id = "RUSTSEC-2024-0429", reason = "glib 0.18 unsound VariantStrIter via gtk 0.18 tray/notify; no gtk-rs 0.20 migration path, not in signing/network path" },
     { id = "RUSTSEC-2026-0194", reason = "quick-xml XML DoS; only reached via wayland-scanner (build-time protocol XML) and tauri-winrt-notification (self-generated Windows toast XML), never untrusted input; fix requires 0.41.0, unavailable at the pinned transitive minors" },
     { id = "RUSTSEC-2026-0195", reason = "quick-xml XML DoS; only reached via wayland-scanner (build-time protocol XML) and tauri-winrt-notification (self-generated Windows toast XML), never untrusted input; fix requires 0.41.0, unavailable at the pinned transitive minors" },
 ]


### PR DESCRIPTION
Refs #652.