### PR TITLE
cert-pin: allow multiple SPKI pins per host for safe certificate rotation

### DIFF
--- a/keep-desktop/src/app/settings.rs
+++ b/keep-desktop/src/app/settings.rs
@@ -234,7 +234,11 @@ impl App {
         let mut entries: Vec<(String, String)> = pins
             .pins()
             .iter()
-            .map(|(host, hash)| (host.clone(), hex::encode(hash)))
+            .flat_map(|(host, hashes)| {
+                hashes
+                    .iter()
+                    .map(move |hash| (host.clone(), hex::encode(hash)))
+            })
             .collect();
         entries.sort_unstable();
         entries

--- a/keep-desktop/src/app/util.rs
+++ b/keep-desktop/src/app/util.rs
@@ -153,19 +153,21 @@ pub(crate) fn load_cert_pins(keep_path: &std::path::Path) -> keep_frost_net::Cer
     let Ok(contents) = std::fs::read_to_string(&path) else {
         return keep_frost_net::CertificatePinSet::new();
     };
-    let map: std::collections::HashMap<String, String> =
-        serde_json::from_str(&contents).unwrap_or_default();
-    let mut pins = keep_frost_net::CertificatePinSet::new();
-    for (hostname, hex_hash) in map {
-        let Ok(bytes) = hex::decode(&hex_hash) else {
-            continue;
-        };
-        let Ok(hash) = <[u8; 32]>::try_from(bytes.as_slice()) else {
-            continue;
-        };
-        pins.add_pin(hostname, hash);
+    match keep_frost_net::CertificatePinSet::from_json_bytes(contents.as_bytes()) {
+        Ok((pins, malformed)) => {
+            if !malformed.is_empty() {
+                tracing::warn!(
+                    "Dropping malformed certificate pins: {}",
+                    malformed.join(", ")
+                );
+            }
+            pins
+        }
+        Err(e) => {
+            tracing::warn!("Failed to parse certificate pins: {e}");
+            keep_frost_net::CertificatePinSet::new()
+        }
     }
-    pins
 }
 
 pub(crate) fn save_cert_pins(
@@ -173,12 +175,7 @@ pub(crate) fn save_cert_pins(
     pins: &keep_frost_net::CertificatePinSet,
 ) {
     let path = cert_pins_path(keep_path);
-    let map: std::collections::HashMap<&String, String> = pins
-        .pins()
-        .iter()
-        .map(|(k, v)| (k, hex::encode(v)))
-        .collect();
-    if let Ok(json) = serde_json::to_string_pretty(&map) {
+    if let Ok(json) = serde_json::to_string_pretty(&pins.to_hex_map()) {
         if let Err(e) = write_private(&path, &json) {
             tracing::error!("Failed to save certificate pins: {e}");
         }

--- a/keep-desktop/src/frost.rs
+++ b/keep-desktop/src/frost.rs
@@ -76,7 +76,7 @@ pub(crate) async fn verify_relay_certificates(
             let mut guard = certificate_pins
                 .lock()
                 .map_err(|_| ConnectionError::Other("Pin lock poisoned".to_string()))?;
-            if guard.get_pin(&hostname).is_none() {
+            if !guard.is_pinned(&hostname) {
                 guard.add_pin(hostname, hash);
             }
             let pins_snapshot = guard.clone();

--- a/keep-frost-net/src/cert_pin.rs
+++ b/keep-frost-net/src/cert_pin.rs
@@ -23,7 +23,11 @@ pub type SpkiHash = [u8; 32];
 
 #[derive(Clone, Debug, Default)]
 pub struct CertificatePinSet {
-    pins: HashMap<String, SpkiHash>,
+    /// One or more accepted SPKI hashes per hostname. Multiple pins let an
+    /// operator stage a backup pin (RFC 7469) before rotating a relay's
+    /// certificate, so both the current and next key verify during the
+    /// overlap instead of a rotation hard-failing every connection.
+    pins: HashMap<String, Vec<SpkiHash>>,
 }
 
 impl CertificatePinSet {
@@ -31,19 +35,32 @@ impl CertificatePinSet {
         Self::default()
     }
 
+    /// Add an accepted pin for `hostname`. Additive and de-duplicated: an
+    /// existing pin for the host is retained (so a rotation can pre-stage the
+    /// next key alongside the current one), and adding the same hash twice is
+    /// a no-op.
     pub fn add_pin(&mut self, hostname: String, hash: SpkiHash) {
-        self.pins.insert(hostname, hash);
+        let entry = self.pins.entry(hostname).or_default();
+        if !entry.contains(&hash) {
+            entry.push(hash);
+        }
     }
 
-    pub fn get_pin(&self, hostname: &str) -> Option<&SpkiHash> {
-        self.pins.get(hostname)
+    /// All accepted pins for `hostname` (empty slice if none).
+    pub fn get_pins(&self, hostname: &str) -> &[SpkiHash] {
+        self.pins.get(hostname).map_or(&[], Vec::as_slice)
     }
 
-    pub fn remove_pin(&mut self, hostname: &str) -> Option<SpkiHash> {
+    /// Whether `hostname` has at least one pin (used to gate TOFU).
+    pub fn is_pinned(&self, hostname: &str) -> bool {
+        self.pins.get(hostname).is_some_and(|v| !v.is_empty())
+    }
+
+    pub fn remove_pin(&mut self, hostname: &str) -> Option<Vec<SpkiHash>> {
         self.pins.remove(hostname)
     }
 
-    pub fn pins(&self) -> &HashMap<String, SpkiHash> {
+    pub fn pins(&self) -> &HashMap<String, Vec<SpkiHash>> {
         &self.pins
     }
 
@@ -140,18 +157,26 @@ pub async fn verify_relay_certificate(
 
     let spki_hash = hash_spki(spki_bytes);
 
-    if let Some(expected) = pins.get_pin(&hostname) {
-        if spki_hash.ct_ne(expected).into() {
-            return Err(FrostNetError::CertificatePinMismatch {
-                hostname,
-                expected: "***".into(),
-                actual: hex::encode(spki_hash),
-            });
-        }
-        Ok((spki_hash, None))
-    } else {
-        Ok((spki_hash, Some((hostname, spki_hash))))
+    let expected = pins.get_pins(&hostname);
+    if expected.is_empty() {
+        // Trust-on-first-use: no pin yet, surface the observed hash to pin.
+        return Ok((spki_hash, Some((hostname, spki_hash))));
     }
+    // Accept if the observed hash matches ANY pinned key (current or a staged
+    // backup). Fold the constant-time comparisons without short-circuiting so
+    // the match position does not leak via timing.
+    let mut matched = subtle::Choice::from(0u8);
+    for pin in expected {
+        matched |= spki_hash.ct_eq(pin);
+    }
+    if !bool::from(matched) {
+        return Err(FrostNetError::CertificatePinMismatch {
+            hostname,
+            expected: "***".into(),
+            actual: hex::encode(spki_hash),
+        });
+    }
+    Ok((spki_hash, None))
 }
 
 fn hash_spki(spki_der: &[u8]) -> SpkiHash {
@@ -244,12 +269,28 @@ mod tests {
 
         let hash = [42u8; 32];
         pins.add_pin("relay.example.com".into(), hash);
-        assert_eq!(pins.get_pin("relay.example.com"), Some(&hash));
+        assert!(pins.is_pinned("relay.example.com"));
+        assert_eq!(pins.get_pins("relay.example.com"), &[hash]);
         assert!(!pins.is_empty());
 
         let removed = pins.remove_pin("relay.example.com");
-        assert_eq!(removed, Some(hash));
+        assert_eq!(removed, Some(vec![hash]));
         assert!(pins.is_empty());
+    }
+
+    #[test]
+    fn test_multi_pin_for_rotation() {
+        // A host can hold a current pin plus a staged backup; adding is
+        // additive and de-duplicated, and both are accepted.
+        let mut pins = CertificatePinSet::new();
+        let current = [1u8; 32];
+        let backup = [2u8; 32];
+        pins.add_pin("relay.example.com".into(), current);
+        pins.add_pin("relay.example.com".into(), backup);
+        pins.add_pin("relay.example.com".into(), current); // dedup, no-op
+        assert_eq!(pins.get_pins("relay.example.com"), &[current, backup]);
+        assert!(pins.get_pins("other.example.com").is_empty());
+        assert!(!pins.is_pinned("other.example.com"));
     }
 
     #[test]

--- a/keep-frost-net/src/cert_pin.rs
+++ b/keep-frost-net/src/cert_pin.rs
@@ -42,10 +42,11 @@ impl CertificatePinSet {
     /// Add an accepted pin for `hostname`. Additive and de-duplicated: an
     /// existing pin for the host is retained (so a rotation can pre-stage the
     /// next key alongside the current one), and adding the same hash twice is
-    /// a no-op.
+    /// a no-op. Capped at `MAX_PINS_PER_HOST`; further pins for a full host are
+    /// ignored so the bounded invariant holds for every caller, not just loads.
     pub fn add_pin(&mut self, hostname: String, hash: SpkiHash) {
         let entry = self.pins.entry(hostname).or_default();
-        if !entry.contains(&hash) {
+        if entry.len() < MAX_PINS_PER_HOST && !entry.contains(&hash) {
             entry.push(hash);
         }
     }
@@ -358,6 +359,15 @@ mod tests {
         assert_eq!(pins.get_pins("relay.example.com"), &[current, backup]);
         assert!(pins.get_pins("other.example.com").is_empty());
         assert!(!pins.is_pinned("other.example.com"));
+    }
+
+    #[test]
+    fn test_add_pin_enforces_max_per_host() {
+        let mut pins = CertificatePinSet::new();
+        for i in 0..(MAX_PINS_PER_HOST as u8 + 3) {
+            pins.add_pin("relay.example.com".into(), [i; 32]);
+        }
+        assert_eq!(pins.get_pins("relay.example.com").len(), MAX_PINS_PER_HOST);
     }
 
     #[test]

--- a/keep-frost-net/src/cert_pin.rs
+++ b/keep-frost-net/src/cert_pin.rs
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: © 2026 PrivKey LLC
 // SPDX-License-Identifier: MIT
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -20,6 +20,10 @@ use crate::error::{FrostNetError, Result};
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub type SpkiHash = [u8; 32];
+
+/// Upper bound on accepted pins per host. A handful covers current + staged
+/// backup keys (RFC 7469); anything larger is treated as corruption.
+pub const MAX_PINS_PER_HOST: usize = 8;
 
 #[derive(Clone, Debug, Default)]
 pub struct CertificatePinSet {
@@ -67,6 +71,74 @@ impl CertificatePinSet {
     pub fn is_empty(&self) -> bool {
         self.pins.is_empty()
     }
+
+    /// Serializable view of the pin set: host -> lowercase hex SPKI hashes.
+    /// Deterministic ordering via `BTreeMap` so persisted files are stable.
+    pub fn to_hex_map(&self) -> BTreeMap<String, Vec<String>> {
+        self.pins
+            .iter()
+            .map(|(host, hashes)| (host.clone(), hashes.iter().map(hex::encode).collect()))
+            .collect()
+    }
+
+    /// Parse a persisted cert-pin JSON object, accepting both the legacy
+    /// single-hash-per-host format and the current per-host list format.
+    ///
+    /// Returns the decoded pin set plus a list of `"host: reason"` strings for
+    /// entries that could not be decoded. Callers that want fail-closed loading
+    /// should reject when the malformed list is non-empty. Failing closed on an
+    /// empty pin list prevents an empty-array downgrade from silently clearing a
+    /// host's pins.
+    pub fn from_json_bytes(
+        bytes: &[u8],
+    ) -> std::result::Result<(Self, Vec<String>), serde_json::Error> {
+        #[derive(serde::Deserialize)]
+        #[serde(untagged)]
+        enum StoredPins {
+            Single(String),
+            Multiple(Vec<String>),
+        }
+        let map: HashMap<String, StoredPins> = serde_json::from_slice(bytes)?;
+        let mut set = Self::new();
+        let mut malformed = Vec::new();
+        for (hostname, stored) in map {
+            let hashes = match stored {
+                StoredPins::Single(s) => vec![s],
+                StoredPins::Multiple(v) => v,
+            };
+            for (i, hash_hex) in hashes.iter().enumerate() {
+                if i >= MAX_PINS_PER_HOST {
+                    malformed.push(format!("{hostname}: too many pins ({})", hashes.len()));
+                    break;
+                }
+                match hex::decode(hash_hex) {
+                    Ok(raw) => match <[u8; 32]>::try_from(raw) {
+                        Ok(hash) => set.add_pin(hostname.clone(), hash),
+                        Err(raw) => {
+                            malformed.push(format!("{hostname}: invalid length {}", raw.len()))
+                        }
+                    },
+                    Err(e) => malformed.push(format!("{hostname}: hex decode failed: {e}")),
+                }
+            }
+            if hashes.is_empty() {
+                malformed.push(format!("{hostname}: empty pin list"));
+            }
+        }
+        Ok((set, malformed))
+    }
+}
+
+/// Constant-time membership test: does `observed` equal any hash in `expected`?
+///
+/// Folds every comparison without short-circuiting so the match position does
+/// not leak through timing. Do not replace with `==` / `.iter().any()`.
+fn pins_match(observed: &SpkiHash, expected: &[SpkiHash]) -> bool {
+    let mut matched = subtle::Choice::from(0u8);
+    for pin in expected {
+        matched |= observed.ct_eq(pin);
+    }
+    bool::from(matched)
 }
 
 pub async fn verify_relay_certificate(
@@ -163,13 +235,8 @@ pub async fn verify_relay_certificate(
         return Ok((spki_hash, Some((hostname, spki_hash))));
     }
     // Accept if the observed hash matches ANY pinned key (current or a staged
-    // backup). Fold the constant-time comparisons without short-circuiting so
-    // the match position does not leak via timing.
-    let mut matched = subtle::Choice::from(0u8);
-    for pin in expected {
-        matched |= spki_hash.ct_eq(pin);
-    }
-    if !bool::from(matched) {
+    // backup), using a constant-time fold that does not leak the match position.
+    if !pins_match(&spki_hash, expected) {
         return Err(FrostNetError::CertificatePinMismatch {
             hostname,
             expected: "***".into(),
@@ -291,6 +358,98 @@ mod tests {
         assert_eq!(pins.get_pins("relay.example.com"), &[current, backup]);
         assert!(pins.get_pins("other.example.com").is_empty());
         assert!(!pins.is_pinned("other.example.com"));
+    }
+
+    #[test]
+    fn test_pins_match_first_pin() {
+        let observed = [7u8; 32];
+        assert!(pins_match(&observed, &[[7u8; 32], [8u8; 32]]));
+    }
+
+    #[test]
+    fn test_pins_match_backup_pin() {
+        let observed = [8u8; 32];
+        assert!(pins_match(&observed, &[[7u8; 32], [8u8; 32]]));
+    }
+
+    #[test]
+    fn test_pins_match_rejects_unknown() {
+        let observed = [9u8; 32];
+        assert!(!pins_match(&observed, &[[7u8; 32], [8u8; 32]]));
+    }
+
+    #[test]
+    fn test_pins_match_empty_expected() {
+        assert!(!pins_match(&[7u8; 32], &[]));
+    }
+
+    #[test]
+    fn test_from_json_legacy_single_string() {
+        let hex = hex::encode([0x42u8; 32]);
+        let json = format!(r#"{{"relay.example.com":"{hex}"}}"#);
+        let (pins, malformed) = CertificatePinSet::from_json_bytes(json.as_bytes()).unwrap();
+        assert!(malformed.is_empty());
+        assert_eq!(pins.get_pins("relay.example.com"), &[[0x42u8; 32]]);
+    }
+
+    #[test]
+    fn test_from_json_list_format() {
+        let a = hex::encode([0x11u8; 32]);
+        let b = hex::encode([0x22u8; 32]);
+        let json = format!(r#"{{"relay.example.com":["{a}","{b}"]}}"#);
+        let (pins, malformed) = CertificatePinSet::from_json_bytes(json.as_bytes()).unwrap();
+        assert!(malformed.is_empty());
+        assert_eq!(
+            pins.get_pins("relay.example.com"),
+            &[[0x11u8; 32], [0x22u8; 32]]
+        );
+    }
+
+    #[test]
+    fn test_from_json_empty_array_is_malformed() {
+        let json = r#"{"relay.example.com":[]}"#;
+        let (pins, malformed) = CertificatePinSet::from_json_bytes(json.as_bytes()).unwrap();
+        assert!(!pins.is_pinned("relay.example.com"));
+        assert!(malformed.iter().any(|m| m.contains("empty pin list")));
+    }
+
+    #[test]
+    fn test_from_json_over_cap_is_malformed() {
+        let pins_hex: Vec<String> = (0..MAX_PINS_PER_HOST + 2)
+            .map(|i| hex::encode([i as u8; 32]))
+            .collect();
+        let json = serde_json::json!({ "relay.example.com": pins_hex }).to_string();
+        let (pins, malformed) = CertificatePinSet::from_json_bytes(json.as_bytes()).unwrap();
+        assert_eq!(pins.get_pins("relay.example.com").len(), MAX_PINS_PER_HOST);
+        assert!(malformed.iter().any(|m| m.contains("too many pins")));
+    }
+
+    #[test]
+    fn test_from_json_malformed_hex_and_length() {
+        let valid = hex::encode([0x42u8; 32]);
+        let json = format!(
+            r#"{{"bad.example.com":"nothex","short.example.com":"aabb","good.example.com":"{valid}"}}"#
+        );
+        let (pins, malformed) = CertificatePinSet::from_json_bytes(json.as_bytes()).unwrap();
+        assert_eq!(pins.get_pins("good.example.com"), &[[0x42u8; 32]]);
+        assert!(!pins.is_pinned("bad.example.com"));
+        assert!(!pins.is_pinned("short.example.com"));
+        assert!(malformed.iter().any(|m| m.contains("hex decode failed")));
+        assert!(malformed.iter().any(|m| m.contains("invalid length")));
+    }
+
+    #[test]
+    fn test_to_hex_map_roundtrip() {
+        let mut pins = CertificatePinSet::new();
+        pins.add_pin("relay.example.com".into(), [0x01u8; 32]);
+        pins.add_pin("relay.example.com".into(), [0x02u8; 32]);
+        let json = serde_json::to_vec(&pins.to_hex_map()).unwrap();
+        let (restored, malformed) = CertificatePinSet::from_json_bytes(&json).unwrap();
+        assert!(malformed.is_empty());
+        assert_eq!(
+            restored.get_pins("relay.example.com"),
+            &[[0x01u8; 32], [0x02u8; 32]]
+        );
     }
 
     #[test]

--- a/keep-frost-net/tests/cert_pins_file_test.rs
+++ b/keep-frost-net/tests/cert_pins_file_test.rs
@@ -13,28 +13,14 @@ fn load_cert_pins(keep_path: &Path) -> CertificatePinSet {
     let Ok(contents) = std::fs::read_to_string(&path) else {
         return CertificatePinSet::new();
     };
-    let map: HashMap<String, String> = serde_json::from_str(&contents).unwrap_or_default();
-    let mut pins = CertificatePinSet::new();
-    for (hostname, hex_hash) in map {
-        let Ok(bytes) = hex::decode(&hex_hash) else {
-            continue;
-        };
-        let Ok(hash) = <[u8; 32]>::try_from(bytes.as_slice()) else {
-            continue;
-        };
-        pins.add_pin(hostname, hash);
-    }
-    pins
+    CertificatePinSet::from_json_bytes(contents.as_bytes())
+        .map(|(pins, _malformed)| pins)
+        .unwrap_or_default()
 }
 
 fn save_cert_pins(keep_path: &Path, pins: &CertificatePinSet) {
     let path = keep_path.join("cert-pins.json");
-    let map: HashMap<&String, String> = pins
-        .pins()
-        .iter()
-        .map(|(k, v)| (k, hex::encode(v)))
-        .collect();
-    let json = serde_json::to_string_pretty(&map).expect("serialize");
+    let json = serde_json::to_string_pretty(&pins.to_hex_map()).expect("serialize");
     std::fs::write(&path, &json).expect("write cert-pins.json");
 }
 
@@ -50,8 +36,8 @@ fn test_cert_pins_file_roundtrip() {
 
     let loaded = load_cert_pins(dir.path());
     assert_eq!(loaded.pins().len(), 2);
-    assert_eq!(loaded.get_pin("relay.damus.io"), Some(&[0x42u8; 32]));
-    assert_eq!(loaded.get_pin("relay.primal.net"), Some(&[0xABu8; 32]));
+    assert_eq!(loaded.get_pins("relay.damus.io"), &[[0x42u8; 32]]);
+    assert_eq!(loaded.get_pins("relay.primal.net"), &[[0xABu8; 32]]);
 }
 
 #[test]
@@ -71,11 +57,11 @@ fn test_cert_pins_file_display() {
     save_cert_pins(dir.path(), &pins);
 
     let contents = std::fs::read_to_string(dir.path().join("cert-pins.json")).expect("read");
-    let map: HashMap<String, String> = serde_json::from_str(&contents).expect("parse");
+    let map: HashMap<String, Vec<String>> = serde_json::from_str(&contents).expect("parse");
 
     assert_eq!(map.len(), 1);
-    let stored_hex = map.get("relay.damus.io").expect("key exists");
-    assert_eq!(stored_hex, &hex::encode(hash));
+    let stored = map.get("relay.damus.io").expect("key exists");
+    assert_eq!(stored, &vec![hex::encode(hash)]);
 }
 
 #[test]
@@ -88,13 +74,13 @@ fn test_pin_replacement_via_json_mutation() {
 
     let path = dir.path().join("cert-pins.json");
     let contents = std::fs::read_to_string(&path).expect("read");
-    let mut map: HashMap<String, String> = serde_json::from_str(&contents).expect("parse");
-    map.insert("relay.damus.io".into(), hex::encode([0xFF; 32]));
+    let mut map: HashMap<String, Vec<String>> = serde_json::from_str(&contents).expect("parse");
+    map.insert("relay.damus.io".into(), vec![hex::encode([0xFF; 32])]);
     let json = serde_json::to_string_pretty(&map).expect("serialize");
     std::fs::write(&path, &json).expect("write");
 
     let loaded = load_cert_pins(dir.path());
-    assert_eq!(loaded.get_pin("relay.damus.io"), Some(&[0xFFu8; 32]));
+    assert_eq!(loaded.get_pins("relay.damus.io"), &[[0xFFu8; 32]]);
 }
 
 #[test]
@@ -122,9 +108,9 @@ fn test_load_invalid_hex_entry() {
 
     let loaded = load_cert_pins(dir.path());
     assert_eq!(loaded.pins().len(), 1);
-    assert_eq!(loaded.get_pin("valid.example.com"), Some(&[0x42u8; 32]));
-    assert!(loaded.get_pin("bad-hex.example.com").is_none());
-    assert!(loaded.get_pin("wrong-len.example.com").is_none());
+    assert_eq!(loaded.get_pins("valid.example.com"), &[[0x42u8; 32]]);
+    assert!(!loaded.is_pinned("bad-hex.example.com"));
+    assert!(!loaded.is_pinned("wrong-len.example.com"));
 }
 
 #[test]
@@ -137,13 +123,13 @@ fn test_json_mutation_with_invalid_hex() {
 
     let path = dir.path().join("cert-pins.json");
     let contents = std::fs::read_to_string(&path).expect("read");
-    let mut map: HashMap<String, String> = serde_json::from_str(&contents).expect("parse");
-    map.insert("relay.damus.io".into(), "not-hex".into());
+    let mut map: HashMap<String, Vec<String>> = serde_json::from_str(&contents).expect("parse");
+    map.insert("relay.damus.io".into(), vec!["not-hex".into()]);
     let json = serde_json::to_string_pretty(&map).expect("serialize");
     std::fs::write(&path, &json).expect("write");
 
     let loaded = load_cert_pins(dir.path());
-    assert!(loaded.get_pin("relay.damus.io").is_none());
+    assert!(!loaded.is_pinned("relay.damus.io"));
 }
 
 #[test]
@@ -162,6 +148,6 @@ fn test_clear_all_pins_file() {
     assert!(loaded.is_empty());
 
     let contents = std::fs::read_to_string(dir.path().join("cert-pins.json")).expect("read");
-    let map: HashMap<String, String> = serde_json::from_str(&contents).expect("parse");
+    let map: HashMap<String, Vec<String>> = serde_json::from_str(&contents).expect("parse");
     assert!(map.is_empty());
 }

--- a/keep-frost-net/tests/tls_cert_pin_verification.rs
+++ b/keep-frost-net/tests/tls_cert_pin_verification.rs
@@ -3,7 +3,6 @@
 
 #![forbid(unsafe_code)]
 
-use std::collections::HashMap;
 use std::sync::Once;
 
 use keep_frost_net::{
@@ -30,19 +29,9 @@ async fn fetch_pin() -> SpkiHash {
 }
 
 fn roundtrip_pins(original: &CertificatePinSet) -> CertificatePinSet {
-    let map: HashMap<String, String> = original
-        .pins()
-        .iter()
-        .map(|(k, v)| (k.clone(), hex::encode(v)))
-        .collect();
-    let json = serde_json::to_string(&map).expect("serialize");
-    let deserialized: HashMap<String, String> = serde_json::from_str(&json).expect("deserialize");
-    let mut restored = CertificatePinSet::new();
-    for (hostname, hex_hash) in deserialized {
-        let bytes = hex::decode(&hex_hash).expect("hex decode");
-        let h: [u8; 32] = bytes.try_into().expect("32 bytes");
-        restored.add_pin(hostname, h);
-    }
+    let json = serde_json::to_vec(&original.to_hex_map()).expect("serialize");
+    let (restored, malformed) = CertificatePinSet::from_json_bytes(&json).expect("deserialize");
+    assert!(malformed.is_empty());
     restored
 }
 
@@ -117,7 +106,7 @@ async fn test_clear_and_repin() {
     let mut pins = CertificatePinSet::new();
     pins.add_pin(TEST_HOSTNAME.into(), original_hash);
     pins.remove_pin(TEST_HOSTNAME);
-    assert!(pins.get_pin(TEST_HOSTNAME).is_none());
+    assert!(!pins.is_pinned(TEST_HOSTNAME));
 
     let (new_hash, new_pin) = verify_relay_certificate(TEST_RELAY, &pins)
         .await

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1257,9 +1257,11 @@ impl KeepMobile {
             .unwrap_or_default()
             .pins()
             .iter()
-            .map(|(hostname, hash)| CertificatePin {
-                hostname: hostname.clone(),
-                spki_hash: hex::encode(hash),
+            .flat_map(|(hostname, hashes)| {
+                hashes.iter().map(move |hash| CertificatePin {
+                    hostname: hostname.clone(),
+                    spki_hash: hex::encode(hash),
+                })
             })
             .collect())
     }
@@ -2586,7 +2588,7 @@ impl KeepMobile {
                 match keep_frost_net::verify_relay_certificate(relay, &pins).await {
                     Ok((_hash, new_pin)) => {
                         if let Some((hostname, hash)) = new_pin {
-                            if pins.get_pin(&hostname).is_none() {
+                            if !pins.is_pinned(&hostname) {
                                 pins.add_pin(hostname, hash);
                                 pins_changed = true;
                             }
@@ -2615,7 +2617,7 @@ impl KeepMobile {
                         return true;
                     }
                     url.host_str()
-                        .map(|h| pins.get_pin(h).is_some())
+                        .map(|h| pins.is_pinned(h))
                         .unwrap_or(false)
                 })
                 .cloned()

--- a/keep-mobile/src/persistence.rs
+++ b/keep-mobile/src/persistence.rs
@@ -154,22 +154,36 @@ pub(crate) fn load_cert_pins(
         Err(KeepMobileError::StorageNotFound) => return Ok(None),
         Err(e) => return Err(e),
     };
-    let map: HashMap<String, String> =
+    // Accept both the current per-host list format and the legacy single-hash
+    // format so pins persisted before multi-pin support still load.
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum StoredPins {
+        Single(String),
+        Multiple(Vec<String>),
+    }
+    let map: HashMap<String, StoredPins> =
         serde_json::from_slice(&data).map_err(|e| KeepMobileError::StorageError {
             msg: format!("Failed to deserialize cert pins: {e}"),
         })?;
 
     let mut pins = keep_frost_net::CertificatePinSet::new();
     let mut malformed = Vec::new();
-    for (hostname, hash_hex) in map {
-        match hex::decode(&hash_hex) {
-            Ok(bytes) => match <[u8; 32]>::try_from(bytes) {
-                Ok(hash) => pins.add_pin(hostname, hash),
-                Err(bytes) => {
-                    malformed.push(format!("{}: invalid length {}", hostname, bytes.len()))
-                }
-            },
-            Err(e) => malformed.push(format!("{hostname}: hex decode failed: {e}")),
+    for (hostname, stored) in map {
+        let hashes = match stored {
+            StoredPins::Single(s) => vec![s],
+            StoredPins::Multiple(v) => v,
+        };
+        for hash_hex in hashes {
+            match hex::decode(&hash_hex) {
+                Ok(bytes) => match <[u8; 32]>::try_from(bytes) {
+                    Ok(hash) => pins.add_pin(hostname.clone(), hash),
+                    Err(bytes) => {
+                        malformed.push(format!("{}: invalid length {}", hostname, bytes.len()))
+                    }
+                },
+                Err(e) => malformed.push(format!("{hostname}: hex decode failed: {e}")),
+            }
         }
     }
     if malformed.is_empty() {
@@ -189,10 +203,10 @@ pub(crate) fn persist_cert_pins(
     storage: &Arc<dyn SecureStorage>,
     pins: &keep_frost_net::CertificatePinSet,
 ) -> Result<(), KeepMobileError> {
-    let map: HashMap<String, String> = pins
+    let map: HashMap<String, Vec<String>> = pins
         .pins()
         .iter()
-        .map(|(k, v)| (k.clone(), hex::encode(v)))
+        .map(|(k, v)| (k.clone(), v.iter().map(hex::encode).collect()))
         .collect();
     let data = serde_json::to_vec(&map).map_err(|e| KeepMobileError::StorageError {
         msg: format!("Failed to serialize cert pins: {e}"),

--- a/keep-mobile/src/persistence.rs
+++ b/keep-mobile/src/persistence.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2026 PrivKey LLC
 // SPDX-License-Identifier: MIT
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -154,38 +154,12 @@ pub(crate) fn load_cert_pins(
         Err(KeepMobileError::StorageNotFound) => return Ok(None),
         Err(e) => return Err(e),
     };
-    // Accept both the current per-host list format and the legacy single-hash
-    // format so pins persisted before multi-pin support still load.
-    #[derive(serde::Deserialize)]
-    #[serde(untagged)]
-    enum StoredPins {
-        Single(String),
-        Multiple(Vec<String>),
-    }
-    let map: HashMap<String, StoredPins> =
-        serde_json::from_slice(&data).map_err(|e| KeepMobileError::StorageError {
-            msg: format!("Failed to deserialize cert pins: {e}"),
-        })?;
-
-    let mut pins = keep_frost_net::CertificatePinSet::new();
-    let mut malformed = Vec::new();
-    for (hostname, stored) in map {
-        let hashes = match stored {
-            StoredPins::Single(s) => vec![s],
-            StoredPins::Multiple(v) => v,
-        };
-        for hash_hex in hashes {
-            match hex::decode(&hash_hex) {
-                Ok(bytes) => match <[u8; 32]>::try_from(bytes) {
-                    Ok(hash) => pins.add_pin(hostname.clone(), hash),
-                    Err(bytes) => {
-                        malformed.push(format!("{}: invalid length {}", hostname, bytes.len()))
-                    }
-                },
-                Err(e) => malformed.push(format!("{hostname}: hex decode failed: {e}")),
+    let (pins, malformed) =
+        keep_frost_net::CertificatePinSet::from_json_bytes(&data).map_err(|e| {
+            KeepMobileError::StorageError {
+                msg: format!("Failed to deserialize cert pins: {e}"),
             }
-        }
-    }
+        })?;
     if malformed.is_empty() {
         Ok(Some(pins))
     } else {
@@ -203,14 +177,10 @@ pub(crate) fn persist_cert_pins(
     storage: &Arc<dyn SecureStorage>,
     pins: &keep_frost_net::CertificatePinSet,
 ) -> Result<(), KeepMobileError> {
-    let map: HashMap<String, Vec<String>> = pins
-        .pins()
-        .iter()
-        .map(|(k, v)| (k.clone(), v.iter().map(hex::encode).collect()))
-        .collect();
-    let data = serde_json::to_vec(&map).map_err(|e| KeepMobileError::StorageError {
-        msg: format!("Failed to serialize cert pins: {e}"),
-    })?;
+    let data =
+        serde_json::to_vec(&pins.to_hex_map()).map_err(|e| KeepMobileError::StorageError {
+            msg: format!("Failed to serialize cert pins: {e}"),
+        })?;
     storage.store_share_by_key(
         CERT_PINS_STORAGE_KEY.into(),
         data,


### PR DESCRIPTION
## Problem

`CertificatePinSet` stored exactly one SPKI pin per host and `add_pin` overwrote it, so certificate rotation was impossible without a hard failure: once a relay rotated its key, every pinned connection failed `CertificatePinMismatch` and the only recovery was clearing the pin entirely (dropping the protection).

## Change

Hold one *or more* accepted SPKI hashes per host (`HashMap<String, Vec<SpkiHash>>`), the RFC 7469 backup-pin model:

- `add_pin` is now additive and de-duplicated, so an operator can stage the next certificate's pin alongside the current one before rotating.
- `verify_relay_certificate` accepts a leaf whose SPKI matches ANY pinned hash for the host. The match is a constant-time fold over the pins (no short-circuit), so which pin matched, or that none did, does not leak via timing.
- `get_pins` / `is_pinned` replace the single-value `get_pin`; TOFU still only auto-pins a host with no existing pins.

Persistence migrates transparently: `load_cert_pins` accepts both the legacy single-hash-per-host JSON and the new per-host list (untagged), and writes the list format going forward. `get_certificate_pins` emits one entry per (host, hash).

## Verification

New `test_multi_pin_for_rotation` plus the updated `test_pin_set_operations`; `cargo test -p keep-frost-net --lib cert_pin` and `cargo test -p keep-mobile` (167) pass; clippy clean on both crates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Certificate pinning now supports multiple pins per hostname, helping with smoother certificate rotation and backup pins.
  * Saved pin data is now read and written in a more flexible format, including support for older pin files.

* **Bug Fixes**
  * Improved handling of malformed pin entries so valid pins still load.
  * Pin verification now uses the current set of stored pins more reliably across desktop and mobile flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->