### PR TITLE
frost-net: deterministic tests for handle_ecdh_share/complete gates

### DIFF
--- a/keep-frost-net/src/node/ecdh.rs
+++ b/keep-frost-net/src/node/ecdh.rs
@@ -466,4 +466,33 @@ mod gate_tests {
             Err(FrostNetError::PolicyViolation(_))
         ));
     }
+    /// A round2 share from a peer whose share index is not announced is
+    /// rejected (`verify_peer_share_index`). Also pins the whole-function
+    /// "replace with Ok(())" mutation, since the correct path returns Err.
+    #[tokio::test]
+    async fn handle_ecdh_share_rejects_unannounced_peer() {
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        let payload = EcdhSharePayload::new([1u8; 32], 2, vec![0u8; 33]);
+        assert!(matches!(
+            node.handle_ecdh_share(from, payload).await,
+            Err(FrostNetError::UntrustedPeer(_))
+        ));
+    }
+
+    /// A completed-secret announcement for an unknown session is rejected
+    /// (session-lookup gate) rather than silently accepted.
+    #[tokio::test]
+    async fn handle_ecdh_complete_rejects_unknown_session() {
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        let payload = EcdhCompletePayload {
+            session_id: [9u8; 32],
+            shared_secret: Zeroizing::new(vec![0u8; 32]),
+        };
+        assert!(matches!(
+            node.handle_ecdh_complete(from, payload).await,
+            Err(FrostNetError::Session(_))
+        ));
+    }
 }


### PR DESCRIPTION
Advances #543, following #690. Extends the deterministic responder-gate coverage from `handle_ecdh_request` to the other two ingress handlers, again by calling them directly on a crate-internal node (no relay run loop, ~0.1s).

## Added

- **`handle_ecdh_share` rejects an unannounced peer** (`verify_peer_share_index`): a share whose sender/index does not match an announced peer is refused with `UntrustedPeer`. This also pins the whole-function "replace with Ok(())" mutation, since the correct path returns `Err`.
- **`handle_ecdh_complete` rejects an unknown session**: a completed-secret announcement for a session that does not exist is refused with a session error rather than silently accepted.

## Verification

`cargo test -p keep-frost-net --lib` 344 pass; clippy clean.

## #543 remaining

The `request_ecdh` requester-orchestration survivors and the deeper `handle_ecdh_share`/`complete` paths (valid peer + live session) need the full requester->responder message flow over the multinode harness and remain for follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for peer exchange handling to ensure invalid or unexpected messages are rejected.
  * Verified that unannounced peer shares are refused.
  * Verified that completed secret data for unknown sessions is rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->