### PR TITLE
frost-net: bound structured payload decode and reject out-of-range sighash flag

### DIFF
--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -2449,7 +2449,11 @@ mod tests {
         let oversized_hex = "00".repeat(MAX_STRUCTURED_PAYLOAD_SIZE + 1);
         value["structured_payload"] = serde_json::Value::String(oversized_hex);
         let json = serde_json::to_string(&value).unwrap();
-        assert!(KfpMessage::from_json(&json).is_err());
+        // Assert on the deserialize-time message so this pins the before-decode
+        // guard specifically, not the later `validate` size gate (which would
+        // also reject and carries a distinct, capitalized message).
+        let err = KfpMessage::from_json(&json).expect_err("oversized payload must be refused");
+        assert!(err.to_string().contains("structured payload exceeds maximum size"));
     }
 
     #[test]

--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -2453,7 +2453,9 @@ mod tests {
         // guard specifically, not the later `validate` size gate (which would
         // also reject and carries a distinct, capitalized message).
         let err = KfpMessage::from_json(&json).expect_err("oversized payload must be refused");
-        assert!(err.to_string().contains("structured payload exceeds maximum size"));
+        assert!(err
+            .to_string()
+            .contains("structured payload exceeds maximum size"));
     }
 
     #[test]

--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -1003,8 +1003,17 @@ mod hex_bytes_opt {
     }
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Vec<u8>>, D::Error> {
         let opt = Option::<String>::deserialize(d)?;
-        opt.map(|h| hex::decode(&h).map_err(serde::de::Error::custom))
-            .transpose()
+        match opt {
+            // Bound the encoded length before decoding so an oversized payload
+            // is rejected without first allocating its Vec. Hex is two chars
+            // per byte, so the decoded size cannot exceed the same cap
+            // `validate` enforces.
+            Some(h) if h.len() > super::MAX_STRUCTURED_PAYLOAD_SIZE.saturating_mul(2) => Err(
+                serde::de::Error::custom("structured payload exceeds maximum size"),
+            ),
+            Some(h) => Ok(Some(hex::decode(&h).map_err(serde::de::Error::custom)?)),
+            None => Ok(None),
+        }
     }
 }
 
@@ -2420,6 +2429,27 @@ mod tests {
         .with_structured_payload(oversized);
         let msg = KfpMessage::SignRequest(payload);
         assert!(msg.validate().is_err());
+    }
+
+    /// #529: an oversized *encoded* structured payload is rejected during
+    /// deserialization, before `hex::decode` allocates the Vec, so a peer
+    /// cannot force arbitrary allocation ahead of the `validate` size gate.
+    #[test]
+    fn oversized_encoded_structured_payload_refused_before_decode() {
+        let payload = SignRequestPayload::new(
+            [1u8; 32],
+            [2u8; 32],
+            vec![1, 2, 3],
+            MSG_TYPE_NOSTR_EVENT,
+            vec![1, 2],
+        );
+        let msg = KfpMessage::SignRequest(payload);
+        let mut value: serde_json::Value = serde_json::from_str(&msg.to_json().unwrap()).unwrap();
+        // Hex string one decoded byte over the cap (two chars per byte).
+        let oversized_hex = "00".repeat(MAX_STRUCTURED_PAYLOAD_SIZE + 1);
+        value["structured_payload"] = serde_json::Value::String(oversized_hex);
+        let json = serde_json::to_string(&value).unwrap();
+        assert!(KfpMessage::from_json(&json).is_err());
     }
 
     #[test]

--- a/keep-frost-net/src/structured_payload.rs
+++ b/keep-frost-net/src/structured_payload.rs
@@ -216,10 +216,15 @@ fn verify_bitcoin_sighash(digest: &[u8], structured: &[u8]) -> Result<()> {
             })
         })
         .collect::<Result<Vec<_>>>()?;
-    let sighash_flag =
-        TapSighashType::from_consensus_u8(payload.sighash_type as u8).map_err(|e| {
-            FrostNetError::PolicyViolation(format!("bitcoin-sighash flag invalid: {e}"))
-        })?;
+    let sighash_type = u8::try_from(payload.sighash_type).map_err(|_| {
+        FrostNetError::PolicyViolation(format!(
+            "bitcoin-sighash flag {} out of byte range",
+            payload.sighash_type
+        ))
+    })?;
+    let sighash_flag = TapSighashType::from_consensus_u8(sighash_type).map_err(|e| {
+        FrostNetError::PolicyViolation(format!("bitcoin-sighash flag invalid: {e}"))
+    })?;
     let mut cache = SighashCache::new(&psbt.unsigned_tx);
     let sighash = cache
         .taproot_key_spend_signature_hash(idx, &Prevouts::All(&prevouts), sighash_flag)
@@ -373,6 +378,18 @@ mod tests {
         let wrong_digest = [0x42u8; 32];
         let err = verify_structured_payload(MSG_TYPE_NOSTR_EVENT, &wrong_digest, &bytes)
             .expect_err("non-matching payload must be refused on the responder branch");
+        assert!(matches!(err, FrostNetError::PolicyViolation(_)));
+    }
+
+    #[test]
+    fn bitcoin_sighash_out_of_byte_range_flag_refuses() {
+        // A sighash_type outside the u8 range must be rejected, not truncated
+        // into a valid flag (e.g. 256 wrapping to Default).
+        let (digest, mut payload) = build_bitcoin_sighash_payload();
+        payload.sighash_type = 256;
+        let bytes = serde_json::to_vec(&payload).unwrap();
+        let err = verify_structured_payload(MSG_TYPE_BITCOIN_SIGHASH, &digest, &bytes)
+            .expect_err("out-of-range sighash flag must be refused");
         assert!(matches!(err, FrostNetError::PolicyViolation(_)));
     }
 


### PR DESCRIPTION
## Summary

Two defense-in-depth fixes on top of #529.

**1. Pre-decode size gate.** The `hex_bytes_opt` deserializer for `SignRequestPayload::structured_payload` previously decoded the full hex string and only bounced it at `validate()`. A hostile peer could force an oversize allocation (one hex byte per two encoded chars) up to whatever the wire message cap allows. Reject at the boundary using `MAX_STRUCTURED_PAYLOAD_SIZE * 2` on the encoded length, so `hex::decode` never allocates a Vec that would immediately be rejected.

**2. Reject out-of-range sighash flag.** `verify_bitcoin_sighash` used `payload.sighash_type as u8`, which silently truncates. A caller passing `sighash_type: 256` would wrap to `0` (`TapSighashType::Default`) and slip past the flag check even though `256` is not a valid sighash flag. Use a checked `u8::try_from` and return `PolicyViolation` on out-of-range values before touching `TapSighashType::from_consensus_u8`.

## Tests

- `oversized_encoded_structured_payload_refused_before_decode`: hex string above `MAX_STRUCTURED_PAYLOAD_SIZE * 2` bounces on deserialize.
- `bitcoin_sighash_out_of_byte_range_flag_refuses`: `sighash_type = 256` is refused instead of truncating to `Default`.

`cargo test -p keep-frost-net` all pass, `cargo clippy -p keep-frost-net --all-targets -- -D warnings` clean.