### PR TITLE
keep-mobile: gate uniffi cli feature to the bindgen binary for reproducible builds

### DIFF
--- a/keep-mobile/Cargo.toml
+++ b/keep-mobile/Cargo.toml
@@ -16,7 +16,7 @@ keep-frost-net = { path = "../keep-frost-net", default-features = false }
 keep-nip46 = { path = "../keep-nip46" }
 bitcoin = { version = "0.32", features = ["serde", "base64"] }
 frost-secp256k1-tr = { version = "3.0", default-features = false }
-uniffi = { version = "0.32", features = ["cli"] }
+uniffi = { version = "0.32" }
 thiserror = "2.0"
 tokio = { version = "1.52", features = ["rt-multi-thread", "sync", "time"] }
 hex = "0.4"
@@ -40,6 +40,15 @@ tracing-android = "0.2"
 [build-dependencies]
 uniffi = { version = "0.32", features = ["build"] }
 
+[features]
+# The uniffi CLI (uniffi_bindgen + its askama templates) is only needed by the
+# uniffi-bindgen binary below, not by the runtime cdylib. Keeping it out of the
+# library build stops the non-deterministic bindgen/askama codegen from being
+# linked into libkeep_mobile.so, which is required for reproducible F-Droid
+# builds. Enable it only when building the binary (see required-features).
+cli = ["uniffi/cli"]
+
 [[bin]]
 name = "uniffi-bindgen"
 path = "src/bin/uniffi-bindgen.rs"
+required-features = ["cli"]


### PR DESCRIPTION
## Problem

Release builds of `libkeep_mobile.so` are not byte-reproducible: two clean compiles of the same source produce different libraries. This breaks the reproducible-build verification required for F-Droid.

The cause is the `cli` feature on the `uniffi` dependency. `keep-mobile` enabled `uniffi = { features = ["cli"] }` crate-wide, purely so the `uniffi-bindgen` binary can call `uniffi::uniffi_bindgen_main()`. Because Cargo unifies features per crate, `cli` also compiled `uniffi_bindgen` (and its `askama` template engine) into the runtime cdylib. `askama`'s compile-time template codegen is non-deterministic, so the linked `.so` varies between builds.

This regressed when `uniffi` was bumped 0.31 → 0.32 (which pulled `askama` 0.14 → 0.16). 0.31 builds were reproducible.

Isolation confirmed the only two non-deterministic crates in the library were `uniffi` and `uniffi_bindgen`; the differing bytes were ~333 scattered bytes in `.gcc_except_table`/`.symtab`.

## Fix

Gate the `cli` feature to the `uniffi-bindgen` binary via `required-features`, so the runtime library no longer compiles the bindgen/askama code:

- the cdylib builds `uniffi` without `cli` → reproducible;
- the `uniffi-bindgen` binary keeps working, built with `--features cli`.

## Verification

- Two clean release builds of the arm64 `.so` are now byte-identical (`sha256 7ba0eba3…`), where before they differed.
- `uniffi-bindgen generate` (built with `--features cli`) produces byte-identical Kotlin bindings to the previous setup — no output change.
- Without the feature, the binary fails fast with `requires the features: cli`, as intended.

## Consumer note

Anything invoking the `uniffi-bindgen` binary must now pass `--features cli`, e.g. `cargo run --features cli --bin uniffi-bindgen generate ...`. The keep-android build script (`build-rust.sh`) will be updated to match when it adopts this commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration so the Uniffi CLI and bindgen tool are only included when the optional `cli` feature is enabled.
  * Reduced default build footprint by keeping CLI-related functionality out of standard builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->