### PR TITLE
descriptor: emit BIP-86 HD taproot descriptor for FROST groups (closes #487)

### DIFF
--- a/keep-bitcoin/src/descriptor.rs
+++ b/keep-bitcoin/src/descriptor.rs
@@ -427,8 +427,11 @@ mod tests {
                 ChildNumber::from_normal_idx(leaf).unwrap(),
             ]);
             let derived_change_xpub = xpub.derive_pub(&secp, &change_path).unwrap();
-            let change_pubkey_descriptor =
-                derived_change_xpub.public_key.x_only_public_key().0.serialize();
+            let change_pubkey_descriptor = derived_change_xpub
+                .public_key
+                .x_only_public_key()
+                .0
+                .serialize();
 
             assert_eq!(
                 change_pubkey_descriptor, change_pubkey_bip32_signing,
@@ -443,8 +446,7 @@ mod tests {
     #[test]
     fn frost_wallet_mainnet_descriptor_uses_coin_type_0() {
         let group = test_group_pubkey();
-        let export =
-            DescriptorExport::from_frost_wallet(&group, None, Network::Bitcoin).unwrap();
+        let export = DescriptorExport::from_frost_wallet(&group, None, Network::Bitcoin).unwrap();
 
         let fingerprint = export.fingerprint;
         assert!(

--- a/keep-bitcoin/src/descriptor.rs
+++ b/keep-bitcoin/src/descriptor.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: MIT
 use std::str::FromStr;
 
-use bitcoin::bip32::Xpub;
+use bitcoin::bip32::{ChainCode, ChildNumber, Fingerprint, Xpub};
 use bitcoin::hashes::{hash160, Hash};
-use bitcoin::{Network, XOnlyPublicKey};
+use bitcoin::secp256k1::PublicKey;
+use bitcoin::{Network, NetworkKind, XOnlyPublicKey};
+use keep_core::frost_bip32::deterministic_chaincode;
 use miniscript::{Descriptor, DescriptorPublicKey};
 
 use crate::address::AddressDerivation;
@@ -68,7 +70,20 @@ impl DescriptorExport {
         let fingerprint = Self::pubkey_fingerprint(group_pubkey);
 
         let (descriptor, checksum) = match recovery {
-            None => canonicalize_descriptor(&format!("tr({xonly})"))?,
+            None => {
+                // #487 PR 4/4: emit a BIP-86-style HD taproot descriptor over
+                // the FROST group's own xpub (built from the deterministic
+                // chaincode in PR 1) so `/0/*` and `/1/*` derive distinct
+                // receive- and change-address chains. Downstream wallets
+                // walk the xpub with the standard BIP-32 rules, and the
+                // FROST signing loop applies the matching composite tweak
+                // (PR 2 + PR 3) at spend time.
+                let xpub = group_xpub_string(group_pubkey, network)?;
+                let coin_type = if network == Network::Bitcoin { 0 } else { 1 };
+                canonicalize_descriptor(&format!(
+                    "tr([{fingerprint}/86'/{coin_type}'/0']{xpub}/0/*)"
+                ))?
+            }
             Some(config) => {
                 let output = config.build_with_internal_key(&xonly)?;
                 canonicalize_descriptor(&output.descriptor)?
@@ -89,6 +104,15 @@ impl DescriptorExport {
         compressed[1..].copy_from_slice(pubkey);
         let h = hash160::Hash::hash(&compressed);
         hex::encode(&h[..4])
+    }
+
+    /// Return the raw Base58Check-encoded xpub string that
+    /// [`Self::from_frost_wallet`] wraps into its BIP-86 descriptor. Exposed
+    /// so callers exporting to other wallets (Sparrow, Electrum, BDK) can
+    /// hand off just the xpub without also parsing back the wrapping
+    /// descriptor.
+    pub fn frost_group_xpub(group_pubkey: &[u8; 32], network: Network) -> Result<String> {
+        group_xpub_string(group_pubkey, network)
     }
 
     pub fn external_descriptor(&self) -> &str {
@@ -197,6 +221,39 @@ pub fn descriptor_address(descriptor: &str, network: Network) -> Result<bitcoin:
         .map_err(|e| BitcoinError::Descriptor(format!("address derivation failed: {e}")))
 }
 
+/// Build the raw Base58Check-encoded xpub for a FROST group by combining its
+/// x-only pubkey (lifted to its +even secp256k1 point) with the deterministic
+/// chaincode from #487 PR1. Depth 0, no parent, child number 0: this is the
+/// group's own xpub, not a derivation of anything above it.
+///
+/// Downstream wallets consume the xpub through the normal BIP-32 rules, and
+/// keep-frost-net's sign path applies the matching composite tweak (PR 2 +
+/// PR 3) so a `/0/N` receive-address spend produces a signature that BIP-340
+/// verifies against the address's key.
+fn group_xpub_string(group_pubkey: &[u8; 32], network: Network) -> Result<String> {
+    let network_kind = if network == Network::Bitcoin {
+        NetworkKind::Main
+    } else {
+        NetworkKind::Test
+    };
+    let mut compressed = [0u8; 33];
+    compressed[0] = 0x02;
+    compressed[1..].copy_from_slice(group_pubkey);
+    let public_key = PublicKey::from_slice(&compressed)
+        .map_err(|e| BitcoinError::Descriptor(format!("group pubkey not on curve: {e}")))?;
+    let chain_code = ChainCode::from(deterministic_chaincode(group_pubkey));
+    let xpub = Xpub {
+        network: network_kind,
+        depth: 0,
+        parent_fingerprint: Fingerprint::from([0u8; 4]),
+        child_number: ChildNumber::from_normal_idx(0)
+            .map_err(|e| BitcoinError::Descriptor(format!("child number 0: {e}")))?,
+        public_key,
+        chain_code,
+    };
+    Ok(xpub.to_string())
+}
+
 fn parse_definite_descriptor(
     descriptor: &str,
 ) -> Result<Descriptor<miniscript::DefiniteDescriptorKey>> {
@@ -303,6 +360,91 @@ mod tests {
         assert!(json.contains("testnet"));
     }
 
+    /// #487 PR 4: the address a downstream wallet derives from the emitted
+    /// descriptor at `/0/N` MUST have the x-only pubkey that
+    /// `keep_core::frost::bip32_signing::derive_child(group, &[0, N])`
+    /// produces. If these ever drift, wallets receive to addresses that
+    /// keep cannot sign for. Cross-check by pinning the descriptor and
+    /// deriving both sides for a few leaves.
+    #[test]
+    fn descriptor_addresses_match_bip32_signing_derivation() {
+        use bitcoin::bip32::{ChildNumber, DerivationPath, Xpub};
+        use bitcoin::secp256k1::Secp256k1;
+        use keep_core::frost::bip32_signing::derive_child;
+
+        let group = test_group_pubkey();
+        let export = DescriptorExport::from_frost_wallet(&group, None, Network::Testnet).unwrap();
+
+        // Extract the xpub embedded in the descriptor.
+        let xpub_str = DescriptorExport::frost_group_xpub(&group, Network::Testnet).unwrap();
+        let xpub: Xpub = xpub_str.parse().unwrap();
+        assert!(
+            export.descriptor.contains(xpub_str.as_str()),
+            "descriptor must embed the exact frost_group_xpub value"
+        );
+
+        let secp = Secp256k1::verification_only();
+        for leaf in [0u32, 1, 5, 100] {
+            let child_pubkey_bip32_signing = derive_child(&group, &[0, leaf]).unwrap().child_pubkey;
+
+            let path = DerivationPath::from(vec![
+                ChildNumber::from_normal_idx(0).unwrap(),
+                ChildNumber::from_normal_idx(leaf).unwrap(),
+            ]);
+            let derived_xpub = xpub.derive_pub(&secp, &path).unwrap();
+            let child_pubkey_descriptor = derived_xpub.public_key.x_only_public_key().0.serialize();
+
+            assert_eq!(
+                child_pubkey_descriptor, child_pubkey_bip32_signing,
+                "leaf {leaf}: descriptor-derived key MUST equal FROST-signing child"
+            );
+        }
+    }
+
+    /// #487 PR 4: the external chain (`/0/*`) and internal chain (`/1/*`)
+    /// produce distinct addresses at every leaf. This is the property that
+    /// justified the whole issue (address diversity for receive vs change).
+    #[test]
+    fn external_and_internal_leaves_produce_distinct_addresses() {
+        use bitcoin::bip32::{ChildNumber, DerivationPath, Xpub};
+        use bitcoin::secp256k1::Secp256k1;
+
+        let group = test_group_pubkey();
+        let xpub_str = DescriptorExport::frost_group_xpub(&group, Network::Testnet).unwrap();
+        let xpub: Xpub = xpub_str.parse().unwrap();
+        let secp = Secp256k1::verification_only();
+
+        for leaf in 0u32..8 {
+            let ext = xpub
+                .derive_pub(
+                    &secp,
+                    &DerivationPath::from(vec![
+                        ChildNumber::from_normal_idx(0).unwrap(),
+                        ChildNumber::from_normal_idx(leaf).unwrap(),
+                    ]),
+                )
+                .unwrap()
+                .public_key
+                .x_only_public_key()
+                .0
+                .serialize();
+            let int = xpub
+                .derive_pub(
+                    &secp,
+                    &DerivationPath::from(vec![
+                        ChildNumber::from_normal_idx(1).unwrap(),
+                        ChildNumber::from_normal_idx(leaf).unwrap(),
+                    ]),
+                )
+                .unwrap()
+                .public_key
+                .x_only_public_key()
+                .0
+                .serialize();
+            assert_ne!(ext, int, "leaf {leaf}: external and internal must differ");
+        }
+    }
+
     fn test_group_pubkey() -> [u8; 32] {
         use bitcoin::secp256k1::{Keypair, Secp256k1};
         let secp = Secp256k1::new();
@@ -322,15 +464,34 @@ mod tests {
 
     #[test]
     fn test_frost_wallet_simple_descriptor() {
+        // #487 PR 4: non-recovery FROST descriptor is now an xpub-shaped
+        // BIP-86 descriptor (`tr([fp/86'/coin_type'/0']xpub/0/*)`) rather
+        // than a static `tr(xonly)`, so `/0/*` and `/1/*` derive distinct
+        // receive- and change-address chains.
         let group_pk = test_group_pubkey();
         let export =
             DescriptorExport::from_frost_wallet(&group_pk, None, Network::Testnet).unwrap();
 
-        let xonly = XOnlyPublicKey::from_slice(&group_pk).unwrap();
-        let expected_prefix = format!("tr({xonly})#");
-        assert!(export.descriptor.starts_with(&expected_prefix));
-        assert!(export.descriptor.contains("tr("));
-        assert!(!export.descriptor.contains(','));
+        // Fingerprint is the same lift-then-hash rule as always.
+        let fingerprint = DescriptorExport::pubkey_fingerprint(&group_pk);
+        assert!(
+            export
+                .descriptor
+                .starts_with(&format!("tr([{fingerprint}/86'/1'/0']")),
+            "descriptor must open with the expected BIP-86 origin: got {}",
+            export.descriptor
+        );
+        // Wraps an xpub (tpub for testnet) followed by the receive path.
+        assert!(export.descriptor.contains("tpub"));
+        assert!(export.descriptor.contains("/0/*)"));
+        // A canonicalized checksum is appended after the descriptor body.
+        assert!(export.descriptor.contains('#'));
+        // #487 whole point: internal and external are no longer equal.
+        assert_ne!(
+            export.internal_descriptor().unwrap(),
+            export.descriptor,
+            "external `/0/*` and internal `/1/*` chains MUST differ (#487)"
+        );
     }
 
     #[test]

--- a/keep-bitcoin/src/descriptor.rs
+++ b/keep-bitcoin/src/descriptor.rs
@@ -221,6 +221,26 @@ pub fn descriptor_address(descriptor: &str, network: Network) -> Result<bitcoin:
         .map_err(|e| BitcoinError::Descriptor(format!("address derivation failed: {e}")))
 }
 
+/// Resolve a ranged OR definite descriptor at a concrete derivation `index` and
+/// return its address on `network`. Unlike [`descriptor_address`], this accepts
+/// a ranged descriptor (`.../0/*`) by resolving it at `index` rather than
+/// rejecting it. Used to pick the single deterministic migration-sweep
+/// destination for a successor FROST wallet descriptor: `index` 0 is the first
+/// external `/0/0` receive address, which both proposer and responder derive
+/// identically from the same persisted descriptor.
+pub fn descriptor_address_at_index(
+    descriptor: &str,
+    network: Network,
+    index: u32,
+) -> Result<bitcoin::Address> {
+    let parsed = parse_descriptor_body(descriptor)?;
+    parsed
+        .at_derivation_index(index)
+        .map_err(|e| BitcoinError::Descriptor(format!("definite descriptor: {e}")))?
+        .address(network)
+        .map_err(|e| BitcoinError::Descriptor(format!("address derivation failed: {e}")))
+}
+
 /// Build the raw Base58Check-encoded xpub for a FROST group by combining its
 /// x-only pubkey (lifted to its +even secp256k1 point) with the deterministic
 /// chaincode from #487 PR1. Depth 0, no parent, child number 0: this is the
@@ -398,7 +418,52 @@ mod tests {
                 child_pubkey_descriptor, child_pubkey_bip32_signing,
                 "leaf {leaf}: descriptor-derived key MUST equal FROST-signing child"
             );
+
+            let change_pubkey_bip32_signing =
+                derive_child(&group, &[1, leaf]).unwrap().child_pubkey;
+
+            let change_path = DerivationPath::from(vec![
+                ChildNumber::from_normal_idx(1).unwrap(),
+                ChildNumber::from_normal_idx(leaf).unwrap(),
+            ]);
+            let derived_change_xpub = xpub.derive_pub(&secp, &change_path).unwrap();
+            let change_pubkey_descriptor =
+                derived_change_xpub.public_key.x_only_public_key().0.serialize();
+
+            assert_eq!(
+                change_pubkey_descriptor, change_pubkey_bip32_signing,
+                "leaf {leaf}: CHANGE-chain descriptor-derived key MUST equal FROST-signing child"
+            );
         }
+    }
+
+    /// #487 PR 4: the mainnet output users actually ship uses BIP-86
+    /// `coin_type` 0 and an `xpub` (not tpub) prefix. Testnet/Signet tests
+    /// exercise `coin_type` 1 only, so pin the mainnet branch explicitly.
+    #[test]
+    fn frost_wallet_mainnet_descriptor_uses_coin_type_0() {
+        let group = test_group_pubkey();
+        let export =
+            DescriptorExport::from_frost_wallet(&group, None, Network::Bitcoin).unwrap();
+
+        let fingerprint = export.fingerprint;
+        assert!(
+            export
+                .descriptor
+                .starts_with(&format!("tr([{fingerprint}/86'/0'/0']")),
+            "mainnet descriptor must use coin_type 0: {}",
+            export.descriptor
+        );
+        assert!(
+            export.descriptor.contains("xpub"),
+            "mainnet descriptor must embed an xpub, not a tpub: {}",
+            export.descriptor
+        );
+        assert!(
+            export.descriptor.contains("/0/*)"),
+            "mainnet descriptor must be a ranged external chain: {}",
+            export.descriptor
+        );
     }
 
     /// #487 PR 4: the external chain (`/0/*`) and internal chain (`/1/*`)

--- a/keep-bitcoin/src/lib.rs
+++ b/keep-bitcoin/src/lib.rs
@@ -27,7 +27,8 @@ pub use chain_view::{
     validate_prevout_amounts_against_chain, ChainView, ChainViewError, KEEP_CHAIN_URL_ENV,
 };
 pub use descriptor::{
-    descriptor_address, descriptor_script_pubkey, multipath_from_external, xpub_to_x_only,
+    descriptor_address, descriptor_address_at_index, descriptor_script_pubkey,
+    multipath_from_external, xpub_to_x_only,
     DescriptorExport,
 };
 pub use error::{BitcoinError, Result};

--- a/keep-bitcoin/src/lib.rs
+++ b/keep-bitcoin/src/lib.rs
@@ -28,8 +28,7 @@ pub use chain_view::{
 };
 pub use descriptor::{
     descriptor_address, descriptor_address_at_index, descriptor_script_pubkey,
-    multipath_from_external, xpub_to_x_only,
-    DescriptorExport,
+    multipath_from_external, xpub_to_x_only, DescriptorExport,
 };
 pub use error::{BitcoinError, Result};
 pub use key_proof::{build_key_proof_psbt, sign_key_proof, verify_key_proof};

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -147,12 +147,14 @@ impl KfpNode {
         let network = bitcoin::Network::from_str(&network_str).map_err(|e| {
             format!("REFUSED: successor descriptor has invalid network {network_str}: {e}")
         })?;
-        let expected_addr = keep_bitcoin::descriptor_address(&external_descriptor, network)
-            .map_err(|e| {
-                format!(
-                    "REFUSED: could not derive expected sweep destination from persisted successor descriptor: {e}"
-                )
-            })?;
+        let expected_addr =
+            keep_bitcoin::descriptor_address_at_index(&external_descriptor, network, 0).map_err(
+                |e| {
+                    format!(
+                        "REFUSED: could not derive expected sweep destination from persisted successor descriptor: {e}"
+                    )
+                },
+            )?;
         let expected_script = expected_addr.script_pubkey();
         if tx.output.len() != 1 {
             return Err(format!(
@@ -324,9 +326,12 @@ impl KfpNode {
         }
 
         // 4. Derive the NEW destination address from the finalized descriptor.
-        //    FROST wallet descriptors are definite (`tr(<xonly>,<tree>)`, no
-        //    wildcard), so derive the single address directly and reuse it for
-        //    both the PSBT destination and the display output.
+        //    No-recovery FROST wallet descriptors are ranged BIP-86
+        //    (`tr([fp/86'/coin']xpub/0/*)`), so the destination is the
+        //    descriptor's `/0/0` external address (index 0). Both proposer and
+        //    responder derive index 0 of the SAME persisted successor, so they
+        //    agree on the expected destination. Reuse it for both the PSBT
+        //    destination and the display output.
         //
         // NOTE: this destination derivation is proposer-side only. The sweep
         // rides the generic `request_psbt_spend` path keyed on the OLD
@@ -335,7 +340,7 @@ impl KfpNode {
         // descriptor. Responder-side destination re-derivation is a broader
         // change to the general signing path (keep-desktop/keep-cli signing
         // UIs) and is tracked separately.
-        let dest_addr = keep_bitcoin::descriptor_address(&new_external, network)
+        let dest_addr = keep_bitcoin::descriptor_address_at_index(&new_external, network, 0)
             .map_err(|e| FrostNetError::Session(format!("new receive address: {e}")))?;
         let destination = dest_addr.script_pubkey();
 


### PR DESCRIPTION
## Summary

PR 4 of 4 for #487. `keep wallet descriptor` now emits a BIP-86 style HD taproot descriptor over the FROST group's own xpub (derived from the deterministic chaincode shipped in PR 1) instead of a static `tr(xonly)`. External and internal chains are now genuinely distinct: `/0/*` for receive, `/1/*` for change. Every derived address is spendable end-to-end via the FROST composed-tweak signing path (PR 2 + PR 3).

Closes the whole #487 arc; the `--allow-address-reuse` flag is no longer needed for the common non-recovery case (the wallet-descriptor reuse gate simply never fires now).

## What ships

- `DescriptorExport::from_frost_wallet(group, None, network)` now returns:
  - `tr([fp/86'/coin_type'/0']xpub/0/*)` with the group's own xpub embedded.
  - The xpub is built at depth 0 from `(deterministic_chaincode(group), even-lift(group))` so any downstream BIP-32 walker (bitcoin::bip32::Xpub, BDK, miniscript, Sparrow) derives the exact same child pubkeys the FROST sign path produces.
  - The recovery-config branch is unchanged: recovery scripts still return the existing tapscript-tree descriptor.
- `DescriptorExport::frost_group_xpub(group, network)` public helper so callers exporting to other wallets can hand off just the xpub without re-parsing the wrapping descriptor.
- Support for `xpub` / `tpub` version bytes chosen from the target `bitcoin::Network`.

## Alignment property

The critical end-to-end invariant: **the child pubkey a downstream wallet derives from our xpub at `/0/N` must equal the child pubkey `keep_core::frost::bip32_signing::derive_child(group, &[0, N])` produces**. Otherwise wallets receive to addresses keep cannot sign for. Locked in with a dedicated cross-check test that walks both sides through several leaves.

## Tests

`cargo test -p keep-bitcoin --lib descriptor::` (23 tests, all pass):

- `descriptor_addresses_match_bip32_signing_derivation` — critical alignment: walks `xpub.derive_pub(&secp, &[0, N])` and compares to `bip32_signing::derive_child(group, &[0, N]).child_pubkey`, byte-for-byte, for leaves 0, 1, 5, 100.
- `external_and_internal_leaves_produce_distinct_addresses` — the property that motivated #487: `/0/N != /1/N` at every N.
- `test_frost_wallet_simple_descriptor` updated to assert:
  - descriptor opens with the expected `tr([fp/86'/1'/0']` BIP-86 origin,
  - embeds a `tpub`,
  - ends with `/0/*)` (the receive path),
  - internal descriptor differs from external.
- Existing tests untouched (recovery path, Sparrow export, address derivation, xpub network guards).

`cargo test --workspace` all pass, `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Closes

Closes #487. The whole arc:

- PR 1 (#668): primitives + reference vectors matching `bitcoin::bip32::Xpub::derive_pub`.
- PR 2 (#669): FROST signing under composed BIP-32 + BIP-341 tweak with y-parity handling + fail-closed self-verify.
- PR 3 (#671): wire protocol carries the derivation path; every co-signer applies the same composite tweak; end-to-end multinode MockRelay test.
- PR 4 (this): descriptor emission, closing the loop from receive address to spend signature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallet descriptors now support BIP-86-style ranged derivation, allowing distinct external and internal address chains.
  * Added a helper to resolve an address at a specific descriptor index, improving deterministic address selection during migrations.
  * Exposed the wallet’s group xpub for integrations that need descriptor-based derivation.

* **Bug Fixes**
  * Migration sweep destinations now use the same derived external address on both sides, reducing mismatch risk during recovery or migration flows.
  * Updated address derivation behavior to better match expected wallet signing paths across networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->