### PR TITLE
release: bump workspace version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "keep-agent"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "keep-bitcoin"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "bitcoin",
  "getrandom 0.4.3",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "keep-cli"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "keep-core"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "aes 0.9.1",
  "argon2",
@@ -4635,7 +4635,7 @@ dependencies = [
 
 [[package]]
 name = "keep-desktop"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4668,14 +4668,14 @@ dependencies = [
 
 [[package]]
 name = "keep-enclave"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "keep-enclave-host",
 ]
 
 [[package]]
 name = "keep-enclave-host"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -4706,7 +4706,7 @@ dependencies = [
 
 [[package]]
 name = "keep-frost-net"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "keep-mobile"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4776,7 +4776,7 @@ dependencies = [
 
 [[package]]
 name = "keep-nip46"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "bitflags 2.13.0",
  "chrono",
@@ -4803,7 +4803,7 @@ dependencies = [
 
 [[package]]
 name = "keep-web"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "axum",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.4.9"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"


### PR DESCRIPTION
Bumps the workspace version from 0.4.9 to 0.5.0 ahead of the v0.5.0 release. A single `[workspace.package]` version drives all ten crates; `Cargo.lock` is regenerated to match, so the release CI's `cargo build --release --locked` stays green. Rebased on latest main (includes #698 and #700, the cluster keep-state replication work).

The jump to a minor version (not a patch) reflects the scope since v0.4.9: 71 commits adding threshold-OPRF vault unlock with TPM attestation, HD FROST wallets (BIP-32/BIP-86), a software DKG path, keep-state HA replication, and substantial signing/crypto hardening.

## Release process (after merge)
Tag the merged commit `v0.5.0` and push; the Release workflow (triggered on `v*`) builds the linux/macos/macos-arm/windows CLI + desktop binaries, generates `SHA256SUMS`, and publishes the GitHub release. Then apply the notes below to that release (overriding the auto-generated PR list).

## Drafted release notes (v0.5.0)

## Highlights
- **Threshold-OPRF vault unlock with TPM attestation**: a FROST group can gate a secret unlock behind a threshold-OPRF over secp256k1, each participant's `frost network serve` enforcing a TPM2 remote-attestation policy (opt-in) (#618–#643).
- **HD FROST wallets (BIP-32 / BIP-86)**: FROST groups derive child keys by composing a BIP-32 tweak with FROST signing and emit BIP-86 HD taproot descriptors, with the derivation path carried through the sign wire protocol (closes #487) (#668–#672).
- **Software distributed key generation**: users without hardware can run DKG entirely in software, with participants authenticated against the signed group roster to close a relay-index hijack, plus bounded decoy-flood handling (#673, closes #674, closes #676).
- **Signing hardening**: PSBT prevout amounts validated against a chain view before signing (closes #502); structured-payload verification defeats cross-domain label spoofs (closes #529); NIP-98 approval prompts surface the URL/method being authorized (#665, #667, #677).
- **Cryptographic robustness**: RNG health-check failures return a recoverable error instead of panicking; the post-refresh group-key check was corrected; TLS certificate pinning supports multiple pins per host for safe rotation; AEAD/deps advanced (RustCrypto 0.11, quinn-proto RUSTSEC-2026-0037) (#686, #688, #694, #696, #645, #641).
- **Multi-node availability**: keep-state replication over a Nostr relay, with a shared cluster vault data key, enables high-availability operation (#698, #700).
- **Test coverage**: extensive mutation-killing and integration coverage across the DKG, PSBT, ECDH, and signing coordination paths (#681–#693).

Full changelog: https://github.com/privkeyio/keep/compare/v0.4.9...v0.5.0
