### PR TITLE
keep-core: return Result instead of panicking on RNG failure in key generation

### DIFF
--- a/keep-core/src/backup.rs
+++ b/keep-core/src/backup.rs
@@ -236,7 +236,7 @@ pub fn create_backup_from_data(
     let mut json_bytes = serde_json::to_vec(&backup)
         .map_err(|e| KeepError::Other(format!("backup serialization failed: {e}")))?;
 
-    let salt: [u8; SALT_SIZE] = entropy::random_bytes();
+    let salt: [u8; SALT_SIZE] = entropy::try_random_bytes()?;
     let params = Argon2Params::DEFAULT;
     let key = crypto::derive_key(passphrase.as_bytes(), &salt, params)?;
     let encrypted = crypto::encrypt(&json_bytes, &key)?;
@@ -549,7 +549,7 @@ pub fn restore_backup(
         return Err(KeepError::AlreadyExists(target.display().to_string()));
     }
 
-    let rand_suffix: [u8; 8] = entropy::random_bytes();
+    let rand_suffix: [u8; 8] = entropy::try_random_bytes()?;
     let temp_name = format!(
         "{}.restore-{}",
         target

--- a/keep-core/src/crypto.rs
+++ b/keep-core/src/crypto.rs
@@ -627,7 +627,7 @@ pub mod nip44 {
     /// Returns the encrypted payload as raw bytes (version + nonce + ciphertext + MAC).
     pub fn encrypt(shared_secret: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>> {
         let conversation_key = derive_conversation_key(shared_secret)?;
-        let nonce: [u8; 32] = entropy::random_bytes();
+        let nonce: [u8; 32] = entropy::try_random_bytes()?;
         let (chacha_key, chacha_nonce, hmac_key) = derive_message_keys(&conversation_key, &nonce)?;
 
         let padded = pad_plaintext(plaintext)?;
@@ -816,7 +816,7 @@ pub mod nip44 {
         kind: u32,
         scope: &str,
     ) -> Result<Vec<u8>> {
-        let nonce: [u8; 32] = entropy::random_bytes();
+        let nonce: [u8; 32] = entropy::try_random_bytes()?;
         encrypt_v3_with_nonce(shared_secret, plaintext, kind, scope, &nonce)
     }
 
@@ -1049,7 +1049,7 @@ pub mod nip04 {
     ///
     /// Returns the encrypted payload in NIP-04 format: base64(ciphertext)?iv=base64(iv)
     pub fn encrypt(shared_secret: &[u8; 32], plaintext: &[u8]) -> Result<String> {
-        let iv: [u8; 16] = entropy::random_bytes();
+        let iv: [u8; 16] = entropy::try_random_bytes()?;
 
         let cipher = Aes256CbcEnc::new(shared_secret.into(), &iv.into());
         let ciphertext = cipher.encrypt_padded_vec::<Pkcs7>(plaintext);

--- a/keep-core/src/crypto.rs
+++ b/keep-core/src/crypto.rs
@@ -327,7 +327,7 @@ impl SecretKey {
     }
 
     pub fn generate() -> Result<Self> {
-        let bytes: [u8; KEY_SIZE] = entropy::random_bytes();
+        let bytes: [u8; KEY_SIZE] = entropy::try_random_bytes()?;
         Self::new(bytes)
     }
 
@@ -454,7 +454,7 @@ pub fn encrypt_with_aad(plaintext: &[u8], aad: &[u8], key: &SecretKey) -> Result
     let cipher = XChaCha20Poly1305::new_from_slice(&*decrypted)
         .map_err(|_| KeepError::Encryption("Encryption failed".into()))?;
 
-    let nonce: [u8; NONCE_SIZE] = entropy::random_bytes();
+    let nonce: [u8; NONCE_SIZE] = entropy::try_random_bytes()?;
 
     let ciphertext = cipher
         .encrypt(
@@ -528,6 +528,13 @@ pub fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
 /// Generate cryptographically secure random bytes.
 pub fn random_bytes<const N: usize>() -> [u8; N] {
     entropy::random_bytes()
+}
+
+/// Generate cryptographically secure random bytes, returning an error instead
+/// of panicking if the RNG health check fails. Preferred over [`random_bytes`]
+/// in key/secret generation paths that can propagate a `Result` (#685).
+pub fn try_random_bytes<const N: usize>() -> Result<[u8; N]> {
+    Ok(entropy::try_random_bytes()?)
 }
 
 /// NIP-44 encryption using a raw ECDH shared secret.
@@ -1081,6 +1088,21 @@ pub mod nip04 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn try_random_bytes_returns_ok_and_distinct() {
+        let a: [u8; 32] = try_random_bytes().expect("healthy RNG");
+        let b: [u8; 32] = try_random_bytes().expect("healthy RNG");
+        assert_ne!(a, b, "two draws must differ");
+    }
+
+    #[test]
+    fn entropy_health_error_maps_to_keep_encryption_error() {
+        // The RNG-failure path returns a recoverable error rather than panicking
+        // (#685); it surfaces as a crypto/encryption-class KeepError.
+        let err = crate::error::KeepError::from(crate::entropy::EntropyHealthError);
+        assert!(matches!(err, crate::error::KeepError::Encryption(_)));
+    }
 
     #[test]
     fn test_hmac_sha256_rfc4231_case1() {

--- a/keep-core/src/error.rs
+++ b/keep-core/src/error.rs
@@ -551,6 +551,12 @@ pub enum KeepError {
     Other(String),
 }
 
+impl From<crate::entropy::EntropyHealthError> for KeepError {
+    fn from(e: crate::entropy::EntropyHealthError) -> Self {
+        KeepError::Encryption(e.to_string())
+    }
+}
+
 #[allow(missing_docs)]
 impl KeepError {
     pub fn code(&self) -> Option<ErrorCode> {

--- a/keep-core/src/frost/transport.rs
+++ b/keep-core/src/frost/transport.rs
@@ -54,7 +54,7 @@ impl ShareExport {
         ciphersuite: Ciphersuite,
         passphrase: &str,
     ) -> Result<Self> {
-        let salt: [u8; 32] = crypto::random_bytes();
+        let salt: [u8; 32] = crypto::try_random_bytes()?;
         let key = crypto::derive_key(passphrase.as_bytes(), &salt, crypto::Argon2Params::DEFAULT)?;
 
         let key_bytes = share.key_package_bytes().to_vec();

--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -215,7 +215,7 @@ impl HiddenStorage {
 
         file.write_all(&outer_header.to_bytes())?;
 
-        let mut hidden_area: [u8; HEADER_SIZE] = crypto::random_bytes();
+        let mut hidden_area: [u8; HEADER_SIZE] = crypto::try_random_bytes()?;
         if let Some(encrypted_hh) = encrypted_hidden_header {
             hidden_area[..24].copy_from_slice(&encrypted_hh.nonce);
             hidden_area[24..24 + encrypted_hh.ciphertext.len()]

--- a/keep-core/src/keys.rs
+++ b/keep-core/src/keys.rs
@@ -45,7 +45,7 @@ impl NostrKeypair {
     pub fn generate() -> Result<Self> {
         const MAX_RETRIES: usize = 64;
         for _ in 0..MAX_RETRIES {
-            let mut secret_bytes: [u8; 32] = crypto::random_bytes();
+            let mut secret_bytes: [u8; 32] = crypto::try_random_bytes()?;
             if let Ok(signing_key) = SigningKey::from_bytes(&secret_bytes) {
                 let verifying_key = signing_key.verifying_key();
                 return Ok(Self {
@@ -306,10 +306,10 @@ pub mod nip49 {
         }
         let password_nfkc = Zeroizing::new(password.nfkc().collect::<String>());
 
-        let salt: [u8; 16] = entropy::random_bytes();
+        let salt: [u8; 16] = entropy::try_random_bytes()?;
         let symmetric_key = derive_key(&password_nfkc, &salt, log_n)?;
 
-        let nonce: [u8; 24] = entropy::random_bytes();
+        let nonce: [u8; 24] = entropy::try_random_bytes()?;
         let key_security_byte: u8 = 0x01;
 
         let cipher = XChaCha20Poly1305::new_from_slice(symmetric_key.as_ref())

--- a/keep-core/src/mnemonic.rs
+++ b/keep-core/src/mnemonic.rs
@@ -9,8 +9,8 @@ use crate::error::{KeepError, Result};
 /// Generate a BIP-39 mnemonic phrase with the given word count (12 or 24).
 pub fn generate_mnemonic(word_count: u32) -> Result<Zeroizing<String>> {
     let entropy = match word_count {
-        12 => Zeroizing::new(crate::crypto::random_bytes::<16>().to_vec()),
-        24 => Zeroizing::new(crate::crypto::random_bytes::<32>().to_vec()),
+        12 => Zeroizing::new(crate::crypto::try_random_bytes::<16>()?.to_vec()),
+        24 => Zeroizing::new(crate::crypto::try_random_bytes::<32>()?.to_vec()),
         _ => {
             return Err(KeepError::InvalidMnemonic(
                 "word count must be 12 or 24".into(),


### PR DESCRIPTION
Closes #685.

## Problem

`keep-core`'s `random_bytes()` calls `.expect()` and panics if the RNG health check (constant/zero-output detection) fails. In safety-critical crypto a catastrophic RNG failure should surface as a recoverable `Result`, not abort the process. A `Result`-returning `try_random_bytes()` already existed but had no callers.

## Change

Route the key/secret/nonce generation paths that already run in `Result` contexts through `try_random_bytes()?` so a health-check failure returns an error instead of panicking:

- BIP-39 mnemonic entropy (`generate_mnemonic`)
- keypair secret (`Keys::generate`) and export salt/nonce
- data-key generation (`EncryptionKey::generate`) and an XChaCha20 nonce
- backup salt and restore-temp-name suffix
- share-export salt

Adds a `crypto::try_random_bytes` re-export and a `From<EntropyHealthError> for KeepError` (maps to the encryption-error class) so the conversions are a clean `?`.

This is behavior-preserving on the healthy path (the RNG returns bytes exactly as before); it only changes the catastrophic-failure path from panic to a returned error where predictable output would mean key compromise.

## Scope / follow-up

The remaining `random_bytes()` sites are infallible constructors (session ids in `compute_session_id` / `Coordinator::new`, and storage/hidden-volume header salt+nonce in `Header::new` / `OuterHeader::new`); converting those requires changing constructor signatures to `Result` and is a separate change. Test-only callers keep using the panicking helper.

## Tests

Two new unit tests (`try_random_bytes` Ok/distinct; `EntropyHealthError -> KeepError::Encryption` mapping); `cargo test -p keep-core --lib` 322 pass; clippy clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when generating backups, keys, mnemonics, and encrypted data by returning an error if secure randomness is unavailable instead of failing unexpectedly.
  * Updated restore and export flows to handle temporary name and salt generation failures more gracefully.
  * Added handling so entropy-related failures are reported as recoverable encryption errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->