### PR TITLE
frost-net: carry BIP-32 derivation path through the sign wire protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/keep-core/src/frost/bip32_signing.rs
+++ b/keep-core/src/frost/bip32_signing.rs
@@ -40,6 +40,38 @@ use super::SharePackage;
 use crate::error::{KeepError, Result};
 use crate::frost_bip32::{derive_path_composite, deterministic_chaincode, CompositeDerivation};
 
+/// Parity-adjust the aggregate BIP-32 tweak for the group's true verifying
+/// key and return it as a `bitcoin::secp256k1::Scalar` for both the point
+/// additions and the signing-share scalar add.
+///
+/// `derive_path_composite` walks BIP-32 from the +even lift of the x-only
+/// group pubkey, matching what every downstream wallet (and every reference
+/// BIP-32 implementation) does when handed an xpub shaped from an x-only key.
+/// But the FROST verifying key can have either parity. If it is odd-y, then
+/// `real_vk = -even_lift(x_only(real_vk))`, so applying the primitive's `t`
+/// scalar directly lands on `real_vk + t·G = -(even_lift + (-t)·G)` whose
+/// x-coordinate is x_only(even_lift + (-t)·G), NOT x_only(even_lift + t·G).
+/// To land the tweaked key on the same x-only child pubkey wallets derive,
+/// negate the tweak in the odd-y case. The tweaked key ends up as
+/// `-(child_target)`, which BIP-340 accepts (verification is x-only).
+fn effective_tweak_scalar(
+    vk_bytes: &[u8],
+    aggregate_tweak: [u8; 32],
+) -> Result<bitcoin::secp256k1::Scalar> {
+    let real_vk_is_odd = vk_bytes.first() == Some(&0x03);
+    let mut effective_tweak = aggregate_tweak;
+    if real_vk_is_odd {
+        // Negate: n - t, using SecretKey's built-in modular negate (the
+        // `negate` method returns -k mod n).
+        let sk = bitcoin::secp256k1::SecretKey::from_slice(&effective_tweak)
+            .map_err(|e| KeepError::Frost(format!("aggregate tweak invalid: {e}")))?;
+        effective_tweak = sk.negate().secret_bytes();
+    }
+    bitcoin::secp256k1::Scalar::from_be_bytes(effective_tweak).map_err(|_| {
+        KeepError::Frost("BIP-32 aggregate tweak >= curve order; refusing to sign".into())
+    })
+}
+
 /// Add the aggregate BIP-32 scalar tweak `t_agg` to every field of a
 /// `KeyPackage`: `signing_share += t_agg`, `verifying_share += t_agg·G`,
 /// `verifying_key += t_agg·G`. Returns the tweaked package.
@@ -52,40 +84,14 @@ use crate::frost_bip32::{derive_path_composite, deterministic_chaincode, Composi
 fn tweak_key_package(kp: &KeyPackage, tweak: &[u8; 32]) -> Result<KeyPackage> {
     let secp = Secp256k1::verification_only();
 
-    // Parity handling. `derive_path_composite` walks BIP-32 from the +even
-    // lift of the x-only group pubkey, matching what every downstream wallet
-    // (and every reference BIP-32 implementation) does when handed an xpub
-    // shaped from an x-only key. But the FROST KeyPackage carries the
-    // group's TRUE verifying_key, which can have either parity. If it is
-    // odd-y, then `real_vk = -even_lift(x_only(real_vk))`, so applying the
-    // primitive's `t` scalar directly lands on `real_vk + t·G = -(even_lift + (-t)·G)`
-    // whose x-coordinate is x_only(even_lift + (-t)·G) — NOT
-    // x_only(even_lift + t·G). To land the tweaked VK on the same x-only
-    // child pubkey wallets derive, negate the tweak in the odd-y case. The
-    // resulting KeyPackage will have `-(child_target)` as its VerifyingKey,
-    // which BIP-340 accepts (verification is x-only, ignores sign).
     let vk_bytes = kp
         .verifying_key()
         .serialize()
         .map_err(|e| KeepError::Frost(format!("verifying key serialize: {e}")))?;
-    let real_vk_is_odd = vk_bytes.first() == Some(&0x03);
-    let mut effective_tweak = *tweak;
-    if real_vk_is_odd {
-        // Negate: n - t, using SecretKey's built-in modular negate (the
-        // `negate` method returns -k mod n).
-        let sk = bitcoin::secp256k1::SecretKey::from_slice(&effective_tweak)
-            .map_err(|e| KeepError::Frost(format!("aggregate tweak invalid: {e}")))?;
-        effective_tweak = sk.negate().secret_bytes();
-    }
-    let tweak = &effective_tweak;
-
-    // Convert the (possibly negated) aggregate tweak into a
-    // bitcoin::secp256k1::Scalar for point additions and into a
-    // bitcoin::secp256k1::SecretKey for the scalar addition on the signing
-    // share. Both accept 32 big-endian bytes.
-    let scalar = bitcoin::secp256k1::Scalar::from_be_bytes(*tweak).map_err(|_| {
-        KeepError::Frost("BIP-32 aggregate tweak >= curve order; refusing to sign".into())
-    })?;
+    // Parity-adjusted aggregate tweak, shared by the signing-share scalar add
+    // and the point additions below so the secret and public tweaks cannot
+    // drift.
+    let scalar = effective_tweak_scalar(&vk_bytes, *tweak)?;
 
     // Signing share: raw 32-byte big-endian scalar. Add tweak modulo n via
     // SecretKey::add_tweak (we abuse the SecretKey type for its modular
@@ -184,16 +190,7 @@ pub fn tweak_public_key_package_at_path(
         .verifying_key()
         .serialize()
         .map_err(|e| KeepError::Frost(format!("verifying key serialize: {e}")))?;
-    let real_vk_is_odd = vk_bytes.first() == Some(&0x03);
-    let mut effective_tweak = composite.aggregate_tweak;
-    if real_vk_is_odd {
-        let sk = bitcoin::secp256k1::SecretKey::from_slice(&effective_tweak)
-            .map_err(|e| KeepError::Frost(format!("aggregate tweak invalid: {e}")))?;
-        effective_tweak = sk.negate().secret_bytes();
-    }
-    let scalar = bitcoin::secp256k1::Scalar::from_be_bytes(effective_tweak).map_err(|_| {
-        KeepError::Frost("BIP-32 aggregate tweak >= curve order; refusing to sign".into())
-    })?;
+    let scalar = effective_tweak_scalar(&vk_bytes, composite.aggregate_tweak)?;
 
     // Tweak every verifying share so aggregation validates the tweaked
     // signature shares. Preserve the identifier ordering the input carried.
@@ -420,6 +417,83 @@ mod tests {
             let composite = derive_child(&group, &[0, 9]).unwrap();
             let secp = Secp256k1::verification_only();
             let sig = Signature::from_slice(&sig).unwrap();
+            let xonly = XOnlyPublicKey::from_slice(&composite.child_pubkey).unwrap();
+            let msg = Message::from_digest(message);
+            secp.verify_schnorr(&sig, &msg, &xonly).unwrap();
+            break;
+        }
+        assert!(
+            exercised_odd_y,
+            "no odd-y group VK produced in 64 dealer runs; branch left untested"
+        );
+    }
+
+    /// Exercise the odd-y group-VK negation branch in
+    /// `tweak_public_key_package_at_path` (the aggregation-side tweak). Loop
+    /// dealer runs until the group's TRUE verifying key serializes to 0x03
+    /// (odd y), then tweak the `PublicKeyPackage` at a non-empty path, run a
+    /// local FROST round with the correspondingly tweaked `KeyPackage`s,
+    /// aggregate against the tweaked pubkey package, and assert the aggregate
+    /// verifies under the derived child pubkey. Without this the negation
+    /// branch of the aggregation-side tweak is only hit ~50% of the time.
+    #[test]
+    fn odd_y_tweaked_pubkey_package_aggregates_under_child() {
+        use frost_secp256k1_tr::rand_core::OsRng;
+        use frost_secp256k1_tr::{round1, round2, SigningPackage};
+        use std::collections::BTreeMap;
+
+        let message = [0x88u8; 32];
+        let path = [0u32, 9];
+        let mut exercised_odd_y = false;
+        for _ in 0..64 {
+            let shares = make_shares(2, 3);
+            let vk_prefix = shares[0]
+                .key_package()
+                .unwrap()
+                .verifying_key()
+                .serialize()
+                .unwrap()[0];
+            if vk_prefix != 0x03 {
+                continue;
+            }
+            exercised_odd_y = true;
+            let group = *shares[0].group_pubkey();
+
+            let pkp = shares[0].pubkey_package().unwrap();
+            let tweaked_pkp = tweak_public_key_package_at_path(&pkp, &group, &path).unwrap();
+
+            let tweaked_kps: Vec<KeyPackage> = shares[..2]
+                .iter()
+                .map(|s| {
+                    tweak_key_package_at_path(&s.key_package().unwrap(), &group, &path).unwrap()
+                })
+                .collect();
+
+            let mut nonces_map = BTreeMap::new();
+            let mut commitments_map = BTreeMap::new();
+            for kp in &tweaked_kps {
+                let (nonces, commitments) = round1::commit(kp.signing_share(), &mut OsRng);
+                nonces_map.insert(*kp.identifier(), nonces);
+                commitments_map.insert(*kp.identifier(), commitments);
+            }
+
+            let signing_package = SigningPackage::new(commitments_map, &message);
+
+            let mut sig_shares = BTreeMap::new();
+            for kp in &tweaked_kps {
+                let id = *kp.identifier();
+                let nonces = &nonces_map[&id];
+                let share = round2::sign(&signing_package, nonces, kp).unwrap();
+                sig_shares.insert(id, share);
+            }
+
+            let signature =
+                frost_secp256k1_tr::aggregate(&signing_package, &sig_shares, &tweaked_pkp).unwrap();
+            let serialized = signature.serialize().unwrap();
+
+            let composite = derive_child(&group, &path).unwrap();
+            let secp = Secp256k1::verification_only();
+            let sig = Signature::from_slice(serialized.as_slice()).unwrap();
             let xonly = XOnlyPublicKey::from_slice(&composite.child_pubkey).unwrap();
             let msg = Message::from_digest(message);
             secp.verify_schnorr(&sig, &msg, &xonly).unwrap();

--- a/keep-core/src/frost/bip32_signing.rs
+++ b/keep-core/src/frost/bip32_signing.rs
@@ -31,8 +31,8 @@
 
 use bitcoin::secp256k1::{schnorr::Signature, Message, Secp256k1, XOnlyPublicKey};
 use frost_secp256k1_tr::{
-    keys::{KeyPackage, SigningShare, VerifyingShare},
-    VerifyingKey,
+    keys::{KeyPackage, PublicKeyPackage, SigningShare, VerifyingShare},
+    Identifier, VerifyingKey,
 };
 use zeroize::Zeroizing;
 
@@ -144,6 +144,88 @@ pub fn derive_child(group_pubkey: &[u8; 32], path: &[u32]) -> Result<CompositeDe
     let cc = deterministic_chaincode(group_pubkey);
     derive_path_composite(group_pubkey, &cc, path)
         .map_err(|e| KeepError::Frost(format!("BIP-32 child derivation failed: {e}")))
+}
+
+/// Tweak an unstyled FROST `KeyPackage` for a BIP-32 unhardened path off the
+/// group pubkey. Empty path returns the input unchanged. Used by the network
+/// signing path so every participant applies the same composite tweak to its
+/// own package before running the standard round1/round2 (#487 PR 3/4).
+pub fn tweak_key_package_at_path(
+    kp: &KeyPackage,
+    group_pubkey: &[u8; 32],
+    path: &[u32],
+) -> Result<KeyPackage> {
+    if path.is_empty() {
+        return Ok(kp.clone());
+    }
+    let composite = derive_child(group_pubkey, path)?;
+    tweak_key_package(kp, &composite.aggregate_tweak)
+}
+
+/// Tweak a FROST `PublicKeyPackage` for the same BIP-32 unhardened path so
+/// the aggregation step verifies signature shares under the tweaked
+/// verifying shares and produces a signature over the derived child key.
+/// Empty path returns the input unchanged.
+pub fn tweak_public_key_package_at_path(
+    pkp: &PublicKeyPackage,
+    group_pubkey: &[u8; 32],
+    path: &[u32],
+) -> Result<PublicKeyPackage> {
+    if path.is_empty() {
+        return Ok(pkp.clone());
+    }
+    let composite = derive_child(group_pubkey, path)?;
+    let secp = Secp256k1::verification_only();
+
+    // Same y-parity handling as `tweak_key_package`: when the group's real
+    // VerifyingKey has odd-y, negate the composite scalar so the tweaked
+    // aggregation package lands on the same x-only child pubkey.
+    let vk_bytes = pkp
+        .verifying_key()
+        .serialize()
+        .map_err(|e| KeepError::Frost(format!("verifying key serialize: {e}")))?;
+    let real_vk_is_odd = vk_bytes.first() == Some(&0x03);
+    let mut effective_tweak = composite.aggregate_tweak;
+    if real_vk_is_odd {
+        let sk = bitcoin::secp256k1::SecretKey::from_slice(&effective_tweak)
+            .map_err(|e| KeepError::Frost(format!("aggregate tweak invalid: {e}")))?;
+        effective_tweak = sk.negate().secret_bytes();
+    }
+    let scalar = bitcoin::secp256k1::Scalar::from_be_bytes(effective_tweak).map_err(|_| {
+        KeepError::Frost("BIP-32 aggregate tweak >= curve order; refusing to sign".into())
+    })?;
+
+    // Tweak every verifying share so aggregation validates the tweaked
+    // signature shares. Preserve the identifier ordering the input carried.
+    let mut new_shares: std::collections::BTreeMap<Identifier, VerifyingShare> =
+        std::collections::BTreeMap::new();
+    for (id, vs) in pkp.verifying_shares() {
+        let vs_bytes = vs
+            .serialize()
+            .map_err(|e| KeepError::Frost(format!("verifying share serialize: {e}")))?;
+        let vs_pk = bitcoin::secp256k1::PublicKey::from_slice(&vs_bytes)
+            .map_err(|e| KeepError::Frost(format!("verifying share is not a valid point: {e}")))?;
+        let tweaked_vs_pk = vs_pk
+            .add_exp_tweak(&secp, &scalar)
+            .map_err(|e| KeepError::Frost(format!("verifying share + tweak·G invalid: {e}")))?;
+        let tweaked_vs = VerifyingShare::deserialize(&tweaked_vs_pk.serialize())
+            .map_err(|e| KeepError::Frost(format!("tweaked verifying share deserialize: {e}")))?;
+        new_shares.insert(*id, tweaked_vs);
+    }
+
+    let vk_pk = bitcoin::secp256k1::PublicKey::from_slice(&vk_bytes)
+        .map_err(|e| KeepError::Frost(format!("verifying key is not a valid point: {e}")))?;
+    let tweaked_vk_pk = vk_pk
+        .add_exp_tweak(&secp, &scalar)
+        .map_err(|e| KeepError::Frost(format!("verifying key + tweak·G invalid: {e}")))?;
+    let tweaked_verifying_key = VerifyingKey::deserialize(&tweaked_vk_pk.serialize())
+        .map_err(|e| KeepError::Frost(format!("tweaked verifying key deserialize: {e}")))?;
+
+    Ok(PublicKeyPackage::new(
+        new_shares,
+        tweaked_verifying_key,
+        pkp.min_signers(),
+    ))
 }
 
 /// Sign `message` under the FROST group's BIP-32 unhardened child key at

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -333,6 +333,12 @@ pub struct SessionInfo {
     /// [`RequireStructuredPayloadHooks`] for hybrid Nostr + Bitcoin groups;
     /// the recompute-and-compare is performed unconditionally when present.
     pub structured_payload: Option<Vec<u8>>,
+    /// BIP-32 unhardened derivation path off the group pubkey (#487 PR3).
+    /// Empty means the request signs under the group key; non-empty means
+    /// the aggregate signature will verify under the derived child pubkey.
+    /// Hooks can inspect this to gate signing under specific chains (e.g.
+    /// enforce `/0/*` for receive and refuse `/1/*` on a receive-only role).
+    pub derivation_path: Vec<u32>,
 }
 
 impl From<&NetworkSession> for SessionInfo {
@@ -352,6 +358,7 @@ impl From<&NetworkSession> for SessionInfo {
             // not the body. Fine for notification purposes; the recompute
             // check runs in pre_sign where the request is in scope.
             structured_payload: None,
+            derivation_path: session.derivation_path().to_vec(),
         }
     }
 }
@@ -2851,6 +2858,7 @@ mod tests {
             requester: 1,
             message_type: "raw".to_string(),
             structured_payload: None,
+            derivation_path: Vec::new(),
         }
     }
 
@@ -2865,6 +2873,7 @@ mod tests {
             requester: 1,
             message_type: crate::MSG_TYPE_NOSTR_EVENT.to_string(),
             structured_payload: structured,
+            derivation_path: Vec::new(),
         }
     }
 

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -428,7 +428,19 @@ impl KfpNode {
             "Received sign request"
         );
 
-        let key_package = self.share.key_package()?;
+        // #487 PR3: apply the composite BIP-32 tweak for the requester's
+        // derivation path before we commit. Every subsequent step in this
+        // session (round2 sign, aggregation) must use the SAME tweaked
+        // package for the aggregate signature to verify, so we persist the
+        // path on the session at the same time as the commitment below.
+        let key_package = keep_core::frost::bip32_signing::tweak_key_package_at_path(
+            &self.share.key_package()?,
+            &self.group_pubkey,
+            &request.derivation_path,
+        )
+        .map_err(|e| {
+            FrostNetError::Crypto(format!("BIP-32 tweak on responder key package failed: {e}"))
+        })?;
 
         let existing_commitment = {
             let sessions = self.sessions.read();
@@ -481,6 +493,7 @@ impl KfpNode {
             requester,
             message_type: request.message_type.clone(),
             structured_payload: request.structured_payload.clone(),
+            derivation_path: request.derivation_path.clone(),
         };
 
         // Recompute the digest from the structured payload BEFORE the pre-sign
@@ -659,6 +672,7 @@ impl KfpNode {
                 &request.session_salt,
             )?;
             session.set_message_type(request.message_type.clone());
+            session.set_derivation_path(request.derivation_path.clone());
 
             // All nonce_refs have now been validated above, and a pre-exchange
             // request that reaches here covers the full threshold set. The
@@ -849,7 +863,21 @@ impl KfpNode {
                 return Ok(());
             }
 
-            let pubkey_pkg = self.aggregation_pubkey_package(session.participants())?;
+            // #487 PR3: aggregate under the composite-tweaked pubkey
+            // package when the session is signing at a derivation path, so
+            // signature-share validation and the aggregate signature line
+            // up under the derived child key.
+            let base_pubkey_pkg = self.aggregation_pubkey_package(session.participants())?;
+            let pubkey_pkg = keep_core::frost::bip32_signing::tweak_public_key_package_at_path(
+                &base_pubkey_pkg,
+                &self.group_pubkey,
+                session.derivation_path(),
+            )
+            .map_err(|e| {
+                FrostNetError::Crypto(format!(
+                    "BIP-32 tweak on aggregation pubkey package failed: {e}"
+                ))
+            })?;
             session.try_aggregate(&pubkey_pkg)?.map(|sig| {
                 (
                     sig,
@@ -886,9 +914,7 @@ impl KfpNode {
     }
 
     pub(crate) async fn generate_and_send_share(&self, session_id: &[u8; 32]) -> Result<()> {
-        let key_package = self.share.key_package()?;
-
-        let (signing_package, nonces) = {
+        let (signing_package, nonces, derivation_path) = {
             let mut sessions = self.sessions.write();
             let session = match sessions.get_session_mut(session_id) {
                 Some(s) => s,
@@ -907,8 +933,21 @@ impl KfpNode {
                 None => return Ok(()),
             };
 
-            (signing_package, nonces)
+            let derivation_path = session.derivation_path().to_vec();
+            (signing_package, nonces, derivation_path)
         };
+
+        // #487 PR3: sign under the composite-tweaked key package when the
+        // session carries a derivation path, so the sig share aggregates to
+        // a signature under the derived child pubkey rather than the group.
+        let key_package = keep_core::frost::bip32_signing::tweak_key_package_at_path(
+            &self.share.key_package()?,
+            &self.group_pubkey,
+            &derivation_path,
+        )
+        .map_err(|e| {
+            FrostNetError::Crypto(format!("BIP-32 tweak on responder key package failed: {e}"))
+        })?;
 
         let sig_share = frost_secp256k1_tr::round2::sign(&signing_package, &nonces, &key_package)
             .map_err(|e| FrostNetError::Crypto(format!("Signing failed: {e}")))?;
@@ -1141,9 +1180,31 @@ impl KfpNode {
     /// cross-domain label spoof before signing.
     pub async fn request_signature_structured(
         &self,
+        message: Vec<u8>,
+        message_type: &str,
+        structured_payload: Option<Vec<u8>>,
+    ) -> Result<[u8; 64]> {
+        self.request_signature_at_path(message, message_type, structured_payload, Vec::new())
+            .await
+    }
+
+    /// Request a threshold signature under a BIP-32 unhardened child of the
+    /// group pubkey. Every participant tweaks its FROST KeyPackage by the
+    /// composite BIP-32 scalar for `derivation_path` before running the
+    /// standard round1/round2, and the aggregated BIP-340 signature verifies
+    /// under the derived child pubkey rather than the group pubkey.
+    ///
+    /// Empty `derivation_path` is equivalent to
+    /// [`Self::request_signature_structured`] and signs under the group
+    /// pubkey; non-empty paths are the entry point for HD spending
+    /// (`/0/*` receive, `/1/*` change) once #487 PR 4 wires the descriptor.
+    /// Hardened indexes are refused at protocol validation.
+    pub async fn request_signature_at_path(
+        &self,
         mut message: Vec<u8>,
         message_type: &str,
         structured_payload: Option<Vec<u8>>,
+        derivation_path: Vec<u32>,
     ) -> Result<[u8; 64]> {
         // On a round timeout the co-signers that failed to commit are treated as
         // unresponsive and excluded, then we re-select from the remaining online
@@ -1187,6 +1248,7 @@ impl KfpNode {
                     round_message,
                     message_type,
                     structured_payload.clone(),
+                    derivation_path.clone(),
                     &excluded,
                     logical_id,
                     attempt,
@@ -1282,11 +1344,13 @@ impl KfpNode {
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn signing_round(
         &self,
         message: Vec<u8>,
         message_type: &str,
         structured_payload: Option<Vec<u8>>,
+        derivation_path: Vec<u32>,
         exclude: &[u16],
         logical_id: [u8; 32],
         attempt: usize,
@@ -1330,10 +1394,23 @@ impl KfpNode {
             SigningOperation::SignRequestInitiated,
         );
 
-        let key_package = self
-            .share
-            .key_package()
-            .map_err(|e| SigningRoundError::fatal(e.into()))?;
+        // #487 PR3: apply the composite BIP-32 tweak to our own key package
+        // for the requested path before generating round1 nonces, so the
+        // commitment we announce matches what co-signers will validate
+        // against their own tweaked packages.
+        let key_package = keep_core::frost::bip32_signing::tweak_key_package_at_path(
+            &self
+                .share
+                .key_package()
+                .map_err(|e| SigningRoundError::fatal(e.into()))?,
+            &self.group_pubkey,
+            &derivation_path,
+        )
+        .map_err(|e| {
+            SigningRoundError::fatal(FrostNetError::Crypto(format!(
+                "BIP-32 tweak on requester key package failed: {e}"
+            )))
+        })?;
         let (nonces, our_commitment) =
             frost_secp256k1_tr::round1::commit(key_package.signing_share(), &mut OsRng);
 
@@ -1384,6 +1461,9 @@ impl KfpNode {
         if let Some(sp) = structured_payload.as_ref() {
             request = request.with_structured_payload(sp.clone());
         }
+        if !derivation_path.is_empty() {
+            request = request.with_derivation_path(derivation_path.clone());
+        }
 
         let session_info = SessionInfo {
             session_id,
@@ -1393,6 +1473,7 @@ impl KfpNode {
             requester: self.share.metadata.identifier,
             message_type: message_type.to_string(),
             structured_payload: structured_payload.clone(),
+            derivation_path: derivation_path.clone(),
         };
         let hooks = self.hooks.read().clone();
         hooks.pre_sign(&session_info)?;
@@ -1407,6 +1488,7 @@ impl KfpNode {
                 &session_salt,
             )?;
             session.set_message_type(message_type.to_string());
+            session.set_derivation_path(derivation_path.clone());
 
             session.set_our_nonces(nonces);
             session.set_our_commitment(our_commitment);

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -428,20 +428,6 @@ impl KfpNode {
             "Received sign request"
         );
 
-        // #487 PR3: apply the composite BIP-32 tweak for the requester's
-        // derivation path before we commit. Every subsequent step in this
-        // session (round2 sign, aggregation) must use the SAME tweaked
-        // package for the aggregate signature to verify, so we persist the
-        // path on the session at the same time as the commitment below.
-        let key_package = keep_core::frost::bip32_signing::tweak_key_package_at_path(
-            &self.share.key_package()?,
-            &self.group_pubkey,
-            &request.derivation_path,
-        )
-        .map_err(|e| {
-            FrostNetError::Crypto(format!("BIP-32 tweak on responder key package failed: {e}"))
-        })?;
-
         let existing_commitment = {
             let sessions = self.sessions.read();
             sessions
@@ -657,6 +643,22 @@ impl KfpNode {
             .await?;
             return Ok(());
         }
+
+        // #487 PR3: apply the composite BIP-32 tweak for the requester's
+        // derivation path before we commit. Every subsequent step in this
+        // session (round2 sign, aggregation) must use the SAME tweaked package
+        // for the aggregate signature to verify, so we persist the path on the
+        // session at the same time as the commitment below. Computed here, after
+        // the resend early-return, so a duplicate request that just re-echoes our
+        // cached commitment never recomputes the derivation.
+        let key_package = keep_core::frost::bip32_signing::tweak_key_package_at_path(
+            &self.share.key_package()?,
+            &self.group_pubkey,
+            &request.derivation_path,
+        )
+        .map_err(|e| {
+            FrostNetError::Crypto(format!("BIP-32 tweak on responder key package failed: {e}"))
+        })?;
 
         // `None` signals that the pre-exchange path required a pooled nonce that
         // vanished (consumed, evicted, or lost on restart) between validation
@@ -1206,6 +1208,26 @@ impl KfpNode {
         structured_payload: Option<Vec<u8>>,
         derivation_path: Vec<u32>,
     ) -> Result<[u8; 64]> {
+        // Reject an oversized or hardened path locally, mirroring the wire-side
+        // check in `KfpMessage::validate`, so a bad path fails fast with a clear
+        // message instead of after a network round-trip.
+        if derivation_path.len() > crate::protocol::MAX_DERIVATION_PATH_DEPTH {
+            return Err(FrostNetError::Protocol(format!(
+                "Derivation path depth {} exceeds maximum {}",
+                derivation_path.len(),
+                crate::protocol::MAX_DERIVATION_PATH_DEPTH
+            )));
+        }
+        if derivation_path
+            .iter()
+            .any(|&i| i >= crate::protocol::BIP32_HARDENED_INDEX_START)
+        {
+            return Err(FrostNetError::Protocol(
+                "Derivation path contains a hardened index; only unhardened indexes are \
+                 meaningful for FROST groups"
+                    .into(),
+            ));
+        }
         // On a round timeout the co-signers that failed to commit are treated as
         // unresponsive and excluded, then we re-select from the remaining online
         // peers and retry. This fails over to other live co-signers in seconds
@@ -1367,12 +1389,23 @@ impl KfpNode {
         // unchanged participant set (everyone responded but no signature was
         // produced) derives a distinct id and fresh nonce instead of colliding
         // with the just-completed attempt and tripping the replay guard. Attempt
-        // 0 uses an empty salt to keep the common single-attempt id stable and
-        // wire-compatible with peers that predate salted failover.
-        let session_salt: Vec<u8> = if attempt == 0 {
+        // 0 with an empty path uses an empty salt to keep the common
+        // single-attempt id stable and wire-compatible with peers that predate
+        // salted failover. The derivation path is folded in so two requests over
+        // the same digest + participant set at DISTINCT child paths derive
+        // distinct session ids: otherwise they collide at attempt 0 and a
+        // responder resends its cached commitment for the first path, never
+        // adopting the second. The responder recomputes and validates the id
+        // from the transmitted salt, so this binds the path on both sides.
+        let session_salt: Vec<u8> = if attempt == 0 && derivation_path.is_empty() {
             Vec::new()
         } else {
-            (attempt as u64).to_be_bytes().to_vec()
+            let mut salt = Vec::with_capacity(8 + derivation_path.len() * 4);
+            salt.extend_from_slice(&(attempt as u64).to_be_bytes());
+            for index in &derivation_path {
+                salt.extend_from_slice(&index.to_be_bytes());
+            }
+            salt
         };
         let session_id =
             derive_session_id_salted(&message, &participants, threshold, &session_salt);

--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -1017,7 +1017,7 @@ pub struct SignRequestPayload {
 
 /// BIP-32 says index >= 2^31 selects hardened derivation (needs the private
 /// key). FROST groups only ever do unhardened public derivation.
-const BIP32_HARDENED_INDEX_START: u32 = 0x8000_0000;
+pub(crate) const BIP32_HARDENED_INDEX_START: u32 = 0x8000_0000;
 
 /// Cap on the derivation path depth carried in a sign request. BIP-86-style
 /// wallets never exceed `/0/*` or `/1/*` (depth 2) below the account xpub,
@@ -2498,6 +2498,39 @@ mod tests {
         assert!(err
             .to_string()
             .contains("structured payload exceeds maximum size"));
+    }
+
+    /// A derivation path deeper than `MAX_DERIVATION_PATH_DEPTH` is refused at
+    /// validation so a hostile peer cannot force a large derivation walk.
+    #[test]
+    fn oversized_derivation_path_refused_at_validate() {
+        let path: Vec<u32> = (0..=MAX_DERIVATION_PATH_DEPTH as u32).collect();
+        let payload = SignRequestPayload::new(
+            [1u8; 32],
+            [2u8; 32],
+            vec![1, 2, 3],
+            MSG_TYPE_NOSTR_EVENT,
+            vec![1, 2],
+        )
+        .with_derivation_path(path);
+        let msg = KfpMessage::SignRequest(payload);
+        assert!(msg.validate().is_err());
+    }
+
+    /// A hardened index (>= 2^31) is refused: FROST groups have no group
+    /// secret for hardened derivation, only unhardened paths are meaningful.
+    #[test]
+    fn hardened_derivation_index_refused_at_validate() {
+        let payload = SignRequestPayload::new(
+            [1u8; 32],
+            [2u8; 32],
+            vec![1, 2, 3],
+            MSG_TYPE_NOSTR_EVENT,
+            vec![1, 2],
+        )
+        .with_derivation_path(vec![0, BIP32_HARDENED_INDEX_START]);
+        let msg = KfpMessage::SignRequest(payload);
+        assert!(msg.validate().is_err());
     }
 
     #[test]

--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -294,6 +294,16 @@ impl KfpMessage {
                         return Err("Structured payload exceeds maximum size");
                     }
                 }
+                if p.derivation_path.len() > MAX_DERIVATION_PATH_DEPTH {
+                    return Err("Derivation path exceeds maximum depth");
+                }
+                if p.derivation_path
+                    .iter()
+                    .any(|&i| i >= BIP32_HARDENED_INDEX_START)
+                {
+                    return Err("Derivation path contains a hardened index; \
+                         only unhardened indexes are meaningful for FROST groups");
+                }
                 if p.participants.len() > MAX_PARTICIPANTS {
                     return Err("Participants list exceeds maximum size");
                 }
@@ -991,7 +1001,29 @@ pub struct SignRequestPayload {
         with = "hex_bytes_opt"
     )]
     pub structured_payload: Option<Vec<u8>>,
+    /// BIP-32 unhardened derivation path off the group pubkey (#487 PR 3).
+    /// When non-empty, every FROST participant tweaks its KeyPackage by the
+    /// composite BIP-32 scalar for this path before signing, and the
+    /// aggregated signature verifies under the derived child pubkey rather
+    /// than the group pubkey. Empty (or absent, for pre-#487 peers) means
+    /// "sign under the group key" — the pre-existing behavior.
+    ///
+    /// Hardened indexes (>= 2^31) are refused at protocol validation: FROST
+    /// groups have no group secret to hand out for hardened derivation, so
+    /// only unhardened paths (`/0/*`, `/1/*`, etc.) are meaningful.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub derivation_path: Vec<u32>,
 }
+
+/// BIP-32 says index >= 2^31 selects hardened derivation (needs the private
+/// key). FROST groups only ever do unhardened public derivation.
+const BIP32_HARDENED_INDEX_START: u32 = 0x8000_0000;
+
+/// Cap on the derivation path depth carried in a sign request. BIP-86-style
+/// wallets never exceed `/0/*` or `/1/*` (depth 2) below the account xpub,
+/// and BIP-32 itself allows at most 255 levels. Bounding this at protocol
+/// validate keeps a hostile peer from forcing a large derivation walk.
+pub const MAX_DERIVATION_PATH_DEPTH: usize = 8;
 
 mod hex_bytes_opt {
     use serde::{Deserialize, Deserializer, Serializer};
@@ -1052,7 +1084,17 @@ impl SignRequestPayload {
             nonce_refs: Vec::new(),
             session_salt: Vec::new(),
             structured_payload: None,
+            derivation_path: Vec::new(),
         }
+    }
+
+    /// Attach a BIP-32 unhardened derivation path off the group pubkey. On
+    /// signing, every participant applies the composite BIP-32 tweak for
+    /// this path and the aggregate signature verifies under the derived
+    /// child pubkey. Empty path returns the request unchanged.
+    pub fn with_derivation_path(mut self, path: Vec<u32>) -> Self {
+        self.derivation_path = path;
+        self
     }
 
     pub fn with_metadata(mut self, metadata: serde_json::Value) -> Self {

--- a/keep-frost-net/src/session.rs
+++ b/keep-frost-net/src/session.rs
@@ -70,6 +70,8 @@ pub struct CachedSessionState {
     message_type: String,
     threshold: u16,
     participants: Vec<u16>,
+    #[serde(default)]
+    derivation_path: Vec<u32>,
     state: SessionState,
     commitments: Vec<(Vec<u8>, Vec<u8>)>,
     signature_shares: Vec<(Vec<u8>, Vec<u8>)>,
@@ -91,6 +93,12 @@ pub struct NetworkSession {
     message_type: String,
     threshold: u16,
     participants: Vec<u16>,
+    /// BIP-32 unhardened derivation path off the group pubkey (#487 PR3).
+    /// Empty means "sign under the group key" (pre-#487 behavior). Non-empty
+    /// means every participant tweaks its KeyPackage by the composite
+    /// BIP-32 scalar before running round1/round2, and the aggregate
+    /// signature verifies under the derived child pubkey.
+    derivation_path: Vec<u32>,
     state: SessionState,
     created_at: Instant,
     timeout: Duration,
@@ -116,6 +124,7 @@ impl NetworkSession {
             message_type: String::new(),
             threshold,
             participants,
+            derivation_path: Vec::new(),
             state: SessionState::AwaitingCommitments,
             created_at: Instant::now(),
             timeout: Duration::from_secs(30),
@@ -155,6 +164,19 @@ impl NetworkSession {
 
     pub fn set_message_type(&mut self, message_type: String) {
         self.message_type = message_type;
+    }
+
+    /// BIP-32 unhardened derivation path off the group pubkey (#487 PR3).
+    /// Empty means sign under the group key. Set by the responder when it
+    /// accepts a `SignRequestPayload` that carries a non-empty path so the
+    /// later round2 and aggregation steps see the same value the round1
+    /// commitment was generated against.
+    pub fn derivation_path(&self) -> &[u32] {
+        &self.derivation_path
+    }
+
+    pub fn set_derivation_path(&mut self, path: Vec<u32>) {
+        self.derivation_path = path;
     }
 
     pub fn state(&self) -> SessionState {
@@ -488,6 +510,7 @@ impl NetworkSession {
             message_type: self.message_type.clone(),
             threshold: self.threshold,
             participants: self.participants.clone(),
+            derivation_path: self.derivation_path.clone(),
             state: self.state,
             commitments,
             signature_shares,
@@ -594,6 +617,7 @@ impl NetworkSession {
             message_type: cached.message_type,
             threshold: cached.threshold,
             participants: cached.participants,
+            derivation_path: cached.derivation_path,
             state: cached.state,
             created_at: Instant::now(),
             timeout: Duration::from_secs(30),

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -3853,3 +3853,103 @@ async fn test_single_flight_suppresses_concurrent_announce_quotes() {
         "expected 1 startup + 1 reciprocal quote (second reciprocal suppressed), got {total}"
     );
 }
+
+/// #487 PR3: end-to-end multinode signing under a BIP-32 unhardened
+/// derivation path. Every co-signer independently computes the composite
+/// tweak from the request's `derivation_path`, applies it to its
+/// KeyPackage before round1/round2, and aggregates under the tweaked
+/// PublicKeyPackage. The resulting BIP-340 signature MUST verify under the
+/// derived child pubkey and MUST NOT verify under the parent group pubkey.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_full_signing_flow_at_derivation_path() {
+    use std::sync::Arc;
+
+    let mock_relay = MockRelay::run().await.expect("Failed to start mock relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let config = ThresholdConfig::two_of_three();
+    let dealer = TrustedDealer::new(config);
+    let (mut shares, _pubkey_pkg) = dealer.generate("test-bip32-signing").unwrap();
+    let group_pubkey: [u8; 32] = *shares[0].group_pubkey();
+
+    let share1 = shares.remove(0);
+    let share2 = shares.remove(0);
+    let share3 = shares.remove(0);
+
+    let mut node1 = KfpNode::new(share1, vec![relay.clone()]).await.unwrap();
+    let mut node2 = KfpNode::new(share2, vec![relay.clone()]).await.unwrap();
+    let mut node3 = KfpNode::new(share3, vec![relay]).await.unwrap();
+
+    let mut rx3 = node3.subscribe();
+    let shutdown1 = node1.take_shutdown_handle();
+    let shutdown2 = node2.take_shutdown_handle();
+    let shutdown3 = node3.take_shutdown_handle();
+
+    let node3 = Arc::new(node3);
+    let node3_for_run = Arc::clone(&node3);
+
+    let node1_handle = tokio::spawn(async move {
+        let _ = node1.run().await;
+    });
+    let node2_handle = tokio::spawn(async move {
+        let _ = node2.run().await;
+    });
+    let node3_handle = tokio::spawn(async move {
+        let _ = node3_for_run.run().await;
+    });
+
+    let mut peers_discovered = 0u32;
+    let discovery_timeout = timeout(Duration::from_secs(45), async {
+        while peers_discovered < 2 {
+            if let Ok(keep_frost_net::KfpNodeEvent::PeerDiscovered { .. }) = rx3.recv().await {
+                peers_discovered += 1;
+            }
+        }
+    })
+    .await;
+
+    if discovery_timeout.is_err() {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        graceful_shutdown(shutdown3, node3_handle).await;
+        panic!("Peer discovery timed out: only {peers_discovered} peers discovered");
+    }
+
+    // 32-byte digest so it fits `Message::from_digest_slice` for BIP-340.
+    let message = [0x33u8; 32].to_vec();
+    let derivation_path = vec![0u32, 5u32];
+
+    let sign_result = timeout(Duration::from_secs(60), async {
+        node3
+            .request_signature_at_path(message.clone(), "raw", None, derivation_path.clone())
+            .await
+    })
+    .await;
+
+    graceful_shutdown(shutdown1, node1_handle).await;
+    graceful_shutdown(shutdown2, node2_handle).await;
+    graceful_shutdown(shutdown3, node3_handle).await;
+
+    let sig_bytes = match sign_result {
+        Ok(Ok(s)) => s,
+        Ok(Err(e)) => panic!("BIP-32 signing failed: {e:?}"),
+        Err(_) => panic!("BIP-32 signing timed out after 60 seconds"),
+    };
+
+    let composite =
+        keep_core::frost::bip32_signing::derive_child(&group_pubkey, &derivation_path).unwrap();
+
+    use bitcoin::secp256k1::{schnorr::Signature, Message, Secp256k1, XOnlyPublicKey};
+    let secp = Secp256k1::verification_only();
+    let sig = Signature::from_slice(&sig_bytes).unwrap();
+    let child_xonly = XOnlyPublicKey::from_slice(&composite.child_pubkey).unwrap();
+    let msg = Message::from_digest_slice(&message).unwrap();
+    secp.verify_schnorr(&sig, &msg, &child_xonly)
+        .expect("aggregate signature must verify under the derived child pubkey");
+
+    let group_xonly = XOnlyPublicKey::from_slice(&group_pubkey).unwrap();
+    assert!(
+        secp.verify_schnorr(&sig, &msg, &group_xonly).is_err(),
+        "child-derived signature MUST NOT verify under the parent group pubkey"
+    );
+}

--- a/keep-web/src/bunker.rs
+++ b/keep-web/src/bunker.rs
@@ -432,6 +432,7 @@ mod tests {
             requester: 1,
             message_type: String::new(),
             structured_payload: None,
+            derivation_path: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

PR 3 of 4 for #487. Extends the FROST-over-Nostr sign protocol so a requester can ask co-signers to produce a signature under a BIP-32 unhardened child of the group pubkey. Every participant (requester and responders) applies the same composite BIP-32 tweak to its own `KeyPackage` before running the standard round1/round2, and the aggregation step uses a tweaked `PublicKeyPackage`. The resulting BIP-340 aggregate signature verifies under the derived child pubkey rather than the group pubkey.

Empty path is equivalent to the pre-#487 behavior (sign under the group key). Pre-#487 peers stay wire-compatible: the field is `serde(default)` and omitted when empty.

## Wire format

`SignRequestPayload` gains:

- `derivation_path: Vec<u32>` — BIP-32 unhardened path off the group pubkey. `serde(default)`, omitted when empty.

Validated at protocol validate:

- Cap `MAX_DERIVATION_PATH_DEPTH = 8` — BIP-86-style wallets never exceed depth 2 below the account xpub, so 8 is generous while bounding a hostile peer.
- Reject any index `>= 2^31` (hardened). FROST groups have no group secret to hand out for hardened derivation.

## Session persistence

`NetworkSession` gains a `derivation_path: Vec<u32>` field with matching accessor / setter and cache serialization (`CachedSessionState`, `serde(default)` for backward compat). The responder sets it once when it accepts the sign request; every subsequent step (round2 sign, aggregation) reads it from the session so the same tweak is applied consistently.

## Hook visibility

`SessionInfo` gains `derivation_path: Vec<u32>`. Hooks can inspect and gate signing under specific chains (e.g. enforce `/0/*` for receive-only, refuse `/1/*` from an untrusted client).

## New requester API

`KfpNode::request_signature_at_path(message, message_type, structured_payload, derivation_path)`. `request_signature` and `request_signature_structured` are preserved as thin delegates (empty path).

## New pub API in `keep_core::frost::bip32_signing`

- `tweak_key_package_at_path(kp, group_pubkey, path)` — applies the composite BIP-32 tweak to a `KeyPackage` (signing share + verifying share + verifying key). Empty path returns the input unchanged.
- `tweak_public_key_package_at_path(pkp, group_pubkey, path)` — same tweak for the aggregation `PublicKeyPackage`.

Both handle the y-parity case (negate composite tweak when the group VerifyingKey has odd-y), same rule as `sign_with_local_shares_at_path` from PR 2.

## Tests

- `test_full_signing_flow_at_derivation_path` (new, `tests/multinode_test.rs`) — end-to-end 2-of-3 multinode signing at `/0/5` via MockRelay:
  - aggregate signature MUST verify under the derived child pubkey
  - aggregate signature MUST NOT verify under the parent group pubkey
- Existing 36 multinode tests pass (regression coverage on the untouched empty-path path)
- Existing bip32_signing local tests still pass (12 primitives + 6 signing)
- `cargo test --workspace --features keep-frost-net/testing` all pass
- `cargo clippy --workspace --all-targets --features keep-frost-net/testing -- -D warnings` clean

## Next in the arc

4. Descriptor emission: `DescriptorExport::from_frost_wallet` emits an xpub-shaped BIP-86 descriptor `tr([fp/86'/coin_type'/0']xpub/0/*)` from the group pubkey + deterministic chaincode, so `wallet descriptor` produces distinct external and internal chains and `--allow-address-reuse` is no longer needed for the common case. Regtest end-to-end address-and-spend test.

## Advances

Advances #487 (PR 3 of 4; the issue stays open until PR 4 lands).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for signing requests using an unhardened derivation path, so signatures can be generated for derived keys.
  * Session state now retains the selected derivation path across reconnects and cached sessions.
  * Validation now rejects unsupported derivation paths and overly deep paths.

* **Tests**
  * Added end-to-end coverage for signing and verifying signatures at a derivation path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->