### PR TITLE
frost-bip32: bound derivation path, zeroize share scalars, cover odd-y branch

### DIFF
--- a/keep-core/src/frost/bip32_signing.rs
+++ b/keep-core/src/frost/bip32_signing.rs
@@ -10,7 +10,7 @@
 //! `frost::round1`/`round2`/`aggregate` runs against those tweaked packages.
 //! The resulting BIP-340 aggregate signature verifies under the derived
 //! child pubkey returned by
-//! [`keep_bitcoin::frost_bip32::derive_path_composite`].
+//! [`crate::frost_bip32::derive_path_composite`].
 //!
 //! Design notes for the review of #487:
 //!
@@ -29,15 +29,12 @@
 //!   BIP-340. A tweak accounting mistake would fail this check, so a
 //!   silently-wrong signature cannot escape the helper.
 
-use std::collections::BTreeMap;
-
 use bitcoin::secp256k1::{schnorr::Signature, Message, Secp256k1, XOnlyPublicKey};
 use frost_secp256k1_tr::{
-    self as frost,
-    keys::{KeyPackage, PublicKeyPackage, SigningShare, VerifyingShare},
-    rand_core::OsRng,
-    round1, round2, Identifier, SigningPackage, VerifyingKey,
+    keys::{KeyPackage, SigningShare, VerifyingShare},
+    VerifyingKey,
 };
+use zeroize::Zeroizing;
 
 use super::SharePackage;
 use crate::error::{KeepError, Result};
@@ -67,11 +64,11 @@ fn tweak_key_package(kp: &KeyPackage, tweak: &[u8; 32]) -> Result<KeyPackage> {
     // child pubkey wallets derive, negate the tweak in the odd-y case. The
     // resulting KeyPackage will have `-(child_target)` as its VerifyingKey,
     // which BIP-340 accepts (verification is x-only, ignores sign).
-    let vk_bytes_probe = kp
+    let vk_bytes = kp
         .verifying_key()
         .serialize()
         .map_err(|e| KeepError::Frost(format!("verifying key serialize: {e}")))?;
-    let real_vk_is_odd = vk_bytes_probe.first() == Some(&0x03);
+    let real_vk_is_odd = vk_bytes.first() == Some(&0x03);
     let mut effective_tweak = *tweak;
     if real_vk_is_odd {
         // Negate: n - t, using SecretKey's built-in modular negate (the
@@ -89,20 +86,22 @@ fn tweak_key_package(kp: &KeyPackage, tweak: &[u8; 32]) -> Result<KeyPackage> {
     let scalar = bitcoin::secp256k1::Scalar::from_be_bytes(*tweak).map_err(|_| {
         KeepError::Frost("BIP-32 aggregate tweak >= curve order; refusing to sign".into())
     })?;
-    let tweak_sk = bitcoin::secp256k1::SecretKey::from_slice(tweak).map_err(|e| {
-        KeepError::Frost(format!("BIP-32 aggregate tweak is not a valid scalar: {e}"))
-    })?;
 
     // Signing share: raw 32-byte big-endian scalar. Add tweak modulo n via
     // SecretKey::add_tweak (we abuse the SecretKey type for its modular
-    // arithmetic; the tweak itself is not a secret).
-    let ss_bytes = kp.signing_share().serialize();
-    let ss_sk = bitcoin::secp256k1::SecretKey::from_slice(&ss_bytes)
+    // arithmetic; the tweak itself is not a secret). The share scalar and its
+    // tweaked copy are real secret material, so keep every plaintext copy in a
+    // Zeroizing buffer that scrubs on drop.
+    let ss_bytes = Zeroizing::new(kp.signing_share().serialize());
+    let ss_sk = bitcoin::secp256k1::SecretKey::from_slice(ss_bytes.as_slice())
         .map_err(|e| KeepError::Frost(format!("signing share is not a valid scalar: {e}")))?;
-    let tweaked_ss_sk = ss_sk
-        .add_tweak(&bitcoin::secp256k1::Scalar::from_be_bytes(tweak_sk.secret_bytes()).unwrap())
-        .map_err(|e| KeepError::Frost(format!("signing share + tweak invalid: {e}")))?;
-    let tweaked_signing_share = SigningShare::deserialize(&tweaked_ss_sk.secret_bytes())
+    let tweaked_ss_bytes = Zeroizing::new(
+        ss_sk
+            .add_tweak(&scalar)
+            .map_err(|e| KeepError::Frost(format!("signing share + tweak invalid: {e}")))?
+            .secret_bytes(),
+    );
+    let tweaked_signing_share = SigningShare::deserialize(&*tweaked_ss_bytes)
         .map_err(|e| KeepError::Frost(format!("tweaked signing share deserialize: {e}")))?;
 
     // Verifying share: 33-byte compressed pubkey. Add tweak·G via
@@ -120,10 +119,7 @@ fn tweak_key_package(kp: &KeyPackage, tweak: &[u8; 32]) -> Result<KeyPackage> {
         .map_err(|e| KeepError::Frost(format!("tweaked verifying share deserialize: {e}")))?;
 
     // Verifying key (group-level): same shape as VerifyingShare — 33 bytes.
-    let vk_bytes = kp
-        .verifying_key()
-        .serialize()
-        .map_err(|e| KeepError::Frost(format!("verifying key serialize: {e}")))?;
+    // Reuse the bytes already serialized above for the parity probe.
     let vk_pk = bitcoin::secp256k1::PublicKey::from_slice(&vk_bytes)
         .map_err(|e| KeepError::Frost(format!("verifying key is not a valid point: {e}")))?;
     let tweaked_vk_pk = vk_pk
@@ -143,7 +139,7 @@ fn tweak_key_package(kp: &KeyPackage, tweak: &[u8; 32]) -> Result<KeyPackage> {
 
 /// Derive the child pubkey and aggregate tweak for a group at a given BIP-32
 /// unhardened path, using the deterministic chaincode
-/// (`keep_bitcoin::frost_bip32::deterministic_chaincode`).
+/// (`crate::frost_bip32::deterministic_chaincode`).
 pub fn derive_child(group_pubkey: &[u8; 32], path: &[u32]) -> Result<CompositeDerivation> {
     let cc = deterministic_chaincode(group_pubkey);
     derive_path_composite(group_pubkey, &cc, path)
@@ -167,6 +163,15 @@ pub fn sign_with_local_shares_at_path(
     if shares.is_empty() {
         return Err(KeepError::Frost("No shares provided".into()));
     }
+    // The BIP-340 self-verify below (and every taproot sighash) is over a
+    // 32-byte digest. Reject a wrong-length message up front instead of doing
+    // a full signing round and only failing at the verify step.
+    if message.len() != 32 {
+        return Err(KeepError::Frost(format!(
+            "Signable message must be 32 bytes, got {}",
+            message.len()
+        )));
+    }
     let threshold = shares[0].metadata.threshold as usize;
     if shares.len() < threshold {
         return Err(KeepError::Frost(format!(
@@ -187,47 +192,7 @@ pub fn sign_with_local_shares_at_path(
         .map(|s| tweak_key_package(&s.key_package()?, &composite.aggregate_tweak))
         .collect::<Result<Vec<_>>>()?;
 
-    let mut nonces_map: BTreeMap<Identifier, round1::SigningNonces> = BTreeMap::new();
-    let mut commitments_map: BTreeMap<Identifier, round1::SigningCommitments> = BTreeMap::new();
-    let mut verifying_shares: BTreeMap<Identifier, VerifyingShare> = BTreeMap::new();
-
-    for kp in &tweaked_kps {
-        let (nonces, commitments) = round1::commit(kp.signing_share(), &mut OsRng);
-        nonces_map.insert(*kp.identifier(), nonces);
-        commitments_map.insert(*kp.identifier(), commitments);
-        verifying_shares.insert(*kp.identifier(), *kp.verifying_share());
-    }
-
-    let signing_package = SigningPackage::new(commitments_map, message);
-
-    let mut signature_shares: BTreeMap<Identifier, round2::SignatureShare> = BTreeMap::new();
-    for kp in &tweaked_kps {
-        let id = *kp.identifier();
-        let nonces = nonces_map
-            .remove(&id)
-            .ok_or_else(|| KeepError::Frost("Missing nonces for share".into()))?;
-        let sig_share = round2::sign(&signing_package, &nonces, kp)
-            .map_err(|e| KeepError::Frost(format!("Signing failed: {e}")))?;
-        signature_shares.insert(id, sig_share);
-    }
-
-    let pubkey_pkg = PublicKeyPackage::new(
-        verifying_shares,
-        *tweaked_kps[0].verifying_key(),
-        Some(*tweaked_kps[0].min_signers()),
-    );
-    let signature = frost::aggregate(&signing_package, &signature_shares, &pubkey_pkg)
-        .map_err(|e| KeepError::Frost(format!("Aggregation failed: {e}")))?;
-
-    let serialized = signature
-        .serialize()
-        .map_err(|e| KeepError::Frost(format!("Failed to serialize signature: {e}")))?;
-    let bytes_slice = serialized.as_slice();
-    if bytes_slice.len() != 64 {
-        return Err(KeepError::Frost("Invalid signature length".into()));
-    }
-    let mut sig_bytes = [0u8; 64];
-    sig_bytes.copy_from_slice(bytes_slice);
+    let sig_bytes = super::signing::aggregate_local(&tweaked_kps, message)?;
 
     // Independent verification: the aggregate MUST verify under the derived
     // child pubkey using BIP-340. A wrong tweak on any share would break
@@ -343,6 +308,45 @@ mod tests {
         let xonly = XOnlyPublicKey::from_slice(&composite.child_pubkey).unwrap();
         let msg = Message::from_digest(message);
         secp.verify_schnorr(&sig, &msg, &xonly).unwrap();
+    }
+
+    /// Exercise the odd-y group-VK negation branch in `tweak_key_package`.
+    /// The group's TRUE verifying key has random parity per dealer run, so
+    /// generate until it serializes to 0x03 (odd y), then assert the composed
+    /// signature still verifies under the derived child pubkey. Without this,
+    /// the exact parity-correctness branch is only hit ~50% of the time.
+    #[test]
+    fn odd_y_group_vk_signs_and_verifies_under_child() {
+        let message = [0x77u8; 32];
+        let mut exercised_odd_y = false;
+        for _ in 0..64 {
+            let shares = make_shares(2, 3);
+            let vk_prefix = shares[0]
+                .key_package()
+                .unwrap()
+                .verifying_key()
+                .serialize()
+                .unwrap()[0];
+            if vk_prefix != 0x03 {
+                continue;
+            }
+            exercised_odd_y = true;
+            let group = *shares[0].group_pubkey();
+
+            let sig = sign_with_local_shares_at_path(&shares[..2], &message, &[0, 9]).unwrap();
+
+            let composite = derive_child(&group, &[0, 9]).unwrap();
+            let secp = Secp256k1::verification_only();
+            let sig = Signature::from_slice(&sig).unwrap();
+            let xonly = XOnlyPublicKey::from_slice(&composite.child_pubkey).unwrap();
+            let msg = Message::from_digest(message);
+            secp.verify_schnorr(&sig, &msg, &xonly).unwrap();
+            break;
+        }
+        assert!(
+            exercised_odd_y,
+            "no odd-y group VK produced in 64 dealer runs; branch left untested"
+        );
     }
 
     /// Fewer shares than the threshold refuses without ever computing a

--- a/keep-core/src/frost/signing.rs
+++ b/keep-core/src/frost/signing.rs
@@ -235,8 +235,6 @@ impl SigningSession {
 
 /// Sign using local shares only (no network). Requires threshold shares.
 pub fn sign_with_local_shares(shares: &[super::SharePackage], message: &[u8]) -> Result<[u8; 64]> {
-    use frost::{keys::PublicKeyPackage, round1, round2};
-
     if shares.is_empty() {
         return Err(KeepError::Frost("No shares provided".into()));
     }
@@ -250,14 +248,26 @@ pub fn sign_with_local_shares(shares: &[super::SharePackage], message: &[u8]) ->
         )));
     }
 
-    let signing_shares = &shares[..threshold];
+    let kps: Vec<KeyPackage> = shares[..threshold]
+        .iter()
+        .map(|s| s.key_package())
+        .collect::<Result<Vec<_>>>()?;
+    aggregate_local(&kps, message)
+}
+
+/// Run the FROST round1/round2/aggregate flow over an explicit set of
+/// `KeyPackage`s and return the 64-byte BIP-340 signature. Shared by the
+/// plain local-shares path and the BIP-32 child-key signing path (which
+/// passes tweaked packages). `kps` must be non-empty and already reduced to
+/// exactly the threshold set of signers.
+pub(super) fn aggregate_local(kps: &[KeyPackage], message: &[u8]) -> Result<[u8; 64]> {
+    use frost::{round1, round2};
 
     let mut nonces_map: BTreeMap<Identifier, round1::SigningNonces> = BTreeMap::new();
     let mut commitments_map: BTreeMap<Identifier, round1::SigningCommitments> = BTreeMap::new();
     let mut verifying_shares: BTreeMap<Identifier, frost::keys::VerifyingShare> = BTreeMap::new();
 
-    for share in signing_shares {
-        let kp = share.key_package()?;
+    for kp in kps {
         let (nonces, commitments) = round1::commit(kp.signing_share(), &mut OsRng);
         nonces_map.insert(*kp.identifier(), nonces);
         commitments_map.insert(*kp.identifier(), commitments);
@@ -267,23 +277,20 @@ pub fn sign_with_local_shares(shares: &[super::SharePackage], message: &[u8]) ->
     let signing_package = SigningPackage::new(commitments_map, message);
 
     let mut signature_shares: BTreeMap<Identifier, round2::SignatureShare> = BTreeMap::new();
-
-    for share in signing_shares {
-        let kp = share.key_package()?;
+    for kp in kps {
         let id = *kp.identifier();
         let nonces = nonces_map
             .remove(&id)
             .ok_or_else(|| KeepError::Frost("Missing nonces for share".into()))?;
-        let sig_share = round2::sign(&signing_package, &nonces, &kp)
+        let sig_share = round2::sign(&signing_package, &nonces, kp)
             .map_err(|e| KeepError::Frost(format!("Signing failed: {e}")))?;
         signature_shares.insert(id, sig_share);
     }
 
-    let first_kp = signing_shares[0].key_package()?;
     let pubkey_pkg = PublicKeyPackage::new(
         verifying_shares,
-        *first_kp.verifying_key(),
-        Some(*first_kp.min_signers()),
+        *kps[0].verifying_key(),
+        Some(*kps[0].min_signers()),
     );
     let signature = frost::aggregate(&signing_package, &signature_shares, &pubkey_pkg)
         .map_err(|e| KeepError::Frost(format!("Aggregation failed: {e}")))?;

--- a/keep-core/src/frost_bip32.rs
+++ b/keep-core/src/frost_bip32.rs
@@ -65,6 +65,12 @@ const CHAINCODE_DOMAIN: &[u8] = b"keep-frost-bip32-chaincode-v1";
 /// (see the module doc), so every index must live below the hardened bit.
 pub const HARDENED_INDEX_START: u32 = 0x8000_0000;
 
+/// Maximum derivation-path length accepted by the path walkers. BIP-32's own
+/// serialized `depth` field is a single byte, so 255 is the natural ceiling;
+/// a real receive/change path is length 2. Bounding it keeps a wire-supplied
+/// path (see #487) from forcing unbounded HMAC-SHA512 + EC work on a signer.
+pub const MAX_DERIVATION_DEPTH: usize = 255;
+
 /// Derive the deterministic 32-byte chaincode for a FROST group key.
 ///
 /// `group_pubkey` is the BIP-340 x-only 32-byte aggregated FROST group key.
@@ -218,6 +224,12 @@ pub fn derive_path_composite(
             "derive_path_composite requires at least one index",
         ));
     }
+    if path.len() > MAX_DERIVATION_DEPTH {
+        return Err(derivation_path_error(format!(
+            "derivation path length {} exceeds maximum {MAX_DERIVATION_DEPTH}",
+            path.len()
+        )));
+    }
     let mut parent_point = even_lift(group_pubkey)?;
     let mut parent_chaincode = *chaincode;
 
@@ -296,6 +308,12 @@ pub fn derive_path(
         return Err(derivation_path_error(
             "derive_path requires at least one index",
         ));
+    }
+    if path.len() > MAX_DERIVATION_DEPTH {
+        return Err(derivation_path_error(format!(
+            "derivation path length {} exceeds maximum {MAX_DERIVATION_DEPTH}",
+            path.len()
+        )));
     }
     let mut parent_point = even_lift(group_pubkey)?;
     let mut parent_chaincode = *chaincode;
@@ -516,6 +534,17 @@ mod tests {
         let cc = deterministic_chaincode(&group);
         assert!(derive_path(&group, &cc, &[]).is_err());
         assert!(derive_path_composite(&group, &cc, &[]).is_err());
+    }
+
+    /// A path longer than `MAX_DERIVATION_DEPTH` is refused before doing the
+    /// per-index HMAC + EC work, bounding CPU on a wire-supplied path.
+    #[test]
+    fn overlong_path_refused() {
+        let group = stable_group_pubkey();
+        let cc = deterministic_chaincode(&group);
+        let too_long = vec![0u32; MAX_DERIVATION_DEPTH + 1];
+        assert!(derive_path(&group, &cc, &too_long).is_err());
+        assert!(derive_path_composite(&group, &cc, &too_long).is_err());
     }
 
     /// #487 PR2 core: the aggregate scalar tweak returned by


### PR DESCRIPTION
## Summary

Follow-up hardening for the BIP-32 composed FROST signing merged in #669 (part of #487). No behavior change on the happy path; tightens the unhappy paths, closes a test gap on the parity branch, and removes duplication introduced by that PR.

## Changes

**Security / correctness**
- **Bound derivation-path length.** `derive_path` and `derive_path_composite` now reject paths longer than `MAX_DERIVATION_DEPTH` (255, matching BIP-32's single-byte `depth` field). A real receive/change path is length 2; the bound keeps a future wire-supplied path from forcing unbounded HMAC-SHA512 + EC work on a signer.
- **Zeroize signing-share scalars.** In `tweak_key_package`, the plaintext share scalar and its tweaked copy are held in `zeroize::Zeroizing` buffers so secret material is scrubbed on drop instead of lingering in freed stack memory.
- **Reject wrong-length messages up front.** `sign_with_local_shares_at_path` validates `message.len() == 32` at entry, rejecting a bad sighash before running a full signing round rather than failing at the trailing self-verify.

**Test coverage**
- Added a test that deterministically exercises the odd-y group-verifying-key negation branch (previously reached only ~50% of runs due to random dealer parity), asserting the composed signature still verifies under the derived child pubkey.
- Added a test that an over-length path is refused.

**Quality**
- Extracted the shared FROST round1/round2/aggregate body into `aggregate_local`, used by both `sign_with_local_shares` and the path-signing entry point, removing a near-verbatim duplicate.
- Removed a redundant scalar reconstruction and a duplicate group-key serialization in `tweak_key_package`.
- Repointed two stale intra-doc links to `crate::frost_bip32::*` after the module move.

## Tests

`cargo test -p keep-core --lib` passes (311 tests, including the moved BIP-32 suites and the two new tests). Clippy clean on keep-core.
