### PR TITLE
keep-web: fix Windows-only failure in the replication test

### DIFF
--- a/keep-web/src/state_replication.rs
+++ b/keep-web/src/state_replication.rs
@@ -205,10 +205,15 @@ mod tests {
             iterations: 1,
             parallelism: 1,
         };
-        let active = Keep::create_with_params(&path_a, "vaultpass", fast).unwrap();
+        // Create the active vault, then drop it so its redb handle releases the
+        // file lock before copying: Windows refuses to copy a file another
+        // handle holds open, unlike Unix. Reopen the active afterward.
+        Keep::create_with_params(&path_a, "vaultpass", fast).unwrap();
         std::fs::create_dir_all(&path_b).unwrap();
         std::fs::copy(path_a.join("keep.hdr"), path_b.join("keep.hdr")).unwrap();
         std::fs::copy(path_a.join("keep.db"), path_b.join("keep.db")).unwrap();
+        let mut active = Keep::open(&path_a).unwrap();
+        active.unlock("vaultpass").unwrap();
         let mut standby = Keep::open(&path_b).unwrap();
         standby.unlock("vaultpass").unwrap();
 


### PR DESCRIPTION
Fixes the `build-windows` CI failure on `main` (the only red job on the v0.5.0 commit; linux/macos, lint, msrv, deny, fuzz, and the release binaries are all green).

## Cause
`state_replication::tests::active_write_reaches_standby_end_to_end` created the active vault and then `std::fs::copy`'d its `keep.db` to seed a standby while the active still held the redb file open. Windows refuses to copy a file another handle holds open (sharing violation), so the copy `.unwrap()` panicked; Unix allows it, so it passed on the Linux/macOS runners and in PR CI (the Windows job runs only on `main`).

## Fix
Drop the freshly-created active vault (releasing the redb lock) before copying `keep.hdr`/`keep.db`, then reopen and unlock the active. Test-only change; no product code is affected, so no re-release of the v0.5.0 binaries is needed.

`cargo test -p keep-web --bins active_write_reaches_standby_end_to_end` passes.
