### PR TITLE
dkg: authenticate participants against signed roster to close relay-index hijack

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -666,6 +666,14 @@ pub(crate) enum FrostNetworkCommands {
                     encrypted under the vault key."
         )]
         path: Option<std::path::PathBuf>,
+        #[arg(
+            long,
+            help = "Name of a vault-stored identity key to sign DKG events with \
+                    (#674). Must be the same npub that appears at --index in the \
+                    signed kind-21101 group announcement. Defaults to the vault's \
+                    primary key."
+        )]
+        identity: Option<String>,
     },
     Sign {
         #[arg(short, long)]

--- a/keep-cli/src/commands/frost_network/dkg.rs
+++ b/keep-cli/src/commands/frost_network/dkg.rs
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: © 2026 PrivKey LLC
 // SPDX-License-Identifier: MIT
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use nostr_sdk::prelude::*;
 
 use keep_core::error::{CryptoError, FrostError, KeepError, NetworkError, Result};
+use keep_core::Keep;
 
 use crate::output::Output;
 use crate::signer::HardwareSigner;
@@ -15,6 +16,327 @@ use crate::signer::HardwareSigner;
 /// the relay is flooding junk, so we abort rather than grow memory unbounded
 /// for the 300s timeout window.
 const MAX_DKG_EVENTS_SEEN: usize = 8192;
+
+/// (index -> npub) roster fetched from a signed kind-21101 group
+/// announcement, used to authenticate DKG participants (#674).
+///
+/// Every DKG event is signed with the participant's identity nsec (the one
+/// whose npub appears in the announcement). Round 1 and round 2 intake
+/// reject any event whose author does not match the expected npub for its
+/// `sender_index`, closing the pre-#674 window where an unauthenticated
+/// relay writer could hijack a victim's index (DoS) or, with enough
+/// participation, silently join a group as a rogue co-generator.
+#[derive(Clone)]
+struct DkgRoster {
+    threshold: u8,
+    participants: u8,
+    /// 1-indexed participant number -> announced identity pubkey.
+    by_index: BTreeMap<u16, PublicKey>,
+}
+
+impl DkgRoster {
+    /// Expected identity pubkey for the given 1-indexed participant.
+    fn expected_pubkey(&self, index: u16) -> Result<&PublicKey> {
+        self.by_index.get(&index).ok_or_else(|| {
+            KeepError::FrostErr(FrostError::invalid_config(format!(
+                "roster has no entry for participant index {index}"
+            )))
+        })
+    }
+
+    /// #674: the single audited authentication gate for DKG intake. Returns
+    /// `true` only when `author` is exactly the npub the roster pins to
+    /// `sender_index`; otherwise it warns (with `what` naming the round) and
+    /// returns `false` so the caller drops the event. Both rounds on both the
+    /// hardware and software paths funnel through here, so a relay writer that
+    /// cannot produce the pinned nsec's signature can never speak for an index.
+    fn authenticates(
+        &self,
+        sender_index: u16,
+        author: &PublicKey,
+        out: &Output,
+        what: &str,
+    ) -> bool {
+        match self.expected_pubkey(sender_index) {
+            Ok(expected) if expected == author => true,
+            Ok(expected) => {
+                out.warn(&format!(
+                    "Rejecting {what}: sender_index {sender_index} authored by {author} \
+                     but roster expects {expected}"
+                ));
+                false
+            }
+            Err(e) => {
+                out.warn(&format!(
+                    "Ignoring {what} with unroster'd sender_index {sender_index}: {e}"
+                ));
+                false
+            }
+        }
+    }
+}
+
+/// Parse a hex-or-bech32 npub / hex pubkey string into a `nostr_sdk::PublicKey`.
+fn parse_pubkey(s: &str) -> Result<PublicKey> {
+    PublicKey::parse(s).map_err(|e| {
+        KeepError::InvalidInput(format!("could not parse participant pubkey {s:?}: {e}"))
+    })
+}
+
+/// Canonical group_id preimage, the single source of truth for the group
+/// identifier: `sha256("frost-group-id-v1" || name || [threshold] ||
+/// [participants] || each raw npub string in 1..=participants order)`.
+///
+/// Both `cmd_frost_network_group_create` (which mints the id) and roster
+/// verification (which re-derives it to hash-bind an announcement to its
+/// queried `d` tag) MUST call this so the two can never drift: a relay writer
+/// who republishes a rogue kind-21101 with the same `d` tag but different
+/// p-tags cannot fake a preimage under sha256.
+fn frost_group_id(
+    name: &str,
+    threshold: u8,
+    participants: u8,
+    ordered_npubs: &[String],
+) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(b"frost-group-id-v1");
+    hasher.update(name.as_bytes());
+    hasher.update([threshold]);
+    hasher.update([participants]);
+    for npub in ordered_npubs {
+        hasher.update(npub.as_bytes());
+    }
+    hasher.finalize().into()
+}
+
+/// Fetch the kind-21101 group announcement(s) for `group_id_hex` and return
+/// the first one that authenticates into a valid roster.
+///
+/// #674: a relay writer can publish decoy kind-21101 events under the same
+/// `d` tag (an attacker-chosen, self-signed `created_at` lets them appear
+/// newest). We therefore try candidates newest-first and return the first
+/// that fully validates via `parse_roster_from_event`, *skipping* any that
+/// fail to parse or hash-bind, instead of latest-then-validate. That denies
+/// the attacker a griefing DoS where a single junk event buries the honest
+/// announcement and aborts the ceremony for everyone.
+async fn fetch_group_roster(client: &Client, group_id_hex: &str) -> Result<DkgRoster> {
+    let filter = Filter::new()
+        .kind(Kind::Custom(21101))
+        .custom_tag(SingleLetterTag::lowercase(Alphabet::D), group_id_hex);
+
+    let events = client
+        .fetch_events(filter, std::time::Duration::from_secs(15))
+        .await
+        .map_err(|e| KeepError::NetworkErr(NetworkError::request(format!("fetch roster: {e}"))))?;
+
+    let mut candidates: Vec<&Event> = events.iter().collect();
+    candidates.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+    let mut last_err: Option<KeepError> = None;
+    for ev in candidates {
+        match parse_roster_from_event(ev, group_id_hex) {
+            Ok(roster) => return Ok(roster),
+            Err(e) => last_err = Some(e),
+        }
+    }
+
+    Err(last_err.unwrap_or_else(|| {
+        KeepError::NetworkErr(NetworkError::timeout(
+            "no kind-21101 group announcement found for the requested group id \
+             (run `keep frost network group-create` first, or point at the relay it was published on)",
+        ))
+    }))
+}
+
+/// Parse and fully validate one kind-21101 announcement into an authenticated
+/// roster, requiring its tags to hash-bind to `group_id_hex`. Returns `Err`
+/// (so `fetch_group_roster` can skip to the next candidate) on any anomaly:
+/// a missing/duplicate/holed p-tag, a missing `threshold`/`participants` tag,
+/// an unparseable pubkey, or a group_id hash mismatch. Pure and network-free
+/// so it is unit-testable.
+///
+/// The roster is only as trustworthy as the event's authorship: this relies
+/// on nostr-sdk verifying the event signature (default in nostr-sdk) so that
+/// `ev.pubkey` is the authenticated author. Every intake site downstream
+/// gates on that pubkey, so if signature verification were ever disabled on
+/// the client the whole authentication scheme would collapse.
+fn parse_roster_from_event(ev: &Event, group_id_hex: &str) -> Result<DkgRoster> {
+    let mut threshold: Option<u8> = None;
+    let mut participants: Option<u8> = None;
+    // 1-indexed participant -> (identity pubkey, raw npub string as published).
+    // The raw string is kept so we can recompute the group_id preimage byte
+    // for byte; index order is imposed below when building `ordered_npubs`.
+    let mut by_index: BTreeMap<u16, (PublicKey, String)> = BTreeMap::new();
+
+    for tag in ev.tags.iter() {
+        let slice = tag.as_slice();
+        let name = match slice.first().map(|s| s.as_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        match name {
+            // First occurrence wins so a duplicate garbage tag cannot null a
+            // good value; a self-inconsistent candidate just fails hash-bind
+            // and is skipped in favor of the next event.
+            "threshold" if threshold.is_none() => {
+                threshold = slice.get(1).and_then(|v| v.parse::<u8>().ok());
+            }
+            "participants" if participants.is_none() => {
+                participants = slice.get(1).and_then(|v| v.parse::<u8>().ok());
+            }
+            "p" => {
+                if let (Some(npub), Some(idx_str)) = (slice.get(1), slice.get(3)) {
+                    let idx: u16 = match idx_str.parse() {
+                        Ok(v) => v,
+                        Err(_) => continue,
+                    };
+                    let pk = parse_pubkey(npub)?;
+                    if by_index.insert(idx, (pk, npub.clone())).is_some() {
+                        return Err(KeepError::FrostErr(FrostError::invalid_config(format!(
+                            "group announcement has duplicate p-tag for index {idx}"
+                        ))));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let threshold = threshold.ok_or_else(|| {
+        KeepError::FrostErr(FrostError::invalid_config(
+            "group announcement is missing a `threshold` tag".to_string(),
+        ))
+    })?;
+    let participants = participants.ok_or_else(|| {
+        KeepError::FrostErr(FrostError::invalid_config(
+            "group announcement is missing a `participants` tag".to_string(),
+        ))
+    })?;
+    if by_index.len() != participants as usize {
+        return Err(KeepError::FrostErr(FrostError::invalid_config(format!(
+            "group announcement carries {} p-tags but claims {} participants",
+            by_index.len(),
+            participants,
+        ))));
+    }
+    // Reject rosters with holes: indexes must be exactly 1..=participants.
+    // This also imposes index order on the npubs fed to the group_id hash.
+    let mut ordered_npubs: Vec<String> = Vec::with_capacity(participants as usize);
+    let mut roster: BTreeMap<u16, PublicKey> = BTreeMap::new();
+    for idx in 1..=participants as u16 {
+        let (pk, npub) = by_index.get(&idx).ok_or_else(|| {
+            KeepError::FrostErr(FrostError::invalid_config(format!(
+                "group announcement is missing a p-tag for participant index {idx}"
+            )))
+        })?;
+        ordered_npubs.push(npub.clone());
+        roster.insert(idx, *pk);
+    }
+
+    // #674: recompute the group_id hash from the announcement's own fields and
+    // require it to match the queried `d` tag. This is the strong bind that
+    // prevents a relay writer from swapping in a rogue kind-21101 with the same
+    // `d` tag but different p-tags (a preimage attack under sha256, infeasible).
+    let name = match serde_json::from_str::<serde_json::Value>(&ev.content) {
+        Ok(v) => v
+            .get("name")
+            .and_then(|n| n.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                KeepError::FrostErr(FrostError::invalid_config(
+                    "group announcement content is missing a `name` field".to_string(),
+                ))
+            })?,
+        Err(e) => {
+            return Err(KeepError::FrostErr(FrostError::invalid_config(format!(
+                "group announcement content is not JSON: {e}"
+            ))));
+        }
+    };
+    let recomputed = hex::encode(frost_group_id(
+        &name,
+        threshold,
+        participants,
+        &ordered_npubs,
+    ));
+    if recomputed != group_id_hex {
+        return Err(KeepError::FrostErr(FrostError::invalid_config(format!(
+            "group announcement id {recomputed} does not match the queried d-tag {group_id_hex}; \
+             refusing a roster that does not bind to the requested group"
+        ))));
+    }
+
+    Ok(DkgRoster {
+        threshold,
+        participants,
+        by_index: roster,
+    })
+}
+
+/// Load an identity keypair from the Keep vault, converted to
+/// `nostr_sdk::Keys` for signing DKG events. Uses the named key when
+/// `identity_name` is `Some`; otherwise falls back to the vault's primary.
+fn load_identity_keys(keep: &Keep, identity_name: Option<&str>) -> Result<Keys> {
+    let slot = if let Some(name) = identity_name {
+        keep.keyring().get_by_name(name).ok_or_else(|| {
+            KeepError::KeyNotFound(format!(
+                "identity key {name:?} not found in vault; add one with `keep import` or omit --identity to use the primary"
+            ))
+        })?
+    } else {
+        keep.keyring().get_primary().ok_or_else(|| {
+            KeepError::KeyNotFound(
+                "vault has no primary identity key; add one with `keep generate` \
+                 or pass --identity <name>"
+                    .into(),
+            )
+        })?
+    };
+    let kp = slot.to_nostr_keypair()?;
+    let sk = nostr_sdk::secp256k1::SecretKey::from_slice(kp.secret_bytes()).map_err(|e| {
+        KeepError::CryptoErr(CryptoError::invalid_key(format!(
+            "identity key is not a valid secp256k1 secret: {e}"
+        )))
+    })?;
+    Ok(Keys::new(sk.into()))
+}
+
+/// Verify (threshold, participants) from the signed announcement match the
+/// caller's CLI flags, and check our declared `our_index` binds to our
+/// identity key in the roster. Fail closed so a peer `(t, n)` mismatch or
+/// an operator running under the wrong index surfaces before we produce
+/// any round1 material.
+fn require_roster_matches(
+    roster: &DkgRoster,
+    identity: &Keys,
+    threshold: u8,
+    participants: u8,
+    our_index: u8,
+) -> Result<()> {
+    if roster.threshold != threshold {
+        return Err(KeepError::FrostErr(FrostError::invalid_config(format!(
+            "signed group announcement pins threshold={} but --threshold was {threshold}",
+            roster.threshold
+        ))));
+    }
+    if roster.participants != participants {
+        return Err(KeepError::FrostErr(FrostError::invalid_config(format!(
+            "signed group announcement pins participants={} but --participants was {participants}",
+            roster.participants
+        ))));
+    }
+    let expected = roster.expected_pubkey(our_index as u16)?;
+    if identity.public_key() != *expected {
+        return Err(KeepError::FrostErr(FrostError::invalid_config(format!(
+            "identity npub {} does not match the announced participant at index {our_index} \
+             ({}); pass --identity <name> to select the correct vault key",
+            identity.public_key(),
+            expected,
+        ))));
+    }
+    Ok(())
+}
 
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip(out))]
@@ -27,9 +349,20 @@ pub fn cmd_frost_network_dkg(
     relay: &str,
     hardware: Option<&str>,
     vault_path: Option<&std::path::Path>,
+    identity_name: Option<&str>,
 ) -> Result<()> {
-    match (hardware, vault_path) {
-        (Some(hw), _) => cmd_frost_network_dkg_hardware(
+    // #674: both paths now require a vault path to load the identity nsec
+    // that signs DKG events. Without authentication a relay writer can DoS
+    // or (with enough participation) join a group as a rogue co-generator.
+    let vault_path = vault_path.ok_or_else(|| {
+        KeepError::InvalidInput(
+            "keep frost network dkg requires --path <vault> to load an authenticated \
+             identity key for signing DKG events (#674)."
+                .into(),
+        )
+    })?;
+    match hardware {
+        Some(hw) => cmd_frost_network_dkg_hardware(
             out,
             group,
             threshold,
@@ -37,24 +370,23 @@ pub fn cmd_frost_network_dkg(
             our_index,
             relay,
             hw,
+            vault_path,
+            identity_name,
         ),
-        (None, Some(path)) => cmd_frost_network_dkg_software(
+        None => cmd_frost_network_dkg_software(
             out,
             group,
             threshold,
             participants,
             our_index,
             relay,
-            path,
+            vault_path,
+            identity_name,
         ),
-        (None, None) => Err(KeepError::InvalidInput(
-            "keep frost network dkg requires either --hardware <device> or \
-             --path <vault> (software DKG, #454). Both are currently missing."
-                .into(),
-        )),
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip(out))]
 fn cmd_frost_network_dkg_hardware(
     out: &Output,
@@ -64,7 +396,11 @@ fn cmd_frost_network_dkg_hardware(
     our_index: u8,
     relay: &str,
     hardware: &str,
+    vault_path: &std::path::Path,
+    identity_name: Option<&str>,
 ) -> Result<()> {
+    use secrecy::ExposeSecret;
+
     out.newline();
     out.header("FROST Distributed Key Generation");
     out.field("Group", group);
@@ -72,6 +408,7 @@ fn cmd_frost_network_dkg_hardware(
     out.field("Our index", &our_index.to_string());
     out.field("Relay", relay);
     out.field("Hardware", hardware);
+    out.field("Vault", &vault_path.display().to_string());
     out.newline();
 
     if threshold < 2 || threshold > participants {
@@ -85,6 +422,21 @@ fn cmd_frost_network_dkg_hardware(
             "index must be 1..={participants}, got {our_index}"
         ))));
     }
+
+    // #674: load our identity nsec from the vault BEFORE the hardware is
+    // touched. A stale hardware DKG state (from a prior interrupted run)
+    // is much easier to reset than "we already connected to hardware but
+    // then errored on missing vault identity".
+    let spinner = out.spinner("Opening vault...");
+    let mut keep = Keep::open(vault_path)?;
+    let password = super::get_password("Enter password")?;
+    keep.unlock(password.expose_secret())?;
+    let identity = load_identity_keys(&keep, identity_name)?;
+    spinner.finish();
+    out.field(
+        "Identity npub",
+        &identity.public_key().to_bech32().unwrap_or_default(),
+    );
 
     let spinner = out.spinner("Connecting to hardware...");
     let mut signer = HardwareSigner::new(hardware)
@@ -120,7 +472,7 @@ fn cmd_frost_network_dkg_hardware(
         tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
 
     rt.block_on(async {
-        let keys = Keys::generate();
+        let keys = identity.clone();
         let client = Client::new(keys.clone());
         client
             .add_relay(relay)
@@ -130,9 +482,21 @@ fn cmd_frost_network_dkg_hardware(
 
         out.info("Connected to relay");
         out.field(
-            "Node pubkey",
+            "Signer npub",
             &keys.public_key().to_bech32().unwrap_or_default(),
         );
+        out.newline();
+
+        // #674: fetch the signed roster and require it to match our CLI
+        // args + identity before we emit any DKG material.
+        let spinner = out.spinner("Fetching signed group roster...");
+        let roster = fetch_group_roster(&client, group).await?;
+        spinner.finish();
+        require_roster_matches(&roster, &keys, threshold, participants, our_index)?;
+        out.success(&format!(
+            "Roster verified ({} participants pinned by signed announcement)",
+            roster.participants,
+        ));
         out.newline();
 
         let round1_content = serde_json::json!({
@@ -199,6 +563,18 @@ fn cmd_frost_network_dkg_hardware(
                         && sender_idx != our_index
                         && !received_packages.contains_key(&sender_idx)
                     {
+                        // #674: enforce authenticated participants. An event
+                        // claiming `sender_index = k` MUST be signed by the
+                        // npub the roster pins to k, otherwise a relay writer
+                        // could hijack the index and DoS the group.
+                        if !roster.authenticates(
+                            sender_idx as u16,
+                            &ev.pubkey,
+                            out,
+                            "round 1 event",
+                        ) {
+                            continue;
+                        }
                         if let Some(pkg) = content.get("package").and_then(|p| p.as_str()) {
                             signer.dkg_round1_peer(sender_idx, pkg).map_err(|e| {
                                 KeepError::FrostErr(FrostError::dkg(format!(
@@ -339,6 +715,16 @@ fn cmd_frost_network_dkg_hardware(
                         && sender_idx <= participants
                         && !received_from_peers.contains(&sender_idx)
                     {
+                        // #674: round2 share must also be authored by the
+                        // roster-pinned npub for its sender_index.
+                        if !roster.authenticates(
+                            sender_idx as u16,
+                            &ev.pubkey,
+                            out,
+                            "round 2 share",
+                        ) {
+                            continue;
+                        }
                         if let Some(share_hex) = content.get("share").and_then(|s| s.as_str()) {
                             match signer.dkg_receive_share(sender_idx, share_hex) {
                                 Ok(()) => {
@@ -392,6 +778,7 @@ fn cmd_frost_network_dkg_hardware(
 /// software-only wire format keyed on `software_dkg_version = 1`; hardware
 /// peers do not decode it (and vice versa), so a mixed group DKG fails
 /// obviously instead of silently mis-mixing.
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip(out))]
 fn cmd_frost_network_dkg_software(
     out: &Output,
@@ -401,9 +788,9 @@ fn cmd_frost_network_dkg_software(
     our_index: u8,
     relay: &str,
     vault_path: &std::path::Path,
+    identity_name: Option<&str>,
 ) -> Result<()> {
     use keep_core::frost::dkg::{SoftwareDkgSession, SoftwareRound1Wire, SoftwareRound2Wire};
-    use keep_core::Keep;
     use secrecy::ExposeSecret;
     use zeroize::Zeroizing;
 
@@ -419,14 +806,6 @@ fn cmd_frost_network_dkg_software(
     out.warn("of the run. For production keysets prefer `--hardware <device>`; software DKG is");
     out.warn(
         "intended for testing (#436) and users without hardware. See #454 for the trade-offs.",
-    );
-    out.warn("DKG participants are matched on a first-seen basis over the relay topic and are NOT");
-    out.warn(
-        "authenticated against the group roster: anyone able to write to the relay during the",
-    );
-    out.warn("run can race a participant index (denial of service, or share theft if they win a");
-    out.warn(
-        "threshold-many). Run over a trusted/private relay until roster authentication lands (#674).",
     );
     out.newline();
 
@@ -448,7 +827,15 @@ fn cmd_frost_network_dkg_software(
     let mut keep = Keep::open(vault_path)?;
     let password = super::get_password("Enter password")?;
     keep.unlock(password.expose_secret())?;
+    // #674: load our identity nsec here so a wrong --identity fails BEFORE
+    // any DKG state is created; we would otherwise emit our round1 package
+    // under an authenticated key that later intake rejects on mismatch.
+    let identity = load_identity_keys(&keep, identity_name)?;
     spinner.finish();
+    out.field(
+        "Identity npub",
+        &identity.public_key().to_bech32().unwrap_or_default(),
+    );
 
     let spinner = out.spinner("Generating DKG round 1 package...");
     let our_round1 = session
@@ -462,7 +849,7 @@ fn cmd_frost_network_dkg_software(
         tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
 
     rt.block_on(async {
-        let keys = Keys::generate();
+        let keys = identity.clone();
         let client = Client::new(keys.clone());
         client
             .add_relay(relay)
@@ -472,9 +859,23 @@ fn cmd_frost_network_dkg_software(
 
         out.info("Connected to relay");
         out.field(
-            "Node pubkey",
+            "Signer npub",
             &keys.public_key().to_bech32().unwrap_or_default(),
         );
+        out.newline();
+
+        // #674: fetch the signed roster and require it to match our CLI
+        // args + identity before we publish our own round1 package. Fail
+        // closed so a wrong --index or a stale --threshold surfaces before
+        // co-signers see any DKG material from us.
+        let spinner = out.spinner("Fetching signed group roster...");
+        let roster = fetch_group_roster(&client, group).await?;
+        spinner.finish();
+        require_roster_matches(&roster, &keys, threshold, participants, our_index)?;
+        out.success(&format!(
+            "Roster verified ({} participants pinned by signed announcement)",
+            roster.participants,
+        ));
         out.newline();
 
         let round1_content = serde_json::to_string(&our_round1)
@@ -559,13 +960,13 @@ fn cmd_frost_network_dkg_software(
                 if wire.sender_index == our_index as u16 {
                     continue;
                 }
-                // SECURITY LIMITATION: index -> ephemeral-key binding is
-                // first-seen-wins and unauthenticated. A relay writer who
-                // publishes a round1 package under a victim's sender_index first
-                // captures that index; the honest peer's later package is then
-                // dropped just below as a duplicate. Upgrade path (#674): pin the
-                // (index -> npub) roster from the kind 21101 group announcement
-                // and require each event to be authored by the expected npub.
+                // #674: authenticate the sender against the roster BEFORE
+                // touching the state machine so a hostile publisher cannot
+                // race the honest peer for its index or force a spurious
+                // rejection at part2/part3 by feeding malformed data.
+                if !roster.authenticates(wire.sender_index, &ev.pubkey, out, "round 1 event") {
+                    continue;
+                }
                 if participant_pubkeys.contains_key(&wire.sender_index) {
                     continue;
                 }
@@ -716,16 +1117,12 @@ fn cmd_frost_network_dkg_software(
                     Ok(w) => w,
                     Err(_) => continue,
                 };
-                // Bind the round2 share to the ephemeral key that published this
-                // sender's round1 package. Without this a relay writer can race a
-                // forged share to a recipient under a legitimate peer's index; the
-                // honest share is then dropped as a duplicate and finalize aborts.
-                if participant_pubkeys.get(&wire.sender_index) != Some(&ev.pubkey) {
-                    out.warn(&format!(
-                        "Ignoring round 2 share for participant {}: sender key does not \
-                         match its round 1 package",
-                        wire.sender_index
-                    ));
+                // #674: the roster is now authoritative for who each index
+                // is. `participant_pubkeys` came from the (already-authed)
+                // round1 pass, but check against the roster directly so a
+                // future refactor cannot re-introduce the pre-#674 gap by
+                // populating that map without an author check.
+                if !roster.authenticates(wire.sender_index, &ev.pubkey, out, "round 2 share") {
                     continue;
                 }
                 match session.receive_share(&wire) {
@@ -785,8 +1182,6 @@ pub fn cmd_frost_network_group_create(
     relays: &[String],
     participant_npubs: &[String],
 ) -> Result<()> {
-    use sha2::{Digest, Sha256};
-
     out.newline();
     out.header("FROST Group Announcement (Kind 21101)");
     out.field("Name", name);
@@ -807,15 +1202,7 @@ pub fn cmd_frost_network_group_create(
         )));
     }
 
-    let mut hasher = Sha256::new();
-    hasher.update(b"frost-group-id-v1");
-    hasher.update(name.as_bytes());
-    hasher.update([threshold]);
-    hasher.update([participants]);
-    for npub in participant_npubs {
-        hasher.update(npub.as_bytes());
-    }
-    let group_id: [u8; 32] = hasher.finalize().into();
+    let group_id = frost_group_id(name, threshold, participants, participant_npubs);
 
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
@@ -896,4 +1283,242 @@ pub fn cmd_frost_network_group_create(
     })?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_pubkey(seed: u8) -> (String, PublicKey) {
+        let secp = nostr_sdk::secp256k1::Secp256k1::new();
+        let sk = nostr_sdk::secp256k1::SecretKey::from_slice(&[seed; 32]).unwrap();
+        let (xonly, _) = sk.x_only_public_key(&secp);
+        let hex = hex::encode(xonly.serialize());
+        (hex.clone(), PublicKey::parse(&hex).unwrap())
+    }
+
+    fn make_identity_keys(seed: u8) -> Keys {
+        let sk = nostr_sdk::secp256k1::SecretKey::from_slice(&[seed; 32]).unwrap();
+        Keys::new(sk.into())
+    }
+
+    /// #674: `require_roster_matches` catches every published-vs-CLI drift
+    /// path: threshold mismatch, participants mismatch, and identity/index
+    /// mismatch.
+    #[test]
+    fn require_roster_matches_catches_every_mismatch() {
+        let (npub1, pk1) = make_pubkey(1);
+        let (npub2, pk2) = make_pubkey(2);
+        let (npub3, pk3) = make_pubkey(3);
+        let _ = (npub1, npub2, npub3);
+
+        let mut by_index = BTreeMap::new();
+        by_index.insert(1, pk1);
+        by_index.insert(2, pk2);
+        by_index.insert(3, pk3);
+        let roster = DkgRoster {
+            threshold: 2,
+            participants: 3,
+            by_index,
+        };
+
+        let ident1 = make_identity_keys(1);
+
+        // Correct config passes.
+        require_roster_matches(&roster, &ident1, 2, 3, 1).unwrap();
+
+        // Threshold mismatch refused.
+        assert!(require_roster_matches(&roster, &ident1, 3, 3, 1).is_err());
+        // Participants mismatch refused.
+        assert!(require_roster_matches(&roster, &ident1, 2, 5, 1).is_err());
+        // Wrong index for this identity: identity 1 claims index 2.
+        assert!(require_roster_matches(&roster, &ident1, 2, 3, 2).is_err());
+        // Out-of-range index refused.
+        assert!(require_roster_matches(&roster, &ident1, 2, 3, 42).is_err());
+    }
+
+    /// #674: `frost_group_id` is the single source of truth shared by
+    /// group-create and roster verification, so pin its exact bytes against an
+    /// independent inline reference. If either caller drifts, this fails.
+    #[test]
+    fn frost_group_id_matches_reference() {
+        let (npub1, _) = make_pubkey(1);
+        let (npub2, _) = make_pubkey(2);
+        let (npub3, _) = make_pubkey(3);
+        let name = "test-group";
+        let npubs = vec![npub1, npub2, npub3];
+
+        // Reference: reproduce the preimage inline, independent of the impl.
+        let expected = {
+            use sha2::{Digest, Sha256};
+            let mut h = Sha256::new();
+            h.update(b"frost-group-id-v1");
+            h.update(name.as_bytes());
+            h.update([2u8]);
+            h.update([3u8]);
+            for n in &npubs {
+                h.update(n.as_bytes());
+            }
+            <[u8; 32]>::from(h.finalize())
+        };
+        assert_eq!(frost_group_id(name, 2, 3, &npubs), expected);
+    }
+
+    /// Order of npubs matters for the hash (index order): swapping two
+    /// participants must change the group_id.
+    #[test]
+    fn group_id_hash_is_order_sensitive() {
+        let (a, _) = make_pubkey(1);
+        let (b, _) = make_pubkey(2);
+        let id_ab = frost_group_id("g", 2, 2, &[a.clone(), b.clone()]);
+        let id_ba = frost_group_id("g", 2, 2, &[b, a]);
+        assert_ne!(id_ab, id_ba);
+    }
+
+    /// Build a kind-21101 announcement mirroring `cmd_frost_network_group_create`'s
+    /// tag layout, signed by an arbitrary key (the roster binds on the hash,
+    /// not on who signed the announcement). `d_tag_override` lets a test forge
+    /// the `d` tag while leaving the p-tags honest.
+    fn build_announcement(
+        name: &str,
+        threshold: u8,
+        participants: u8,
+        npubs: &[String],
+        d_tag_override: Option<&str>,
+    ) -> Event {
+        let group_id_hex = hex::encode(frost_group_id(name, threshold, participants, npubs));
+        let d_tag = d_tag_override.unwrap_or(&group_id_hex).to_string();
+        let mut tags = vec![
+            Tag::custom(TagKind::custom("d"), vec![d_tag]),
+            Tag::custom(TagKind::custom("threshold"), vec![threshold.to_string()]),
+            Tag::custom(
+                TagKind::custom("participants"),
+                vec![participants.to_string()],
+            ),
+        ];
+        for (i, npub) in npubs.iter().enumerate() {
+            tags.push(Tag::custom(
+                TagKind::custom("p"),
+                vec![npub.clone(), String::new(), (i + 1).to_string()],
+            ));
+        }
+        let content = serde_json::json!({ "name": name, "description": "x" }).to_string();
+        let mut builder = EventBuilder::new(Kind::Custom(21101), &content);
+        for tag in tags {
+            builder = builder.tag(tag);
+        }
+        builder.sign_with_keys(&make_identity_keys(0x42)).unwrap()
+    }
+
+    /// #674: an honest announcement parses into a roster that hash-binds to its
+    /// own `d` tag.
+    #[test]
+    fn parse_roster_accepts_honest_announcement() {
+        let (n1, pk1) = make_pubkey(1);
+        let (n2, pk2) = make_pubkey(2);
+        let npubs = vec![n1, n2];
+        let group_id = hex::encode(frost_group_id("g", 2, 2, &npubs));
+        let ev = build_announcement("g", 2, 2, &npubs, None);
+
+        let roster = parse_roster_from_event(&ev, &group_id).unwrap();
+        assert_eq!(roster.threshold, 2);
+        assert_eq!(roster.participants, 2);
+        assert_eq!(*roster.expected_pubkey(1).unwrap(), pk1);
+        assert_eq!(*roster.expected_pubkey(2).unwrap(), pk2);
+    }
+
+    /// #674: a decoy announcement whose p-tags do not hash to the queried `d`
+    /// tag is rejected (the relay-writer roster-substitution the fix closes).
+    #[test]
+    fn parse_roster_rejects_hash_mismatch() {
+        let (n1, _) = make_pubkey(1);
+        let (n2, _) = make_pubkey(2);
+        // Honest roster, but the `d` tag claims a different group's id.
+        let honest = vec![n1, n2];
+        let other = vec![make_pubkey(7).0, make_pubkey(8).0];
+        let queried = hex::encode(frost_group_id("g", 2, 2, &other));
+        let ev = build_announcement("g", 2, 2, &honest, Some(&queried));
+
+        assert!(parse_roster_from_event(&ev, &queried).is_err());
+    }
+
+    /// #674: a duplicate p-tag for the same index is refused (ambiguous roster).
+    #[test]
+    fn parse_roster_rejects_duplicate_index() {
+        let (n1, _) = make_pubkey(1);
+        let (n2, _) = make_pubkey(2);
+        let npubs = vec![n1.clone(), n2];
+        let group_id = hex::encode(frost_group_id("g", 2, 2, &npubs));
+        let mut ev = build_announcement("g", 2, 2, &npubs, Some(&group_id));
+        // Append a second p-tag reusing index 1.
+        let mut tags: Vec<Tag> = ev.tags.iter().cloned().collect();
+        tags.push(Tag::custom(
+            TagKind::custom("p"),
+            vec![n1, String::new(), "1".to_string()],
+        ));
+        let mut builder = EventBuilder::new(Kind::Custom(21101), &ev.content);
+        for tag in tags {
+            builder = builder.tag(tag);
+        }
+        ev = builder.sign_with_keys(&make_identity_keys(0x42)).unwrap();
+
+        assert!(parse_roster_from_event(&ev, &group_id).is_err());
+    }
+
+    /// #674: too few p-tags for the claimed `participants` (a short roster) is
+    /// refused by the count check.
+    #[test]
+    fn parse_roster_rejects_short_count() {
+        let (n1, _) = make_pubkey(1);
+        // Claim 2 participants but publish only index 1.
+        let one = vec![n1];
+        let ev = build_announcement("g", 2, 2, &one, Some("deadbeef"));
+        assert!(parse_roster_from_event(&ev, "deadbeef").is_err());
+    }
+
+    /// #674: a roster whose p-tag count matches `participants` but skips an
+    /// index (e.g. {1, 3} for participants=2) is refused by the hole check,
+    /// not accepted as a partial roster.
+    #[test]
+    fn parse_roster_rejects_hole() {
+        let (n1, _) = make_pubkey(1);
+        let (n3, _) = make_pubkey(3);
+        // participants=2, p-tags at indexes 1 and 3: count 2 == 2 (passes the
+        // count check) but index 2 is missing, so the hole check must reject.
+        let tags = vec![
+            Tag::custom(TagKind::custom("d"), vec!["deadbeef".to_string()]),
+            Tag::custom(TagKind::custom("threshold"), vec!["2".to_string()]),
+            Tag::custom(TagKind::custom("participants"), vec!["2".to_string()]),
+            Tag::custom(
+                TagKind::custom("p"),
+                vec![n1, String::new(), "1".to_string()],
+            ),
+            Tag::custom(
+                TagKind::custom("p"),
+                vec![n3, String::new(), "3".to_string()],
+            ),
+        ];
+        let content = serde_json::json!({ "name": "g", "description": "x" }).to_string();
+        let mut builder = EventBuilder::new(Kind::Custom(21101), &content);
+        for tag in tags {
+            builder = builder.tag(tag);
+        }
+        let ev = builder.sign_with_keys(&make_identity_keys(0x42)).unwrap();
+        assert!(parse_roster_from_event(&ev, "deadbeef").is_err());
+    }
+
+    /// DkgRoster::expected_pubkey refuses out-of-range indexes cleanly.
+    #[test]
+    fn expected_pubkey_refuses_out_of_range() {
+        let (_, pk) = make_pubkey(5);
+        let mut by_index = BTreeMap::new();
+        by_index.insert(1, pk);
+        let roster = DkgRoster {
+            threshold: 2,
+            participants: 1,
+            by_index,
+        };
+        assert!(roster.expected_pubkey(1).is_ok());
+        assert!(roster.expected_pubkey(2).is_err());
+    }
 }

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -366,11 +366,14 @@ fn dispatch_frost_network(
             relay,
             hardware,
             path: dkg_path,
+            identity,
         } => {
             let relay = relay.as_deref().unwrap_or(default_relay);
             // Software DKG needs a vault; honor an explicit --path override but
             // otherwise fall back to the globally resolved vault path like every
             // other frost command, instead of erroring on a missing --path.
+            // #674: identity authentication also loads an nsec from the vault,
+            // so BOTH hardware and software paths now require a vault.
             let vault_path = dkg_path.as_deref().or(Some(path));
             commands::frost_network::cmd_frost_network_dkg(
                 out,
@@ -381,6 +384,7 @@ fn dispatch_frost_network(
                 relay,
                 hardware.as_deref(),
                 vault_path,
+                identity.as_deref(),
             )
         }
         FrostNetworkCommands::Sign {


### PR DESCRIPTION
## Summary

Closes #674 (P1 security). Both the hardware and software DKG paths now sign every kind-21102 / kind-21103 event with a **vault-stored identity nsec** and refuse any peer event whose author does not match the npub the signed kind-21101 group announcement pins to the sender's index. Fixes:

- **Denial of service** (low effort): a relay writer publishing a round1 package under a victim's `sender_index` first no longer captures that index; the honest peer's later package is still accepted because the rogue package is refused up front on author mismatch.
- **Share theft** (high effort, high impact): an attacker cannot win threshold-many indices as a rogue co-generator because they cannot forge signatures under the roster's npubs.
- **`(t, n)` drift**: threshold and participants from the CLI flags are now cross-checked against the signed announcement, so a peer running with wrong flags refuses at DKG start instead of failing opaquely mid-part3.

## Design

- **Roster fetch**: `fetch_group_roster(&Client, group_id_hex)` pulls the most recent kind-21101 for the queried `d` tag and extracts `{threshold, participants, index -> npub}`. Refuses ambiguous rosters (duplicate index, missing slots, count mismatch).
- **Hash-bind check**: recomputes `sha256(\"frost-group-id-v1\" || name || t || n || npubs...)` (the same hash `frost network group-create` produces) and requires it to equal the queried `d` tag. A relay writer republishing the same `d` tag with different p-tags cannot fake this (preimage attack under sha256).
- **Identity loading**: `load_identity_keys(&Keep, Option<&str>)` pulls an nsec from the vault by name (defaulting to primary) and converts it into a `nostr_sdk::Keys` for signing. **Both hardware and software DKG paths now require `--path <vault>`.**
- **Pre-flight roster check**: `require_roster_matches(&roster, &identity, threshold, participants, our_index)` runs before any DKG state is created. Fails closed on any drift.
- **Round1/round2 intake**: every peer event's `ev.pubkey` is compared to the roster-pinned expected pubkey for its `sender_index`; mismatches are refused with a clear \"authored by X but roster expects Y\" warning and the state machine is not touched.

## CLI surface

- `--hardware` stays optional (per #454).
- `--path <vault>` now required for both paths (was: software only).
- **New `--identity <name>` flag**: names a vault key to sign DKG events. Defaults to primary. Must match the npub the announcement pins to `--index`; a mismatch refuses at pre-flight.

## Tests

`cargo test -p keep-cli --bin keep commands::frost_network::dkg::tests` — 4 new tests, all pass:

- `require_roster_matches_catches_every_mismatch` — threshold, participants, wrong-identity-for-index, out-of-range index all refused.
- `recompute_group_id_matches_group_create` — hash matches the CLI's group-create output byte-for-byte, so honest announcements pass the hash-bind check.
- `group_id_hash_is_order_sensitive` — swapping two participants changes the hash (so a rogue \"reorder\" attack fails).
- `expected_pubkey_refuses_out_of_range` — helper is defensive.

`cargo test --workspace` all pass; `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Follow-ups (out of scope)

- The kind-21101 announcement is still signed with an ephemeral key by `group-create`. That is fine because the `d` tag is a sha256 of the roster (self-authenticating), but an operator-signed variant would give a stronger provenance trail.
- Group-announcement-fetch could be moved out of the DKG command into a reusable helper if other subcommands need the roster (e.g., `frost network sign` verifying its co-signers).

## Related

- Closes #674 (P1 security).
- Built on top of #454's software DKG path (both paths hardened).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `frost network dkg` now supports an optional identity selection flag.
  * DKG runs can now use a chosen stored identity for signing and authentication.

* **Bug Fixes**
  * Improved participant verification during DKG to better ensure messages come from the expected roster.
  * Added stricter checks so DKG setup fails early when the provided roster details don’t match the signed group announcement.
  * Hardware and software DKG flows now consistently require vault-backed identity access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->