### PR TITLE
keep-core: return Result instead of panicking on RNG failure in vault headers

### DIFF
--- a/keep-core/src/hidden/header.rs
+++ b/keep-core/src/hidden/header.rs
@@ -41,14 +41,14 @@ pub struct OuterHeader {
 
 impl OuterHeader {
     /// Create a new outer header.
-    pub fn new(params: Argon2Params, outer_size: u64, total_size: u64) -> Self {
-        Self {
+    pub fn new(params: Argon2Params, outer_size: u64, total_size: u64) -> Result<Self> {
+        Ok(Self {
             magic: *OUTER_MAGIC,
             version: 1,
             flags: 0,
             reserved: 0,
-            salt: crypto::random_bytes(),
-            nonce: crypto::random_bytes(),
+            salt: crypto::try_random_bytes()?,
+            nonce: crypto::try_random_bytes()?,
             encrypted_data_key: [0; 48],
             argon2_memory_kib: params.memory_kib,
             argon2_iterations: params.iterations,
@@ -57,7 +57,7 @@ impl OuterHeader {
             outer_data_size: outer_size,
             total_size,
             padding: [0; 360],
-        }
+        })
     }
 
     /// The Argon2 parameters.
@@ -196,12 +196,12 @@ pub struct HiddenHeader {
 
 impl HiddenHeader {
     /// Create a new hidden header.
-    pub fn new(hidden_offset: u64, hidden_size: u64) -> Self {
+    pub fn new(hidden_offset: u64, hidden_size: u64) -> Result<Self> {
         let mut header = Self {
             version: 1,
             reserved: 0,
-            salt: crypto::random_bytes(),
-            nonce: crypto::random_bytes(),
+            salt: crypto::try_random_bytes()?,
+            nonce: crypto::try_random_bytes()?,
             encrypted_data_key: [0; 48],
             _align_pad: 0,
             hidden_data_offset: hidden_offset,
@@ -211,7 +211,7 @@ impl HiddenHeader {
         };
 
         header.checksum = header.compute_checksum();
-        header
+        Ok(header)
     }
 
     /// Compute checksum.
@@ -339,7 +339,7 @@ mod tests {
 
     #[test]
     fn test_outer_header_roundtrip() {
-        let header = OuterHeader::new(Argon2Params::TESTING, 1000, 2000);
+        let header = OuterHeader::new(Argon2Params::TESTING, 1000, 2000).unwrap();
         let bytes = header.to_bytes();
         let parsed = OuterHeader::from_bytes(&bytes).unwrap();
 
@@ -352,7 +352,7 @@ mod tests {
 
     #[test]
     fn test_hidden_header_roundtrip() {
-        let header = HiddenHeader::new(1024, 500);
+        let header = HiddenHeader::new(1024, 500).unwrap();
         let bytes = header.to_bytes();
         let parsed = HiddenHeader::from_bytes(&bytes).unwrap();
 
@@ -365,7 +365,7 @@ mod tests {
 
     #[test]
     fn test_hidden_header_checksum_detects_corruption() {
-        let mut header = HiddenHeader::new(1024, 500);
+        let mut header = HiddenHeader::new(1024, 500).unwrap();
         header.hidden_data_size = 999;
         assert!(!header.verify_checksum());
     }

--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -149,7 +149,7 @@ impl HiddenStorage {
 
         let outer_size = total_size - DATA_START_OFFSET - hidden_size;
 
-        let mut outer_header = OuterHeader::new(params, outer_size, total_size);
+        let mut outer_header = OuterHeader::new(params, outer_size, total_size)?;
 
         let outer_data_key = SecretKey::generate()?;
         let outer_master_key =
@@ -166,7 +166,7 @@ impl HiddenStorage {
         let (hidden_header, hidden_data_key, encrypted_hidden_header) =
             if let Some(hp) = hidden_password {
                 let hidden_offset = DATA_START_OFFSET + outer_size;
-                let mut hh = HiddenHeader::new(hidden_offset, hidden_size);
+                let mut hh = HiddenHeader::new(hidden_offset, hidden_size)?;
 
                 let hidden_data_key = SecretKey::generate()?;
                 let kdf_salt = derive_hidden_salt(&outer_header.salt, hp);

--- a/keep-core/src/rotation.rs
+++ b/keep-core/src/rotation.rs
@@ -333,7 +333,7 @@ impl Storage {
     }
 
     fn create_header_with_key(&self, password: &str, data_key: &SecretKey) -> Result<Header> {
-        let mut header = Header::new(self.header.argon2_params());
+        let mut header = Header::new(self.header.argon2_params())?;
         let master_key =
             crypto::derive_key(password.as_bytes(), &header.salt, header.argon2_params())?;
         let header_key = crypto::derive_subkey(&master_key, b"keep-header-key")?;

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -113,19 +113,19 @@ pub(crate) struct Header {
 }
 
 impl Header {
-    pub(crate) fn new(params: Argon2Params) -> Self {
-        Self {
+    pub(crate) fn new(params: Argon2Params) -> Result<Self> {
+        Ok(Self {
             magic: *HEADER_MAGIC,
             version: HEADER_VERSION,
             flags: 0,
-            salt: crypto::random_bytes(),
-            nonce: crypto::random_bytes(),
+            salt: crypto::try_random_bytes()?,
+            nonce: crypto::try_random_bytes()?,
             encrypted_data_key: [0; 48],
             argon2_memory_kib: params.memory_kib,
             argon2_iterations: params.iterations,
             argon2_parallelism: params.parallelism,
             _padding: [0; 140],
-        }
+        })
     }
 
     pub(crate) fn argon2_params(&self) -> Argon2Params {
@@ -282,7 +282,7 @@ impl Storage {
     ) -> Result<Self> {
         validate_new_password(password)?;
 
-        let mut header = Header::new(params);
+        let mut header = Header::new(params)?;
         let data_key = SecretKey::generate()?;
         let master_key = crypto::derive_key(password.as_bytes(), &header.salt, params)?;
         let header_key = crypto::derive_subkey(&master_key, b"keep-header-key")?;
@@ -1448,7 +1448,7 @@ mod tests {
 
     #[test]
     fn test_header_rejects_malicious_argon2_params() {
-        let valid_header = Header::new(Argon2Params::TESTING);
+        let valid_header = Header::new(Argon2Params::TESTING).unwrap();
         let valid_bytes = valid_header.to_bytes();
 
         Header::from_bytes(&valid_bytes).expect("valid header should parse");

--- a/keep-core/tests/property_tests.rs
+++ b/keep-core/tests/property_tests.rs
@@ -100,7 +100,7 @@ proptest! {
         outer_size in 0u64..1_000_000,
         total_size in 0u64..10_000_000
     ) {
-        let header = OuterHeader::new(Argon2Params::TESTING, outer_size, total_size);
+        let header = OuterHeader::new(Argon2Params::TESTING, outer_size, total_size).unwrap();
         let bytes = header.to_bytes();
         prop_assert_eq!(bytes.len(), HEADER_SIZE);
         let parsed = OuterHeader::from_bytes(&bytes).unwrap();
@@ -115,7 +115,7 @@ proptest! {
         offset in 1024u64..1_000_000,
         size in 0u64..1_000_000
     ) {
-        let header = HiddenHeader::new(offset, size);
+        let header = HiddenHeader::new(offset, size).unwrap();
         prop_assert!(header.verify_checksum());
         let bytes = header.to_bytes();
         prop_assert_eq!(bytes.len(), HEADER_SIZE);
@@ -159,13 +159,13 @@ proptest! {
 
 #[test]
 fn header_boundary_sizes() {
-    let header = OuterHeader::new(Argon2Params::TESTING, 0, 0);
+    let header = OuterHeader::new(Argon2Params::TESTING, 0, 0).unwrap();
     let bytes = header.to_bytes();
     let parsed = OuterHeader::from_bytes(&bytes).unwrap();
     assert_eq!(parsed.outer_data_size, 0);
     assert_eq!(parsed.total_size, 0);
 
-    let header = OuterHeader::new(Argon2Params::TESTING, u64::MAX, u64::MAX);
+    let header = OuterHeader::new(Argon2Params::TESTING, u64::MAX, u64::MAX).unwrap();
     let bytes = header.to_bytes();
     let parsed = OuterHeader::from_bytes(&bytes).unwrap();
     assert_eq!(parsed.outer_data_size, u64::MAX);


### PR DESCRIPTION
Closes #687. Follow-up to #686.

## Change

Convert the three vault-header constructors that generate the KDF salt+nonce from `-> Self` (panicking `random_bytes()`) to `-> Result<Self>` using `try_random_bytes()?`, so a catastrophic RNG failure during vault creation returns a recoverable error instead of aborting the process:

- `storage::Header::new`
- `hidden::header::OuterHeader::new`
- `hidden::header::HiddenHeader::new`

All production callers (vault create in `storage.rs`, hidden-volume create in `volume.rs`, header re-create in `rotation.rs`) already sit in `Result`-returning functions, so this is a clean `?` propagation. These constructors are internal to keep-core (no external callers). Behavior-preserving on the healthy path.

## Not in this PR

The session-id sites (`SigningSession::compute_session_id`, `Coordinator::new`) produce a coordination nonce rather than key material (lower severity) and are infallible constructors whose conversion ripples through the session types; tracked as a separate follow-up.

## Tests

`cargo test -p keep-core --lib` 322 pass (storage + hidden-volume roundtrip tests exercise these constructors); keep-cli builds; clippy clean.
