### PR TITLE
keep-mobile: serialize live-node lifecycle so node/node_tasks swap atomically

### DIFF
--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -445,6 +445,12 @@ pub struct KeepMobile {
     /// permission grants) so a relay edit and an engine grant/revoke write do
     /// not clobber each other's section.
     pub(crate) relay_config_lock: Arc<std::sync::Mutex<()>>,
+    /// Serializes the live-node lifecycle so the `(node, node_tasks)` pair is
+    /// always swapped atomically. `do_initialize` (install) and
+    /// `invalidate_live_node` (teardown) each hold this for their whole run, so
+    /// a concurrent FFI init racing a delete/rotate cannot interleave into a
+    /// node whose tasks were just aborted, or tasks pointing at a nulled node.
+    node_lifecycle_lock: Arc<std::sync::Mutex<()>>,
 }
 
 struct PendingRequest {
@@ -587,6 +593,7 @@ impl KeepMobile {
             descriptor_write_lock: Arc::new(std::sync::Mutex::new(())),
             bunker_config_lock: Arc::new(std::sync::Mutex::new(())),
             relay_config_lock: Arc::new(std::sync::Mutex::new(())),
+            node_lifecycle_lock: Arc::new(std::sync::Mutex::new(())),
         })
     }
 
@@ -889,6 +896,12 @@ impl KeepMobile {
     /// release their Arc clones, so the node drops and its share material
     /// zeroizes once the runtime finishes cancelling them.
     fn invalidate_live_node(&self) {
+        // Serialize teardown against a concurrent `do_initialize` so the
+        // (node, node_tasks) pair is swapped atomically. Held for the whole fn.
+        let _lifecycle = self
+            .node_lifecycle_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         for handle in self
             .node_tasks
             .lock()
@@ -2530,6 +2543,16 @@ impl KeepMobile {
         relays: Vec<String>,
         proxy: Option<std::net::SocketAddr>,
     ) -> Result<(), KeepMobileError> {
+        // Serialize install against a concurrent teardown (invalidate_live_node)
+        // so the (node, node_tasks) pair is swapped atomically. Held for the
+        // whole fn; neither path nests the other, so this cannot self-deadlock.
+        // The guard spans the relay I/O below (TLS pin verification, connect), so
+        // a concurrent teardown waits out the whole init; acceptable under the
+        // single-user mobile FFI model where init runs off the UI thread.
+        let _lifecycle = self
+            .node_lifecycle_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         for relay in &relays {
             network::validate_relay_url(relay)?;
         }


### PR DESCRIPTION
Closes #648.

## Problem

`KeepMobile` tracks the live FROST node across two independently-locked fields, `node` (`RwLock<Option<Arc<KfpNode>>>`) and `node_tasks` (`Mutex<Vec<JoinHandle>>`), updated non-atomically. `do_initialize` installs the node and its task handles in two separate lock acquisitions; `invalidate_live_node` tears them down in the inverse order, also separately. A concurrent init racing a teardown (delete/rotate) from two host threads could interleave into a node whose tasks were just aborted (a silently dead signer), or task handles pointing at an already-nulled node. Low severity: mobile UniFFI usage is effectively single-threaded today, so no interleaving is expected in practice.

## Change

Add a `node_lifecycle_lock: Arc<Mutex<()>>` (matching the struct's existing operation-lock pattern) held for the full duration of both leaf mutators, `do_initialize` and `invalidate_live_node`, so the `(node, node_tasks)` pair is always swapped atomically with respect to the other path.

Reentrancy-safe: the lock lives only in those two functions and neither nests the other (`do_initialize` uses `retire_prior_node_tasks`, not `invalidate_live_node`), so it cannot self-deadlock. The guard is a plain `std::sync::MutexGuard` held across the internal `block_on`; nothing inside the async body re-acquires it.

## Tests

`cargo test -p keep-mobile` node-lifecycle tests pass (4/4: import/teardown + retire-prior-tasks); build and clippy clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability during node startup and shutdown by preventing overlapping lifecycle operations.
  * Reduced race conditions that could cause interrupted tasks or inconsistent node state during rapid changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->