### PR TITLE
frost-bip32: compose BIP-32 tweak with FROST signing to sign under child key

### DIFF
--- a/keep-bitcoin/src/lib.rs
+++ b/keep-bitcoin/src/lib.rs
@@ -7,7 +7,13 @@ mod address;
 pub mod chain_view;
 mod descriptor;
 mod error;
-pub mod frost_bip32;
+/// BIP-32 unhardened child-key primitives for FROST group keys (#487).
+///
+/// Re-exported from `keep_core::frost_bip32` so downstream call sites that
+/// used the pre-#487-PR2 path (`keep_bitcoin::frost_bip32::*`) keep
+/// compiling; the module lives in keep-core because bip32-composed FROST
+/// signing lives there and keep-bitcoin cannot depend upward on keep-core.
+pub use keep_core::frost_bip32;
 pub mod key_proof;
 pub mod psbt;
 pub mod recovery;

--- a/keep-core/src/frost/bip32_signing.rs
+++ b/keep-core/src/frost/bip32_signing.rs
@@ -1,0 +1,368 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+//! FROST signing under a BIP-32 unhardened derivation path (#487, PR 2 of 4).
+//!
+//! Wire this into the existing FROST 2-round signing loop without touching
+//! its network, storage, or wire format. Each participant applies ONE
+//! composite BIP-32 scalar tweak to its own `KeyPackage` (signing share,
+//! verifying share, and the group verifying key), then the standard
+//! `frost::round1`/`round2`/`aggregate` runs against those tweaked packages.
+//! The resulting BIP-340 aggregate signature verifies under the derived
+//! child pubkey returned by
+//! [`keep_bitcoin::frost_bip32::derive_path_composite`].
+//!
+//! Design notes for the review of #487:
+//!
+//! - **Composite tweak, one per signer.** BIP-32 unhardened tweaks compose
+//!   additively over the group, so a single scalar `t_agg` applied to every
+//!   share is enough; no per-signer tree walk. `derive_path_composite`
+//!   double-checks the invariant `parent + t_agg·G == child` before we ever
+//!   tweak a share, so a stale composite cannot silently produce signatures
+//!   that verify under nothing.
+//! - **Public accessors only.** The tweaked KeyPackages are rebuilt through
+//!   `frost::keys::{SigningShare,VerifyingShare,VerifyingKey}::{serialize,deserialize}`
+//!   and `KeyPackage::new`, all of which are on the public API of
+//!   `frost-core`. No `internals` feature flag is required.
+//! - **Signature verifier check.** After aggregation we independently
+//!   verify the produced signature against the derived child pubkey using
+//!   BIP-340. A tweak accounting mistake would fail this check, so a
+//!   silently-wrong signature cannot escape the helper.
+
+use std::collections::BTreeMap;
+
+use bitcoin::secp256k1::{schnorr::Signature, Message, Secp256k1, XOnlyPublicKey};
+use frost_secp256k1_tr::{
+    self as frost,
+    keys::{KeyPackage, PublicKeyPackage, SigningShare, VerifyingShare},
+    rand_core::OsRng,
+    round1, round2, Identifier, SigningPackage, VerifyingKey,
+};
+
+use super::SharePackage;
+use crate::error::{KeepError, Result};
+use crate::frost_bip32::{derive_path_composite, deterministic_chaincode, CompositeDerivation};
+
+/// Add the aggregate BIP-32 scalar tweak `t_agg` to every field of a
+/// `KeyPackage`: `signing_share += t_agg`, `verifying_share += t_agg·G`,
+/// `verifying_key += t_agg·G`. Returns the tweaked package.
+///
+/// The three additions must all be consistent for the standard FROST round
+/// to produce a signature that verifies under the derived child pubkey.
+/// The point-addition uses libsecp256k1 directly rather than
+/// frost-secp256k1-tr's internal `Tweak` trait, which is BIP-341-specific
+/// and does not accept a raw scalar.
+fn tweak_key_package(kp: &KeyPackage, tweak: &[u8; 32]) -> Result<KeyPackage> {
+    let secp = Secp256k1::verification_only();
+
+    // Parity handling. `derive_path_composite` walks BIP-32 from the +even
+    // lift of the x-only group pubkey, matching what every downstream wallet
+    // (and every reference BIP-32 implementation) does when handed an xpub
+    // shaped from an x-only key. But the FROST KeyPackage carries the
+    // group's TRUE verifying_key, which can have either parity. If it is
+    // odd-y, then `real_vk = -even_lift(x_only(real_vk))`, so applying the
+    // primitive's `t` scalar directly lands on `real_vk + t·G = -(even_lift + (-t)·G)`
+    // whose x-coordinate is x_only(even_lift + (-t)·G) — NOT
+    // x_only(even_lift + t·G). To land the tweaked VK on the same x-only
+    // child pubkey wallets derive, negate the tweak in the odd-y case. The
+    // resulting KeyPackage will have `-(child_target)` as its VerifyingKey,
+    // which BIP-340 accepts (verification is x-only, ignores sign).
+    let vk_bytes_probe = kp
+        .verifying_key()
+        .serialize()
+        .map_err(|e| KeepError::Frost(format!("verifying key serialize: {e}")))?;
+    let real_vk_is_odd = vk_bytes_probe.first() == Some(&0x03);
+    let mut effective_tweak = *tweak;
+    if real_vk_is_odd {
+        // Negate: n - t, using SecretKey's built-in modular negate (the
+        // `negate` method returns -k mod n).
+        let sk = bitcoin::secp256k1::SecretKey::from_slice(&effective_tweak)
+            .map_err(|e| KeepError::Frost(format!("aggregate tweak invalid: {e}")))?;
+        effective_tweak = sk.negate().secret_bytes();
+    }
+    let tweak = &effective_tweak;
+
+    // Convert the (possibly negated) aggregate tweak into a
+    // bitcoin::secp256k1::Scalar for point additions and into a
+    // bitcoin::secp256k1::SecretKey for the scalar addition on the signing
+    // share. Both accept 32 big-endian bytes.
+    let scalar = bitcoin::secp256k1::Scalar::from_be_bytes(*tweak).map_err(|_| {
+        KeepError::Frost("BIP-32 aggregate tweak >= curve order; refusing to sign".into())
+    })?;
+    let tweak_sk = bitcoin::secp256k1::SecretKey::from_slice(tweak).map_err(|e| {
+        KeepError::Frost(format!("BIP-32 aggregate tweak is not a valid scalar: {e}"))
+    })?;
+
+    // Signing share: raw 32-byte big-endian scalar. Add tweak modulo n via
+    // SecretKey::add_tweak (we abuse the SecretKey type for its modular
+    // arithmetic; the tweak itself is not a secret).
+    let ss_bytes = kp.signing_share().serialize();
+    let ss_sk = bitcoin::secp256k1::SecretKey::from_slice(&ss_bytes)
+        .map_err(|e| KeepError::Frost(format!("signing share is not a valid scalar: {e}")))?;
+    let tweaked_ss_sk = ss_sk
+        .add_tweak(&bitcoin::secp256k1::Scalar::from_be_bytes(tweak_sk.secret_bytes()).unwrap())
+        .map_err(|e| KeepError::Frost(format!("signing share + tweak invalid: {e}")))?;
+    let tweaked_signing_share = SigningShare::deserialize(&tweaked_ss_sk.secret_bytes())
+        .map_err(|e| KeepError::Frost(format!("tweaked signing share deserialize: {e}")))?;
+
+    // Verifying share: 33-byte compressed pubkey. Add tweak·G via
+    // PublicKey::add_exp_tweak.
+    let vs_bytes = kp
+        .verifying_share()
+        .serialize()
+        .map_err(|e| KeepError::Frost(format!("verifying share serialize: {e}")))?;
+    let vs_pk = bitcoin::secp256k1::PublicKey::from_slice(&vs_bytes)
+        .map_err(|e| KeepError::Frost(format!("verifying share is not a valid point: {e}")))?;
+    let tweaked_vs_pk = vs_pk
+        .add_exp_tweak(&secp, &scalar)
+        .map_err(|e| KeepError::Frost(format!("verifying share + tweak·G invalid: {e}")))?;
+    let tweaked_verifying_share = VerifyingShare::deserialize(&tweaked_vs_pk.serialize())
+        .map_err(|e| KeepError::Frost(format!("tweaked verifying share deserialize: {e}")))?;
+
+    // Verifying key (group-level): same shape as VerifyingShare — 33 bytes.
+    let vk_bytes = kp
+        .verifying_key()
+        .serialize()
+        .map_err(|e| KeepError::Frost(format!("verifying key serialize: {e}")))?;
+    let vk_pk = bitcoin::secp256k1::PublicKey::from_slice(&vk_bytes)
+        .map_err(|e| KeepError::Frost(format!("verifying key is not a valid point: {e}")))?;
+    let tweaked_vk_pk = vk_pk
+        .add_exp_tweak(&secp, &scalar)
+        .map_err(|e| KeepError::Frost(format!("verifying key + tweak·G invalid: {e}")))?;
+    let tweaked_verifying_key = VerifyingKey::deserialize(&tweaked_vk_pk.serialize())
+        .map_err(|e| KeepError::Frost(format!("tweaked verifying key deserialize: {e}")))?;
+
+    Ok(KeyPackage::new(
+        *kp.identifier(),
+        tweaked_signing_share,
+        tweaked_verifying_share,
+        tweaked_verifying_key,
+        *kp.min_signers(),
+    ))
+}
+
+/// Derive the child pubkey and aggregate tweak for a group at a given BIP-32
+/// unhardened path, using the deterministic chaincode
+/// (`keep_bitcoin::frost_bip32::deterministic_chaincode`).
+pub fn derive_child(group_pubkey: &[u8; 32], path: &[u32]) -> Result<CompositeDerivation> {
+    let cc = deterministic_chaincode(group_pubkey);
+    derive_path_composite(group_pubkey, &cc, path)
+        .map_err(|e| KeepError::Frost(format!("BIP-32 child derivation failed: {e}")))
+}
+
+/// Sign `message` under the FROST group's BIP-32 unhardened child key at
+/// `path` using local shares (no network). Every share is tweaked by the
+/// composite BIP-32 scalar tweak before running the standard round1/round2
+/// aggregation, so the resulting BIP-340 signature verifies under the
+/// derived child pubkey returned by [`derive_child`].
+///
+/// The returned signature is independently verified against the child key
+/// before it leaves this function, so a tweak accounting mistake fails
+/// closed rather than surfacing as a silently-wrong signature.
+pub fn sign_with_local_shares_at_path(
+    shares: &[SharePackage],
+    message: &[u8],
+    path: &[u32],
+) -> Result<[u8; 64]> {
+    if shares.is_empty() {
+        return Err(KeepError::Frost("No shares provided".into()));
+    }
+    let threshold = shares[0].metadata.threshold as usize;
+    if shares.len() < threshold {
+        return Err(KeepError::Frost(format!(
+            "Need {} shares to sign, only {} provided",
+            threshold,
+            shares.len()
+        )));
+    }
+    let signing_shares = &shares[..threshold];
+
+    let group_pubkey = shares[0].group_pubkey();
+    let composite = derive_child(group_pubkey, path)?;
+
+    // Deserialize + tweak every KeyPackage up front so a single bad share
+    // fails before we mutate any signing state.
+    let tweaked_kps: Vec<KeyPackage> = signing_shares
+        .iter()
+        .map(|s| tweak_key_package(&s.key_package()?, &composite.aggregate_tweak))
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut nonces_map: BTreeMap<Identifier, round1::SigningNonces> = BTreeMap::new();
+    let mut commitments_map: BTreeMap<Identifier, round1::SigningCommitments> = BTreeMap::new();
+    let mut verifying_shares: BTreeMap<Identifier, VerifyingShare> = BTreeMap::new();
+
+    for kp in &tweaked_kps {
+        let (nonces, commitments) = round1::commit(kp.signing_share(), &mut OsRng);
+        nonces_map.insert(*kp.identifier(), nonces);
+        commitments_map.insert(*kp.identifier(), commitments);
+        verifying_shares.insert(*kp.identifier(), *kp.verifying_share());
+    }
+
+    let signing_package = SigningPackage::new(commitments_map, message);
+
+    let mut signature_shares: BTreeMap<Identifier, round2::SignatureShare> = BTreeMap::new();
+    for kp in &tweaked_kps {
+        let id = *kp.identifier();
+        let nonces = nonces_map
+            .remove(&id)
+            .ok_or_else(|| KeepError::Frost("Missing nonces for share".into()))?;
+        let sig_share = round2::sign(&signing_package, &nonces, kp)
+            .map_err(|e| KeepError::Frost(format!("Signing failed: {e}")))?;
+        signature_shares.insert(id, sig_share);
+    }
+
+    let pubkey_pkg = PublicKeyPackage::new(
+        verifying_shares,
+        *tweaked_kps[0].verifying_key(),
+        Some(*tweaked_kps[0].min_signers()),
+    );
+    let signature = frost::aggregate(&signing_package, &signature_shares, &pubkey_pkg)
+        .map_err(|e| KeepError::Frost(format!("Aggregation failed: {e}")))?;
+
+    let serialized = signature
+        .serialize()
+        .map_err(|e| KeepError::Frost(format!("Failed to serialize signature: {e}")))?;
+    let bytes_slice = serialized.as_slice();
+    if bytes_slice.len() != 64 {
+        return Err(KeepError::Frost("Invalid signature length".into()));
+    }
+    let mut sig_bytes = [0u8; 64];
+    sig_bytes.copy_from_slice(bytes_slice);
+
+    // Independent verification: the aggregate MUST verify under the derived
+    // child pubkey using BIP-340. A wrong tweak on any share would break
+    // this check, so we surface it as an explicit error rather than
+    // returning a silently-wrong signature.
+    let secp = Secp256k1::verification_only();
+    let sig = Signature::from_slice(&sig_bytes)
+        .map_err(|e| KeepError::Frost(format!("Aggregate signature is not schnorr-shaped: {e}")))?;
+    let child_xonly = XOnlyPublicKey::from_slice(&composite.child_pubkey)
+        .map_err(|e| KeepError::Frost(format!("Derived child pubkey invalid: {e}")))?;
+    let msg = Message::from_digest_slice(message)
+        .map_err(|e| KeepError::Frost(format!("Signable message must be 32 bytes: {e}")))?;
+    secp.verify_schnorr(&sig, &msg, &child_xonly).map_err(|e| {
+        KeepError::Frost(format!(
+            "BIP-32 composed signing produced a signature that does not verify \
+                 under the derived child pubkey: {e}"
+        ))
+    })?;
+
+    Ok(sig_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frost::{ThresholdConfig, TrustedDealer};
+
+    fn make_shares(threshold: u16, total: u16) -> Vec<SharePackage> {
+        let config = ThresholdConfig::new(threshold, total).unwrap();
+        let dealer = TrustedDealer::new(config);
+        let (shares, _pubkey_package) = dealer.generate("bip32-sign-test").unwrap();
+        shares
+    }
+
+    /// The group pubkey exposed by a `SharePackage` is what every downstream
+    /// caller identifies the group by. Derivation must produce a different
+    /// x-only key at every leaf, and the signature we build must verify
+    /// under that derived x-only key.
+    #[test]
+    fn signs_and_verifies_under_derived_child_pubkey_at_leaf() {
+        let shares = make_shares(2, 3);
+        let group = *shares[0].group_pubkey();
+        let message = [0x11u8; 32];
+
+        let sig = sign_with_local_shares_at_path(&shares[..2], &message, &[0, 5]).unwrap();
+
+        let composite = derive_child(&group, &[0, 5]).unwrap();
+        // Redundant with the check baked into the helper, but leaves an
+        // explicit at-rest assertion in the test suite that a
+        // /0/5-derived signature verifies where a /0/5-derived address
+        // would receive to.
+        let secp = Secp256k1::verification_only();
+        let sig = Signature::from_slice(&sig).unwrap();
+        let xonly = XOnlyPublicKey::from_slice(&composite.child_pubkey).unwrap();
+        let msg = Message::from_digest(message);
+        secp.verify_schnorr(&sig, &msg, &xonly).unwrap();
+    }
+
+    /// A signature produced under the child key MUST NOT verify under the
+    /// group key. Otherwise the whole point of derivation (per-address
+    /// signing keys) is defeated.
+    #[test]
+    fn child_signature_does_not_verify_under_group_pubkey() {
+        let shares = make_shares(2, 3);
+        let group = *shares[0].group_pubkey();
+        let message = [0x22u8; 32];
+
+        let sig = sign_with_local_shares_at_path(&shares[..2], &message, &[0, 7]).unwrap();
+
+        let secp = Secp256k1::verification_only();
+        let sig = Signature::from_slice(&sig).unwrap();
+        let group_xonly = XOnlyPublicKey::from_slice(&group).unwrap();
+        let msg = Message::from_digest(message);
+        assert!(
+            secp.verify_schnorr(&sig, &msg, &group_xonly).is_err(),
+            "child-derived signature must not verify under the parent group key"
+        );
+    }
+
+    /// External chain (`/0/N`) and internal chain (`/1/N`) at the same leaf
+    /// index produce distinct signatures under distinct pubkeys. This is
+    /// the property #487 needs to hold end-to-end: change and receive
+    /// addresses become distinct AND separately spendable.
+    #[test]
+    fn external_and_internal_leaves_sign_under_distinct_child_pubkeys() {
+        let shares = make_shares(2, 3);
+        let group = *shares[0].group_pubkey();
+        let message = [0x33u8; 32];
+
+        let sig_ext = sign_with_local_shares_at_path(&shares[..2], &message, &[0, 4]).unwrap();
+        let sig_int = sign_with_local_shares_at_path(&shares[..2], &message, &[1, 4]).unwrap();
+        assert_ne!(sig_ext, sig_int);
+
+        let ext_child = derive_child(&group, &[0, 4]).unwrap().child_pubkey;
+        let int_child = derive_child(&group, &[1, 4]).unwrap().child_pubkey;
+        assert_ne!(ext_child, int_child);
+    }
+
+    /// The 3-of-5 case at a two-level path, exercising a deeper walk than
+    /// the 2-of-3 tests. Signature must still verify under the
+    /// path-derived child pubkey with more signers reaching threshold.
+    #[test]
+    fn three_of_five_signs_and_verifies_at_two_level_path() {
+        let shares = make_shares(3, 5);
+        let group = *shares[0].group_pubkey();
+        let message = [0x44u8; 32];
+
+        let sig = sign_with_local_shares_at_path(&shares[..3], &message, &[1, 99]).unwrap();
+
+        let composite = derive_child(&group, &[1, 99]).unwrap();
+        let secp = Secp256k1::verification_only();
+        let sig = Signature::from_slice(&sig).unwrap();
+        let xonly = XOnlyPublicKey::from_slice(&composite.child_pubkey).unwrap();
+        let msg = Message::from_digest(message);
+        secp.verify_schnorr(&sig, &msg, &xonly).unwrap();
+    }
+
+    /// Fewer shares than the threshold refuses without ever computing a
+    /// composite tweak or emitting a partial signature.
+    #[test]
+    fn below_threshold_refuses() {
+        let shares = make_shares(2, 3);
+        let message = [0x55u8; 32];
+        let err = sign_with_local_shares_at_path(&shares[..1], &message, &[0, 0])
+            .expect_err("below threshold must be refused");
+        assert!(matches!(err, KeepError::Frost(_)));
+    }
+
+    /// Empty path refuses (matches the primitive) before any signing work.
+    #[test]
+    fn empty_path_refuses() {
+        let shares = make_shares(2, 3);
+        let message = [0x66u8; 32];
+        let err = sign_with_local_shares_at_path(&shares[..2], &message, &[])
+            .expect_err("empty path must be refused");
+        assert!(matches!(err, KeepError::Frost(_)));
+    }
+}

--- a/keep-core/src/frost/mod.rs
+++ b/keep-core/src/frost/mod.rs
@@ -6,6 +6,7 @@
 //! This module provides threshold signatures using the FROST protocol,
 //! allowing multiple parties to collaboratively sign messages without
 //! any single party having access to the complete private key.
+pub mod bip32_signing;
 mod coordinator;
 mod dealer;
 mod recover;

--- a/keep-core/src/frost_bip32.rs
+++ b/keep-core/src/frost_bip32.rs
@@ -44,9 +44,17 @@
 //! in tests, so any drift from BIP-32 fails a unit test.
 
 use bitcoin::hashes::{sha256, sha512, Hash as _, HashEngine as _, Hmac, HmacEngine};
-use bitcoin::secp256k1::{PublicKey, Scalar, Secp256k1};
+use bitcoin::secp256k1::{PublicKey, Scalar, Secp256k1, SecretKey};
 
-use crate::error::{BitcoinError, Result};
+use crate::error::{KeepError, Result};
+
+/// Local shim so downstream call sites (moved from keep-bitcoin in #487 PR2)
+/// keep using the same variant name for BIP-32 pathing errors. Every
+/// derivation failure is reported as `KeepError::Frost(...)` under the hood.
+#[inline]
+fn derivation_path_error(msg: impl Into<String>) -> KeepError {
+    KeepError::Frost(msg.into())
+}
 
 /// Domain separator for the deterministic chaincode. Bumping the version tag
 /// invalidates every previously derived child; keep it stable across releases.
@@ -92,7 +100,7 @@ fn even_lift(xonly: &[u8; 32]) -> Result<PublicKey> {
     compressed[0] = 0x02;
     compressed[1..].copy_from_slice(xonly);
     PublicKey::from_slice(&compressed)
-        .map_err(|e| BitcoinError::DerivationPath(format!("x-only pubkey not on curve: {e}")))
+        .map_err(|e| derivation_path_error(format!("x-only pubkey not on curve: {e}")))
 }
 
 /// One BIP-32 unhardened `ckd_pub` step on a full parent point.
@@ -107,7 +115,7 @@ fn ckd_pub_point(
     index: u32,
 ) -> Result<([u8; 32], [u8; 32], PublicKey)> {
     if index >= HARDENED_INDEX_START {
-        return Err(BitcoinError::DerivationPath(format!(
+        return Err(derivation_path_error(format!(
             "hardened index {index} not supported for FROST groups; \
              only unhardened public derivation is meaningful without a group secret"
         )));
@@ -131,13 +139,13 @@ fn ckd_pub_point(
         // value for i." We surface this so callers can retry at their layer;
         // for the deterministic chaincode + reasonable indexes this has
         // never been observed in practice.
-        BitcoinError::DerivationPath(format!(
+        derivation_path_error(format!(
             "BIP-32 child tweak >= curve order at index {index}; caller must skip to next index"
         ))
     })?;
     let secp = Secp256k1::verification_only();
     let child_point = parent_point.add_exp_tweak(&secp, &scalar).map_err(|e| {
-        BitcoinError::DerivationPath(format!("BIP-32 child tweak produced invalid point: {e}"))
+        derivation_path_error(format!("BIP-32 child tweak produced invalid point: {e}"))
     })?;
     Ok((tweak, child_chaincode, child_point))
 }
@@ -166,6 +174,112 @@ pub fn derive_child(
     })
 }
 
+/// Result of walking a full BIP-32 path, with the aggregate scalar tweak
+/// needed to reproduce the terminal child key from the +even lift of the
+/// group key. Used by FROST signing so every co-signer applies one
+/// composite tweak to its share instead of walking the tree per signer.
+///
+/// BIP-32 unhardened tweaks compose additively over the group:
+/// `child_final = group_lifted + t_agg·G (mod n)` where `t_agg = sum(t_i)`
+/// with each `t_i` computed against the actual on-curve parent point at
+/// its own depth. The stepwise tweaks are NOT interchangeable with the
+/// aggregate at intermediate depths (the HMAC input at level `i+1` depends
+/// on level `i`'s real parity, not on any x-only summary), so callers that
+/// want the aggregate must use this walker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CompositeDerivation {
+    /// Aggregate BIP-32 scalar tweak: applying it once to every FROST
+    /// signing share (mod n) and the group verifying key produces a
+    /// tweaked signing set whose aggregate signature verifies under
+    /// [`Self::child_pubkey`]. This is the single scalar the composed
+    /// BIP-32 + BIP-341 sign path passes to `KeyPackage`.
+    pub aggregate_tweak: [u8; 32],
+    /// Terminal chaincode. Callers walking children below the terminal
+    /// node (e.g. a wallet exposing further sub-paths) use it as the
+    /// parent chaincode for the next step.
+    pub terminal_chaincode: [u8; 32],
+    /// Terminal x-only child public key: the address-forming key at the
+    /// end of the path, and the key an aggregated signature must verify
+    /// against.
+    pub child_pubkey: [u8; 32],
+}
+
+/// Walk a BIP-32 path and return the aggregate scalar tweak plus the
+/// terminal chaincode and x-only child pubkey. Refuses hardened indexes
+/// and refuses paths whose stepwise tweaks aggregate to zero mod n (an
+/// invalid signing key; also a BIP-32-spec-mandated retry condition).
+pub fn derive_path_composite(
+    group_pubkey: &[u8; 32],
+    chaincode: &[u8; 32],
+    path: &[u32],
+) -> Result<CompositeDerivation> {
+    if path.is_empty() {
+        return Err(derivation_path_error(
+            "derive_path_composite requires at least one index",
+        ));
+    }
+    let mut parent_point = even_lift(group_pubkey)?;
+    let mut parent_chaincode = *chaincode;
+
+    // Accumulate the scalar tweak in a SecretKey for modular add_tweak
+    // arithmetic. The value is not a secret (chaincodes and unhardened
+    // tweaks are public by construction), we just reuse the API surface
+    // for its mod-n scalar addition. Seed with the first step's tweak.
+    let first_index = path[0];
+    let (first_tweak, first_cc, first_point) =
+        ckd_pub_point(&parent_point, &parent_chaincode, first_index)?;
+    let mut acc = SecretKey::from_slice(&first_tweak).map_err(|e| {
+        derivation_path_error(format!("BIP-32 first tweak is not a valid scalar: {e}"))
+    })?;
+    parent_point = first_point;
+    parent_chaincode = first_cc;
+
+    for &index in &path[1..] {
+        let (step_tweak, step_cc, step_point) =
+            ckd_pub_point(&parent_point, &parent_chaincode, index)?;
+        let step_scalar = Scalar::from_be_bytes(step_tweak).map_err(|_| {
+            derivation_path_error(format!("BIP-32 step tweak >= curve order at index {index}"))
+        })?;
+        acc = acc.add_tweak(&step_scalar).map_err(|e| {
+            derivation_path_error(format!(
+                "BIP-32 aggregate tweak became invalid at index {index}: {e}"
+            ))
+        })?;
+        parent_point = step_point;
+        parent_chaincode = step_cc;
+    }
+
+    let aggregate_tweak = acc.secret_bytes();
+    // Sanity-check invariant: applying the aggregate tweak to the +even
+    // lift of the group key must reproduce the terminal child point.
+    // Any drift here means the composite tweak cannot be used for FROST
+    // signing under the derived child key, which is the whole point of
+    // this helper. Refuse rather than return an unsigned-worthy tweak.
+    let secp = Secp256k1::verification_only();
+    let reproduced = even_lift(group_pubkey)?
+        .add_exp_tweak(
+            &secp,
+            &Scalar::from_be_bytes(aggregate_tweak).map_err(|_| {
+                derivation_path_error("aggregate tweak >= curve order after accumulation")
+            })?,
+        )
+        .map_err(|e| {
+            derivation_path_error(format!("aggregate tweak produced invalid point: {e}"))
+        })?;
+    if reproduced != parent_point {
+        return Err(derivation_path_error(
+            "composed BIP-32 tweak does not reproduce terminal child point; \
+             signing under the aggregate would diverge from stepwise derivation",
+        ));
+    }
+
+    Ok(CompositeDerivation {
+        aggregate_tweak,
+        terminal_chaincode: parent_chaincode,
+        child_pubkey: parent_point.x_only_public_key().0.serialize(),
+    })
+}
+
 /// Walk a full BIP-32 path (all unhardened) starting from the group key and
 /// its deterministic chaincode, returning the terminal derivation. Convenience
 /// wrapper: the descriptor path `m/0/*` at index N is `derive_path(&[0, N])`.
@@ -179,8 +293,8 @@ pub fn derive_path(
     path: &[u32],
 ) -> Result<ChildDerivation> {
     if path.is_empty() {
-        return Err(BitcoinError::DerivationPath(
-            "derive_path requires at least one index".into(),
+        return Err(derivation_path_error(
+            "derive_path requires at least one index",
         ));
     }
     let mut parent_point = even_lift(group_pubkey)?;
@@ -245,7 +359,7 @@ mod tests {
         let cc = deterministic_chaincode(&group);
         let err = derive_child(&group, &cc, HARDENED_INDEX_START)
             .expect_err("hardened index must be refused");
-        assert!(matches!(err, BitcoinError::DerivationPath(_)));
+        assert!(matches!(err, KeepError::Frost(_)));
         // The last unhardened index still works.
         derive_child(&group, &cc, HARDENED_INDEX_START - 1).unwrap();
     }
@@ -401,5 +515,89 @@ mod tests {
         let group = stable_group_pubkey();
         let cc = deterministic_chaincode(&group);
         assert!(derive_path(&group, &cc, &[]).is_err());
+        assert!(derive_path_composite(&group, &cc, &[]).is_err());
+    }
+
+    /// #487 PR2 core: the aggregate scalar tweak returned by
+    /// `derive_path_composite` reproduces the same terminal child point as
+    /// the stepwise walk. This is the invariant every co-signer relies on
+    /// when applying ONE composite tweak to its share instead of walking
+    /// the tree per signer.
+    #[test]
+    fn composite_tweak_reproduces_terminal_child_point() {
+        let group = stable_group_pubkey();
+        let cc = deterministic_chaincode(&group);
+        for path in &[
+            &[0u32][..],
+            &[1u32][..],
+            &[0, 0][..],
+            &[0, 1][..],
+            &[1, 0][..],
+            &[1, 42][..],
+            &[0, 100_000][..],
+        ] {
+            let stepwise = derive_path(&group, &cc, path).unwrap();
+            let composite = derive_path_composite(&group, &cc, path).unwrap();
+
+            // Composite and stepwise walks converge on the same terminal
+            // (chaincode, x-only child pubkey), so callers of either
+            // helper see a consistent tree.
+            assert_eq!(
+                composite.child_pubkey, stepwise.child_pubkey,
+                "path {path:?}: composite child pubkey diverges from stepwise walk"
+            );
+            assert_eq!(
+                composite.terminal_chaincode, stepwise.child_chaincode,
+                "path {path:?}: composite chaincode diverges from stepwise walk"
+            );
+
+            // The aggregate tweak, applied once to the +even lift of the
+            // group pubkey, reproduces the terminal child point. This is
+            // the property the FROST signing path (PR 3 of #487) will
+            // depend on for its one-tweak-per-share optimisation.
+            let secp = Secp256k1::verification_only();
+            let parent = even_lift(&group).unwrap();
+            let scalar = Scalar::from_be_bytes(composite.aggregate_tweak).unwrap();
+            let reproduced = parent.add_exp_tweak(&secp, &scalar).unwrap();
+            assert_eq!(
+                reproduced.x_only_public_key().0.serialize(),
+                composite.child_pubkey,
+                "path {path:?}: applying aggregate tweak to +even group does not reproduce child"
+            );
+        }
+    }
+
+    /// The aggregate tweak for a single-step path equals the stepwise
+    /// tweak byte-for-byte: the composite walker MUST NOT drift away
+    /// from the primitive for the trivial case.
+    #[test]
+    fn composite_matches_stepwise_tweak_at_depth_one() {
+        let group = stable_group_pubkey();
+        let cc = deterministic_chaincode(&group);
+        for &index in &[0u32, 1, 2, 7, 42, 100_000] {
+            let step = derive_child(&group, &cc, index).unwrap();
+            let composite = derive_path_composite(&group, &cc, &[index]).unwrap();
+            assert_eq!(step.tweak, composite.aggregate_tweak, "index {index}");
+        }
+    }
+
+    /// Different composite paths must yield different aggregate tweaks:
+    /// the whole point of derivation is address (and signing-key) diversity.
+    #[test]
+    fn composite_tweaks_differ_across_paths() {
+        let group = stable_group_pubkey();
+        let cc = deterministic_chaincode(&group);
+        let a = derive_path_composite(&group, &cc, &[0, 0])
+            .unwrap()
+            .aggregate_tweak;
+        let b = derive_path_composite(&group, &cc, &[0, 1])
+            .unwrap()
+            .aggregate_tweak;
+        let c = derive_path_composite(&group, &cc, &[1, 0])
+            .unwrap()
+            .aggregate_tweak;
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(b, c);
     }
 }

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -50,6 +50,8 @@ pub mod entropy;
 pub mod error;
 /// FROST threshold signature implementation.
 pub mod frost;
+/// BIP-32 unhardened child-key primitives for FROST group keys (#487).
+pub mod frost_bip32;
 /// Hidden volume storage for plausible deniability.
 pub mod hidden;
 /// In-memory keyring for unlocked keys.


### PR DESCRIPTION
## Summary

PR 2 of 4 for #487. Wires the crypto primitives from PR 1 into the existing local-shares signing loop. Every participant applies ONE composite BIP-32 scalar tweak to its own `KeyPackage` (signing share, verifying share, group verifying key), then the standard `frost::round1`/`round2`/`aggregate` runs against those tweaked packages. The resulting BIP-340 aggregate signature verifies under the derived child pubkey.

No wire format change, no storage bump. All new surface is under `keep_core::frost::bip32_signing`.

## Design

- **Composite tweak, one per signer.** BIP-32 unhardened tweaks compose additively over the group (`child = parent + t_agg·G mod n`), so a single scalar applied to every share is enough. No per-signer tree walk.
- **`derive_path_composite`** (added to keep-core::frost_bip32) accumulates the stepwise tweaks with `SecretKey::add_tweak` and double-checks the invariant `parent + t_agg·G == child` before returning, so a broken composite cannot silently produce signatures that verify under nothing.
- **Public API only.** Tweaked KeyPackages are rebuilt through `frost::keys::{SigningShare,VerifyingShare,VerifyingKey}::{serialize,deserialize}` and `KeyPackage::new`, all on the public API of `frost-core`. No `internals` feature flag required.
- **Y-parity handling.** `derive_path_composite` walks from the +even lift of the x-only group pubkey, matching what every downstream BIP-32 wallet does. When the FROST KeyPackage's real `VerifyingKey` has odd-y, we negate the tweak scalar so the tweaked VK's x-only matches the primitive's derived child pubkey. Confirmed passing on both parity cases across all tests.
- **Fail-closed post-check.** After aggregation the helper independently verifies the produced signature against the derived child pubkey using BIP-340. A tweak-accounting mistake fails this check rather than surfacing as a silently-wrong signature.

## Layout change

Moves `frost_bip32` from `keep-bitcoin` to `keep-core`. Rationale:

- keep-bitcoin cannot depend upward on keep-core (cycle), so the composed FROST-signing helper cannot live in keep-bitcoin.
- keep-core is the natural home for anything under `frost::`, and `bip32_signing` reaches into `frost::SharePackage` and `frost_secp256k1_tr::keys::KeyPackage`.
- `keep-bitcoin::frost_bip32` is preserved as a `pub use keep_core::frost_bip32` re-export so any external caller that used the pre-PR2 path keeps compiling.

## Tests

`cargo test -p keep-core --lib frost::bip32_signing::` (6 tests, all pass) plus the pre-existing 12 tests in `frost_bip32::` (moved with the module):

- `signs_and_verifies_under_derived_child_pubkey_at_leaf` — 2-of-3, `/0/5`; sig verifies under BIP-340 x-only of the derived child.
- **`child_signature_does_not_verify_under_group_pubkey`** — a child-derived signature MUST NOT verify under the parent group key, otherwise the whole point of derivation is defeated.
- `external_and_internal_leaves_sign_under_distinct_child_pubkeys` — `/0/4` and `/1/4` produce different signatures under different child pubkeys.
- `three_of_five_signs_and_verifies_at_two_level_path` — deeper 3-of-5 at `/1/99`.
- `below_threshold_refuses` — no partial signature emitted when count < threshold.
- `empty_path_refuses` — matches the primitive.

Workspace tests pass (one pre-existing timing-flaky test in keep-frost-net's `test_session_expiry_during_signing` passed on rerun; unrelated). Clippy clean.

## Next in the arc

3. Wire protocol: `SignRequestPayload` carries the derivation path so network signers can recompute the composite tweak and match.
4. Descriptor emission: `from_frost_wallet` emits an xpub-shaped BIP-86 descriptor so `wallet descriptor` produces distinct external and internal chains and `--allow-address-reuse` is no longer needed for the common case; regtest end-to-end test.

## Closes

Advances #487 (this is PR 2 of 4; the issue stays open until PR 4 lands).