### PR TITLE
frost-net: deterministic tests for sign-path responder gates

### DIFF
--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -1980,8 +1980,7 @@ mod gate_tests {
         let (node, _relay) = test_node().await;
         let from = Keys::generate().public_key();
         let group = *node.group_pubkey();
-        let mut req =
-            SignRequestPayload::new([1u8; 32], group, vec![0u8; 32], "test", vec![1]);
+        let mut req = SignRequestPayload::new([1u8; 32], group, vec![0u8; 32], "test", vec![1]);
         req.created_at = 1; // ancient -> outside the replay window
         assert!(matches!(
             node.handle_sign_request(from, req).await,
@@ -1996,8 +1995,7 @@ mod gate_tests {
         let (node, _relay) = test_node().await;
         let from = Keys::generate().public_key();
         let group = *node.group_pubkey();
-        let mut req =
-            SignRequestPayload::new([1u8; 32], group, vec![0u8; 32], "test", vec![1]);
+        let mut req = SignRequestPayload::new([1u8; 32], group, vec![0u8; 32], "test", vec![1]);
         req.created_at = Timestamp::now().as_secs() + 3600; // beyond MAX_FUTURE_SKEW_SECS
         assert!(matches!(
             node.handle_sign_request(from, req).await,

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -1950,6 +1950,30 @@ mod gate_tests {
         (node, mock)
     }
 
+    /// A sign request for a different group is silently ignored (returns Ok
+    /// without opening a session). Pins the group-membership early-return: if
+    /// the gate were bypassed the request would fall through to the peer lookup
+    /// and return `UntrustedPeer` (the random `from` is not an announced peer),
+    /// so asserting `Ok` still kills the predicate mutation.
+    #[tokio::test]
+    async fn handle_sign_request_ignores_foreign_group() {
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        let req = SignRequestPayload::new([1u8; 32], [0xAA; 32], vec![0u8; 32], "test", vec![1]);
+        assert!(node.handle_sign_request(from, req).await.is_ok());
+    }
+
+    /// A sign request whose participant set excludes our own identifier is
+    /// ignored. Same mutation-kill property as the foreign-group case.
+    #[tokio::test]
+    async fn handle_sign_request_ignores_non_participant() {
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        let group = *node.group_pubkey();
+        let req = SignRequestPayload::new([1u8; 32], group, vec![0u8; 32], "test", vec![2, 3]);
+        assert!(node.handle_sign_request(from, req).await.is_ok());
+    }
+
     /// A stale sign request (created_at outside the replay window) is rejected.
     #[tokio::test]
     async fn handle_sign_request_rejects_stale_replay() {
@@ -1959,6 +1983,22 @@ mod gate_tests {
         let mut req =
             SignRequestPayload::new([1u8; 32], group, vec![0u8; 32], "test", vec![1]);
         req.created_at = 1; // ancient -> outside the replay window
+        assert!(matches!(
+            node.handle_sign_request(from, req).await,
+            Err(FrostNetError::ReplayDetected(_))
+        ));
+    }
+
+    /// A far-future sign request (created_at beyond the skew bound) is rejected.
+    /// Pins the upper side of the replay window, distinct from the stale case.
+    #[tokio::test]
+    async fn handle_sign_request_rejects_future_skew() {
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        let group = *node.group_pubkey();
+        let mut req =
+            SignRequestPayload::new([1u8; 32], group, vec![0u8; 32], "test", vec![1]);
+        req.created_at = Timestamp::now().as_secs() + 3600; // beyond MAX_FUTURE_SKEW_SECS
         assert!(matches!(
             node.handle_sign_request(from, req).await,
             Err(FrostNetError::ReplayDetected(_))

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -1923,3 +1923,85 @@ mod tests {
         assert_eq!(nonce_commitment_content_hash(7, &entries), expected);
     }
 }
+
+#[cfg(test)]
+mod gate_tests {
+    //! Deterministic responder-gate coverage for the sign-path ingress
+    //! handlers (#541 lineage). Each handler runs its early-return gates
+    //! before any session work, so the outcome is observable from the return
+    //! value alone: build a real node, call the handler directly, no relay
+    //! run loop or event-timing.
+
+    use super::*;
+    use crate::node::PeerPolicy;
+    use keep_core::frost::{ThresholdConfig, TrustedDealer};
+    use nostr_relay_builder::MockRelay;
+
+    async fn test_node() -> (KfpNode, MockRelay) {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .ok();
+        let mock = MockRelay::run().await.unwrap();
+        let relay = mock.url().await.to_string();
+        let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+        let (mut shares, _) = dealer.generate("signing-gate-test").unwrap();
+        // First share -> FROST identifier 1.
+        let node = KfpNode::new(shares.remove(0), vec![relay]).await.unwrap();
+        (node, mock)
+    }
+
+    /// A stale sign request (created_at outside the replay window) is rejected.
+    #[tokio::test]
+    async fn handle_sign_request_rejects_stale_replay() {
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        let group = *node.group_pubkey();
+        let mut req =
+            SignRequestPayload::new([1u8; 32], group, vec![0u8; 32], "test", vec![1]);
+        req.created_at = 1; // ancient -> outside the replay window
+        assert!(matches!(
+            node.handle_sign_request(from, req).await,
+            Err(FrostNetError::ReplayDetected(_))
+        ));
+    }
+
+    /// A peer denied by policy cannot open a sign request. Fresh `created_at`
+    /// passes the replay gate so the policy gate is what trips.
+    #[tokio::test]
+    async fn handle_sign_request_rejects_denied_peer() {
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        let group = *node.group_pubkey();
+        node.set_peer_policy(PeerPolicy::new(from).allow_receive(false));
+        let req = SignRequestPayload::new([1u8; 32], group, vec![0u8; 32], "test", vec![1]);
+        assert!(matches!(
+            node.handle_sign_request(from, req).await,
+            Err(FrostNetError::PolicyViolation(_))
+        ));
+    }
+
+    /// A nonce commitment from a peer whose share index is not announced is
+    /// rejected (`verify_peer_share_index`).
+    #[tokio::test]
+    async fn handle_commitment_rejects_unannounced_peer() {
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        let payload = CommitmentPayload::new([1u8; 32], 2, vec![0u8; 33]);
+        assert!(matches!(
+            node.handle_commitment(from, payload).await,
+            Err(FrostNetError::UntrustedPeer(_))
+        ));
+    }
+
+    /// A signature share from an unannounced peer is rejected.
+    #[tokio::test]
+    async fn handle_signature_share_rejects_unannounced_peer() {
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        let payload = SignatureSharePayload::new([1u8; 32], 2, vec![0u8; 32]);
+        assert!(matches!(
+            node.handle_signature_share(from, payload).await,
+            Err(FrostNetError::UntrustedPeer(_))
+        ));
+    }
+}


### PR DESCRIPTION
Follow-up to #541 (signing-module mutation testing). Adds deterministic responder-gate coverage for the sign-path ingress handlers by calling them directly on a crate-internal node, no relay run loop or event-timing (~0.1s), the same approach used for the ECDH handlers in #690/#691.

## Gates covered

- **`handle_sign_request` rejects a stale request** (`ReplayDetected`): created_at outside the replay window.
- **`handle_sign_request` rejects a policy-denied peer** (`PolicyViolation`): fresh created_at passes the replay gate, so the peer-policy gate is what trips.
- **`handle_commitment` rejects an unannounced peer** (`UntrustedPeer`): a nonce commitment whose sender/share-index does not match an announced peer.
- **`handle_signature_share` rejects an unannounced peer** (`UntrustedPeer`).

These pin the early-return predicates on the most security-critical (signing) ingress path, which previously had no direct handler-gate tests (the existing `mod tests` covers only the pure failover/dedup helpers).

## Verification

`cargo test -p keep-frost-net --lib` 348 pass; clippy clean.
