### PR TITLE
nip46: surface NIP-98 url/method in the approval prompt

### DIFF
--- a/keep-cli/src/commands/serve.rs
+++ b/keep-cli/src/commands/serve.rs
@@ -46,7 +46,7 @@ impl ServerCallbacks for TuiCallbacks {
             action: request.method,
             kind: request.event_kind.map(|k| k.as_u16()),
             content_preview: request.event_content,
-            http_auth: request.http_auth.map(|d| (d.url, d.method)),
+            http_auth: request.http_auth,
             response_tx,
         };
 

--- a/keep-cli/src/commands/serve.rs
+++ b/keep-cli/src/commands/serve.rs
@@ -46,6 +46,7 @@ impl ServerCallbacks for TuiCallbacks {
             action: request.method,
             kind: request.event_kind.map(|k| k.as_u16()),
             content_preview: request.event_content,
+            http_auth: request.http_auth.map(|d| (d.url, d.method)),
             response_tx,
         };
 

--- a/keep-cli/src/tui.rs
+++ b/keep-cli/src/tui.rs
@@ -47,6 +47,9 @@ pub struct ApprovalRequest {
     pub action: String,
     pub kind: Option<u16>,
     pub content_preview: Option<String>,
+    /// NIP-98 (kind 27235) HTTP-auth target (url, method) surfaced so the
+    /// operator can see what a bearer-credential sign request authorizes.
+    pub http_auth: Option<(Option<String>, Option<String>)>,
     pub response_tx: Sender<bool>,
 }
 
@@ -265,6 +268,20 @@ impl Tui {
             lines.push(Line::from(vec![
                 Span::styled("Kind: ", Style::default().fg(Color::Gray)),
                 Span::styled(kind.to_string(), Style::default().fg(Color::Cyan)),
+            ]));
+        }
+
+        if let Some((ref url, ref method)) = req.http_auth {
+            lines.push(Line::from(vec![
+                Span::styled("HTTP auth: ", Style::default().fg(Color::Gray)),
+                Span::styled(
+                    format!(
+                        "{} {}",
+                        method.as_deref().unwrap_or("<no method>"),
+                        url.as_deref().unwrap_or("<no url>"),
+                    ),
+                    Style::default().fg(Color::Red),
+                ),
             ]));
         }
 

--- a/keep-cli/src/tui.rs
+++ b/keep-cli/src/tui.rs
@@ -9,6 +9,7 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
+use keep_nip46::types::HttpAuthDetails;
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
@@ -47,9 +48,9 @@ pub struct ApprovalRequest {
     pub action: String,
     pub kind: Option<u16>,
     pub content_preview: Option<String>,
-    /// NIP-98 (kind 27235) HTTP-auth target (url, method) surfaced so the
-    /// operator can see what a bearer-credential sign request authorizes.
-    pub http_auth: Option<(Option<String>, Option<String>)>,
+    /// NIP-98 (kind 27235) HTTP-auth target surfaced so the operator can see
+    /// what a bearer-credential sign request authorizes.
+    pub http_auth: Option<HttpAuthDetails>,
     pub response_tx: Sender<bool>,
 }
 
@@ -271,14 +272,14 @@ impl Tui {
             ]));
         }
 
-        if let Some((ref url, ref method)) = req.http_auth {
+        if let Some(ref auth) = req.http_auth {
             lines.push(Line::from(vec![
                 Span::styled("HTTP auth: ", Style::default().fg(Color::Gray)),
                 Span::styled(
                     format!(
                         "{} {}",
-                        method.as_deref().unwrap_or("<no method>"),
-                        url.as_deref().unwrap_or("<no url>"),
+                        auth.method.as_deref().unwrap_or("<no method>"),
+                        auth.url.as_deref().unwrap_or("<no url>"),
                     ),
                     Style::default().fg(Color::Red),
                 ),

--- a/keep-desktop/src/app/mod.rs
+++ b/keep-desktop/src/app/mod.rs
@@ -1076,6 +1076,7 @@ mod tests {
             event_kind: None,
             event_content: None,
             requested_permissions: None,
+            http_auth: None,
         };
         app.notify_bunker_approval(&display);
     }

--- a/keep-desktop/src/bunker_service.rs
+++ b/keep-desktop/src/bunker_service.rs
@@ -85,6 +85,7 @@ impl keep_nip46::types::ServerCallbacks for DesktopCallbacks {
             event_kind: request.event_kind.map(|k| u32::from(k.as_u16())),
             event_content: request.event_content,
             requested_permissions: request.requested_permissions,
+            http_auth: request.http_auth.map(|d| (d.url, d.method)),
         };
         if self
             .tx

--- a/keep-desktop/src/bunker_service.rs
+++ b/keep-desktop/src/bunker_service.rs
@@ -85,7 +85,7 @@ impl keep_nip46::types::ServerCallbacks for DesktopCallbacks {
             event_kind: request.event_kind.map(|k| u32::from(k.as_u16())),
             event_content: request.event_content,
             requested_permissions: request.requested_permissions,
-            http_auth: request.http_auth.map(|d| (d.url, d.method)),
+            http_auth: request.http_auth,
         };
         if self
             .tx

--- a/keep-desktop/src/local_signer_service.rs
+++ b/keep-desktop/src/local_signer_service.rs
@@ -58,7 +58,7 @@ impl keep_nip46::types::ServerCallbacks for LocalSignerCallbacks {
             method: request.method,
             event_kind: request.event_kind.map(|k| u32::from(k.as_u16())),
             event_content: request.event_content,
-            http_auth: request.http_auth.map(|d| (d.url, d.method)),
+            http_auth: request.http_auth,
         };
         if self
             .tx

--- a/keep-desktop/src/local_signer_service.rs
+++ b/keep-desktop/src/local_signer_service.rs
@@ -58,6 +58,7 @@ impl keep_nip46::types::ServerCallbacks for LocalSignerCallbacks {
             method: request.method,
             event_kind: request.event_kind.map(|k| u32::from(k.as_u16())),
             event_content: request.event_content,
+            http_auth: request.http_auth.map(|d| (d.url, d.method)),
         };
         if self
             .tx

--- a/keep-desktop/src/nostrconnect.rs
+++ b/keep-desktop/src/nostrconnect.rs
@@ -27,6 +27,7 @@ impl App {
             event_kind: None,
             event_content: request.url.clone(),
             requested_permissions: request.perms.clone(),
+            http_auth: None,
         };
         self.bunker_pending_approval = Some(display);
 

--- a/keep-desktop/src/screen/bunker.rs
+++ b/keep-desktop/src/screen/bunker.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, VecDeque};
 
 use iced::widget::{button, column, container, qr_code, row, scrollable, text, text_input, Space};
 use iced::{Alignment, Element, Length};
+use keep_nip46::types::HttpAuthDetails;
 
 use crate::theme;
 
@@ -67,10 +68,9 @@ pub struct PendingApprovalDisplay {
     pub event_kind: Option<u32>,
     pub event_content: Option<String>,
     pub requested_permissions: Option<String>,
-    /// NIP-98 (kind 27235) HTTP-auth target (url, method) surfaced so the user
-    /// can see what a bearer-credential sign request authorizes. `None` for
-    /// non-27235 requests.
-    pub http_auth: Option<(Option<String>, Option<String>)>,
+    /// NIP-98 (kind 27235) HTTP-auth target surfaced so the user can see what a
+    /// bearer-credential sign request authorizes. `None` for non-27235 requests.
+    pub http_auth: Option<HttpAuthDetails>,
 }
 
 #[derive(Debug, Clone)]
@@ -801,16 +801,8 @@ impl State {
             );
         }
 
-        if let Some((ref url, ref method)) = approval.http_auth {
-            details = details.push(
-                text(format!(
-                    "HTTP auth: {} {}",
-                    method.as_deref().unwrap_or("<no method>"),
-                    url.as_deref().unwrap_or("<no url>"),
-                ))
-                .size(theme::size::SMALL)
-                .color(theme::color::DANGER),
-            );
+        if let Some(row) = super::http_auth_row(&approval.http_auth) {
+            details = details.push(row);
         }
 
         if let Some(ref content) = approval.event_content {

--- a/keep-desktop/src/screen/bunker.rs
+++ b/keep-desktop/src/screen/bunker.rs
@@ -67,6 +67,10 @@ pub struct PendingApprovalDisplay {
     pub event_kind: Option<u32>,
     pub event_content: Option<String>,
     pub requested_permissions: Option<String>,
+    /// NIP-98 (kind 27235) HTTP-auth target (url, method) surfaced so the user
+    /// can see what a bearer-credential sign request authorizes. `None` for
+    /// non-27235 requests.
+    pub http_auth: Option<(Option<String>, Option<String>)>,
 }
 
 #[derive(Debug, Clone)]
@@ -794,6 +798,18 @@ impl State {
                 text(format!("Kind: {kind}"))
                     .size(theme::size::SMALL)
                     .color(theme::color::TEXT_MUTED),
+            );
+        }
+
+        if let Some((ref url, ref method)) = approval.http_auth {
+            details = details.push(
+                text(format!(
+                    "HTTP auth: {} {}",
+                    method.as_deref().unwrap_or("<no method>"),
+                    url.as_deref().unwrap_or("<no url>"),
+                ))
+                .size(theme::size::SMALL)
+                .color(theme::color::DANGER),
             );
         }
 

--- a/keep-desktop/src/screen/local_signer.rs
+++ b/keep-desktop/src/screen/local_signer.rs
@@ -20,6 +20,10 @@ pub struct PendingApprovalDisplay {
     pub method: String,
     pub event_kind: Option<u32>,
     pub event_content: Option<String>,
+    /// NIP-98 (kind 27235) HTTP-auth target (url, method) surfaced so the user
+    /// can see what a bearer-credential sign request authorizes. `None` for
+    /// non-27235 requests.
+    pub http_auth: Option<(Option<String>, Option<String>)>,
 }
 
 #[derive(Debug, Clone)]
@@ -298,6 +302,18 @@ impl State {
                 text(format!("Kind: {kind}"))
                     .size(theme::size::SMALL)
                     .color(theme::color::TEXT_MUTED),
+            );
+        }
+
+        if let Some((ref url, ref method)) = approval.http_auth {
+            details = details.push(
+                text(format!(
+                    "HTTP auth: {} {}",
+                    method.as_deref().unwrap_or("<no method>"),
+                    url.as_deref().unwrap_or("<no url>"),
+                ))
+                .size(theme::size::SMALL)
+                .color(theme::color::DANGER),
             );
         }
 

--- a/keep-desktop/src/screen/local_signer.rs
+++ b/keep-desktop/src/screen/local_signer.rs
@@ -5,6 +5,7 @@ use std::collections::VecDeque;
 
 use iced::widget::{button, column, container, row, scrollable, text, Space};
 use iced::{Alignment, Element, Length};
+use keep_nip46::types::HttpAuthDetails;
 
 use crate::theme;
 
@@ -20,10 +21,9 @@ pub struct PendingApprovalDisplay {
     pub method: String,
     pub event_kind: Option<u32>,
     pub event_content: Option<String>,
-    /// NIP-98 (kind 27235) HTTP-auth target (url, method) surfaced so the user
-    /// can see what a bearer-credential sign request authorizes. `None` for
-    /// non-27235 requests.
-    pub http_auth: Option<(Option<String>, Option<String>)>,
+    /// NIP-98 (kind 27235) HTTP-auth target surfaced so the user can see what a
+    /// bearer-credential sign request authorizes. `None` for non-27235 requests.
+    pub http_auth: Option<HttpAuthDetails>,
 }
 
 #[derive(Debug, Clone)]
@@ -305,16 +305,8 @@ impl State {
             );
         }
 
-        if let Some((ref url, ref method)) = approval.http_auth {
-            details = details.push(
-                text(format!(
-                    "HTTP auth: {} {}",
-                    method.as_deref().unwrap_or("<no method>"),
-                    url.as_deref().unwrap_or("<no url>"),
-                ))
-                .size(theme::size::SMALL)
-                .color(theme::color::DANGER),
-            );
+        if let Some(row) = super::http_auth_row(&approval.http_auth) {
+            details = details.push(row);
         }
 
         if let Some(ref content) = approval.event_content {

--- a/keep-desktop/src/screen/mod.rs
+++ b/keep-desktop/src/screen/mod.rs
@@ -29,6 +29,25 @@ pub fn truncate_npub(npub: &str) -> String {
     keep_core::display::truncate_str(npub, 12, 6)
 }
 
+/// The NIP-98 (kind 27235) HTTP-auth target line shared by the bunker and
+/// local-signer approval cards, so the wording and danger styling stay in sync.
+/// `None` when the request carries no HTTP-auth target (every non-27235 request).
+pub fn http_auth_row<'a, M: 'a>(
+    http_auth: &Option<keep_nip46::types::HttpAuthDetails>,
+) -> Option<iced::Element<'a, M>> {
+    let auth = http_auth.as_ref()?;
+    Some(
+        iced::widget::text(format!(
+            "HTTP auth: {} {}",
+            auth.method.as_deref().unwrap_or("<no method>"),
+            auth.url.as_deref().unwrap_or("<no url>"),
+        ))
+        .size(crate::theme::size::SMALL)
+        .color(crate::theme::color::DANGER)
+        .into(),
+    )
+}
+
 pub enum Screen {
     Unlock(unlock::State),
     ShareList(shares::State),

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -44,6 +44,19 @@ pub struct BunkerApprovalRequest {
     pub event_kind: Option<u32>,
     pub event_content: Option<String>,
     pub requested_permissions: Option<String>,
+    /// NIP-98 (kind 27235) HTTP-auth target the UI must show so the user is not
+    /// approving a blind bearer credential. Present only for kind-27235 sign
+    /// requests; `None` otherwise.
+    pub http_auth: Option<BunkerHttpAuthDetails>,
+}
+
+/// The `u` (URL) and `method` a NIP-98 HTTP-auth signature will authenticate.
+/// Render both in the approval prompt; a `None` field means the request omitted
+/// that tag and should read as "unspecified", not be hidden.
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct BunkerHttpAuthDetails {
+    pub url: Option<String>,
+    pub method: Option<String>,
 }
 
 /// How long an approval persists. Mirrors keep-android's
@@ -148,6 +161,10 @@ impl ServerCallbacks for CallbackBridge {
                 event_kind: request.event_kind.map(|k| k.as_u16() as u32),
                 event_content: request.event_content,
                 requested_permissions: request.requested_permissions,
+                http_auth: request.http_auth.map(|d| BunkerHttpAuthDetails {
+                    url: d.url,
+                    method: d.method,
+                }),
             })
             .into()
     }

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -24,22 +24,68 @@ use crate::types::{
     NIP98_HTTP_AUTH, NIP98_MAX_REMEMBER_SECS,
 };
 
+/// Max displayed length of a NIP-98 `u`/`method` value. A kilobyte-scale tag
+/// would push the approve/deny controls off-screen (layout DoS) and bury the
+/// real request; legitimate HTTP-auth targets are far shorter than this.
+const NIP98_DISPLAY_MAX: usize = 512;
+
+/// Neutralize a NIP-98 `u`/`method` value before it reaches any approval prompt.
+/// The tag is fully attacker-controlled, so strip the characters that let a
+/// signed URL read as a different (trusted) one: bidi overrides/isolates,
+/// zero-width and BOM code points, and every control character (a URL/method is
+/// single-line, so newlines and tabs are stripped too). Then truncate so an
+/// oversized tag cannot hide the rest of the prompt. Applied here at the single
+/// choke point so every surface (CLI/desktop/mobile/web) inherits it.
+fn sanitize_http_auth_field(value: String) -> String {
+    let mut out: String = value
+        .chars()
+        .filter(|c| {
+            // Explicit bidi/format/zero-width code points that are NOT in the
+            // `Cc` control category `is_control()` covers: line/paragraph
+            // separators (Zl/Zp) and the Arabic letter mark (Cf bidi control).
+            !matches!(c,
+                '\u{061C}'
+                | '\u{200B}'..='\u{200F}'
+                | '\u{2028}'..='\u{2029}'
+                | '\u{202A}'..='\u{202E}'
+                | '\u{2066}'..='\u{2069}'
+                | '\u{FEFF}'
+            ) && !c.is_control()
+        })
+        .collect();
+    if out.chars().count() > NIP98_DISPLAY_MAX {
+        out = out.chars().take(NIP98_DISPLAY_MAX).collect::<String>() + "...";
+    }
+    out
+}
+
 /// Extract the NIP-98 (kind 27235) HTTP-auth target from a sign request so the
 /// approval prompt can show the `u`/method the signature will authenticate.
 /// Returns `None` for every other kind. A 27235 event that omits `u` or
 /// `method` still returns `Some` with the missing field as `None`: the prompt
-/// must surface a malformed HTTP-auth request, not silently drop it.
+/// must surface a malformed HTTP-auth request, not silently drop it. The `u`
+/// and `method` values are sanitized (see [`sanitize_http_auth_field`]) since
+/// they are attacker-controlled and land directly in a signing-approval prompt.
 fn nip98_http_auth(event: &UnsignedEvent) -> Option<HttpAuthDetails> {
     if event.kind != NIP98_HTTP_AUTH {
         return None;
     }
     let mut url = None;
     let mut method = None;
+    // An empty or all-stripped value collapses to `None` so every surface shows
+    // its "unspecified" fallback rather than a blank.
+    let sanitized = |slice: &[String]| {
+        slice
+            .get(1)
+            .cloned()
+            .map(sanitize_http_auth_field)
+            .filter(|s| !s.is_empty())
+    };
     for tag in event.tags.iter() {
         let slice = tag.as_slice();
         match slice.first().map(String::as_str) {
-            Some("u") if url.is_none() => url = slice.get(1).cloned(),
-            Some("method") if method.is_none() => method = slice.get(1).cloned(),
+            Some("u") if url.is_none() => url = sanitized(slice),
+            Some("method") if method.is_none() => method = sanitized(slice),
             _ => {}
         }
     }
@@ -1036,6 +1082,68 @@ mod tests {
         // Every other kind carries no HTTP-auth target.
         let note = UnsignedEvent::new(signer_pk, Timestamp::now(), Kind::TextNote, vec![], "hi");
         assert_eq!(nip98_http_auth(&note), None);
+    }
+
+    #[test]
+    fn nip98_http_auth_sanitizes_spoofing_and_bounds_length() {
+        let signer_pk = Keys::generate().public_key();
+
+        // A `u` carrying an RTL-override, zero-width, line-separator and the
+        // Arabic letter mark (all bidi/format code points) must not be able to
+        // make the displayed URL read as a different host than what is signed.
+        let spoof =
+            "https://evil.com/\u{202E}moc.doog//:sptth\u{200B}\u{2028}\u{2029}\u{061C}";
+        let ev = UnsignedEvent::new(
+            signer_pk,
+            Timestamp::now(),
+            NIP98_HTTP_AUTH,
+            vec![
+                Tag::parse(["u", spoof]).unwrap(),
+                Tag::parse(["method", "GET\u{0007}"]).unwrap(),
+            ],
+            "",
+        );
+        let details = nip98_http_auth(&ev).unwrap();
+        let url = details.url.unwrap();
+        assert_eq!(url, "https://evil.com/moc.doog//:sptth");
+        assert_eq!(details.method.as_deref(), Some("GET"));
+
+        // An empty (or all-stripped) `u`/`method` collapses to `None` so the
+        // prompt shows its "unspecified" fallback, not a blank.
+        let ev = UnsignedEvent::new(
+            signer_pk,
+            Timestamp::now(),
+            NIP98_HTTP_AUTH,
+            vec![
+                Tag::parse(["u", ""]).unwrap(),
+                Tag::parse(["method", "\u{200B}"]).unwrap(),
+            ],
+            "",
+        );
+        assert_eq!(
+            nip98_http_auth(&ev),
+            Some(HttpAuthDetails {
+                url: None,
+                method: None,
+            })
+        );
+
+        // An oversized `u` is truncated so it cannot bury the approve/deny controls.
+        let long = format!("https://evil.example/{}", "a".repeat(5000));
+        let ev = UnsignedEvent::new(
+            signer_pk,
+            Timestamp::now(),
+            NIP98_HTTP_AUTH,
+            vec![Tag::parse(["u", &long]).unwrap()],
+            "",
+        );
+        let url = nip98_http_auth(&ev).unwrap().url.unwrap();
+        assert!(
+            url.chars().count() <= NIP98_DISPLAY_MAX + 3,
+            "displayed url must be length-bounded, got {} chars",
+            url.chars().count()
+        );
+        assert!(url.ends_with("..."), "truncated url must be marked: {url:?}");
     }
 
     // #575: NIP-98 (kind 27235) is never auto-approved, not even per-app via

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -1091,8 +1091,7 @@ mod tests {
         // A `u` carrying an RTL-override, zero-width, line-separator and the
         // Arabic letter mark (all bidi/format code points) must not be able to
         // make the displayed URL read as a different host than what is signed.
-        let spoof =
-            "https://evil.com/\u{202E}moc.doog//:sptth\u{200B}\u{2028}\u{2029}\u{061C}";
+        let spoof = "https://evil.com/\u{202E}moc.doog//:sptth\u{200B}\u{2028}\u{2029}\u{061C}";
         let ev = UnsignedEvent::new(
             signer_pk,
             Timestamp::now(),
@@ -1143,7 +1142,10 @@ mod tests {
             "displayed url must be length-bounded, got {} chars",
             url.chars().count()
         );
-        assert!(url.ends_with("..."), "truncated url must be marked: {url:?}");
+        assert!(
+            url.ends_with("..."),
+            "truncated url must be marked: {url:?}"
+        );
     }
 
     // #575: NIP-98 (kind 27235) is never auto-approved, not even per-app via

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -20,9 +20,31 @@ use crate::frost_signer::{FrostSigner, NetworkFrostSigner};
 use crate::permissions::{AppPermission, Permission, PermissionDuration, PermissionManager};
 use crate::rate_limit::{RateLimitConfig, RateLimiter};
 use crate::types::{
-    ApprovalRequest, ApprovalResult, RememberDuration, ServerCallbacks, NIP98_HTTP_AUTH,
-    NIP98_MAX_REMEMBER_SECS,
+    ApprovalRequest, ApprovalResult, HttpAuthDetails, RememberDuration, ServerCallbacks,
+    NIP98_HTTP_AUTH, NIP98_MAX_REMEMBER_SECS,
 };
+
+/// Extract the NIP-98 (kind 27235) HTTP-auth target from a sign request so the
+/// approval prompt can show the `u`/method the signature will authenticate.
+/// Returns `None` for every other kind. A 27235 event that omits `u` or
+/// `method` still returns `Some` with the missing field as `None`: the prompt
+/// must surface a malformed HTTP-auth request, not silently drop it.
+fn nip98_http_auth(event: &UnsignedEvent) -> Option<HttpAuthDetails> {
+    if event.kind != NIP98_HTTP_AUTH {
+        return None;
+    }
+    let mut url = None;
+    let mut method = None;
+    for tag in event.tags.iter() {
+        let slice = tag.as_slice();
+        match slice.first().map(String::as_str) {
+            Some("u") if url.is_none() => url = slice.get(1).cloned(),
+            Some("method") if method.is_none() => method = slice.get(1).cloned(),
+            _ => {}
+        }
+    }
+    Some(HttpAuthDetails { url, method })
+}
 
 fn clamp_nip98_remember(remember: RememberDuration) -> RememberDuration {
     match remember.as_seconds() {
@@ -350,6 +372,7 @@ impl SignerHandler {
                     event_kind: None,
                     event_content: None,
                     requested_permissions: permissions.clone(),
+                    http_auth: None,
                 })
                 .await;
             if !result.approved {
@@ -441,6 +464,7 @@ impl SignerHandler {
                     event_kind: Some(kind),
                     event_content: Some(unsigned_event.content.clone()),
                     requested_permissions: None,
+                    http_auth: nip98_http_auth(&unsigned_event),
                 })
                 .await;
 
@@ -580,6 +604,7 @@ impl SignerHandler {
             event_kind: None,
             event_content: None,
             requested_permissions: None,
+            http_auth: None,
         };
         if self.request_approval(request).await.approved {
             Ok(())
@@ -882,11 +907,23 @@ mod tests {
     /// assert which operations triggered an interactive prompt. Approves all.
     struct RecordingCallbacks {
         methods: std::sync::Mutex<Vec<String>>,
+        http_auth: std::sync::Mutex<Option<HttpAuthDetails>>,
+    }
+    impl RecordingCallbacks {
+        fn new() -> Self {
+            Self {
+                methods: std::sync::Mutex::new(Vec::new()),
+                http_auth: std::sync::Mutex::new(None),
+            }
+        }
     }
     impl crate::types::ServerCallbacks for RecordingCallbacks {
         fn on_log(&self, _event: crate::types::LogEvent) {}
         fn request_approval(&self, request: ApprovalRequest) -> ApprovalResult {
             self.methods.lock().unwrap().push(request.method);
+            if request.http_auth.is_some() {
+                *self.http_auth.lock().unwrap() = request.http_auth;
+            }
             ApprovalResult::approved_once()
         }
         fn on_connect(&self, _pubkey: &str, _name: &str) {}
@@ -902,9 +939,7 @@ mod tests {
         let keyring = setup_keyring();
         let permissions = Arc::new(Mutex::new(PermissionManager::new()));
         let audit = Arc::new(Mutex::new(AuditLog::new(100)));
-        let cb = Arc::new(RecordingCallbacks {
-            methods: std::sync::Mutex::new(Vec::new()),
-        });
+        let cb = Arc::new(RecordingCallbacks::new());
         // Default connect_grant == Permission::DEFAULT (get_public_key only).
         let handler = SignerHandler::new(keyring, permissions, audit, Some(cb));
 
@@ -933,9 +968,7 @@ mod tests {
             .await
             .set_auto_approve_kinds(HashSet::from([NIP98_HTTP_AUTH]));
         let audit = Arc::new(Mutex::new(AuditLog::new(100)));
-        let cb = Arc::new(RecordingCallbacks {
-            methods: std::sync::Mutex::new(Vec::new()),
-        });
+        let cb = Arc::new(RecordingCallbacks::new());
         let handler = SignerHandler::new(keyring, permissions, audit, Some(cb.clone()))
             .with_connect_grant(Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT);
 
@@ -959,6 +992,50 @@ mod tests {
             methods.iter().any(|m| m == "sign_event"),
             "kind 27235 MUST trigger a per-request approval prompt, saw: {methods:?}"
         );
+
+        // The prompt must carry the `u`/method so the user is not approving a
+        // blind HTTP-auth bearer credential (keep-qjx0).
+        let http_auth = cb.http_auth.lock().unwrap().clone();
+        assert_eq!(
+            http_auth,
+            Some(HttpAuthDetails {
+                url: Some("https://readstr.example/api/feed".into()),
+                method: Some("GET".into()),
+            }),
+            "kind 27235 approval must surface the NIP-98 url/method"
+        );
+    }
+
+    #[test]
+    fn nip98_http_auth_extracts_url_and_method() {
+        let signer_pk = Keys::generate().public_key();
+        let tags = vec![
+            Tag::parse(["u", "https://blossom.example/upload"]).unwrap(),
+            Tag::parse(["method", "PUT"]).unwrap(),
+        ];
+        let ev = UnsignedEvent::new(signer_pk, Timestamp::now(), NIP98_HTTP_AUTH, tags, "");
+        assert_eq!(
+            nip98_http_auth(&ev),
+            Some(HttpAuthDetails {
+                url: Some("https://blossom.example/upload".into()),
+                method: Some("PUT".into()),
+            })
+        );
+
+        // A malformed 27235 event (missing `u`) still surfaces as Some so the
+        // prompt can flag the omission rather than hide the request.
+        let bare = UnsignedEvent::new(signer_pk, Timestamp::now(), NIP98_HTTP_AUTH, vec![], "");
+        assert_eq!(
+            nip98_http_auth(&bare),
+            Some(HttpAuthDetails {
+                url: None,
+                method: None,
+            })
+        );
+
+        // Every other kind carries no HTTP-auth target.
+        let note = UnsignedEvent::new(signer_pk, Timestamp::now(), Kind::TextNote, vec![], "hi");
+        assert_eq!(nip98_http_auth(&note), None);
     }
 
     // #575: NIP-98 (kind 27235) is never auto-approved, not even per-app via

--- a/keep-nip46/src/types.rs
+++ b/keep-nip46/src/types.rs
@@ -22,6 +22,19 @@ pub struct LogEvent {
     pub detail: Option<String>,
 }
 
+/// The security-relevant target of a NIP-98 (kind 27235) HTTP-auth event: the
+/// `u` (URL) and `method` the signature will authenticate. NIP-98 content is
+/// empty, so without these the approval prompt cannot show what is being
+/// authorized and the user approves a blind bearer credential. Populated on
+/// `ApprovalRequest` only for kind-27235 sign requests; `None` otherwise. A
+/// field is `None` when the event omits that tag (a malformed request the UI
+/// should surface as "unspecified", not hide).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpAuthDetails {
+    pub url: Option<String>,
+    pub method: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct ApprovalRequest {
     pub app_pubkey: PublicKey,
@@ -30,6 +43,10 @@ pub struct ApprovalRequest {
     pub event_kind: Option<Kind>,
     pub event_content: Option<String>,
     pub requested_permissions: Option<String>,
+    /// For NIP-98 (kind 27235) sign requests, the `u`/method the prompt must
+    /// show so the user is not approving a blind HTTP-auth token. `None` for
+    /// every other request.
+    pub http_auth: Option<HttpAuthDetails>,
 }
 
 /// How long an approval extends beyond the current request, captured from the

--- a/keep-web/src/bunker.rs
+++ b/keep-web/src/bunker.rs
@@ -86,17 +86,17 @@ impl ServerCallbacks for WebCallbacks {
             map.insert(id, tx);
         }
 
-        let (http_auth_url, http_auth_method) = request
-            .http_auth
-            .map_or((None, None), |d| (d.url, d.method));
+        let http_auth = request.http_auth.map(|d| crate::state::HttpAuth {
+            url: d.url,
+            method: d.method,
+        });
         let _ = self.events.send(Event::Approval {
             id,
             app: request.app_name,
             method: request.method,
             kind: request.event_kind.map(|k| k.as_u16()),
             preview: request.event_content,
-            http_auth_url,
-            http_auth_method,
+            http_auth,
         });
 
         // `block_in_place` requires a multi-thread runtime; both spawners use

--- a/keep-web/src/bunker.rs
+++ b/keep-web/src/bunker.rs
@@ -86,12 +86,17 @@ impl ServerCallbacks for WebCallbacks {
             map.insert(id, tx);
         }
 
+        let (http_auth_url, http_auth_method) = request
+            .http_auth
+            .map_or((None, None), |d| (d.url, d.method));
         let _ = self.events.send(Event::Approval {
             id,
             app: request.app_name,
             method: request.method,
             kind: request.event_kind.map(|k| k.as_u16()),
             preview: request.event_content,
+            http_auth_url,
+            http_auth_method,
         });
 
         // `block_in_place` requires a multi-thread runtime; both spawners use

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -289,9 +289,17 @@ pub enum Event {
         kind: Option<u16>,
         preview: Option<String>,
         /// NIP-98 (kind 27235) HTTP-auth target the browser prompt must show so
-        /// the operator does not approve a blind bearer credential. Both `None`
-        /// for non-27235 requests.
-        http_auth_url: Option<String>,
-        http_auth_method: Option<String>,
+        /// the operator does not approve a blind bearer credential. `None` for
+        /// non-27235 requests; the `url`/`method` stay paired so they cannot
+        /// desynchronize.
+        http_auth: Option<HttpAuth>,
     },
+}
+
+/// The `u`/method a NIP-98 HTTP-auth signature will authenticate, surfaced in
+/// the approval prompt. A field is `None` when the request omits that tag.
+#[derive(Clone, Serialize)]
+pub struct HttpAuth {
+    pub url: Option<String>,
+    pub method: Option<String>,
 }

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -288,5 +288,10 @@ pub enum Event {
         method: String,
         kind: Option<u16>,
         preview: Option<String>,
+        /// NIP-98 (kind 27235) HTTP-auth target the browser prompt must show so
+        /// the operator does not approve a blind bearer credential. Both `None`
+        /// for non-27235 requests.
+        http_auth_url: Option<String>,
+        http_auth_method: Option<String>,
     },
 }

--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -615,8 +615,8 @@
             <strong>{a.app}</strong> requests <strong>{a.method}</strong>{#if a.kind !== null}
               · kind {a.kind}{/if}
             {#if a.preview}<span class="muted"> · {a.preview}</span>{/if}
-            {#if a.kind === 27235}<span class="http-auth"> · HTTP auth: {a.http_auth_method ?? '<no method>'}
-                {a.http_auth_url ?? '<no url>'}</span>{/if}
+            {#if a.kind === 27235}<span class="http-auth"> · HTTP auth: {a.http_auth?.method ?? '<no method>'}
+                {a.http_auth?.url ?? '<no url>'}</span>{/if}
           </span>
           <span class="approval-bar-actions">
             <button class="ok" onclick={() => decide(a, true)}>Approve</button>

--- a/keep-web/ui/src/App.svelte
+++ b/keep-web/ui/src/App.svelte
@@ -615,6 +615,8 @@
             <strong>{a.app}</strong> requests <strong>{a.method}</strong>{#if a.kind !== null}
               · kind {a.kind}{/if}
             {#if a.preview}<span class="muted"> · {a.preview}</span>{/if}
+            {#if a.kind === 27235}<span class="http-auth"> · HTTP auth: {a.http_auth_method ?? '<no method>'}
+                {a.http_auth_url ?? '<no url>'}</span>{/if}
           </span>
           <span class="approval-bar-actions">
             <button class="ok" onclick={() => decide(a, true)}>Approve</button>

--- a/keep-web/ui/src/app.css
+++ b/keep-web/ui/src/app.css
@@ -829,6 +829,13 @@ ol.tasks li {
   gap: 0.5rem;
 }
 
+/* NIP-98 HTTP-auth target: security-critical, so it stands out in the prompt. */
+.http-auth {
+  color: var(--no);
+  font-weight: 600;
+  word-break: break-all;
+}
+
 /* Readiness pill + co-signer presence list. */
 .status-pill {
   font-size: 0.8rem;

--- a/keep-web/ui/src/lib/api.ts
+++ b/keep-web/ui/src/lib/api.ts
@@ -44,6 +44,10 @@ export interface ApprovalEvent {
   method: string
   kind: number | null
   preview: string | null
+  // NIP-98 (kind 27235) HTTP-auth target, so the operator does not approve a
+  // blind bearer credential. Both null for non-27235 requests.
+  http_auth_url: string | null
+  http_auth_method: string | null
 }
 
 export type ServerEvent = LogEvent | ApprovalEvent

--- a/keep-web/ui/src/lib/api.ts
+++ b/keep-web/ui/src/lib/api.ts
@@ -45,9 +45,8 @@ export interface ApprovalEvent {
   kind: number | null
   preview: string | null
   // NIP-98 (kind 27235) HTTP-auth target, so the operator does not approve a
-  // blind bearer credential. Both null for non-27235 requests.
-  http_auth_url: string | null
-  http_auth_method: string | null
+  // blind bearer credential. null for non-27235 requests; url/method stay paired.
+  http_auth: { url: string | null; method: string | null } | null
 }
 
 export type ServerEvent = LogEvent | ApprovalEvent


### PR DESCRIPTION
## Problem

NIP-98 HTTP-auth events (kind 27235) carry the security-relevant target, the `u` (URL) and `method`, in tags, and their content is empty. The NIP-46 approval prompt only surfaced the app name, kind, and (empty) content, so a user approving a kind-27235 sign request could not see what the resulting bearer credential would authenticate. One approval could mint an HTTP-auth token for any URL/method with no visibility.

Existing hardening (kind 27235 always prompts, is never covered by a global/forever grant, and its remember window is hard-clamped) bounds the blast radius but does not tell the user what they are signing.

## Change

Thread a `HttpAuthDetails { url, method }` through the shared `ApprovalRequest` and every downstream approval DTO, populated only for kind-27235 sign requests. The signer core parses the `u`/`method` tags once so each front end renders a trustworthy target instead of re-parsing raw tags. A missing tag surfaces as "unspecified" rather than being hidden, so a malformed request is visible.

Surfaced in every approval path:
- keep-cli TUI popup (new "HTTP auth: METHOD URL" line)
- keep-desktop bunker and local-signer approval cards
- keep-web approval event payload
- keep-mobile `BunkerApprovalRequest` (new `http_auth` field over the UniFFI boundary)

## Follow-ups

The keep-web Svelte view and the keep-android Kotlin approval screen now receive the data at their boundaries; rendering it in those two front ends is tracked separately.

## Tests

- `nip98_http_auth_extracts_url_and_method`: url/method extraction, missing-tag surfacing, and non-27235 returning `None`.
- Extended the existing per-request-prompt test to assert the prompt carries the `u`/method.
- `cargo test -p keep-nip46` (141 pass); clippy clean on keep-nip46, keep-cli, keep-mobile, keep-desktop, keep-web.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approval prompts now show HTTP auth details, including the request URL and method when available.
  * Support was added for surfacing HTTP auth context in desktop, mobile, web, and CLI approval flows.
* **Bug Fixes**
  * Approvals now carry through previously missing HTTP auth information, improving review clarity for certain sign requests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->