### PR TITLE
frost-net: deterministic tests for descriptor-coordination and enrollment responder gates

### DIFF
--- a/keep-frost-net/src/node/descriptor.rs
+++ b/keep-frost-net/src/node/descriptor.rs
@@ -1482,3 +1482,118 @@ impl KfpNode {
         Ok(Zeroizing::new(bytes))
     }
 }
+
+#[cfg(test)]
+mod gate_tests {
+    //! Deterministic responder-gate coverage for every descriptor-coordination
+    //! ingress handler. Each runs a uniform group -> policy -> replay prefix
+    //! before any session work, so the outcome is observable from the return
+    //! value: build a real node, call the handler directly, no relay run loop.
+
+    use super::*;
+    use crate::node::PeerPolicy;
+    use keep_core::frost::{ThresholdConfig, TrustedDealer};
+    use nostr_relay_builder::MockRelay;
+
+    async fn test_node() -> (KfpNode, MockRelay) {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .ok();
+        let mock = MockRelay::run().await.unwrap();
+        let relay = mock.url().await.to_string();
+        let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+        let (mut shares, _) = dealer.generate("descriptor-gate-test").unwrap();
+        (
+            KfpNode::new(shares.remove(0), vec![relay]).await.unwrap(),
+            mock,
+        )
+    }
+
+    /// For a handler with the group/policy/replay prefix: a payload for a
+    /// foreign group is silently ignored (`Ok`), a policy-denied peer gets
+    /// `PolicyViolation`, and a stale `created_at` (default policy allows) gets
+    /// `ReplayDetected`. `$build` maps a group pubkey to a payload whose other
+    /// fields are irrelevant to these gates.
+    macro_rules! policy_replay_gate_tests {
+        ($mod:ident, $handler:ident, $build:expr) => {
+            mod $mod {
+                use super::*;
+
+                #[tokio::test]
+                async fn ignores_foreign_group() {
+                    let (node, _relay) = test_node().await;
+                    let from = Keys::generate().public_key();
+                    // Foreign group -> the membership gate short-circuits before
+                    // any policy/replay work. If that gate regressed, an
+                    // unannounced peer would trip a later gate and return Err.
+                    let payload = ($build)([0xAAu8; 32]);
+                    assert!(node.$handler(from, payload).await.is_ok());
+                }
+
+                #[tokio::test]
+                async fn rejects_denied_peer() {
+                    let (node, _relay) = test_node().await;
+                    let from = Keys::generate().public_key();
+                    node.set_peer_policy(PeerPolicy::new(from).allow_receive(false));
+                    let payload = ($build)(*node.group_pubkey());
+                    assert!(matches!(
+                        node.$handler(from, payload).await,
+                        Err(FrostNetError::PolicyViolation(_))
+                    ));
+                }
+
+                #[tokio::test]
+                async fn rejects_stale_replay() {
+                    let (node, _relay) = test_node().await;
+                    let from = Keys::generate().public_key();
+                    let mut payload = ($build)(*node.group_pubkey());
+                    payload.created_at = 1; // ancient -> outside the replay window
+                    assert!(matches!(
+                        node.$handler(from, payload).await,
+                        Err(FrostNetError::ReplayDetected(_))
+                    ));
+                }
+            }
+        };
+    }
+
+    policy_replay_gate_tests!(descriptor_migrate, handle_descriptor_migrate, |g| {
+        DescriptorMigratePayload::new([1u8; 32], g, [2u8; 32], [3u8; 32], 2)
+    });
+    policy_replay_gate_tests!(descriptor_propose, handle_descriptor_propose, |g| {
+        DescriptorProposePayload::new(
+            [1u8; 32],
+            g,
+            Timestamp::now().as_secs(),
+            "signet",
+            WalletPolicy {
+                recovery_tiers: vec![],
+                version: 1,
+            },
+            "xpub",
+            "fingerprint",
+        )
+    });
+    policy_replay_gate_tests!(descriptor_contribute, handle_descriptor_contribute, |g| {
+        DescriptorContributePayload::new([1u8; 32], g, 2, "xpub", "fingerprint")
+    });
+    policy_replay_gate_tests!(descriptor_finalize, handle_descriptor_finalize, |g| {
+        DescriptorFinalizePayload::new(
+            [1u8; 32],
+            g,
+            "ext",
+            "int",
+            [0u8; 32],
+            std::collections::BTreeMap::new(),
+        )
+    });
+    policy_replay_gate_tests!(descriptor_nack, handle_descriptor_nack, |g| {
+        DescriptorNackPayload::new([1u8; 32], g, "reason")
+    });
+    policy_replay_gate_tests!(descriptor_ack, handle_descriptor_ack, |g| {
+        DescriptorAckPayload::new([1u8; 32], g, [0u8; 32], vec![])
+    });
+    policy_replay_gate_tests!(xpub_announce, handle_xpub_announce, |g| {
+        XpubAnnouncePayload::new(g, 2, vec![])
+    });
+}

--- a/keep-frost-net/src/node/enroll.rs
+++ b/keep-frost-net/src/node/enroll.rs
@@ -431,3 +431,110 @@ impl KfpNode {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod gate_tests {
+    //! Deterministic responder-gate coverage for the OPRF enrollment ingress
+    //! handlers: build a real node, call the handler directly, no relay run loop.
+
+    use super::*;
+    use crate::node::PeerPolicy;
+    use keep_core::frost::{ThresholdConfig, TrustedDealer};
+    use nostr_relay_builder::MockRelay;
+
+    async fn test_node() -> (KfpNode, MockRelay) {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .ok();
+        let mock = MockRelay::run().await.unwrap();
+        let relay = mock.url().await.to_string();
+        let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+        let (mut shares, _) = dealer.generate("enroll-gate-test").unwrap();
+        // First share -> FROST identifier 1.
+        (
+            KfpNode::new(shares.remove(0), vec![relay]).await.unwrap(),
+            mock,
+        )
+    }
+
+    // target_index 1 == our identifier, so the "addressed to us" gate passes and
+    // the request reaches the replay/policy gates.
+    fn enroll(group: [u8; 32]) -> OprfEnrollPayload {
+        OprfEnrollPayload::new(
+            [1u8; 32],
+            group,
+            2,
+            1,
+            2,
+            3,
+            zeroize::Zeroizing::new(vec![0u8; 1]),
+        )
+    }
+
+    #[tokio::test]
+    async fn handle_oprf_enroll_ignores_foreign_group() {
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        // Foreign group -> the membership gate short-circuits (Ok) before the
+        // target/replay/policy gates. If it regressed, target_index 1 still
+        // matches us and an unannounced dealer would trip a later gate (Err).
+        let payload = enroll([0xAAu8; 32]);
+        assert!(node.handle_oprf_enroll(from, payload).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn handle_oprf_enroll_ignores_wrong_target() {
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        let mut payload = enroll(*node.group_pubkey());
+        payload.target_index = 2; // not our identifier (1) -> silently ignored
+        assert!(node.handle_oprf_enroll(from, payload).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn handle_oprf_enroll_rejects_stale_replay() {
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        let mut payload = enroll(*node.group_pubkey());
+        payload.created_at = 1; // ancient -> outside the replay window
+        assert!(matches!(
+            node.handle_oprf_enroll(from, payload).await,
+            Err(FrostNetError::ReplayDetected(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn handle_oprf_enroll_rejects_future_skew() {
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        let mut payload = enroll(*node.group_pubkey());
+        payload.created_at = Timestamp::now().as_secs() + 3600; // beyond skew bound
+        assert!(matches!(
+            node.handle_oprf_enroll(from, payload).await,
+            Err(FrostNetError::ReplayDetected(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn handle_oprf_enroll_rejects_denied_peer() {
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        node.set_peer_policy(PeerPolicy::new(from).allow_receive(false));
+        let payload = enroll(*node.group_pubkey());
+        assert!(matches!(
+            node.handle_oprf_enroll(from, payload).await,
+            Err(FrostNetError::PolicyViolation(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn handle_oprf_enroll_ack_rejects_unannounced_peer() {
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        let payload = OprfEnrollAckPayload::new([1u8; 32], 2);
+        assert!(matches!(
+            node.handle_oprf_enroll_ack(from, payload).await,
+            Err(FrostNetError::UntrustedPeer(_))
+        ));
+    }
+}


### PR DESCRIPTION
Covers the remaining keep-frost-net ingress-handler responder gates in one pass: all six descriptor-coordination handlers and both OPRF-enrollment handlers. Same deterministic approach as the ECDH/signing gate tests, call the handler directly on a crate-internal node and assert the gate outcome from the return value, no relay run loop or event-timing (~0.1s total).

## Descriptor coordination (12 tests, macro-driven)

Every handler runs a uniform `group -> policy -> replay` prefix before any session work. A single `policy_replay_gate_tests!` macro generates, per handler, a policy-denied case (`PolicyViolation`) and a stale-`created_at` case (`ReplayDetected`):

- `handle_descriptor_migrate`, `handle_descriptor_propose`, `handle_descriptor_contribute`, `handle_descriptor_finalize`, `handle_descriptor_nack`, `handle_descriptor_ack`.

## OPRF enrollment (3 tests)

- `handle_oprf_enroll` rejects a stale request (`ReplayDetected`) and a policy-denied peer (`PolicyViolation`) (payload addressed to our identity so it reaches those gates).
- `handle_oprf_enroll_ack` rejects an unannounced peer (`UntrustedPeer`).

These pin the early-return predicates on the descriptor-coordination and enrollment paths, which previously had no direct handler-gate tests, completing the ingress-gate coverage across the PSBT, ECDH, signing, DKG, descriptor, and enrollment handlers.

## Verification

`cargo test -p keep-frost-net --lib` 366 pass; clippy clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for key message-handling gate checks across node descriptor and enrollment flows.
  * Verified that foreign-group and mismatched-target messages are ignored, while denied, stale, future-skewed, and untrusted-peer cases are rejected as expected.
  * Expanded validation for replay protection and policy enforcement on multiple inbound request types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->