### PR TITLE
frost-net: software DKG path so users without hardware can generate a keyset

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -652,8 +652,19 @@ pub(crate) enum FrostNetworkCommands {
         index: u8,
         #[arg(short, long)]
         relay: Option<String>,
-        #[arg(long, help = "Hardware signer device path (e.g., /dev/ttyACM0)")]
-        hardware: String,
+        #[arg(
+            long,
+            help = "Hardware signer device path (e.g., /dev/ttyACM0). \
+                    Omit to run software DKG in-process; --path must then \
+                    point at the vault that stores the resulting share (#454)."
+        )]
+        hardware: Option<String>,
+        #[arg(
+            long,
+            help = "Vault path for software DKG. Required when --hardware is omitted; \
+                    the finalized share is stored here encrypted under the vault key."
+        )]
+        path: Option<std::path::PathBuf>,
     },
     Sign {
         #[arg(short, long)]

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -655,14 +655,15 @@ pub(crate) enum FrostNetworkCommands {
         #[arg(
             long,
             help = "Hardware signer device path (e.g., /dev/ttyACM0). \
-                    Omit to run software DKG in-process; --path must then \
-                    point at the vault that stores the resulting share (#454)."
+                    Omit to run software DKG in-process, storing the resulting \
+                    share in the vault (#454)."
         )]
         hardware: Option<String>,
         #[arg(
             long,
-            help = "Vault path for software DKG. Required when --hardware is omitted; \
-                    the finalized share is stored here encrypted under the vault key."
+            help = "Vault path override for software DKG. Defaults to the global \
+                    --path / configured vault; the finalized share is stored here \
+                    encrypted under the vault key."
         )]
         path: Option<std::path::PathBuf>,
     },

--- a/keep-cli/src/commands/frost_network/dkg.rs
+++ b/keep-cli/src/commands/frost_network/dkg.rs
@@ -10,6 +10,12 @@ use keep_core::error::{CryptoError, FrostError, KeepError, NetworkError, Result}
 use crate::output::Output;
 use crate::signer::HardwareSigner;
 
+/// Upper bound on distinct relay events tracked per software-DKG polling loop.
+/// A DKG topic only ever carries a handful of packages; a set this large means
+/// the relay is flooding junk, so we abort rather than grow memory unbounded
+/// for the 300s timeout window.
+const MAX_DKG_EVENTS_SEEN: usize = 8192;
+
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip(out))]
 pub fn cmd_frost_network_dkg(
@@ -414,16 +420,25 @@ fn cmd_frost_network_dkg_software(
     out.warn(
         "intended for testing (#436) and users without hardware. See #454 for the trade-offs.",
     );
+    out.warn("DKG participants are matched on a first-seen basis over the relay topic and are NOT");
+    out.warn(
+        "authenticated against the group roster: anyone able to write to the relay during the",
+    );
+    out.warn("run can race a participant index (denial of service, or share theft if they win a");
+    out.warn(
+        "threshold-many). Run over a trusted/private relay until roster authentication lands (#674).",
+    );
     out.newline();
 
     let mut session =
         SoftwareDkgSession::init(threshold as u16, participants as u16, our_index as u16)
             .map_err(|e| KeepError::FrostErr(FrostError::invalid_config(e.to_string())))?;
 
-    // `group` is stored as the share name at finalize; reject an out-of-bounds
-    // name now rather than after every network round only for the store to fail.
-    let group_name = group.trim();
-    if group_name.is_empty() || group_name.chars().count() > 64 {
+    // `group` is stored as the share name at finalize and used verbatim as the
+    // relay `d` tag every peer filters on, so validate it as-is (no trim, which
+    // would diverge from what is published) rather than failing after every
+    // network round only for the store to reject it.
+    if group.is_empty() || group.chars().count() > 64 {
         return Err(KeepError::FrostErr(FrostError::invalid_config(
             "group name must be 1..=64 characters".to_string(),
         )));
@@ -494,7 +509,9 @@ fn cmd_frost_network_dkg_software(
             .kind(Kind::Custom(21102))
             .custom_tag(SingleLetterTag::lowercase(Alphabet::D), group.to_string());
 
-        let mut participant_pubkeys: HashMap<u8, PublicKey> = HashMap::new();
+        // Keyed on the u16 wire index (not a truncated u8) so the map cannot
+        // alias two participants if the index type ever widens past 255.
+        let mut participant_pubkeys: HashMap<u16, PublicKey> = HashMap::new();
         let timeout = std::time::Duration::from_secs(300);
         let start = std::time::Instant::now();
         let mut round1_done = 0u32;
@@ -521,6 +538,11 @@ fn cmd_frost_network_dkg_software(
                 if !seen_round1.insert(ev.id) {
                     continue;
                 }
+                if seen_round1.len() > MAX_DKG_EVENTS_SEEN {
+                    return Err(KeepError::NetworkErr(NetworkError::request(
+                        "too many distinct DKG round1 events; aborting to bound memory".to_string(),
+                    )));
+                }
                 // Software-only wire: skip hardware-format events cleanly.
                 let is_software = ev.tags.iter().any(|t| {
                     let slice = t.as_slice();
@@ -537,12 +559,19 @@ fn cmd_frost_network_dkg_software(
                 if wire.sender_index == our_index as u16 {
                     continue;
                 }
-                if participant_pubkeys.contains_key(&(wire.sender_index as u8)) {
+                // SECURITY LIMITATION: index -> ephemeral-key binding is
+                // first-seen-wins and unauthenticated. A relay writer who
+                // publishes a round1 package under a victim's sender_index first
+                // captures that index; the honest peer's later package is then
+                // dropped just below as a duplicate. Upgrade path (#674): pin the
+                // (index -> npub) roster from the kind 21101 group announcement
+                // and require each event to be authored by the expected npub.
+                if participant_pubkeys.contains_key(&wire.sender_index) {
                     continue;
                 }
                 match session.round1_peer(&wire) {
                     Ok(_) => {
-                        participant_pubkeys.insert(wire.sender_index as u8, ev.pubkey);
+                        participant_pubkeys.insert(wire.sender_index, ev.pubkey);
                         round1_done += 1;
                         out.success(&format!(
                             "Received round 1 package from participant {}",
@@ -573,11 +602,9 @@ fn cmd_frost_network_dkg_software(
         spinner.finish();
 
         for (recipient_index, wire) in round2_wires {
-            let recipient_pubkey = participant_pubkeys
-                .get(&(recipient_index as u8))
-                .ok_or_else(|| {
-                    KeepError::FrostErr(FrostError::unknown_participant(recipient_index))
-                })?;
+            let recipient_pubkey = participant_pubkeys.get(&recipient_index).ok_or_else(|| {
+                KeepError::FrostErr(FrostError::unknown_participant(recipient_index))
+            })?;
             // Serialized share is secret until nip44 wraps it; scrub the plaintext.
             let payload = Zeroizing::new(
                 serde_json::to_string(&wire)
@@ -655,6 +682,11 @@ fn cmd_frost_network_dkg_software(
                 if !seen_round2.insert(ev.id) {
                     continue;
                 }
+                if seen_round2.len() > MAX_DKG_EVENTS_SEEN {
+                    return Err(KeepError::NetworkErr(NetworkError::request(
+                        "too many distinct DKG round2 events; aborting to bound memory".to_string(),
+                    )));
+                }
                 let is_software = ev.tags.iter().any(|t| {
                     let slice = t.as_slice();
                     slice.first().map(|s| s.as_str()) == Some("dkg_mode")
@@ -688,7 +720,7 @@ fn cmd_frost_network_dkg_software(
                 // sender's round1 package. Without this a relay writer can race a
                 // forged share to a recipient under a legitimate peer's index; the
                 // honest share is then dropped as a duplicate and finalize aborts.
-                if participant_pubkeys.get(&(wire.sender_index as u8)) != Some(&ev.pubkey) {
+                if participant_pubkeys.get(&wire.sender_index) != Some(&ev.pubkey) {
                     out.warn(&format!(
                         "Ignoring round 2 share for participant {}: sender key does not \
                          match its round 1 package",

--- a/keep-cli/src/commands/frost_network/dkg.rs
+++ b/keep-cli/src/commands/frost_network/dkg.rs
@@ -10,8 +10,47 @@ use keep_core::error::{CryptoError, FrostError, KeepError, NetworkError, Result}
 use crate::output::Output;
 use crate::signer::HardwareSigner;
 
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip(out))]
 pub fn cmd_frost_network_dkg(
+    out: &Output,
+    group: &str,
+    threshold: u8,
+    participants: u8,
+    our_index: u8,
+    relay: &str,
+    hardware: Option<&str>,
+    vault_path: Option<&std::path::Path>,
+) -> Result<()> {
+    match (hardware, vault_path) {
+        (Some(hw), _) => cmd_frost_network_dkg_hardware(
+            out,
+            group,
+            threshold,
+            participants,
+            our_index,
+            relay,
+            hw,
+        ),
+        (None, Some(path)) => cmd_frost_network_dkg_software(
+            out,
+            group,
+            threshold,
+            participants,
+            our_index,
+            relay,
+            path,
+        ),
+        (None, None) => Err(KeepError::InvalidInput(
+            "keep frost network dkg requires either --hardware <device> or \
+             --path <vault> (software DKG, #454). Both are currently missing."
+                .into(),
+        )),
+    }
+}
+
+#[tracing::instrument(skip(out))]
+fn cmd_frost_network_dkg_hardware(
     out: &Output,
     group: &str,
     threshold: u8,
@@ -331,6 +370,333 @@ pub fn cmd_frost_network_dkg(
         out.field("Our index", &result.our_index.to_string());
         out.newline();
         out.info("Share has been stored on the hardware device.");
+        out.info(&format!(
+            "Group '{group}' is now ready for threshold signing."
+        ));
+
+        Ok::<_, KeepError>(())
+    })?;
+
+    Ok(())
+}
+
+/// Run software DKG (#454): every step of the FROST-secp256k1-tr protocol
+/// happens in this process, and the finalized share is persisted to
+/// `vault_path` encrypted under the vault's data key. Peers speak a
+/// software-only wire format keyed on `software_dkg_version = 1`; hardware
+/// peers do not decode it (and vice versa), so a mixed group DKG fails
+/// obviously instead of silently mis-mixing.
+#[tracing::instrument(skip(out))]
+fn cmd_frost_network_dkg_software(
+    out: &Output,
+    group: &str,
+    threshold: u8,
+    participants: u8,
+    our_index: u8,
+    relay: &str,
+    vault_path: &std::path::Path,
+) -> Result<()> {
+    use keep_core::frost::dkg::{SoftwareDkgSession, SoftwareRound1Wire, SoftwareRound2Wire};
+    use keep_core::Keep;
+    use secrecy::ExposeSecret;
+
+    out.newline();
+    out.header("FROST Distributed Key Generation (software)");
+    out.field("Group", group);
+    out.field("Threshold", &format!("{threshold}-of-{participants}"));
+    out.field("Our index", &our_index.to_string());
+    out.field("Relay", relay);
+    out.field("Vault", &vault_path.display().to_string());
+    out.newline();
+    out.warn("Software DKG keeps polynomial state in this process's memory for the duration");
+    out.warn("of the run. For production keysets prefer `--hardware <device>`; software DKG is");
+    out.warn(
+        "intended for testing (#436) and users without hardware. See #454 for the trade-offs.",
+    );
+    out.newline();
+
+    let mut session =
+        SoftwareDkgSession::init(threshold as u16, participants as u16, our_index as u16)
+            .map_err(|e| KeepError::FrostErr(FrostError::invalid_config(e.to_string())))?;
+
+    let spinner = out.spinner("Opening vault...");
+    let mut keep = Keep::open(vault_path)?;
+    let password = super::get_password("Enter password")?;
+    keep.unlock(password.expose_secret())?;
+    spinner.finish();
+
+    let spinner = out.spinner("Generating DKG round 1 package...");
+    let our_round1 = session
+        .round1()
+        .map_err(|e| KeepError::FrostErr(FrostError::dkg(format!("round 1: {e}"))))?;
+    spinner.finish();
+    out.success("Round 1 package generated");
+    out.newline();
+
+    let rt =
+        tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
+
+    rt.block_on(async {
+        let keys = Keys::generate();
+        let client = Client::new(keys.clone());
+        client
+            .add_relay(relay)
+            .await
+            .map_err(|e| KeepError::NetworkErr(NetworkError::relay(e.to_string())))?;
+        client.connect().await;
+
+        out.info("Connected to relay");
+        out.field(
+            "Node pubkey",
+            &keys.public_key().to_bech32().unwrap_or_default(),
+        );
+        out.newline();
+
+        let round1_content = serde_json::to_string(&our_round1)
+            .map_err(|e| KeepError::Runtime(format!("serialize round1: {e}")))?;
+
+        let round1_event = EventBuilder::new(Kind::Custom(21102), &round1_content)
+            .tag(Tag::custom(TagKind::custom("d"), vec![group.to_string()]))
+            .tag(Tag::custom(
+                TagKind::custom("sender_index"),
+                vec![our_index.to_string()],
+            ))
+            .tag(Tag::custom(
+                TagKind::custom("dkg_mode"),
+                vec!["software_v1".to_string()],
+            ))
+            .sign_with_keys(&keys)
+            .map_err(|e| KeepError::CryptoErr(CryptoError::invalid_signature(e.to_string())))?;
+
+        let spinner = out.spinner("Publishing round 1 package...");
+        client
+            .send_event(&round1_event)
+            .await
+            .map_err(|e| KeepError::NetworkErr(NetworkError::publish(e.to_string())))?;
+        spinner.finish();
+
+        let expected_peers = participants - 1;
+        out.info(&format!(
+            "Waiting for {expected_peers} other round 1 packages..."
+        ));
+
+        let filter = Filter::new()
+            .kind(Kind::Custom(21102))
+            .custom_tag(SingleLetterTag::lowercase(Alphabet::D), group.to_string());
+
+        let mut participant_pubkeys: HashMap<u8, PublicKey> = HashMap::new();
+        let timeout = std::time::Duration::from_secs(300);
+        let start = std::time::Instant::now();
+        let mut round1_done = 0u32;
+
+        while round1_done < expected_peers as u32 {
+            if start.elapsed() > timeout {
+                return Err(KeepError::NetworkErr(NetworkError::timeout(
+                    "waiting for peer round1 packages",
+                )));
+            }
+
+            let events = client
+                .fetch_events(filter.clone(), std::time::Duration::from_secs(5))
+                .await
+                .map_err(|e| KeepError::NetworkErr(NetworkError::request(e.to_string())))?;
+
+            for ev in events.iter() {
+                if ev.pubkey == keys.public_key() {
+                    continue;
+                }
+                // Software-only wire: skip hardware-format events cleanly.
+                let is_software = ev.tags.iter().any(|t| {
+                    let slice = t.as_slice();
+                    slice.first().map(|s| s.as_str()) == Some("dkg_mode")
+                        && slice.get(1).map(|s| s.as_str()) == Some("software_v1")
+                });
+                if !is_software {
+                    continue;
+                }
+                let wire: SoftwareRound1Wire = match serde_json::from_str(&ev.content) {
+                    Ok(w) => w,
+                    Err(_) => continue,
+                };
+                if wire.sender_index == our_index as u16 {
+                    continue;
+                }
+                if participant_pubkeys.contains_key(&(wire.sender_index as u8)) {
+                    continue;
+                }
+                match session.round1_peer(&wire) {
+                    Ok(_) => {
+                        participant_pubkeys.insert(wire.sender_index as u8, ev.pubkey);
+                        round1_done += 1;
+                        out.success(&format!(
+                            "Received round 1 package from participant {}",
+                            wire.sender_index
+                        ));
+                    }
+                    Err(e) => {
+                        out.warn(&format!(
+                            "Rejected round 1 package from participant {}: {e}",
+                            wire.sender_index
+                        ));
+                    }
+                }
+            }
+
+            if round1_done < expected_peers as u32 {
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            }
+        }
+
+        out.newline();
+        out.success("All round 1 packages received");
+
+        let spinner = out.spinner("Generating round 2 shares...");
+        let round2_wires = session
+            .round2()
+            .map_err(|e| KeepError::FrostErr(FrostError::dkg(format!("round 2: {e}"))))?;
+        spinner.finish();
+
+        for (recipient_index, wire) in round2_wires {
+            let recipient_pubkey = participant_pubkeys
+                .get(&(recipient_index as u8))
+                .ok_or_else(|| {
+                    KeepError::FrostErr(FrostError::unknown_participant(recipient_index))
+                })?;
+            let payload = serde_json::to_string(&wire)
+                .map_err(|e| KeepError::Runtime(format!("serialize round2: {e}")))?;
+            let encrypted_content = nip44::encrypt(
+                keys.secret_key(),
+                recipient_pubkey,
+                &payload,
+                nip44::Version::default(),
+            )
+            .map_err(|e| KeepError::CryptoErr(CryptoError::encryption(e.to_string())))?;
+
+            let share_event = EventBuilder::new(Kind::Custom(21103), &encrypted_content)
+                .tag(Tag::custom(TagKind::custom("d"), vec![group.to_string()]))
+                .tag(Tag::custom(
+                    TagKind::custom("sender_index"),
+                    vec![our_index.to_string()],
+                ))
+                .tag(Tag::custom(
+                    TagKind::custom("recipient_index"),
+                    vec![recipient_index.to_string()],
+                ))
+                .tag(Tag::custom(
+                    TagKind::custom("dkg_mode"),
+                    vec!["software_v1".to_string()],
+                ))
+                .sign_with_keys(&keys)
+                .map_err(|e| {
+                    KeepError::CryptoErr(CryptoError::invalid_signature(format!(
+                        "share event: {e}"
+                    )))
+                })?;
+
+            client
+                .send_event(&share_event)
+                .await
+                .map_err(|e| KeepError::NetworkErr(NetworkError::publish(format!("share: {e}"))))?;
+
+            out.info(&format!(
+                "Published encrypted round 2 share for participant {recipient_index}"
+            ));
+        }
+
+        out.newline();
+        out.info(&format!(
+            "Waiting for {expected_peers} round 2 shares from peers..."
+        ));
+
+        let share_filter = Filter::new()
+            .kind(Kind::Custom(21103))
+            .custom_tag(SingleLetterTag::lowercase(Alphabet::D), group.to_string());
+
+        let start = std::time::Instant::now();
+        let mut round2_done = 0u32;
+        while round2_done < expected_peers as u32 {
+            if start.elapsed() > timeout {
+                return Err(KeepError::NetworkErr(NetworkError::timeout(
+                    "waiting for peer round2 shares",
+                )));
+            }
+
+            let events = client
+                .fetch_events(share_filter.clone(), std::time::Duration::from_secs(5))
+                .await
+                .map_err(|e| {
+                    KeepError::NetworkErr(NetworkError::request(format!("fetch shares: {e}")))
+                })?;
+
+            for ev in events.iter() {
+                if ev.pubkey == keys.public_key() {
+                    continue;
+                }
+                let is_software = ev.tags.iter().any(|t| {
+                    let slice = t.as_slice();
+                    slice.first().map(|s| s.as_str()) == Some("dkg_mode")
+                        && slice.get(1).map(|s| s.as_str()) == Some("software_v1")
+                });
+                if !is_software {
+                    continue;
+                }
+                let recipient_idx_tag = ev.tags.iter().find_map(|t| {
+                    let slice = t.as_slice();
+                    if slice.first().map(|s| s.as_str()) == Some("recipient_index") {
+                        slice.get(1).and_then(|s| s.parse::<u16>().ok())
+                    } else {
+                        None
+                    }
+                });
+                if recipient_idx_tag != Some(our_index as u16) {
+                    continue;
+                }
+                let decrypted = match nip44::decrypt(keys.secret_key(), &ev.pubkey, &ev.content) {
+                    Ok(d) => d,
+                    Err(_) => continue,
+                };
+                let wire: SoftwareRound2Wire = match serde_json::from_str(&decrypted) {
+                    Ok(w) => w,
+                    Err(_) => continue,
+                };
+                match session.receive_share(&wire) {
+                    Ok(_) => {
+                        round2_done += 1;
+                        out.success(&format!(
+                            "Received round 2 share from participant {}",
+                            wire.sender_index
+                        ));
+                    }
+                    Err(e) => {
+                        out.warn(&format!(
+                            "Rejected round 2 share from participant {}: {e}",
+                            wire.sender_index
+                        ));
+                    }
+                }
+            }
+            if round2_done < expected_peers as u32 {
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            }
+        }
+
+        out.newline();
+        let spinner = out.spinner("Finalizing DKG...");
+        let result = session
+            .finalize()
+            .map_err(|e| KeepError::FrostErr(FrostError::dkg(format!("finalize: {e}"))))?;
+        spinner.finish();
+
+        let spinner = out.spinner("Storing share in vault...");
+        keep.frost_store_dkg_share(&result, threshold as u16, participants as u16, group)?;
+        spinner.finish();
+
+        out.newline();
+        out.success("DKG Complete!");
+        out.field("Group public key", &hex::encode(result.group_pubkey));
+        out.field("Our index", &result.our_index.to_string());
+        out.newline();
+        out.info("Share stored in vault (software DKG).");
         out.info(&format!(
             "Group '{group}' is now ready for threshold signing."
         ));

--- a/keep-cli/src/commands/frost_network/dkg.rs
+++ b/keep-cli/src/commands/frost_network/dkg.rs
@@ -420,6 +420,15 @@ fn cmd_frost_network_dkg_software(
         SoftwareDkgSession::init(threshold as u16, participants as u16, our_index as u16)
             .map_err(|e| KeepError::FrostErr(FrostError::invalid_config(e.to_string())))?;
 
+    // `group` is stored as the share name at finalize; reject an out-of-bounds
+    // name now rather than after every network round only for the store to fail.
+    let group_name = group.trim();
+    if group_name.is_empty() || group_name.chars().count() > 64 {
+        return Err(KeepError::FrostErr(FrostError::invalid_config(
+            "group name must be 1..=64 characters".to_string(),
+        )));
+    }
+
     let spinner = out.spinner("Opening vault...");
     let mut keep = Keep::open(vault_path)?;
     let password = super::get_password("Enter password")?;
@@ -665,13 +674,12 @@ fn cmd_frost_network_dkg_software(
                 if recipient_idx_tag != Some(our_index as u16) {
                     continue;
                 }
-                let decrypted =
-                    match nip44::decrypt(keys.secret_key(), &ev.pubkey, &ev.content) {
-                        // Plaintext carries the peer's secret signing share; scrub
-                        // it from the heap once this iteration drops it.
-                        Ok(d) => Zeroizing::new(d),
-                        Err(_) => continue,
-                    };
+                let decrypted = match nip44::decrypt(keys.secret_key(), &ev.pubkey, &ev.content) {
+                    // Plaintext carries the peer's secret signing share; scrub
+                    // it from the heap once this iteration drops it.
+                    Ok(d) => Zeroizing::new(d),
+                    Err(_) => continue,
+                };
                 let wire: SoftwareRound2Wire = match serde_json::from_str(&decrypted) {
                     Ok(w) => w,
                     Err(_) => continue,

--- a/keep-cli/src/commands/frost_network/dkg.rs
+++ b/keep-cli/src/commands/frost_network/dkg.rs
@@ -399,6 +399,7 @@ fn cmd_frost_network_dkg_software(
     use keep_core::frost::dkg::{SoftwareDkgSession, SoftwareRound1Wire, SoftwareRound2Wire};
     use keep_core::Keep;
     use secrecy::ExposeSecret;
+    use zeroize::Zeroizing;
 
     out.newline();
     out.header("FROST Distributed Key Generation (software)");
@@ -488,6 +489,9 @@ fn cmd_frost_network_dkg_software(
         let timeout = std::time::Duration::from_secs(300);
         let start = std::time::Instant::now();
         let mut round1_done = 0u32;
+        // Events already examined this round, so a relay re-serving the same
+        // event (or a permanently-rejected one) is not reprocessed every poll.
+        let mut seen_round1: HashSet<EventId> = HashSet::new();
 
         while round1_done < expected_peers as u32 {
             if start.elapsed() > timeout {
@@ -503,6 +507,9 @@ fn cmd_frost_network_dkg_software(
 
             for ev in events.iter() {
                 if ev.pubkey == keys.public_key() {
+                    continue;
+                }
+                if !seen_round1.insert(ev.id) {
                     continue;
                 }
                 // Software-only wire: skip hardware-format events cleanly.
@@ -562,12 +569,15 @@ fn cmd_frost_network_dkg_software(
                 .ok_or_else(|| {
                     KeepError::FrostErr(FrostError::unknown_participant(recipient_index))
                 })?;
-            let payload = serde_json::to_string(&wire)
-                .map_err(|e| KeepError::Runtime(format!("serialize round2: {e}")))?;
+            // Serialized share is secret until nip44 wraps it; scrub the plaintext.
+            let payload = Zeroizing::new(
+                serde_json::to_string(&wire)
+                    .map_err(|e| KeepError::Runtime(format!("serialize round2: {e}")))?,
+            );
             let encrypted_content = nip44::encrypt(
                 keys.secret_key(),
                 recipient_pubkey,
-                &payload,
+                payload.as_str(),
                 nip44::Version::default(),
             )
             .map_err(|e| KeepError::CryptoErr(CryptoError::encryption(e.to_string())))?;
@@ -614,6 +624,7 @@ fn cmd_frost_network_dkg_software(
 
         let start = std::time::Instant::now();
         let mut round2_done = 0u32;
+        let mut seen_round2: HashSet<EventId> = HashSet::new();
         while round2_done < expected_peers as u32 {
             if start.elapsed() > timeout {
                 return Err(KeepError::NetworkErr(NetworkError::timeout(
@@ -630,6 +641,9 @@ fn cmd_frost_network_dkg_software(
 
             for ev in events.iter() {
                 if ev.pubkey == keys.public_key() {
+                    continue;
+                }
+                if !seen_round2.insert(ev.id) {
                     continue;
                 }
                 let is_software = ev.tags.iter().any(|t| {
@@ -651,14 +665,29 @@ fn cmd_frost_network_dkg_software(
                 if recipient_idx_tag != Some(our_index as u16) {
                     continue;
                 }
-                let decrypted = match nip44::decrypt(keys.secret_key(), &ev.pubkey, &ev.content) {
-                    Ok(d) => d,
-                    Err(_) => continue,
-                };
+                let decrypted =
+                    match nip44::decrypt(keys.secret_key(), &ev.pubkey, &ev.content) {
+                        // Plaintext carries the peer's secret signing share; scrub
+                        // it from the heap once this iteration drops it.
+                        Ok(d) => Zeroizing::new(d),
+                        Err(_) => continue,
+                    };
                 let wire: SoftwareRound2Wire = match serde_json::from_str(&decrypted) {
                     Ok(w) => w,
                     Err(_) => continue,
                 };
+                // Bind the round2 share to the ephemeral key that published this
+                // sender's round1 package. Without this a relay writer can race a
+                // forged share to a recipient under a legitimate peer's index; the
+                // honest share is then dropped as a duplicate and finalize aborts.
+                if participant_pubkeys.get(&(wire.sender_index as u8)) != Some(&ev.pubkey) {
+                    out.warn(&format!(
+                        "Ignoring round 2 share for participant {}: sender key does not \
+                         match its round 1 package",
+                        wire.sender_index
+                    ));
+                    continue;
+                }
                 match session.receive_share(&wire) {
                     Ok(_) => {
                         round2_done += 1;

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -365,9 +365,13 @@ fn dispatch_frost_network(
             index,
             relay,
             hardware,
-            path,
+            path: dkg_path,
         } => {
             let relay = relay.as_deref().unwrap_or(default_relay);
+            // Software DKG needs a vault; honor an explicit --path override but
+            // otherwise fall back to the globally resolved vault path like every
+            // other frost command, instead of erroring on a missing --path.
+            let vault_path = dkg_path.as_deref().or(Some(path));
             commands::frost_network::cmd_frost_network_dkg(
                 out,
                 &group,
@@ -376,7 +380,7 @@ fn dispatch_frost_network(
                 index,
                 relay,
                 hardware.as_deref(),
-                path.as_deref(),
+                vault_path,
             )
         }
         FrostNetworkCommands::Sign {

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -365,6 +365,7 @@ fn dispatch_frost_network(
             index,
             relay,
             hardware,
+            path,
         } => {
             let relay = relay.as_deref().unwrap_or(default_relay);
             commands::frost_network::cmd_frost_network_dkg(
@@ -374,7 +375,8 @@ fn dispatch_frost_network(
                 participants,
                 index,
                 relay,
-                &hardware,
+                hardware.as_deref(),
+                path.as_deref(),
             )
         }
         FrostNetworkCommands::Sign {

--- a/keep-core/src/frost/dealer.rs
+++ b/keep-core/src/frost/dealer.rs
@@ -159,7 +159,7 @@ impl TrustedDealer {
     }
 }
 
-fn extract_group_pubkey(pubkey_pkg: &PublicKeyPackage) -> Result<[u8; 32]> {
+pub(super) fn extract_group_pubkey(pubkey_pkg: &PublicKeyPackage) -> Result<[u8; 32]> {
     let verifying_key = pubkey_pkg.verifying_key();
     let serialized = verifying_key
         .serialize()

--- a/keep-core/src/frost/dkg.rs
+++ b/keep-core/src/frost/dkg.rs
@@ -1,0 +1,555 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+//! In-process DKG (#454) using the standard frost-secp256k1-tr 3-round protocol.
+//!
+//! `keep frost network dkg` today requires `--hardware <path>` so the private
+//! polynomial coefficients live entirely on an attached signer (M5Stack ESP32,
+//! etc.). That is safer for production but blocks any user without hardware
+//! from participating and blocks CI from exercising DKG end-to-end (#436).
+//!
+//! [`SoftwareDkgSession`] wraps `frost-secp256k1-tr::keys::dkg::{part1,part2,
+//! part3}` behind the same six-step state machine `keep-cli` uses to drive
+//! the hardware signer (`init` -> `round1` -> `round1_peer` -> `round2` ->
+//! `receive_share` -> `finalize`), so the CLI can dispatch on the presence
+//! of `--hardware` without any protocol-level branching.
+//!
+//! ## Wire compatibility
+//!
+//! This module speaks a **software-only** wire format ([`SOFTWARE_DKG_VERSION`]
+//! is emitted alongside every round1 package). The keep-esp32 firmware ships
+//! its own binary format the software side does not know how to parse, and
+//! the mirror is also true, so software peers and hardware peers cannot DKG
+//! with each other on this branch. Mixed groups must all be one or the
+//! other; the CLI marks this explicitly so a bystander does not silently
+//! DKG-with-nobody.
+//!
+//! ## Threat model reminder
+//!
+//! Software DKG puts every participant's polynomial + coefficient
+//! commitments in that participant's process memory for the duration of
+//! the run. That is the same trust surface `frost generate` (trusted
+//! dealer) has for the full group secret, but SPLIT across the group and
+//! reset once `part3` finishes: no single machine ever sees any other
+//! participant's polynomial. That is materially better than trusted-dealer,
+//! materially worse than hardware DKG. Operators of high-value groups
+//! should still prefer hardware; software is here to unblock everyone else
+//! and to give CI a real DKG path.
+
+use std::collections::BTreeMap;
+
+use frost_secp256k1_tr::{
+    keys::dkg::{part1, part2, part3, round1, round2},
+    keys::{KeyPackage, PublicKeyPackage},
+    rand_core::OsRng,
+    Identifier,
+};
+
+use crate::error::{KeepError, Result};
+
+/// Wire discriminator. Bumped when the serialized package layout changes so
+/// old peers reject the newer packages loudly rather than mis-decoding.
+pub const SOFTWARE_DKG_VERSION: u8 = 1;
+
+/// One participant's software DKG state machine. Same six-step public
+/// interface `keep-cli` drives against the hardware signer, so the CLI
+/// dispatches on the presence of `--hardware` without any protocol branching.
+///
+/// The state machine is linear and validates every transition, so an
+/// out-of-order call (e.g. `dkg_round2` before every peer's round1 arrived)
+/// returns a clear error rather than silently producing garbage.
+pub struct SoftwareDkgSession {
+    identifier: Identifier,
+    max_signers: u16,
+    min_signers: u16,
+    our_index: u16,
+    state: DkgState,
+}
+
+enum DkgState {
+    Init,
+    AwaitingRound1 {
+        secret: round1::SecretPackage,
+        our_round1: round1::Package,
+        peer_round1: BTreeMap<Identifier, round1::Package>,
+    },
+    AwaitingRound2 {
+        secret: round2::SecretPackage,
+        round1: BTreeMap<Identifier, round1::Package>,
+        peer_round2: BTreeMap<Identifier, round2::Package>,
+    },
+    Finalized,
+}
+
+/// Wire-format round1 package emitted by [`SoftwareDkgSession::round1`]. The
+/// CLI encodes this as JSON and publishes it on the DKG topic; peers running
+/// this same version decode it back via [`SoftwareDkgSession::round1_peer`].
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SoftwareRound1Wire {
+    /// Discriminator so hardware peers reject the payload rather than
+    /// silently mis-decoding. Must equal [`SOFTWARE_DKG_VERSION`].
+    pub software_dkg_version: u8,
+    /// The 1-indexed participant identifier that produced this package.
+    pub sender_index: u16,
+    /// Hex-encoded `frost_secp256k1_tr::keys::dkg::round1::Package::serialize`
+    /// output.
+    pub package_hex: String,
+}
+
+/// Wire-format round2 share, one per recipient. Encrypted per-recipient at
+/// the CLI level (nip44) before publishing.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SoftwareRound2Wire {
+    /// Discriminator, same rule as [`SoftwareRound1Wire`].
+    pub software_dkg_version: u8,
+    /// The 1-indexed participant identifier that produced this share.
+    pub sender_index: u16,
+    /// Hex-encoded `round2::Package` for the specific recipient.
+    pub package_hex: String,
+}
+
+/// Result returned from [`SoftwareDkgSession::finalize`], mirroring the
+/// hardware finalize shape so the CLI can share printing / storage code.
+pub struct SoftwareDkgResult {
+    /// This participant's finalized KeyPackage. Store via
+    /// `Keep::frost_store_dkg_share`.
+    pub key_package: KeyPackage,
+    /// The group's PublicKeyPackage. Also stored via the same helper so the
+    /// verifying shares for every peer are available during aggregation.
+    pub public_key_package: PublicKeyPackage,
+    /// The BIP-340 x-only 32-byte group pubkey the shares reconstruct to.
+    pub group_pubkey: [u8; 32],
+    /// This participant's 1-indexed share number.
+    pub our_index: u16,
+}
+
+impl SoftwareDkgSession {
+    /// Set up state for a `threshold`-of-`participants` DKG run where this
+    /// process holds share `our_index` (1-indexed). Rejects thresholds
+    /// outside `2..=participants` and indexes outside `1..=participants` so
+    /// a caller cannot pass a validated config to `part1` and get an
+    /// `UnknownIdentifier` late in the run.
+    pub fn init(threshold: u16, participants: u16, our_index: u16) -> Result<Self> {
+        if threshold < 2 || threshold > participants {
+            return Err(KeepError::Frost(format!(
+                "threshold must satisfy 2 <= t ({threshold}) <= n ({participants})"
+            )));
+        }
+        if our_index < 1 || our_index > participants {
+            return Err(KeepError::Frost(format!(
+                "share index must satisfy 1..={participants}, got {our_index}"
+            )));
+        }
+        let identifier = Identifier::try_from(our_index).map_err(|e| {
+            KeepError::Frost(format!(
+                "share index {our_index} is not a valid FROST identifier: {e}"
+            ))
+        })?;
+        Ok(Self {
+            identifier,
+            max_signers: participants,
+            min_signers: threshold,
+            our_index,
+            state: DkgState::Init,
+        })
+    }
+
+    /// Run frost-core's `part1` and return the round1 wire package this
+    /// participant broadcasts to every peer. Must be called before any
+    /// `round1_peer` step and exactly once per session.
+    pub fn round1(&mut self) -> Result<SoftwareRound1Wire> {
+        match self.state {
+            DkgState::Init => {}
+            _ => {
+                return Err(KeepError::Frost(
+                    "SoftwareDkgSession::round1 called out of order (already past round 1)".into(),
+                ));
+            }
+        }
+        let (secret, package) = part1(self.identifier, self.max_signers, self.min_signers, OsRng)
+            .map_err(|e| KeepError::Frost(format!("DKG part1 failed: {e}")))?;
+        let package_bytes = package
+            .serialize()
+            .map_err(|e| KeepError::Frost(format!("serialize round1 package: {e}")))?;
+        let wire = SoftwareRound1Wire {
+            software_dkg_version: SOFTWARE_DKG_VERSION,
+            sender_index: self.our_index,
+            package_hex: hex::encode(&package_bytes),
+        };
+        self.state = DkgState::AwaitingRound1 {
+            secret,
+            our_round1: package,
+            peer_round1: BTreeMap::new(),
+        };
+        Ok(wire)
+    }
+
+    /// Consume a peer's round1 wire package. Rejects a duplicate sender, a
+    /// self-echo, and a version mismatch. Returns `true` if this call
+    /// completed the round1 set (`peers = participants - 1`).
+    pub fn round1_peer(&mut self, wire: &SoftwareRound1Wire) -> Result<bool> {
+        let peer_round1 = match &mut self.state {
+            DkgState::AwaitingRound1 { peer_round1, .. } => peer_round1,
+            _ => {
+                return Err(KeepError::Frost(
+                    "SoftwareDkgSession::round1_peer called out of order".into(),
+                ));
+            }
+        };
+        if wire.software_dkg_version != SOFTWARE_DKG_VERSION {
+            return Err(KeepError::Frost(format!(
+                "peer round1 package uses unsupported software_dkg_version {}, expected {}",
+                wire.software_dkg_version, SOFTWARE_DKG_VERSION
+            )));
+        }
+        if wire.sender_index == self.our_index {
+            return Err(KeepError::Frost(
+                "peer round1 package echoes our own share index; refusing to self-mix".into(),
+            ));
+        }
+        if wire.sender_index < 1 || wire.sender_index > self.max_signers {
+            return Err(KeepError::Frost(format!(
+                "peer round1 sender_index {} out of range [1, {}]",
+                wire.sender_index, self.max_signers,
+            )));
+        }
+        let peer_id = Identifier::try_from(wire.sender_index).map_err(|e| {
+            KeepError::Frost(format!(
+                "peer index {} is not a valid FROST identifier: {e}",
+                wire.sender_index
+            ))
+        })?;
+        if peer_round1.contains_key(&peer_id) {
+            return Err(KeepError::Frost(format!(
+                "duplicate round1 package from peer {}",
+                wire.sender_index
+            )));
+        }
+        let bytes = hex::decode(&wire.package_hex)
+            .map_err(|e| KeepError::Frost(format!("decode round1 package hex: {e}")))?;
+        let package = round1::Package::deserialize(&bytes)
+            .map_err(|e| KeepError::Frost(format!("deserialize round1 package: {e}")))?;
+        peer_round1.insert(peer_id, package);
+        Ok(peer_round1.len() as u16 + 1 == self.max_signers)
+    }
+
+    /// Run frost-core's `part2` and return the per-recipient round2 wire
+    /// packages. Refuses to run until every peer's round1 package has
+    /// landed.
+    pub fn round2(&mut self) -> Result<Vec<(u16, SoftwareRound2Wire)>> {
+        let (secret, our_round1, peer_round1) =
+            match std::mem::replace(&mut self.state, DkgState::Finalized) {
+                DkgState::AwaitingRound1 {
+                    secret,
+                    our_round1,
+                    peer_round1,
+                } if (peer_round1.len() as u16) + 1 == self.max_signers => {
+                    (secret, our_round1, peer_round1)
+                }
+                other => {
+                    // Put the state back so a caller can recover after seeing
+                    // the error instead of losing the round1 collection.
+                    self.state = other;
+                    return Err(KeepError::Frost(
+                        "SoftwareDkgSession::round2 called before every peer's round1 arrived"
+                            .into(),
+                    ));
+                }
+            };
+        let (round2_secret, round2_packages) =
+            part2(secret, &peer_round1).map_err(|e| KeepError::Frost(format!("DKG part2: {e}")))?;
+
+        let mut wires: Vec<(u16, SoftwareRound2Wire)> = Vec::new();
+        for (peer_id, package) in &round2_packages {
+            let recipient_index = identifier_to_u16(peer_id).ok_or_else(|| {
+                KeepError::Frost("DKG part2 returned package for unknown identifier".into())
+            })?;
+            let bytes = package
+                .serialize()
+                .map_err(|e| KeepError::Frost(format!("serialize round2 package: {e}")))?;
+            wires.push((
+                recipient_index,
+                SoftwareRound2Wire {
+                    software_dkg_version: SOFTWARE_DKG_VERSION,
+                    sender_index: self.our_index,
+                    package_hex: hex::encode(&bytes),
+                },
+            ));
+        }
+
+        // Rebuild the full round1 map with our own entry, which `part3` needs.
+        let mut round1_all = peer_round1;
+        round1_all.insert(self.identifier, our_round1);
+
+        self.state = DkgState::AwaitingRound2 {
+            secret: round2_secret,
+            round1: round1_all,
+            peer_round2: BTreeMap::new(),
+        };
+        Ok(wires)
+    }
+
+    /// Consume a peer's round2 share targeted at us. Same version + range +
+    /// duplicate checks as `round1_peer`. Returns `true` if this call
+    /// completed the round2 set.
+    pub fn receive_share(&mut self, wire: &SoftwareRound2Wire) -> Result<bool> {
+        let peer_round2 = match &mut self.state {
+            DkgState::AwaitingRound2 { peer_round2, .. } => peer_round2,
+            _ => {
+                return Err(KeepError::Frost(
+                    "SoftwareDkgSession::receive_share called out of order".into(),
+                ));
+            }
+        };
+        if wire.software_dkg_version != SOFTWARE_DKG_VERSION {
+            return Err(KeepError::Frost(format!(
+                "peer round2 share uses unsupported software_dkg_version {}, expected {}",
+                wire.software_dkg_version, SOFTWARE_DKG_VERSION,
+            )));
+        }
+        if wire.sender_index == self.our_index {
+            return Err(KeepError::Frost(
+                "peer round2 share echoes our own share index; refusing to self-mix".into(),
+            ));
+        }
+        if wire.sender_index < 1 || wire.sender_index > self.max_signers {
+            return Err(KeepError::Frost(format!(
+                "peer round2 sender_index {} out of range [1, {}]",
+                wire.sender_index, self.max_signers,
+            )));
+        }
+        let peer_id = Identifier::try_from(wire.sender_index).map_err(|e| {
+            KeepError::Frost(format!(
+                "peer index {} is not a valid FROST identifier: {e}",
+                wire.sender_index
+            ))
+        })?;
+        if peer_round2.contains_key(&peer_id) {
+            return Err(KeepError::Frost(format!(
+                "duplicate round2 share from peer {}",
+                wire.sender_index
+            )));
+        }
+        let bytes = hex::decode(&wire.package_hex)
+            .map_err(|e| KeepError::Frost(format!("decode round2 share hex: {e}")))?;
+        let package = round2::Package::deserialize(&bytes)
+            .map_err(|e| KeepError::Frost(format!("deserialize round2 share: {e}")))?;
+        peer_round2.insert(peer_id, package);
+        Ok(peer_round2.len() as u16 + 1 == self.max_signers)
+    }
+
+    /// Finalize the DKG. Refuses to run until every peer's round2 share has
+    /// arrived. On success the session state is consumed; further method
+    /// calls return an error.
+    pub fn finalize(&mut self) -> Result<SoftwareDkgResult> {
+        let (secret, round1, round2) = match std::mem::replace(&mut self.state, DkgState::Finalized)
+        {
+            DkgState::AwaitingRound2 {
+                secret,
+                round1,
+                peer_round2,
+            } if (peer_round2.len() as u16) + 1 == self.max_signers => {
+                (secret, round1, peer_round2)
+            }
+            other => {
+                self.state = other;
+                return Err(KeepError::Frost(
+                    "SoftwareDkgSession::finalize called before every peer's round2 arrived".into(),
+                ));
+            }
+        };
+
+        // part3 wants round1 packages from peers only (not our own), so strip
+        // our identifier out before handing the map in.
+        let mut round1_peers = round1;
+        round1_peers.remove(&self.identifier);
+
+        let (key_package, public_key_package) = part3(&secret, &round1_peers, &round2)
+            .map_err(|e| KeepError::Frost(format!("DKG part3: {e}")))?;
+
+        let vk_bytes = public_key_package
+            .verifying_key()
+            .serialize()
+            .map_err(|e| KeepError::Frost(format!("verifying key serialize: {e}")))?;
+        if vk_bytes.len() < 33 {
+            return Err(KeepError::Frost(
+                "verifying key must be 33-byte compressed pubkey".into(),
+            ));
+        }
+        let mut group_pubkey = [0u8; 32];
+        group_pubkey.copy_from_slice(&vk_bytes[1..33]);
+
+        Ok(SoftwareDkgResult {
+            key_package,
+            public_key_package,
+            group_pubkey,
+            our_index: self.our_index,
+        })
+    }
+
+    /// This participant's 1-indexed share number.
+    pub fn our_index(&self) -> u16 {
+        self.our_index
+    }
+}
+
+fn identifier_to_u16(id: &Identifier) -> Option<u16> {
+    // frost-core's `Identifier` serialize is a big-endian 32-byte scalar
+    // where the value we care about lives in the last two bytes for
+    // participant indexes 1..=u16::MAX.
+    let bytes = id.serialize();
+    if bytes.len() < 32 {
+        return None;
+    }
+    for &b in &bytes[..30] {
+        if b != 0 {
+            return None;
+        }
+    }
+    Some(u16::from_be_bytes([bytes[30], bytes[31]]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frost::signing::sign_with_local_shares;
+    use crate::frost::SharePackage;
+
+    /// Run a full 2-of-3 software DKG and verify the resulting shares can
+    /// aggregate a valid signature under the derived group pubkey.
+    #[test]
+    fn end_to_end_2_of_3_software_dkg() {
+        run_group(2, 3);
+    }
+
+    /// A larger 3-of-5 group, exercising deeper participant sets and
+    /// verifying the aggregated signature still verifies under the derived
+    /// group pubkey.
+    #[test]
+    fn end_to_end_3_of_5_software_dkg() {
+        run_group(3, 5);
+    }
+
+    fn run_group(threshold: u16, participants: u16) {
+        let mut sessions: Vec<SoftwareDkgSession> = (1..=participants)
+            .map(|idx| SoftwareDkgSession::init(threshold, participants, idx).unwrap())
+            .collect();
+
+        // Round 1: every session emits a wire package.
+        let round1_wires: Vec<SoftwareRound1Wire> =
+            sessions.iter_mut().map(|s| s.round1().unwrap()).collect();
+
+        // Every session ingests every OTHER session's round1 wire.
+        for (i, session) in sessions.iter_mut().enumerate() {
+            for (j, wire) in round1_wires.iter().enumerate() {
+                if i == j {
+                    continue;
+                }
+                session.round1_peer(wire).unwrap();
+            }
+        }
+
+        // Round 2: each session emits per-recipient wires.
+        let mut per_session_round2: Vec<Vec<(u16, SoftwareRound2Wire)>> =
+            sessions.iter_mut().map(|s| s.round2().unwrap()).collect();
+
+        // Deliver each round2 share to its intended recipient.
+        for (sender_i, wires) in per_session_round2.drain(..).enumerate() {
+            for (recipient_index, wire) in wires {
+                let recipient_i = (recipient_index - 1) as usize;
+                assert_ne!(recipient_i, sender_i, "no self-shares in round 2");
+                sessions[recipient_i].receive_share(&wire).unwrap();
+            }
+        }
+
+        // Finalize every session and check group_pubkey agreement.
+        let results: Vec<SoftwareDkgResult> =
+            sessions.iter_mut().map(|s| s.finalize().unwrap()).collect();
+        let first_group = results[0].group_pubkey;
+        for r in &results {
+            assert_eq!(r.group_pubkey, first_group);
+        }
+
+        // Assemble SharePackages for the threshold set and produce a real
+        // signature. If any DKG step corrupted a share this would fail at
+        // aggregation time.
+        let share_packages: Vec<SharePackage> = results
+            .iter()
+            .take(threshold as usize)
+            .map(|r| {
+                let metadata = crate::frost::ShareMetadata::new(
+                    r.our_index,
+                    threshold,
+                    participants,
+                    r.group_pubkey,
+                    "dkg-test".into(),
+                );
+                SharePackage::new(metadata, &r.key_package, &r.public_key_package).unwrap()
+            })
+            .collect();
+
+        let message = b"software dkg produces spendable shares";
+        let sig = sign_with_local_shares(&share_packages, message).unwrap();
+        assert_eq!(sig.len(), 64);
+    }
+
+    /// A version-tag mismatch on a peer's round1 package MUST refuse rather
+    /// than silently mis-decoding a future / stranger wire format.
+    #[test]
+    fn round1_peer_refuses_bad_version() {
+        let mut a = SoftwareDkgSession::init(2, 2, 1).unwrap();
+        let mut b = SoftwareDkgSession::init(2, 2, 2).unwrap();
+        let _ = a.round1().unwrap();
+        let mut b_wire = b.round1().unwrap();
+        b_wire.software_dkg_version = 99;
+        let err = a
+            .round1_peer(&b_wire)
+            .expect_err("bad version must be refused");
+        assert!(matches!(err, KeepError::Frost(_)));
+    }
+
+    /// A peer sending two round1 packages is refused; otherwise a hostile
+    /// peer could bias the resulting key with a late substitution.
+    #[test]
+    fn duplicate_round1_package_from_peer_refused() {
+        let mut a = SoftwareDkgSession::init(2, 2, 1).unwrap();
+        let mut b = SoftwareDkgSession::init(2, 2, 2).unwrap();
+        let _ = a.round1().unwrap();
+        let b_wire = b.round1().unwrap();
+        a.round1_peer(&b_wire).unwrap();
+        let err = a
+            .round1_peer(&b_wire)
+            .expect_err("duplicate round1 must be refused");
+        assert!(matches!(err, KeepError::Frost(_)));
+    }
+
+    /// Calling `round2` before every peer's round1 lands must refuse without
+    /// destroying the state we already have.
+    #[test]
+    fn round2_before_full_round1_refuses() {
+        let mut s = SoftwareDkgSession::init(2, 3, 1).unwrap();
+        let _ = s.round1().unwrap();
+        let err = s
+            .round2()
+            .expect_err("incomplete round1 -> round2 must be refused");
+        assert!(matches!(err, KeepError::Frost(_)));
+    }
+
+    /// Invalid config (threshold above participants, threshold below 2, or
+    /// out-of-range index) fails at init.
+    #[test]
+    fn init_rejects_bad_config() {
+        assert!(SoftwareDkgSession::init(1, 3, 1).is_err());
+        assert!(SoftwareDkgSession::init(4, 3, 1).is_err());
+        assert!(SoftwareDkgSession::init(2, 3, 0).is_err());
+        assert!(SoftwareDkgSession::init(2, 3, 4).is_err());
+    }
+
+    #[test]
+    fn identifier_round_trip() {
+        for idx in [1u16, 2, 5, 42, 255, 300, 1000, 65535] {
+            let id = Identifier::try_from(idx).unwrap();
+            assert_eq!(identifier_to_u16(&id), Some(idx));
+        }
+    }
+}

--- a/keep-core/src/frost/dkg.rs
+++ b/keep-core/src/frost/dkg.rs
@@ -44,6 +44,7 @@ use frost_secp256k1_tr::{
     rand_core::OsRng,
     Identifier,
 };
+use zeroize::Zeroizing;
 
 use crate::error::{KeepError, Result};
 
@@ -98,14 +99,28 @@ pub struct SoftwareRound1Wire {
 
 /// Wire-format round2 share, one per recipient. Encrypted per-recipient at
 /// the CLI level (nip44) before publishing.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+///
+/// `package_hex` is a secret signing share, so `Debug` is redacted and must
+/// stay that way: this struct crosses `#[tracing::instrument]` boundaries in
+/// the CLI where a derived `Debug` would leak the share into logs.
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct SoftwareRound2Wire {
     /// Discriminator, same rule as [`SoftwareRound1Wire`].
     pub software_dkg_version: u8,
     /// The 1-indexed participant identifier that produced this share.
     pub sender_index: u16,
-    /// Hex-encoded `round2::Package` for the specific recipient.
+    /// Hex-encoded `round2::Package` for the specific recipient. Secret.
     pub package_hex: String,
+}
+
+impl std::fmt::Debug for SoftwareRound2Wire {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SoftwareRound2Wire")
+            .field("software_dkg_version", &self.software_dkg_version)
+            .field("sender_index", &self.sender_index)
+            .field("package_hex", &"<redacted>")
+            .finish()
+    }
 }
 
 /// Result returned from [`SoftwareDkgSession::finalize`], mirroring the
@@ -158,13 +173,10 @@ impl SoftwareDkgSession {
     /// participant broadcasts to every peer. Must be called before any
     /// `round1_peer` step and exactly once per session.
     pub fn round1(&mut self) -> Result<SoftwareRound1Wire> {
-        match self.state {
-            DkgState::Init => {}
-            _ => {
-                return Err(KeepError::Frost(
-                    "SoftwareDkgSession::round1 called out of order (already past round 1)".into(),
-                ));
-            }
+        if !matches!(self.state, DkgState::Init) {
+            return Err(KeepError::Frost(
+                "SoftwareDkgSession::round1 called out of order (already past round 1)".into(),
+            ));
         }
         let (secret, package) = part1(self.identifier, self.max_signers, self.min_signers, OsRng)
             .map_err(|e| KeepError::Frost(format!("DKG part1 failed: {e}")))?;
@@ -264,9 +276,13 @@ impl SoftwareDkgSession {
             let recipient_index = identifier_to_u16(peer_id).ok_or_else(|| {
                 KeepError::Frost("DKG part2 returned package for unknown identifier".into())
             })?;
-            let bytes = package
-                .serialize()
-                .map_err(|e| KeepError::Frost(format!("serialize round2 package: {e}")))?;
+            // `bytes` is a plaintext signing share; keep it in a scrubbed
+            // buffer so it does not linger in freed heap after this loop.
+            let bytes = Zeroizing::new(
+                package
+                    .serialize()
+                    .map_err(|e| KeepError::Frost(format!("serialize round2 package: {e}")))?,
+            );
             wires.push((
                 recipient_index,
                 SoftwareRound2Wire {
@@ -330,8 +346,10 @@ impl SoftwareDkgSession {
                 wire.sender_index
             )));
         }
-        let bytes = hex::decode(&wire.package_hex)
-            .map_err(|e| KeepError::Frost(format!("decode round2 share hex: {e}")))?;
+        let bytes = Zeroizing::new(
+            hex::decode(&wire.package_hex)
+                .map_err(|e| KeepError::Frost(format!("decode round2 share hex: {e}")))?,
+        );
         let package = round2::Package::deserialize(&bytes)
             .map_err(|e| KeepError::Frost(format!("deserialize round2 share: {e}")))?;
         peer_round2.insert(peer_id, package);

--- a/keep-core/src/frost/dkg.rs
+++ b/keep-core/src/frost/dkg.rs
@@ -123,6 +123,16 @@ impl std::fmt::Debug for SoftwareRound2Wire {
     }
 }
 
+impl Drop for SoftwareRound2Wire {
+    fn drop(&mut self) {
+        // `package_hex` is a plaintext signing share. Scrub it on drop so the
+        // hex string does not linger in freed heap; this covers both the wire
+        // we produce in `round2()` and the one serde deserializes on receive.
+        use zeroize::Zeroize;
+        self.package_hex.zeroize();
+    }
+}
+
 /// Result returned from [`SoftwareDkgSession::finalize`], mirroring the
 /// hardware finalize shape so the CLI can share printing / storage code.
 pub struct SoftwareDkgResult {
@@ -259,8 +269,10 @@ impl SoftwareDkgSession {
                     (secret, our_round1, peer_round1)
                 }
                 other => {
-                    // Put the state back so a caller can recover after seeing
-                    // the error instead of losing the round1 collection.
+                    // Restore the pre-call state on an out-of-order call so the
+                    // caller keeps its round1 collection. This recovery only
+                    // covers the guard-mismatch arm; once the guard passes below,
+                    // the state has already advanced to `Finalized`.
                     self.state = other;
                     return Err(KeepError::Frost(
                         "SoftwareDkgSession::round2 called before every peer's round1 arrived"
@@ -268,6 +280,8 @@ impl SoftwareDkgSession {
                     ));
                 }
             };
+        // Past this point the state is already `Finalized`: a `part2` failure is
+        // a terminal protocol error, so the session is intentionally not rewound.
         let (round2_secret, round2_packages) =
             part2(secret, &peer_round1).map_err(|e| KeepError::Frost(format!("DKG part2: {e}")))?;
 
@@ -385,17 +399,9 @@ impl SoftwareDkgSession {
         let (key_package, public_key_package) = part3(&secret, &round1_peers, &round2)
             .map_err(|e| KeepError::Frost(format!("DKG part3: {e}")))?;
 
-        let vk_bytes = public_key_package
-            .verifying_key()
-            .serialize()
-            .map_err(|e| KeepError::Frost(format!("verifying key serialize: {e}")))?;
-        if vk_bytes.len() < 33 {
-            return Err(KeepError::Frost(
-                "verifying key must be 33-byte compressed pubkey".into(),
-            ));
-        }
-        let mut group_pubkey = [0u8; 32];
-        group_pubkey.copy_from_slice(&vk_bytes[1..33]);
+        // Single source of truth for x-only group pubkey extraction, shared with
+        // the trusted-dealer path so both handle the 32- and 33-byte encodings.
+        let group_pubkey = super::dealer::extract_group_pubkey(&public_key_package)?;
 
         Ok(SoftwareDkgResult {
             key_package,

--- a/keep-core/src/frost/mod.rs
+++ b/keep-core/src/frost/mod.rs
@@ -9,6 +9,7 @@
 pub mod bip32_signing;
 mod coordinator;
 mod dealer;
+pub mod dkg;
 mod recover;
 mod refresh;
 mod share;

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -611,6 +611,56 @@ impl Keep {
         Ok(())
     }
 
+    /// Persist a share produced by [`frost::dkg::SoftwareDkgSession::finalize`]
+    /// (#454). Wraps the finalized `KeyPackage` + `PublicKeyPackage` into a
+    /// [`SharePackage`] with fresh metadata, encrypts under the vault's data
+    /// key, stores it, and writes a `FrostShareImport` audit entry.
+    pub fn frost_store_dkg_share(
+        &mut self,
+        result: &crate::frost::dkg::SoftwareDkgResult,
+        threshold: u16,
+        total_shares: u16,
+        name: &str,
+    ) -> Result<()> {
+        if !self.is_unlocked() {
+            return Err(KeepError::Locked);
+        }
+        let name = name.trim();
+        if name.is_empty() {
+            return Err(KeepError::InvalidInput("name cannot be empty".into()));
+        }
+        if name.chars().count() > 64 {
+            return Err(KeepError::InvalidInput(
+                "name must be 64 characters or fewer".into(),
+            ));
+        }
+
+        let metadata = crate::frost::ShareMetadata::new(
+            result.our_index,
+            threshold,
+            total_shares,
+            result.group_pubkey,
+            name.to_string(),
+        );
+        let share = crate::frost::SharePackage::new(
+            metadata,
+            &result.key_package,
+            &result.public_key_package,
+        )?;
+
+        let data_key = self.get_data_key()?;
+        let stored = StoredShare::encrypt(&share, &data_key)?;
+        self.storage.store_share(&stored)?;
+
+        self.audit_event(AuditEventType::FrostShareImport, |e| {
+            e.with_group(&result.group_pubkey)
+                .with_threshold(threshold)
+                .with_participants(vec![result.our_index])
+        });
+
+        Ok(())
+    }
+
     /// Refresh all FROST shares for a group, invalidating old shares.
     pub fn frost_refresh(&mut self, group_pubkey: &[u8; 32]) -> Result<Vec<frost::ShareMetadata>> {
         if !self.is_unlocked() {

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -2291,4 +2291,76 @@ mod tests {
             assert_eq!(p, expected);
         });
     }
+
+    /// Run a software DKG group in-process, persist every finalized share via
+    /// `frost_store_dkg_share`, and confirm the shares reload with intact
+    /// metadata and can be exported. Covers the finalize -> SharePackage ->
+    /// encrypt -> store -> reload bridge that the DKG unit tests do not touch.
+    #[test]
+    fn test_frost_store_dkg_share_roundtrip() {
+        use crate::frost::dkg::{SoftwareDkgSession, SoftwareRound1Wire, SoftwareRound2Wire};
+
+        let (threshold, participants): (u16, u16) = (2, 3);
+
+        let mut sessions: Vec<SoftwareDkgSession> = (1..=participants)
+            .map(|idx| SoftwareDkgSession::init(threshold, participants, idx).unwrap())
+            .collect();
+
+        let round1_wires: Vec<SoftwareRound1Wire> =
+            sessions.iter_mut().map(|s| s.round1().unwrap()).collect();
+        for (i, session) in sessions.iter_mut().enumerate() {
+            for (j, wire) in round1_wires.iter().enumerate() {
+                if i != j {
+                    session.round1_peer(wire).unwrap();
+                }
+            }
+        }
+
+        let mut per_session_round2: Vec<Vec<(u16, SoftwareRound2Wire)>> =
+            sessions.iter_mut().map(|s| s.round2().unwrap()).collect();
+        for (sender_i, wires) in per_session_round2.drain(..).enumerate() {
+            for (recipient_index, wire) in wires {
+                let recipient_i = (recipient_index - 1) as usize;
+                assert_ne!(recipient_i, sender_i);
+                sessions[recipient_i].receive_share(&wire).unwrap();
+            }
+        }
+
+        let results: Vec<_> = sessions.iter_mut().map(|s| s.finalize().unwrap()).collect();
+        let group_pubkey = results[0].group_pubkey;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("keep");
+        let mut keep = test_keep(&path);
+
+        for r in &results {
+            keep.frost_store_dkg_share(r, threshold, participants, "dkg-group")
+                .unwrap();
+        }
+
+        let shares = keep.frost_list_shares().unwrap();
+        assert_eq!(shares.len(), participants as usize);
+        for share in &shares {
+            assert_eq!(share.metadata.group_pubkey, group_pubkey);
+            assert_eq!(share.metadata.threshold, threshold);
+            assert_eq!(share.metadata.total_shares, participants);
+            assert_eq!(share.metadata.name, "dkg-group");
+        }
+        let indices: std::collections::BTreeSet<u16> =
+            shares.iter().map(|s| s.metadata.identifier).collect();
+        assert_eq!(indices, (1..=participants).collect());
+
+        // A stored share decrypts and exports under a passphrase.
+        let export = keep
+            .frost_export_share(&group_pubkey, results[0].our_index, "export-pass")
+            .unwrap();
+        drop(export);
+
+        // A locked vault refuses to store.
+        keep.lock();
+        assert!(matches!(
+            keep.frost_store_dkg_share(&results[0], threshold, participants, "dkg-group"),
+            Err(KeepError::Locked)
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #454. `keep frost network dkg` no longer requires `--hardware <device>`. When the flag is omitted and `--path <vault>` is provided instead, the whole 3-round FROST-secp256k1-tr DKG runs in-process and the finalized share is stored, encrypted, in the vault. Existing hardware users are unchanged.

Unblocks #436 (dkg testing without an ESP32 in the loop) and lets any user without hardware generate a keyset without falling back to trusted-dealer.

## Design

**New module `keep_core::frost::dkg`** with `SoftwareDkgSession` — a linear state machine wrapping `frost-secp256k1-tr::keys::dkg::{part1, part2, part3}` behind the same six-step interface `keep-cli` drives against the hardware signer:

- `init(threshold, participants, our_index)`
- `round1() -> SoftwareRound1Wire`
- `round1_peer(&wire) -> Result<bool>` (true when set is complete)
- `round2() -> Vec<(recipient_index, SoftwareRound2Wire)>`
- `receive_share(&wire) -> Result<bool>`
- `finalize() -> SoftwareDkgResult`

Every transition validates state (out-of-order calls refuse) and every peer package validates the version discriminator, sender index range, and non-self-echo. Duplicate packages are refused so a hostile peer cannot bias the key with a late substitution.

**New keep-core API `Keep::frost_store_dkg_share(&SoftwareDkgResult, threshold, total, name)`** — wraps the finalized KeyPackage + PublicKeyPackage into a `SharePackage` with fresh metadata, encrypts under the vault data key, stores it, writes a `FrostShareImport` audit entry.

**CLI**: `--hardware` becomes optional, new `--path <vault>` accepted. Dispatch matrix:

| `--hardware` | `--path` | behavior |
|:---:|:---:|:---|
| present | any | existing hardware DKG (unchanged) |
| absent | present | software DKG, share stored in that vault |
| absent | absent | refuse with a message pointing at #454 |

## Wire compatibility

Software peers speak a **software-only** JSON wire format keyed on `software_dkg_version = 1` and marked with a `dkg_mode: software_v1` event tag. Hardware peers do not decode this format (their firmware uses its own binary layout), and the software side rejects hardware round1 events as \"not our version\". A mixed hardware/software group therefore fails obviously in the peer-discovery loop instead of silently mis-mixing coefficients. This is called out explicitly in the CLI banner and the module doc.

## Threat model

Software DKG puts every participant's polynomial + coefficient commitments in that participant's process memory for the duration of the run. Materially better than trusted-dealer (no single machine ever sees any other participant's polynomial), materially worse than hardware DKG (which keeps the secret in a signer with no filesystem or network). The CLI warns on every software run.

## Tests

`cargo test -p keep-core --lib frost::dkg::` (7 tests, all pass):

- `end_to_end_2_of_3_software_dkg` — full 2-of-3 in-process DKG. Every session ingests every other's round1 + round2 packages, finalizes, all sessions agree on the group_pubkey, and threshold-many share packages produce a valid schnorr signature via the existing `sign_with_local_shares` path. Proves the DKG output is spendable.
- `end_to_end_3_of_5_software_dkg` — same property on a larger group.
- `round1_peer_refuses_bad_version` — bumped `software_dkg_version` on a peer package refuses.
- `duplicate_round1_package_from_peer_refused` — second round1 package from the same sender refused.
- `round2_before_full_round1_refuses` — out-of-order transition refused without losing state.
- `init_rejects_bad_config` — invalid threshold/participants/index rejected up front.
- `identifier_round_trip` — the u16 <-> Identifier helper round-trips across representative values.

`cargo test --workspace` all pass; `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Follow-ups (out of scope)

- #436 — a MockRelay-based end-to-end DKG-then-sign test can now be written without hardware.
- Hardware / software interop — would require someone with M5Stack firmware ownership to align on a shared wire format; explicitly out of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for software-based FROST DKG from the CLI when no hardware signer is provided.
  * DKG results can now be finalized and stored in the vault automatically.
  * Introduced in-process DKG support in the core library, including share export and audit logging.

* **Bug Fixes**
  * Improved DKG input handling so the command now validates whether hardware or vault-path options are provided before starting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->