### PR TITLE
dkg: bound hardware DKG polling loops with per-run seen-event set

### DIFF
--- a/keep-cli/src/commands/frost_network/dkg.rs
+++ b/keep-cli/src/commands/frost_network/dkg.rs
@@ -532,6 +532,7 @@ fn cmd_frost_network_dkg_hardware(
 
         let mut received_packages: HashMap<u8, String> = HashMap::new();
         let mut participant_pubkeys: HashMap<u8, PublicKey> = HashMap::new();
+        let mut seen_round1: HashSet<EventId> = HashSet::new();
         let timeout = std::time::Duration::from_secs(300);
         let start = std::time::Instant::now();
 
@@ -550,6 +551,18 @@ fn cmd_frost_network_dkg_hardware(
             for ev in events.iter() {
                 if ev.pubkey == keys.public_key() {
                     continue;
+                }
+                // Bound decoy-flood work: a hostile relay can spam junk round1
+                // events during the 300s window; dedupe so each id is parsed
+                // once and abort past a cap so the set cannot grow unbounded
+                // (mirrors the software path).
+                if !seen_round1.insert(ev.id) {
+                    continue;
+                }
+                if seen_round1.len() > MAX_DKG_EVENTS_SEEN {
+                    return Err(KeepError::NetworkErr(NetworkError::request(
+                        "too many distinct DKG round1 events; aborting to bound memory".to_string(),
+                    )));
                 }
 
                 if let Ok(content) = serde_json::from_str::<serde_json::Value>(&ev.content) {
@@ -666,6 +679,7 @@ fn cmd_frost_network_dkg_hardware(
             .custom_tag(SingleLetterTag::lowercase(Alphabet::D), group.to_string());
 
         let mut received_from_peers: HashSet<u8> = HashSet::new();
+        let mut seen_round2: HashSet<EventId> = HashSet::new();
         let start = std::time::Instant::now();
 
         while received_from_peers.len() < expected_peers as usize {
@@ -685,6 +699,17 @@ fn cmd_frost_network_dkg_hardware(
             for ev in events.iter() {
                 if ev.pubkey == keys.public_key() {
                     continue;
+                }
+                // Bound decoy-flood work as in round1: dedupe on event id and
+                // abort past a cap so a flooded relay cannot grow the set
+                // without limit (mirrors the software path).
+                if !seen_round2.insert(ev.id) {
+                    continue;
+                }
+                if seen_round2.len() > MAX_DKG_EVENTS_SEEN {
+                    return Err(KeepError::NetworkErr(NetworkError::request(
+                        "too many distinct DKG round2 events; aborting to bound memory".to_string(),
+                    )));
                 }
 
                 let recipient_idx_tag = ev.tags.iter().find_map(|t| {


### PR DESCRIPTION
Closes #676.

## Problem

The hardware FROST DKG polling loops (`keep frost network dkg --hardware`) had no per-run seen-event set, unlike the software path. During the 300s DKG window a relay writer can flood junk kind-21102/21103 events; each is correctly rejected at the roster authentication gate, but the hardware loop re-parsed the entire `fetch_events` result on every 5s poll and held it in memory, burning CPU/memory. This is a resource-exhaustion hardening gap, not an authentication bypass.

## Change

Mirror the software path's bounded seen-event pattern in both hardware loops: dedupe intake on `ev.id` with a per-run `HashSet<EventId>`, `continue` on already-seen ids, and abort with a bounded-memory error once the set exceeds the existing `MAX_DKG_EVENTS_SEEN` (8192). This keeps the two paths consistent and caps decoy-flood work at one parse per distinct event.

## Not done, on purpose

The issue notes a lighter follow-up: adding `.limit(N)` to the roster fetch filter. That fetch deliberately validates all candidates newest-first so a junk event cannot bury the honest announcement; a `.limit(N)` would let an attacker flood N decoys to push the real announcement out of the fetch window, reintroducing the griefing vector that design avoids. It is also a single bounded 15s fetch, not a polling loop. Left as-is.

## Tests

Existing dkg unit tests pass (9/9); clippy clean on keep-cli. The hardware loops require a physical signer + live relay so are not locally exercisable; this is a mechanical mirror of the already-shipped software-path pattern.
