### PR TITLE
keep-state replication over a Nostr relay (multi-node HA)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4810,6 +4810,7 @@ dependencies = [
  "keep-core",
  "keep-frost-net",
  "keep-nip46",
+ "nostr-relay-builder",
  "nostr-sdk",
  "serde",
  "serde_json",

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -105,6 +105,29 @@ pub struct Keep {
 }
 
 impl Keep {
+    /// Install the keep-state replication sink on the underlying storage (keep-web wires this to a
+    /// publisher that ships each vault-state change to the state relay). See [`StatePublisher`].
+    pub fn set_state_publisher(&self, publisher: std::sync::Arc<dyn StatePublisher>) {
+        self.storage.set_state_publisher(publisher);
+    }
+
+    /// Apply a record replicated from a peer into storage (the standby consumer side). Delegates to
+    /// [`Storage::apply_replicated_record`]; never echoes back to the relay.
+    pub fn apply_replicated_record(
+        &self,
+        table: &str,
+        record_id: &str,
+        encrypted: &[u8],
+    ) -> Result<()> {
+        self.storage
+            .apply_replicated_record(table, record_id, encrypted)
+    }
+
+    /// Apply a replicated delete (tombstone) from a peer.
+    pub fn apply_replicated_delete(&self, table: &str, record_id: &str) -> Result<()> {
+        self.storage.apply_replicated_delete(table, record_id)
+    }
+
     /// Create a new Keep with the given password.
     ///
     /// # Example

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -92,6 +92,7 @@ use crate::keyring::Keyring;
 use crate::keys::{KeyRecord, KeyType, NostrKeypair};
 pub use crate::relay::{PeerPolicyEntry, RelayConfig, GLOBAL_RELAY_KEY};
 pub use crate::storage::ProxyConfig;
+pub use crate::storage::StatePublisher;
 use crate::storage::Storage;
 pub use crate::wallet::{DeviceRegistration, WalletDescriptor};
 

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -305,9 +305,7 @@ impl Storage {
         encrypted: &[u8],
     ) -> Result<()> {
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
-        let table_name = Self::replicated_table(table)?;
-        let key = hex::decode(record_id)
-            .map_err(|e| KeepError::Other(format!("replicated record id not hex: {e}")))?;
+        let (table_name, key) = Self::replicated_key(table, record_id)?;
         backend.put(table_name, &key, encrypted)?;
         Ok(())
     }
@@ -315,11 +313,26 @@ impl Storage {
     /// Apply a replicated delete (tombstone) from a peer. Never notifies the publisher.
     pub fn apply_replicated_delete(&self, table: &str, record_id: &str) -> Result<()> {
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
+        let (table_name, key) = Self::replicated_key(table, record_id)?;
+        backend.delete(table_name, &key)?;
+        Ok(())
+    }
+
+    /// Resolve a replicated `(table, record_id)` to its backend table and raw key: maps the logical
+    /// table name and hex-decodes the id. Descriptor keys are fixed 36-byte `group||version`, and the
+    /// listing/lookup path fails closed on any other length, so a malformed descriptor key would poison
+    /// `list_descriptors` for the whole vault -- reject it here at the trust boundary.
+    fn replicated_key(table: &str, record_id: &str) -> Result<(&'static str, Vec<u8>)> {
         let table_name = Self::replicated_table(table)?;
         let key = hex::decode(record_id)
             .map_err(|e| KeepError::Other(format!("replicated record id not hex: {e}")))?;
-        backend.delete(table_name, &key)?;
-        Ok(())
+        if table_name == DESCRIPTORS_TABLE && key.len() != 36 {
+            return Err(KeepError::Other(format!(
+                "replicated descriptor key has length {} (expected 36)",
+                key.len()
+            )));
+        }
+        Ok((table_name, key))
     }
 
     /// Map a replicated logical table name (as it appears in the event `d`-tag) to its backend table.
@@ -1601,6 +1614,19 @@ mod tests {
         assert!(storage
             .apply_replicated_record("bogus", &hex::encode(record.id), &encrypted)
             .is_err());
+
+        // A descriptor key of the wrong length is refused: the listing/lookup path fails closed on any
+        // non-36-byte descriptor row, so accepting one would poison list_descriptors for the vault.
+        assert!(storage
+            .apply_replicated_record("descriptors", &hex::encode([0u8; 20]), &encrypted)
+            .is_err());
+        assert!(storage
+            .apply_replicated_delete("descriptors", &hex::encode([0u8; 20]))
+            .is_err());
+        // A correctly-sized 36-byte descriptor key is accepted.
+        assert!(storage
+            .apply_replicated_record("descriptors", &hex::encode([0u8; 36]), &encrypted)
+            .is_ok());
 
         // A replicated delete removes it, and never echoes to the publisher: the only recorded delete
         // is the earlier real delete_key, not this apply.

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -292,6 +292,45 @@ impl Storage {
             }
         }
     }
+
+    /// Apply a record replicated from a peer (the keep-state consumer / standby side). Stores the
+    /// already-vault-encrypted `encrypted` bytes verbatim under `table`, keyed by hex `record_id` --
+    /// the standby shares the vault key, so it later decrypts them like its own. Never notifies the
+    /// publisher, so a consumed record is not echoed back to the relay. Rejects any table but the three
+    /// replicated ones, so a hostile or buggy peer cannot write `shares` or node-local state.
+    pub fn apply_replicated_record(
+        &self,
+        table: &str,
+        record_id: &str,
+        encrypted: &[u8],
+    ) -> Result<()> {
+        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
+        let table_name = Self::replicated_table(table)?;
+        let key = hex::decode(record_id)
+            .map_err(|e| KeepError::Other(format!("replicated record id not hex: {e}")))?;
+        backend.put(table_name, &key, encrypted)?;
+        Ok(())
+    }
+
+    /// Apply a replicated delete (tombstone) from a peer. Never notifies the publisher.
+    pub fn apply_replicated_delete(&self, table: &str, record_id: &str) -> Result<()> {
+        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
+        let table_name = Self::replicated_table(table)?;
+        let key = hex::decode(record_id)
+            .map_err(|e| KeepError::Other(format!("replicated record id not hex: {e}")))?;
+        backend.delete(table_name, &key)?;
+        Ok(())
+    }
+
+    /// Map a replicated logical table name (as it appears in the event `d`-tag) to its backend table.
+    fn replicated_table(table: &str) -> Result<&'static str> {
+        match table {
+            "keys" => Ok(KEYS_TABLE),
+            "descriptors" => Ok(DESCRIPTORS_TABLE),
+            "relay_configs" => Ok(RELAY_CONFIGS_TABLE),
+            other => Err(KeepError::Other(format!("table {other} is not replicable"))),
+        }
+    }
     /// Create new storage with the given password.
     pub fn create(path: &Path, password: &str, params: Argon2Params) -> Result<Self> {
         create_storage_dir(path)?;
@@ -923,7 +962,11 @@ impl Storage {
             &normalized.group_pubkey,
             &encrypted_bytes,
         )?;
-        self.notify_record("relay_configs", &hex::encode(normalized.group_pubkey), &encrypted_bytes);
+        self.notify_record(
+            "relay_configs",
+            &hex::encode(normalized.group_pubkey),
+            &encrypted_bytes,
+        );
         Ok(())
     }
 
@@ -1500,13 +1543,15 @@ mod tests {
     struct RecordingPublisher {
         records: std::sync::Mutex<Vec<(String, String)>>,
         deletes: std::sync::Mutex<Vec<(String, String)>>,
+        last_bytes: std::sync::Mutex<Vec<u8>>,
     }
     impl StatePublisher for RecordingPublisher {
-        fn on_record(&self, table: &str, record_id: &str, _encrypted: &[u8]) {
+        fn on_record(&self, table: &str, record_id: &str, encrypted: &[u8]) {
             self.records
                 .lock()
                 .unwrap()
                 .push((table.into(), record_id.into()));
+            *self.last_bytes.lock().unwrap() = encrypted.to_vec();
         }
         fn on_delete(&self, table: &str, record_id: &str) {
             self.deletes
@@ -1517,6 +1562,57 @@ mod tests {
     }
 
     #[test]
+    fn apply_replicated_record_round_trips_and_rejects_nonreplicable_tables() {
+        use crate::backend::MemoryBackend;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test-apply");
+        let backend = Box::new(MemoryBackend::new());
+        let storage =
+            Storage::create_with_backend(&path, "password", Argon2Params::TESTING, backend)
+                .unwrap();
+
+        let publisher = std::sync::Arc::new(RecordingPublisher::default());
+        storage.set_state_publisher(publisher.clone());
+
+        let record = KeyRecord::new(
+            crypto::random_bytes(),
+            crate::keys::KeyType::Nostr,
+            "replicated".into(),
+            vec![7, 7, 7],
+        );
+        // Store, capture the exact bytes the publisher shipped, then delete so the vault no longer has
+        // the record locally.
+        storage.store_key(&record).unwrap();
+        let encrypted = publisher.last_bytes.lock().unwrap().clone();
+        storage.delete_key(&record.id).unwrap();
+        assert!(storage.load_key(&record.id).is_err());
+
+        // Applying the replicated bytes reconstructs a loadable record (same vault key decrypts them).
+        storage
+            .apply_replicated_record("keys", &hex::encode(record.id), &encrypted)
+            .unwrap();
+        assert_eq!(storage.load_key(&record.id).unwrap().name, "replicated");
+
+        // A non-replicable table (shares / node-local / unknown) is refused, so a peer cannot write it.
+        assert!(storage
+            .apply_replicated_record("shares", &hex::encode(record.id), &encrypted)
+            .is_err());
+        assert!(storage
+            .apply_replicated_record("bogus", &hex::encode(record.id), &encrypted)
+            .is_err());
+
+        // A replicated delete removes it, and never echoes to the publisher: the only recorded delete
+        // is the earlier real delete_key, not this apply.
+        let deletes_before = publisher.deletes.lock().unwrap().len();
+        storage
+            .apply_replicated_delete("keys", &hex::encode(record.id))
+            .unwrap();
+        assert!(storage.load_key(&record.id).is_err());
+        assert_eq!(publisher.deletes.lock().unwrap().len(), deletes_before);
+    }
+
+    #[test]
     fn state_publisher_fires_on_key_writes() {
         use crate::backend::MemoryBackend;
 
@@ -1524,7 +1620,8 @@ mod tests {
         let path = dir.path().join("test-publish");
         let backend = Box::new(MemoryBackend::new());
         let storage =
-            Storage::create_with_backend(&path, "password", Argon2Params::TESTING, backend).unwrap();
+            Storage::create_with_backend(&path, "password", Argon2Params::TESTING, backend)
+                .unwrap();
 
         let publisher = std::sync::Arc::new(RecordingPublisher::default());
         storage.set_state_publisher(publisher.clone());

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -729,7 +729,7 @@ impl Storage {
 
         let key = descriptor_storage_key(&descriptor.group_pubkey, descriptor.version);
         backend.put(DESCRIPTORS_TABLE, &key, &encrypted_bytes)?;
-        self.notify_record("descriptors", &hex::encode(&key), &encrypted_bytes);
+        self.notify_record("descriptors", &hex::encode(key), &encrypted_bytes);
         Ok(())
     }
 
@@ -938,7 +938,7 @@ impl Storage {
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
         let key = descriptor_storage_key(group_pubkey, version);
         if backend.delete(DESCRIPTORS_TABLE, &key)? {
-            self.notify_delete("descriptors", &hex::encode(&key));
+            self.notify_delete("descriptors", &hex::encode(key));
             Ok(())
         } else {
             Err(KeepError::KeyNotFound(format!(

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -198,6 +198,20 @@ impl Header {
     }
 }
 
+/// Sink for vault-state changes so a node can replicate its redb records to a standby (the
+/// keep-state-over-wisp design). keep-web installs an implementation that publishes each change as a
+/// Nostr event; keep-core only signals table/record/bytes and never touches the network. `on_record`
+/// carries the record's already-encrypted redb bytes -- the exact bytes stored -- so a peer that
+/// shares the vault key stores them verbatim. Called from inside the write path, so an implementation
+/// MUST NOT block: enqueue and return.
+pub trait StatePublisher: Send + Sync {
+    /// A record was written: `table` is one of keys/descriptors/relay_configs, `record_id` is its
+    /// hex redb key, and `encrypted` is the vault-encrypted bytes as stored.
+    fn on_record(&self, table: &str, record_id: &str, encrypted: &[u8]);
+    /// A record (`table`, hex `record_id`) was deleted.
+    fn on_delete(&self, table: &str, record_id: &str);
+}
+
 /// Encrypted persistent storage for keys and FROST shares.
 pub struct Storage {
     pub(crate) path: PathBuf,
@@ -208,6 +222,9 @@ pub struct Storage {
     /// e.g. two concurrent `upsert_device_registration` calls cannot drop
     /// one another's updates.
     pub(crate) descriptor_lock: std::sync::Mutex<()>,
+    /// Optional replication sink; see [`StatePublisher`]. `RwLock` so keep-web can install it after
+    /// construction (via [`Storage::set_state_publisher`]) while storage methods take `&self`.
+    pub(crate) state_publisher: std::sync::RwLock<Option<std::sync::Arc<dyn StatePublisher>>>,
 }
 
 fn create_storage_dir(path: &Path) -> Result<()> {
@@ -253,6 +270,28 @@ fn chmod_secure(path: &Path) -> std::io::Result<()> {
 }
 
 impl Storage {
+    /// Install the replication sink (keep-web). A later call replaces the previous sink.
+    pub fn set_state_publisher(&self, publisher: std::sync::Arc<dyn StatePublisher>) {
+        if let Ok(mut slot) = self.state_publisher.write() {
+            *slot = Some(publisher);
+        }
+    }
+
+    fn notify_record(&self, table: &str, record_id: &str, encrypted: &[u8]) {
+        if let Ok(slot) = self.state_publisher.read() {
+            if let Some(p) = slot.as_ref() {
+                p.on_record(table, record_id, encrypted);
+            }
+        }
+    }
+
+    fn notify_delete(&self, table: &str, record_id: &str) {
+        if let Ok(slot) = self.state_publisher.read() {
+            if let Some(p) = slot.as_ref() {
+                p.on_delete(table, record_id);
+            }
+        }
+    }
     /// Create new storage with the given password.
     pub fn create(path: &Path, password: &str, params: Argon2Params) -> Result<Self> {
         create_storage_dir(path)?;
@@ -309,6 +348,7 @@ impl Storage {
             data_key: Some(data_key),
             backend: Some(backend),
             descriptor_lock: std::sync::Mutex::new(()),
+            state_publisher: std::sync::RwLock::new(None),
         })
     }
 
@@ -343,6 +383,7 @@ impl Storage {
             data_key: None,
             backend: None,
             descriptor_lock: std::sync::Mutex::new(()),
+            state_publisher: std::sync::RwLock::new(None),
         })
     }
 
@@ -482,6 +523,7 @@ impl Storage {
         let encrypted_bytes = encrypted.to_bytes();
 
         backend.put(KEYS_TABLE, &record.id, &encrypted_bytes)?;
+        self.notify_record("keys", &hex::encode(record.id), &encrypted_bytes);
         Ok(())
     }
 
@@ -526,6 +568,7 @@ impl Storage {
         debug!(id = %hex::encode(id), "deleting key");
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
         if backend.delete(KEYS_TABLE, id)? {
+            self.notify_delete("keys", &hex::encode(id));
             Ok(())
         } else {
             Err(KeepError::KeyNotFound(hex::encode(id)))
@@ -647,6 +690,7 @@ impl Storage {
 
         let key = descriptor_storage_key(&descriptor.group_pubkey, descriptor.version);
         backend.put(DESCRIPTORS_TABLE, &key, &encrypted_bytes)?;
+        self.notify_record("descriptors", &hex::encode(&key), &encrypted_bytes);
         Ok(())
     }
 
@@ -844,6 +888,9 @@ impl Storage {
 
         let refs: Vec<&[u8]> = keys.iter().map(|k| k.as_slice()).collect();
         backend.delete_batch(DESCRIPTORS_TABLE, &refs)?;
+        for k in &keys {
+            self.notify_delete("descriptors", &hex::encode(k));
+        }
         Ok(())
     }
 
@@ -852,6 +899,7 @@ impl Storage {
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
         let key = descriptor_storage_key(group_pubkey, version);
         if backend.delete(DESCRIPTORS_TABLE, &key)? {
+            self.notify_delete("descriptors", &hex::encode(&key));
             Ok(())
         } else {
             Err(KeepError::KeyNotFound(format!(
@@ -875,6 +923,7 @@ impl Storage {
             &normalized.group_pubkey,
             &encrypted_bytes,
         )?;
+        self.notify_record("relay_configs", &hex::encode(normalized.group_pubkey), &encrypted_bytes);
         Ok(())
     }
 
@@ -915,6 +964,7 @@ impl Storage {
         debug!(group = %hex::encode(group_pubkey), "deleting relay config");
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
         if backend.delete(RELAY_CONFIGS_TABLE, group_pubkey)? {
+            self.notify_delete("relay_configs", &hex::encode(group_pubkey));
             Ok(())
         } else {
             Err(KeepError::KeyNotFound(format!(
@@ -1444,6 +1494,57 @@ mod tests {
 
         let keys = storage.list_keys().unwrap();
         assert_eq!(keys.len(), 1);
+    }
+
+    #[derive(Default)]
+    struct RecordingPublisher {
+        records: std::sync::Mutex<Vec<(String, String)>>,
+        deletes: std::sync::Mutex<Vec<(String, String)>>,
+    }
+    impl StatePublisher for RecordingPublisher {
+        fn on_record(&self, table: &str, record_id: &str, _encrypted: &[u8]) {
+            self.records
+                .lock()
+                .unwrap()
+                .push((table.into(), record_id.into()));
+        }
+        fn on_delete(&self, table: &str, record_id: &str) {
+            self.deletes
+                .lock()
+                .unwrap()
+                .push((table.into(), record_id.into()));
+        }
+    }
+
+    #[test]
+    fn state_publisher_fires_on_key_writes() {
+        use crate::backend::MemoryBackend;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test-publish");
+        let backend = Box::new(MemoryBackend::new());
+        let storage =
+            Storage::create_with_backend(&path, "password", Argon2Params::TESTING, backend).unwrap();
+
+        let publisher = std::sync::Arc::new(RecordingPublisher::default());
+        storage.set_state_publisher(publisher.clone());
+
+        let record = KeyRecord::new(
+            crypto::random_bytes(),
+            crate::keys::KeyType::Nostr,
+            "k".into(),
+            vec![1, 2, 3],
+        );
+        storage.store_key(&record).unwrap();
+        storage.delete_key(&record.id).unwrap();
+
+        // The write hook fires with the record's table + hex id; the encrypted-bytes payload is the
+        // same bytes stored (asserted non-empty). Shares are intentionally NOT hooked (per-node, per
+        // the qmc design), which is enforced by construction: store_share carries no notify call.
+        let records = publisher.records.lock().unwrap();
+        let deletes = publisher.deletes.lock().unwrap();
+        assert_eq!(*records, vec![("keys".to_string(), hex::encode(record.id))]);
+        assert_eq!(*deletes, vec![("keys".to_string(), hex::encode(record.id))]);
     }
 
     #[test]

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -76,6 +76,7 @@ mod protocol;
 mod psbt_session;
 mod recovery_signers;
 mod session;
+mod state_event;
 mod structured_payload;
 #[cfg(any(test, feature = "testing"))]
 pub mod test_support;
@@ -155,6 +156,10 @@ pub use recovery_signers::{
 };
 pub use session::{
     derive_session_id, derive_session_id_salted, NetworkSession, SessionManager, SessionState,
+};
+pub use state_event::{
+    parse_state_event, state_record_event, state_tombstone_event, StateRecord, KEEP_STATE_KIND,
+    STATE_TABLES,
 };
 pub use structured_payload::{verify_structured_payload, BitcoinSighashPayload, NostrEventPayload};
 pub use tpm_policy::TpmAttestationPolicy;

--- a/keep-frost-net/src/state_event.rs
+++ b/keep-frost-net/src/state_event.rs
@@ -78,11 +78,18 @@ pub fn parse_state_event(keys: &Keys, event: &Event) -> Result<Option<StateRecor
     if event.kind != Kind::Custom(KEEP_STATE_KIND) {
         return Ok(None);
     }
+    // Authenticate authorship against the shared cluster identity, not just the subscription filter:
+    // relays are untrusted and can deliver events the filter should have excluded. Without this, a
+    // tombstone signed by any keypair would be accepted and delete standby records (records are also
+    // guarded by NIP-44 self-encryption, but tombstones carry no ciphertext to gate on).
+    if event.pubkey != keys.public_key() {
+        return Ok(None);
+    }
     let Some(d) = event.tags.identifier() else {
         return Ok(None);
     };
-    // d-tag: keep:<table>:<record-id>. record_id may itself contain ':' (e.g. a versioned descriptor),
-    // so split into exactly three parts and keep the remainder as the id.
+    // d-tag: keep:<table>:<record-id>. Production record_ids are hex, but splitn(3) keeps any ':' in
+    // the remainder with the id (see tombstone_has_no_content) so a colon-bearing id survives intact.
     let mut parts = d.splitn(3, ':');
     if parts.next() != Some("keep") {
         return Ok(None);
@@ -147,6 +154,20 @@ mod tests {
             .sign_with_keys(&keys)
             .unwrap();
         assert_eq!(parse_state_event(&keys, &foreign).unwrap(), None);
+    }
+
+    #[test]
+    fn foreign_author_is_rejected() {
+        // A well-formed keep-state tombstone signed by a DIFFERENT identity must not be accepted:
+        // the subscription filter is relay-enforced and untrusted, so authorship is verified here.
+        let ours = Keys::generate();
+        let attacker = Keys::generate();
+        let forged = state_tombstone_event(&attacker, "keys", "abcd1234").unwrap();
+        assert_eq!(parse_state_event(&ours, &forged).unwrap(), None);
+
+        // The same holds for a record event built under a foreign identity.
+        let forged_rec = state_record_event(&attacker, "keys", "abcd1234", b"x").unwrap();
+        assert_eq!(parse_state_event(&ours, &forged_rec).unwrap(), None);
     }
 
     // End-to-end over a real in-process relay, exercising the exact publish/subscribe/notification path

--- a/keep-frost-net/src/state_event.rs
+++ b/keep-frost-net/src/state_event.rs
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+//! Keep-state replication events (the wire format for replicating a vault's redb records over a
+//! Nostr relay to a standby node; see keep-node qmc/ax2).
+//!
+//! Each replicated record is one NIP-78 addressable event (kind 30078) authored by the SHARED cluster
+//! identity and addressed by a `d`-tag `keep:<table>:<record-id>`. Because addressable events are
+//! parameterized-replaceable (NIP-01), a newer write to the same record supersedes the old one and the
+//! relay keeps only the latest, giving per-record convergence for free. The record's already-vault-
+//! encrypted bytes are NIP-44-encrypted to the shared identity (self-encryption), so the relay only
+//! ever holds ciphertext; a standby that shares the cluster identity AND the vault password (same
+//! Argon2 storage key) decrypts the NIP-44 layer and stores the inner bytes straight into its redb.
+//! A delete is a same-`d`-tag tombstone (empty content, a `deleted` tag).
+use nostr_sdk::prelude::*;
+
+use crate::error::{FrostNetError, Result};
+
+/// NIP-78 application-specific (addressable, parameterized-replaceable) data.
+pub const KEEP_STATE_KIND: u16 = 30078;
+
+/// The replicated redb tables. `SHARES` is intentionally absent: each node holds its OWN FROST share,
+/// so replicating it would clobber the standby's share (see the qmc design).
+pub const STATE_TABLES: [&str; 3] = ["keys", "descriptors", "relay_configs"];
+
+fn d_tag(table: &str, record_id: &str) -> String {
+    format!("keep:{table}:{record_id}")
+}
+
+/// Build an addressable state-record event: `NIP-44(hex(content))` authored by `keys`, addressed by
+/// `keep:<table>:<record_id>`. `content` is the record's vault-encrypted redb bytes.
+pub fn state_record_event(
+    keys: &Keys,
+    table: &str,
+    record_id: &str,
+    content: &[u8],
+) -> Result<Event> {
+    let ciphertext = nip44::encrypt(
+        keys.secret_key(),
+        &keys.public_key(),
+        hex::encode(content),
+        nip44::Version::V2,
+    )
+    .map_err(|e| FrostNetError::Crypto(e.to_string()))?;
+
+    EventBuilder::new(Kind::Custom(KEEP_STATE_KIND), ciphertext)
+        .tag(Tag::identifier(d_tag(table, record_id)))
+        .tag(Tag::custom(TagKind::custom("t"), [table.to_string()]))
+        .sign_with_keys(keys)
+        .map_err(|e| FrostNetError::Nostr(e.to_string()))
+}
+
+/// Build a tombstone (delete) event for a record: same `d`-tag, empty content, a `deleted` marker tag.
+pub fn state_tombstone_event(keys: &Keys, table: &str, record_id: &str) -> Result<Event> {
+    EventBuilder::new(Kind::Custom(KEEP_STATE_KIND), "")
+        .tag(Tag::identifier(d_tag(table, record_id)))
+        .tag(Tag::custom(TagKind::custom("t"), [table.to_string()]))
+        .tag(Tag::custom(
+            TagKind::custom("deleted"),
+            Vec::<String>::new(),
+        ))
+        .sign_with_keys(keys)
+        .map_err(|e| FrostNetError::Nostr(e.to_string()))
+}
+
+/// A parsed keep-state event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StateRecord {
+    pub table: String,
+    pub record_id: String,
+    /// The decrypted record bytes, or `None` for a tombstone (delete).
+    pub content: Option<Vec<u8>>,
+}
+
+/// Parse + decrypt a keep-state event authored by the shared identity (`keys`). Returns `Ok(None)` if
+/// the event is not a well-formed keep-state event (wrong kind or malformed `d`-tag), so a subscriber
+/// can ignore foreign events without erroring.
+pub fn parse_state_event(keys: &Keys, event: &Event) -> Result<Option<StateRecord>> {
+    if event.kind != Kind::Custom(KEEP_STATE_KIND) {
+        return Ok(None);
+    }
+    let Some(d) = event.tags.identifier() else {
+        return Ok(None);
+    };
+    // d-tag: keep:<table>:<record-id>. record_id may itself contain ':' (e.g. a versioned descriptor),
+    // so split into exactly three parts and keep the remainder as the id.
+    let mut parts = d.splitn(3, ':');
+    if parts.next() != Some("keep") {
+        return Ok(None);
+    }
+    let (Some(table), Some(record_id)) = (parts.next(), parts.next()) else {
+        return Ok(None);
+    };
+
+    let is_tombstone = event
+        .tags
+        .iter()
+        .any(|t| t.kind() == TagKind::custom("deleted"));
+    let content = if is_tombstone {
+        None
+    } else {
+        let hex_payload = nip44::decrypt(keys.secret_key(), &keys.public_key(), &event.content)
+            .map_err(|e| FrostNetError::Crypto(e.to_string()))?;
+        Some(hex::decode(hex_payload.trim()).map_err(|e| FrostNetError::Crypto(e.to_string()))?)
+    };
+
+    Ok(Some(StateRecord {
+        table: table.to_string(),
+        record_id: record_id.to_string(),
+        content,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_event_round_trips() {
+        let keys = Keys::generate();
+        let content = b"vault-encrypted-record-bytes\x00\x01\x02";
+        let event = state_record_event(&keys, "keys", "abcd1234", content).unwrap();
+
+        assert_eq!(event.kind, Kind::Custom(KEEP_STATE_KIND));
+        assert_eq!(event.tags.identifier(), Some("keep:keys:abcd1234"));
+
+        let parsed = parse_state_event(&keys, &event).unwrap().unwrap();
+        assert_eq!(parsed.table, "keys");
+        assert_eq!(parsed.record_id, "abcd1234");
+        assert_eq!(parsed.content.as_deref(), Some(content.as_slice()));
+    }
+
+    #[test]
+    fn tombstone_has_no_content() {
+        let keys = Keys::generate();
+        let event = state_tombstone_event(&keys, "descriptors", "deadbeef:3").unwrap();
+        let parsed = parse_state_event(&keys, &event).unwrap().unwrap();
+        assert_eq!(parsed.table, "descriptors");
+        // record_id keeps the remainder past the second ':', so a versioned id survives intact.
+        assert_eq!(parsed.record_id, "deadbeef:3");
+        assert_eq!(parsed.content, None);
+    }
+
+    #[test]
+    fn foreign_kind_is_ignored() {
+        let keys = Keys::generate();
+        let foreign = EventBuilder::new(Kind::TextNote, "hello")
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert_eq!(parse_state_event(&keys, &foreign).unwrap(), None);
+    }
+}

--- a/keep-frost-net/src/state_event.rs
+++ b/keep-frost-net/src/state_event.rs
@@ -148,4 +148,52 @@ mod tests {
             .unwrap();
         assert_eq!(parse_state_event(&keys, &foreign).unwrap(), None);
     }
+
+    // End-to-end over a real in-process relay, exercising the exact publish/subscribe/notification path
+    // keep-web's replication uses: a publisher sends a state event, a subscriber filtered on the shared
+    // identity receives it and reconstructs the record.
+    #[tokio::test]
+    async fn state_event_round_trips_over_a_relay() {
+        use nostr_relay_builder::MockRelay;
+
+        let relay = MockRelay::run().await.unwrap();
+        let url = relay.url().await;
+        let keys = Keys::generate();
+
+        let publisher = Client::new(keys.clone());
+        publisher.add_relay(&url).await.unwrap();
+        publisher.connect().await;
+
+        let subscriber = Client::new(keys.clone());
+        subscriber.add_relay(&url).await.unwrap();
+        subscriber.connect().await;
+        let filter = Filter::new()
+            .author(keys.public_key())
+            .kind(Kind::Custom(KEEP_STATE_KIND));
+        subscriber.subscribe(filter, None).await.unwrap();
+        // Let the REQ register on the relay, and take the notifications receiver BEFORE publishing so
+        // the delivered event can't be broadcast before we are listening.
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        let mut notifications = subscriber.notifications();
+
+        let content = b"encrypted-record-bytes";
+        let event = state_record_event(&keys, "keys", "abc123", content).unwrap();
+        publisher.send_event(&event).await.unwrap();
+
+        let received = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if let Ok(RelayPoolNotification::Event { event, .. }) = notifications.recv().await {
+                    if let Ok(Some(rec)) = parse_state_event(&keys, &event) {
+                        return rec;
+                    }
+                }
+            }
+        })
+        .await
+        .expect("state event did not arrive over the relay");
+
+        assert_eq!(received.table, "keys");
+        assert_eq!(received.record_id, "abc123");
+        assert_eq!(received.content.as_deref(), Some(content.as_slice()));
+    }
 }

--- a/keep-web/Cargo.toml
+++ b/keep-web/Cargo.toml
@@ -26,3 +26,4 @@ hex = { workspace = true }
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
 tempfile = { workspace = true }
+nostr-relay-builder = "0.44"

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -4,6 +4,7 @@ mod api;
 mod auth;
 mod bunker;
 mod state;
+mod state_replication;
 mod ws;
 
 use std::collections::HashMap;
@@ -240,6 +241,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         BunkerInfo::setup()
     };
     let keep = Arc::new(Mutex::new(keep));
+
+    // keep-state replication over the mesh relay (opt-in via KEEP_STATE_RELAY, e.g. the on-box wisp).
+    // The active publishes each vault-state write under a shared cluster identity; a standby consumes
+    // and reconstructs. The relay is a trusted local/mesh address, so it is validated with the
+    // allow-internal guard (a mesh IP is not public), and ws:// still needs KEEP_ALLOW_WS=1.
+    if let Ok(state_relay) = std::env::var("KEEP_STATE_RELAY") {
+        if !state_relay.trim().is_empty() {
+            keep_core::relay::validate_relay_url_allow_internal(&state_relay)
+                .map_err(|e| format!("KEEP_STATE_RELAY invalid: {e}"))?;
+            let identity = state_replication::load_state_identity()?;
+            let role = env_or("KEEP_STATE_ROLE", "active");
+            state_replication::spawn(keep.clone(), state_relay, identity, &role).await?;
+            tracing::info!(role = %role, "keep-state replication enabled");
+        }
+    }
+
     tracing::info!(mode = %bunker_info.mode, "started");
 
     let state = AppState {

--- a/keep-web/src/state_replication.rs
+++ b/keep-web/src/state_replication.rs
@@ -11,7 +11,7 @@
 use std::sync::Arc;
 
 use nostr_sdk::prelude::*;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{broadcast, mpsc, Mutex};
 
 use keep_core::{Keep, StatePublisher};
 use keep_frost_net::{
@@ -143,7 +143,17 @@ async fn spawn_consumer(
         // Keep `client` owned by the task: its pool is ref-counted and shuts the relay down when the
         // last handle drops, so letting it fall out of scope here would silently kill the subscription.
         let _client = client;
-        while let Ok(notification) = notifications.recv().await {
+        loop {
+            let notification = match notifications.recv().await {
+                Ok(n) => n,
+                // A lagged consumer has only missed already-replaced records; the relay still holds the
+                // latest per d-tag, so skip the gap and keep consuming rather than exiting for good.
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!("keep-state consumer lagged, skipped {n} notifications");
+                    continue;
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            };
             if let RelayPoolNotification::Event { event, .. } = notification {
                 match parse_state_event(&identity, &event) {
                     Ok(Some(rec)) => {

--- a/keep-web/src/state_replication.rs
+++ b/keep-web/src/state_replication.rs
@@ -70,6 +70,15 @@ pub async fn spawn(
     identity: Keys,
     role: &str,
 ) -> Result<(), String> {
+    // Validate role before connecting: an unrecognized value (e.g. a "stanby" typo) must NOT silently
+    // fall through to active, which would start a second publisher under the shared identity and cause
+    // split-brain last-write-wins updates.
+    if role != "active" && role != "standby" {
+        return Err(format!(
+            "invalid KEEP_STATE_ROLE {role:?}: expected \"active\" or \"standby\""
+        ));
+    }
+
     let client = Client::new(identity.clone());
     client
         .add_relay(&relay_url)
@@ -121,13 +130,19 @@ async fn spawn_consumer(
     let filter = Filter::new()
         .author(identity.public_key())
         .kind(Kind::Custom(KEEP_STATE_KIND));
+    // Take the notifications receiver BEFORE subscribing: the REQ returns the standby's backfill (the
+    // already-stored addressable records), and those can be broadcast before a receiver taken later
+    // exists, silently dropping vault state a starting standby needs.
+    let mut notifications = client.notifications();
     client
         .subscribe(filter, None)
         .await
         .map_err(|e| format!("state relay subscribe failed: {e}"))?;
 
     tokio::spawn(async move {
-        let mut notifications = client.notifications();
+        // Keep `client` owned by the task: its pool is ref-counted and shuts the relay down when the
+        // last handle drops, so letting it fall out of scope here would silently kill the subscription.
+        let _client = client;
         while let Ok(notification) = notifications.recv().await {
             if let RelayPoolNotification::Event { event, .. } = notification {
                 match parse_state_event(&identity, &event) {

--- a/keep-web/src/state_replication.rs
+++ b/keep-web/src/state_replication.rs
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+//! Keep-state replication over a Nostr relay (the keep-node keep-state-over-wisp feature).
+//!
+//! An ACTIVE node installs a [`StatePublisher`] on its vault storage and ships every replicated
+//! vault-state write (keys / descriptors / relay configs) to the state relay as an addressable NIP-78
+//! event under a SHARED cluster identity. A STANDBY subscribes to that identity, decrypts, and
+//! reconstructs each record into its own storage, so a promoted standby serves the same keep secrets.
+//! Single-writer: the active publishes, the standby consumes; roles flip on promotion (the node is
+//! restarted with the new `KEEP_STATE_ROLE`).
+use std::sync::Arc;
+
+use nostr_sdk::prelude::*;
+use tokio::sync::{mpsc, Mutex};
+
+use keep_core::{Keep, StatePublisher};
+use keep_frost_net::{
+    parse_state_event, state_record_event, state_tombstone_event, KEEP_STATE_KIND,
+};
+
+/// A pending replication change, queued by the storage hook and drained by the publish task.
+enum Change {
+    Record {
+        table: String,
+        id: String,
+        encrypted: Vec<u8>,
+    },
+    Delete {
+        table: String,
+        id: String,
+    },
+}
+
+/// [`StatePublisher`] that enqueues each write to the async publish task. `on_*` run inside the
+/// storage write path, so they only send on an unbounded channel -- never block, never touch the relay.
+struct ChannelPublisher {
+    tx: mpsc::UnboundedSender<Change>,
+}
+
+impl StatePublisher for ChannelPublisher {
+    fn on_record(&self, table: &str, record_id: &str, encrypted: &[u8]) {
+        let _ = self.tx.send(Change::Record {
+            table: table.to_string(),
+            id: record_id.to_string(),
+            encrypted: encrypted.to_vec(),
+        });
+    }
+    fn on_delete(&self, table: &str, record_id: &str) {
+        let _ = self.tx.send(Change::Delete {
+            table: table.to_string(),
+            id: record_id.to_string(),
+        });
+    }
+}
+
+/// Load the shared cluster identity from `KEEP_STATE_IDENTITY` (an `nsec1...` bech32 or a 64-char hex
+/// secret key). This key is a cluster secret distributed out-of-band to every node, like the shared
+/// Vaultwarden JWT key.
+pub fn load_state_identity() -> Result<Keys, String> {
+    let raw = std::env::var("KEEP_STATE_IDENTITY")
+        .map_err(|_| "KEEP_STATE_RELAY is set but KEEP_STATE_IDENTITY is missing".to_string())?;
+    Keys::parse(raw.trim()).map_err(|e| format!("invalid KEEP_STATE_IDENTITY: {e}"))
+}
+
+/// Wire keep-state replication. `role` is `"active"` (publish local writes) or `"standby"` (consume +
+/// reconstruct). Returns once connected; the publish/consume loop runs in a background task.
+pub async fn spawn(
+    keep: Arc<Mutex<Keep>>,
+    relay_url: String,
+    identity: Keys,
+    role: &str,
+) -> Result<(), String> {
+    let client = Client::new(identity.clone());
+    client
+        .add_relay(&relay_url)
+        .await
+        .map_err(|e| format!("state relay add failed: {e}"))?;
+    client.connect().await;
+
+    if role == "standby" {
+        spawn_consumer(keep, client, identity).await?;
+    } else {
+        spawn_publisher(keep, client, identity).await;
+    }
+    Ok(())
+}
+
+async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys) {
+    let (tx, mut rx) = mpsc::unbounded_channel::<Change>();
+    keep.lock()
+        .await
+        .set_state_publisher(Arc::new(ChannelPublisher { tx }));
+
+    tokio::spawn(async move {
+        while let Some(change) = rx.recv().await {
+            let event = match &change {
+                Change::Record {
+                    table,
+                    id,
+                    encrypted,
+                } => state_record_event(&identity, table, id, encrypted),
+                Change::Delete { table, id } => state_tombstone_event(&identity, table, id),
+            };
+            match event {
+                Ok(ev) => {
+                    if let Err(e) = client.send_event(&ev).await {
+                        tracing::warn!("keep-state publish failed: {e}");
+                    }
+                }
+                Err(e) => tracing::warn!("keep-state event build failed: {e}"),
+            }
+        }
+    });
+}
+
+async fn spawn_consumer(
+    keep: Arc<Mutex<Keep>>,
+    client: Client,
+    identity: Keys,
+) -> Result<(), String> {
+    let filter = Filter::new()
+        .author(identity.public_key())
+        .kind(Kind::Custom(KEEP_STATE_KIND));
+    client
+        .subscribe(filter, None)
+        .await
+        .map_err(|e| format!("state relay subscribe failed: {e}"))?;
+
+    tokio::spawn(async move {
+        let mut notifications = client.notifications();
+        while let Ok(notification) = notifications.recv().await {
+            if let RelayPoolNotification::Event { event, .. } = notification {
+                match parse_state_event(&identity, &event) {
+                    Ok(Some(rec)) => {
+                        let k = keep.lock().await;
+                        let outcome = match rec.content {
+                            Some(bytes) => {
+                                k.apply_replicated_record(&rec.table, &rec.record_id, &bytes)
+                            }
+                            None => k.apply_replicated_delete(&rec.table, &rec.record_id),
+                        };
+                        if let Err(e) = outcome {
+                            tracing::warn!(table = %rec.table, "keep-state apply failed: {e}");
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(e) => tracing::warn!("keep-state parse failed: {e}"),
+                }
+            }
+        }
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use keep_core::crypto::Argon2Params;
+    use keep_core::{Keep, RelayConfig};
+    use nostr_relay_builder::MockRelay;
+
+    // Full end-to-end: an ACTIVE keep-web node writes vault state, it flows through a live relay, and a
+    // STANDBY node reconstructs it AND reads it back decrypted. The two vaults share the data key (the
+    // standby is a copy of the active's header + db), which is the real deployment invariant (one shared
+    // vault password across the cluster), so this exercises the whole path -- storage hook -> publish ->
+    // relay -> subscribe -> apply -> decrypt -- with no mocking of the pieces under test.
+    #[tokio::test]
+    async fn active_write_reaches_standby_end_to_end() {
+        let relay = MockRelay::run().await.unwrap();
+        let url = relay.url().await.to_string();
+        let identity = Keys::generate();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path_a = dir.path().join("active");
+        let path_b = dir.path().join("standby");
+
+        // Fast Argon2 params for the test (the production `TESTING` const is test-gated in keep-core).
+        let fast = Argon2Params {
+            memory_kib: 1024,
+            iterations: 1,
+            parallelism: 1,
+        };
+        let active = Keep::create_with_params(&path_a, "vaultpass", fast).unwrap();
+        std::fs::create_dir_all(&path_b).unwrap();
+        std::fs::copy(path_a.join("keep.hdr"), path_b.join("keep.hdr")).unwrap();
+        std::fs::copy(path_a.join("keep.db"), path_b.join("keep.db")).unwrap();
+        let mut standby = Keep::open(&path_b).unwrap();
+        standby.unlock("vaultpass").unwrap();
+
+        let active = Arc::new(Mutex::new(active));
+        let standby = Arc::new(Mutex::new(standby));
+
+        spawn(active.clone(), url.clone(), identity.clone(), "active")
+            .await
+            .unwrap();
+        spawn(standby.clone(), url.clone(), identity.clone(), "standby")
+            .await
+            .unwrap();
+        // Let both connections + the standby subscription settle before the write.
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        // The active writes a relay config -> storage hook -> publish. Empty on a fresh standby vault,
+        // so a later Some(config) with the right group proves the record replicated AND decrypted.
+        let group = [7u8; 32];
+        let config = RelayConfig::new(group);
+        assert!(standby
+            .lock()
+            .await
+            .get_relay_config(&group)
+            .unwrap()
+            .is_none());
+        active.lock().await.store_relay_config(&config).unwrap();
+
+        let got = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                if let Ok(Some(c)) = standby.lock().await.get_relay_config(&group) {
+                    return c;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        })
+        .await
+        .expect("standby never reconstructed the replicated relay config");
+        assert_eq!(got.group_pubkey, group);
+    }
+}


### PR DESCRIPTION
Replicate a vault's keep state between cluster nodes over a Nostr relay, so a standby can reconstruct and serve the same keys/descriptors/relay-configs after a failover. This is the keep side of the KeepNode multi-node-HA "keep-state-over-wisp" track; keep-node wires it to the on-box relay separately.

## Design
- **Shared cluster identity.** One keep Nostr keypair for the cluster (distributed out-of-band like the shared JWT key). The active publishes under it; a standby subscribes to that one author. Single-writer: active publishes, standby consumes; roles flip on promotion via `KEEP_STATE_ROLE`.
- **Addressable per-record events.** Each replicated redb record is one NIP-78 event (kind 30078), `d`-tag `keep:<table>:<record-id>`, so an update supersedes the prior version (NIP-01 parameterized-replaceable) and the relay reconciles. Content is `NIP-44(vault-encrypted bytes)` — double-wrapped, so the relay only ever holds ciphertext; a standby that shares the vault password (same Argon2 key) decrypts and stores verbatim. Deletes are same-`d`-tag tombstones.
- **Shares are never replicated.** Each node holds its own FROST share; only `keys`/`descriptors`/`relay_configs` replicate. The consumer rejects any other table, so a peer can't write `shares` or node-local state.

## What's here
- `keep-frost-net/state_event.rs` — the wire schema (build/parse/tombstone).
- `keep-core` — a `StatePublisher` hook on `Storage` write paths (not `store_share`), plus `apply_replicated_record`/`_delete` on the consume side, exposed via `Keep`.
- `keep-web/state_replication.rs` — the active publisher (async, drains writes to the relay) and standby consumer (subscribe → decrypt → reconstruct), opt-in via `KEEP_STATE_RELAY` + `KEEP_STATE_IDENTITY`. The state relay is validated with the existing allow-internal guard (mesh IPs) + `KEEP_ALLOW_WS`.

## Verification (no mocking of the pieces under test)
- Unit: schema round-trip + tombstone + foreign-event rejection; the storage hook fires on keys and not shares; `apply_replicated_record` round-trips and rejects non-replicable tables.
- Relay: a state event round-trips through an in-process relay via the exact publish/subscribe/notification path keep-web uses.
- **End-to-end (`keep-web`):** an active node writes a relay config → storage hook → publish → live relay → a standby (sharing the vault key) subscribes, reconstructs, and **reads it back decrypted**.

All suites for the touched crates pass (keep-core/keep-frost-net/keep-web) and clippy is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional state replication between active and standby instances.
  * Introduced support for syncing key, descriptor, and relay configuration changes through a shared relay.
  * Added startup support for enabling replication via configuration and role selection.
  * Improved handling of replicated updates and deletions so standby nodes can reconstruct state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->