### PR TITLE
Shared vault data key for cluster keep-state replication (KEEP_STORAGE_KEY)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4821,6 +4821,7 @@ dependencies = [
  "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
+ "zeroize",
 ]
 
 [[package]]

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -166,7 +166,7 @@ impl Keep {
         path: &Path,
         password: &str,
         params: Argon2Params,
-        data_key: [u8; 32],
+        data_key: [u8; crypto::KEY_SIZE],
     ) -> Result<Self> {
         let storage = Storage::create_with_shared_data_key(path, password, params, data_key)?;
         Ok(Self {

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -159,6 +159,24 @@ impl Keep {
         })
     }
 
+    /// Like [`Self::create_with_params`] but seeds a shared record-encryption key, so every node in a
+    /// cluster shares one vault key (keep-state replication) and a standby decrypts what the active
+    /// shipped. Each node still wraps the key under its own password+salt.
+    pub fn create_with_shared_data_key(
+        path: &Path,
+        password: &str,
+        params: Argon2Params,
+        data_key: [u8; 32],
+    ) -> Result<Self> {
+        let storage = Storage::create_with_shared_data_key(path, password, params, data_key)?;
+        Ok(Self {
+            storage,
+            keyring: Keyring::new(),
+            audit: None,
+            signing_audit: None,
+        })
+    }
+
     /// Open an existing Keep.
     ///
     /// # Example

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -351,7 +351,23 @@ impl Storage {
         let backend = RedbBackend::create(&db_path)?;
         #[cfg(unix)]
         let _ = chmod_secure(&db_path);
-        Self::create_inner(path, password, params, Box::new(backend))
+        Self::create_inner(path, password, params, Box::new(backend), None)
+    }
+
+    /// Create new storage whose data key is the caller-provided `data_key` rather than a fresh random
+    /// one, so every node in a cluster shares one vault key (keep-state replication).
+    pub fn create_with_shared_data_key(
+        path: &Path,
+        password: &str,
+        params: Argon2Params,
+        data_key: [u8; crypto::KEY_SIZE],
+    ) -> Result<Self> {
+        create_storage_dir(path)?;
+        let db_path = path.join("keep.db");
+        let backend = RedbBackend::create(&db_path)?;
+        #[cfg(unix)]
+        let _ = chmod_secure(&db_path);
+        Self::create_inner(path, password, params, Box::new(backend), Some(data_key))
     }
 
     /// Create new storage with a custom backend.
@@ -362,7 +378,7 @@ impl Storage {
         backend: Box<dyn StorageBackend>,
     ) -> Result<Self> {
         create_storage_dir(path)?;
-        Self::create_inner(path, password, params, backend)
+        Self::create_inner(path, password, params, backend, None)
     }
 
     fn create_inner(
@@ -370,11 +386,18 @@ impl Storage {
         password: &str,
         params: Argon2Params,
         backend: Box<dyn StorageBackend>,
+        shared_data_key: Option<[u8; crypto::KEY_SIZE]>,
     ) -> Result<Self> {
         validate_new_password(password)?;
 
         let mut header = Header::new(params)?;
-        let data_key = SecretKey::generate()?;
+        // The data key encrypts every record and is normally random per vault. A cluster can instead
+        // seed the SAME data key on every node (keep-state replication), so a standby decrypts records
+        // the active shipped: each node still wraps it under its OWN password+salt in its own header.
+        let data_key = match shared_data_key {
+            Some(k) => SecretKey::new(k)?,
+            None => SecretKey::generate()?,
+        };
         let master_key = crypto::derive_key(password.as_bytes(), &header.salt, params)?;
         let header_key = crypto::derive_subkey(&master_key, b"keep-header-key")?;
 
@@ -1636,6 +1659,52 @@ mod tests {
             .unwrap();
         assert!(storage.load_key(&record.id).is_err());
         assert_eq!(publisher.deletes.lock().unwrap().len(), deletes_before);
+    }
+
+    #[test]
+    fn shared_data_key_cross_decrypts_across_vaults() {
+        // Two independent vaults with DIFFERENT passwords but the SAME seeded data key: a record
+        // encrypted by one must decrypt in the other. This is the cluster invariant keep-state
+        // replication relies on (the standby reads what the active shipped).
+        let shared: [u8; 32] = crypto::random_bytes();
+        let dir = tempdir().unwrap();
+
+        let a = Storage::create_with_shared_data_key(
+            &dir.path().join("a"),
+            "passwordA",
+            Argon2Params::TESTING,
+            shared,
+        )
+        .unwrap();
+        let b = Storage::create_with_shared_data_key(
+            &dir.path().join("b"),
+            "differentB",
+            Argon2Params::TESTING,
+            shared,
+        )
+        .unwrap();
+
+        let publisher = std::sync::Arc::new(RecordingPublisher::default());
+        a.set_state_publisher(publisher.clone());
+
+        let record = KeyRecord::new(
+            crypto::random_bytes(),
+            crate::keys::KeyType::Nostr,
+            "shared".into(),
+            vec![1, 2, 3],
+        );
+        a.store_key(&record).unwrap();
+        let encrypted = publisher.last_bytes.lock().unwrap().clone();
+
+        b.apply_replicated_record("keys", &hex::encode(record.id), &encrypted)
+            .unwrap();
+        assert_eq!(b.load_key(&record.id).unwrap().name, "shared");
+
+        // Sanity: WITHOUT the shared key, a third vault cannot decrypt the same bytes.
+        let c = Storage::create(&dir.path().join("c"), "passwordC", Argon2Params::TESTING).unwrap();
+        c.apply_replicated_record("keys", &hex::encode(record.id), &encrypted)
+            .unwrap();
+        assert!(c.load_key(&record.id).is_err());
     }
 
     #[test]

--- a/keep-web/Cargo.toml
+++ b/keep-web/Cargo.toml
@@ -22,6 +22,7 @@ tracing-subscriber = { workspace = true }
 nostr-sdk = { workspace = true }
 subtle = { workspace = true }
 hex = { workspace = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -146,7 +146,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(k) => k,
         Err(keep_core::error::KeepError::NotFound(_)) => {
             tracing::info!(path = %vault_path.display(), "no vault found; creating");
-            Keep::create(&vault_path, &password)?
+            match std::env::var("KEEP_STORAGE_KEY") {
+                Ok(hex_key) if !hex_key.trim().is_empty() => {
+                    // Shared cluster data key (keep-state replication): every node creates its vault
+                    // with the SAME record-encryption key so a standby can decrypt the active's records.
+                    // Delivered out-of-band onto the encrypted volume, like the shared JWT key.
+                    let bytes: [u8; 32] = hex::decode(hex_key.trim())
+                        .map_err(|e| format!("KEEP_STORAGE_KEY is not hex: {e}"))?
+                        .try_into()
+                        .map_err(|_| {
+                            "KEEP_STORAGE_KEY must be 32 bytes (64 hex chars)".to_string()
+                        })?;
+                    Keep::create_with_shared_data_key(
+                        &vault_path,
+                        &password,
+                        keep_core::crypto::Argon2Params::DEFAULT,
+                        bytes,
+                    )?
+                }
+                _ => Keep::create(&vault_path, &password)?,
+            }
         }
         Err(e) => return Err(e.into()),
     };

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -16,6 +16,7 @@ use axum::routing::{get, post};
 use axum::Router;
 use tokio::sync::{broadcast, Mutex};
 use tower_http::services::{ServeDir, ServeFile};
+use zeroize::Zeroizing;
 
 use keep_core::Keep;
 
@@ -60,6 +61,35 @@ fn read_secret_file(path: &str) -> Result<String, Box<dyn std::error::Error>> {
         }
     }
     Ok(std::fs::read_to_string(path)?.trim().to_string())
+}
+
+/// Resolve the optional shared cluster data key (keep-state replication). Reads via
+/// `secret_from` so `KEEP_STORAGE_KEY_FILE` is honored (keeps the raw key off the
+/// process environment, like the password and JWT key). Returns `None` when unset,
+/// `Err` when set but malformed so a misconfigured cluster node fails loudly instead
+/// of silently creating a non-replicable vault.
+fn shared_data_key_from_env() -> Result<Option<Zeroizing<[u8; 32]>>, Box<dyn std::error::Error>> {
+    let Some(hex_key) = secret_from("KEEP_STORAGE_KEY")? else {
+        return Ok(None);
+    };
+    Ok(Some(parse_shared_data_key(&hex_key)?))
+}
+
+/// Decode a 32-byte shared data key from hex. Rejects malformed hex, the wrong
+/// length, and an all-zero key so a misconfigured node fails loudly. The generic
+/// hex error avoids echoing the malformed key material back into logs.
+fn parse_shared_data_key(raw: &str) -> Result<Zeroizing<[u8; 32]>, Box<dyn std::error::Error>> {
+    let decoded =
+        Zeroizing::new(hex::decode(raw).map_err(|_| "KEEP_STORAGE_KEY is not valid hex")?);
+    if decoded.len() != 32 {
+        return Err("KEEP_STORAGE_KEY must be 32 bytes (64 hex chars)".into());
+    }
+    let mut key = Zeroizing::new([0u8; 32]);
+    key.copy_from_slice(&decoded);
+    if key.iter().all(|&b| b == 0) {
+        return Err("KEEP_STORAGE_KEY must not be all zero".into());
+    }
+    Ok(key)
 }
 
 fn parse_relays(value: &str) -> Vec<String> {
@@ -146,25 +176,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(k) => k,
         Err(keep_core::error::KeepError::NotFound(_)) => {
             tracing::info!(path = %vault_path.display(), "no vault found; creating");
-            match std::env::var("KEEP_STORAGE_KEY") {
-                Ok(hex_key) if !hex_key.trim().is_empty() => {
-                    // Shared cluster data key (keep-state replication): every node creates its vault
-                    // with the SAME record-encryption key so a standby can decrypt the active's records.
-                    // Delivered out-of-band onto the encrypted volume, like the shared JWT key.
-                    let bytes: [u8; 32] = hex::decode(hex_key.trim())
-                        .map_err(|e| format!("KEEP_STORAGE_KEY is not hex: {e}"))?
-                        .try_into()
-                        .map_err(|_| {
-                            "KEEP_STORAGE_KEY must be 32 bytes (64 hex chars)".to_string()
-                        })?;
+            match shared_data_key_from_env()? {
+                Some(key) => {
+                    tracing::info!(
+                        "creating vault with shared cluster data key (keep-state replication)"
+                    );
                     Keep::create_with_shared_data_key(
                         &vault_path,
                         &password,
                         keep_core::crypto::Argon2Params::DEFAULT,
-                        bytes,
+                        *key,
                     )?
                 }
-                _ => Keep::create(&vault_path, &password)?,
+                None => {
+                    tracing::info!(
+                        "KEEP_STORAGE_KEY not set; creating vault with a per-node random data key (non-replicable)"
+                    );
+                    Keep::create(&vault_path, &password)?
+                }
             }
         }
         Err(e) => return Err(e.into()),
@@ -397,5 +426,28 @@ mod tests {
         let a = *keep.frost_generate(2, 3, "a").unwrap()[0].group_pubkey();
         let npub = keep_core::keys::bytes_to_npub(&a);
         assert_eq!(resolve_group(&keep, Some(&npub)).unwrap().unwrap().0, a);
+    }
+
+    #[test]
+    fn parse_shared_data_key_valid() {
+        let hex_key = hex::encode([7u8; 32]);
+        let key = parse_shared_data_key(&hex_key).unwrap();
+        assert_eq!(*key, [7u8; 32]);
+    }
+
+    #[test]
+    fn parse_shared_data_key_bad_hex() {
+        assert!(parse_shared_data_key("zz").is_err());
+    }
+
+    #[test]
+    fn parse_shared_data_key_wrong_length() {
+        assert!(parse_shared_data_key(&hex::encode([1u8; 31])).is_err());
+        assert!(parse_shared_data_key(&hex::encode([1u8; 33])).is_err());
+    }
+
+    #[test]
+    fn parse_shared_data_key_all_zero() {
+        assert!(parse_shared_data_key(&hex::encode([0u8; 32])).is_err());
     }
 }


### PR DESCRIPTION
Follow-up to the keep-state replication PR (#698): let a cluster's nodes share one vault data key, so a standby can actually decrypt the records the active replicates to it.

## Why
keep-state replication ships each record's vault-encrypted bytes and the standby stores them verbatim, which only works if both nodes hold the SAME record-encryption key. That key (`data_key`) is a fresh random `SecretKey` per vault, wrapped in the header under the password+salt-derived master key. So two independently-created vaults never share it, and the standby's decrypt fails. (The e2e test in #698 only passed because it copied the vault.)

## What
- `keep-core` , `Storage::create_with_shared_data_key` / `Keep::create_with_shared_data_key`: create a vault whose `data_key` is the caller-provided 32 bytes instead of a fresh random one. Each node still wraps it under its OWN password+salt (the header/master-key layer is unchanged), so only the record-encryption key is shared.
- `keep-web` , on first-run vault create, if `KEEP_STORAGE_KEY` (64 hex chars) is set, seed the vault with it. Delivered out-of-band onto the encrypted volume like the shared JWT key; every node holds it in memory once unlocked anyway.

## Test
`shared_data_key_cross_decrypts_across_vaults`: two vaults with DIFFERENT passwords but the same seeded key , a record encrypted by one decrypts in the other; a third vault without the key cannot. keep-core (22 storage tests) + keep-web green, clippy clean.
