### PR TITLE
keep-state: rollback/replay guard via monotonic created_at (keep-ol4n)

### DIFF
--- a/keep-core/src/backend.rs
+++ b/keep-core/src/backend.rs
@@ -168,6 +168,9 @@ impl RedbBackend {
             RELAY_CONFIGS_TABLE,
             CONFIG_TABLE,
             HEALTH_STATUS_TABLE,
+            // Carried through a file-format upgrade so the keep-state rollback-guard high-water-marks
+            // survive; otherwise they reset and the guard reverts to first-sync (TOFU) for every d-tag.
+            STATE_VERSIONS_TABLE,
         ];
 
         type TableEntries = Vec<(Vec<u8>, Vec<u8>)>;

--- a/keep-core/src/backend.rs
+++ b/keep-core/src/backend.rs
@@ -30,6 +30,17 @@ pub const HEALTH_STATUS_TABLE: &str = "key_health_status";
 /// event that is not strictly newer (replay/rollback protection).
 pub const STATE_VERSIONS_TABLE: &str = "state_versions";
 
+/// A single put-or-delete operation for [`StorageBackend::write_atomic`]. `value` `Some` is a put,
+/// `None` is a delete.
+pub struct AtomicOp<'a> {
+    /// Backend table the op targets.
+    pub table: &'a str,
+    /// Raw key bytes.
+    pub key: &'a [u8],
+    /// `Some(bytes)` to put, `None` to delete.
+    pub value: Option<&'a [u8]>,
+}
+
 /// Trait for pluggable storage backends.
 ///
 /// Implementations must be thread-safe (`Send + Sync`).
@@ -70,6 +81,22 @@ pub trait StorageBackend: Send + Sync {
     fn put_batch(&self, table: &str, entries: &[(&[u8], &[u8])]) -> Result<()> {
         for (key, value) in entries {
             self.put(table, key, value)?;
+        }
+        Ok(())
+    }
+
+    /// Apply several put/delete operations across tables. The default implementation applies each op
+    /// sequentially via `put`/`delete` and is NOT atomic; backends with transaction support should
+    /// override this so a crash mid-batch cannot leave the ops half-applied. Each op must target a
+    /// DISTINCT table.
+    fn write_atomic(&self, ops: &[AtomicOp<'_>]) -> Result<()> {
+        for op in ops {
+            match op.value {
+                Some(v) => self.put(op.table, op.key, v)?,
+                None => {
+                    self.delete(op.table, op.key)?;
+                }
+            }
         }
         Ok(())
     }
@@ -480,6 +507,25 @@ impl StorageBackend for RedbBackend {
             let mut tbl = wtxn.open_table(self.table_def(table)?)?;
             for key in keys {
                 tbl.remove(*key)?;
+            }
+        }
+        wtxn.commit()?;
+        Ok(())
+    }
+
+    // Each op must target a distinct table: redb errors on opening the same table twice in one write
+    // txn. The only caller passes exactly [data_table, STATE_VERSIONS_TABLE], always distinct.
+    fn write_atomic(&self, ops: &[AtomicOp<'_>]) -> Result<()> {
+        let wtxn = self.db.begin_write()?;
+        for op in ops {
+            let mut tbl = wtxn.open_table(self.table_def(op.table)?)?;
+            match op.value {
+                Some(v) => {
+                    tbl.insert(op.key, v)?;
+                }
+                None => {
+                    tbl.remove(op.key)?;
+                }
             }
         }
         wtxn.commit()?;

--- a/keep-core/src/backend.rs
+++ b/keep-core/src/backend.rs
@@ -25,6 +25,10 @@ pub const RELAY_CONFIGS_TABLE: &str = "relay_configs";
 pub const CONFIG_TABLE: &str = "config";
 /// Table name for key health status records.
 pub const HEALTH_STATUS_TABLE: &str = "key_health_status";
+/// Table name for the keep-state replication high-water-mark: maps a `<table>:<record-id>` d-tag to
+/// the highest `created_at` (8-byte big-endian) applied for it, so the consumer rejects any replicated
+/// event that is not strictly newer (replay/rollback protection).
+pub const STATE_VERSIONS_TABLE: &str = "state_versions";
 
 /// Trait for pluggable storage backends.
 ///
@@ -108,6 +112,8 @@ const RELAY_CONFIGS_TABLE_DEF: TableDefinition<&[u8], &[u8]> =
 const CONFIG_TABLE_DEF: TableDefinition<&[u8], &[u8]> = TableDefinition::new("config");
 const HEALTH_STATUS_TABLE_DEF: TableDefinition<&[u8], &[u8]> =
     TableDefinition::new("key_health_status");
+const STATE_VERSIONS_TABLE_DEF: TableDefinition<&[u8], &[u8]> =
+    TableDefinition::new("state_versions");
 
 /// Redb-based storage backend (default).
 pub struct RedbBackend {
@@ -332,6 +338,7 @@ impl RedbBackend {
             RELAY_CONFIGS_TABLE => Ok(RELAY_CONFIGS_TABLE_DEF),
             CONFIG_TABLE => Ok(CONFIG_TABLE_DEF),
             HEALTH_STATUS_TABLE => Ok(HEALTH_STATUS_TABLE_DEF),
+            STATE_VERSIONS_TABLE => Ok(STATE_VERSIONS_TABLE_DEF),
             _ => Err(StorageError::database(format!("unknown table: {name}")).into()),
         }
     }

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -135,6 +135,13 @@ impl Keep {
             .apply_replicated_delete(table, record_id, created_at)
     }
 
+    /// The highest keep-state high-water-mark persisted in this vault (0 if none). A promoted standby
+    /// seeds its publisher's monotonic floor from this so a fresh publish is strictly newer than every
+    /// mark standbys already applied. See [`Storage::max_state_version`].
+    pub fn max_state_version(&self) -> Result<u64> {
+        self.storage.max_state_version()
+    }
+
     /// Create a new Keep with the given password.
     ///
     /// # Example

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -118,14 +118,21 @@ impl Keep {
         table: &str,
         record_id: &str,
         encrypted: &[u8],
-    ) -> Result<()> {
+        created_at: u64,
+    ) -> Result<bool> {
         self.storage
-            .apply_replicated_record(table, record_id, encrypted)
+            .apply_replicated_record(table, record_id, encrypted, created_at)
     }
 
-    /// Apply a replicated delete (tombstone) from a peer.
-    pub fn apply_replicated_delete(&self, table: &str, record_id: &str) -> Result<()> {
-        self.storage.apply_replicated_delete(table, record_id)
+    /// Apply a replicated delete (tombstone) from a peer. Returns `false` if ignored as stale.
+    pub fn apply_replicated_delete(
+        &self,
+        table: &str,
+        record_id: &str,
+        created_at: u64,
+    ) -> Result<bool> {
+        self.storage
+            .apply_replicated_delete(table, record_id, created_at)
     }
 
     /// Create a new Keep with the given password.

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -309,11 +309,13 @@ impl Storage {
         created_at: u64,
     ) -> Result<bool> {
         let (table_name, key) = Self::replicated_key(table, record_id)?;
-        if !self.accept_state_version(table, record_id, created_at)? {
+        let vkey = Self::state_version_key(table_name, &key);
+        if !self.state_version_is_newer(&vkey, created_at)? {
             return Ok(false);
         }
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
         backend.put(table_name, &key, encrypted)?;
+        self.advance_state_version(&vkey, created_at)?;
         Ok(true)
     }
 
@@ -326,24 +328,36 @@ impl Storage {
         created_at: u64,
     ) -> Result<bool> {
         let (table_name, key) = Self::replicated_key(table, record_id)?;
-        if !self.accept_state_version(table, record_id, created_at)? {
+        let vkey = Self::state_version_key(table_name, &key);
+        if !self.state_version_is_newer(&vkey, created_at)? {
             return Ok(false);
         }
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
         backend.delete(table_name, &key)?;
+        self.advance_state_version(&vkey, created_at)?;
         Ok(true)
     }
 
-    /// keep-state rollback guard. Returns `true` (and records the new high-water-mark) if `created_at`
-    /// is strictly newer than the highest previously applied for this record's d-tag; `false` if it is
-    /// stale or a replay and must be ignored. `created_at` lives in the SIGNED event, so a malicious
-    /// relay cannot forge a newer one, and persisting the mark keeps the guard across restarts.
-    fn accept_state_version(&self, table: &str, record_id: &str, created_at: u64) -> Result<bool> {
+    /// The rollback-guard high-water-mark key for a replicated record: the backend table name joined to
+    /// the DECODED record key bytes (not the hex string), so it can never diverge from the storage row
+    /// key for a non-canonically-encoded id. Table names are a fixed allowlist with no `:`, so the join
+    /// is unambiguous.
+    fn state_version_key(table_name: &str, key: &[u8]) -> Vec<u8> {
+        let mut vkey = Vec::with_capacity(table_name.len() + 1 + key.len());
+        vkey.extend_from_slice(table_name.as_bytes());
+        vkey.push(b':');
+        vkey.extend_from_slice(key);
+        vkey
+    }
+
+    /// keep-state rollback guard (read-only): `true` if `created_at` is strictly newer than the highest
+    /// previously applied for this d-tag, `false` if it is stale or a replay and must be ignored.
+    /// `created_at` lives in the SIGNED event, so a malicious relay cannot forge a newer one.
+    fn state_version_is_newer(&self, vkey: &[u8], created_at: u64) -> Result<bool> {
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
         // Lazily ensure the table exists so a vault created before this guard migrates transparently.
         backend.create_table(STATE_VERSIONS_TABLE)?;
-        let vkey = format!("{table}:{record_id}").into_bytes();
-        if let Some(prev) = backend.get(STATE_VERSIONS_TABLE, &vkey)? {
+        if let Some(prev) = backend.get(STATE_VERSIONS_TABLE, vkey)? {
             let prev_ts = u64::from_be_bytes(prev.as_slice().try_into().map_err(|_| {
                 KeepError::Other("corrupt keep-state version high-water-mark".to_string())
             })?);
@@ -351,8 +365,16 @@ impl Storage {
                 return Ok(false);
             }
         }
-        backend.put(STATE_VERSIONS_TABLE, &vkey, &created_at.to_be_bytes())?;
         Ok(true)
+    }
+
+    /// Persist the high-water-mark. Called AFTER the data write, so a failed data write never advances
+    /// the mark and strands a version: the same event replayed later still applies (the guard tolerates
+    /// an idempotent re-apply) instead of being permanently rejected as stale.
+    fn advance_state_version(&self, vkey: &[u8], created_at: u64) -> Result<()> {
+        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
+        backend.put(STATE_VERSIONS_TABLE, vkey, &created_at.to_be_bytes())?;
+        Ok(())
     }
 
     /// Resolve a replicated `(table, record_id)` to its backend table and raw key: maps the logical

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -9,7 +9,7 @@ use tracing::{debug, trace, warn};
 
 use crate::backend::{
     RedbBackend, StorageBackend, CONFIG_TABLE, DESCRIPTORS_TABLE, HEALTH_STATUS_TABLE, KEYS_TABLE,
-    RELAY_CONFIGS_TABLE, SHARES_TABLE,
+    RELAY_CONFIGS_TABLE, SHARES_TABLE, STATE_VERSIONS_TABLE,
 };
 use crate::crypto::{self, Argon2Params, EncryptedData, SecretKey, SALT_SIZE};
 use crate::error::{KeepError, Result, StorageError};
@@ -298,24 +298,61 @@ impl Storage {
     /// the standby shares the vault key, so it later decrypts them like its own. Never notifies the
     /// publisher, so a consumed record is not echoed back to the relay. Rejects any table but the three
     /// replicated ones, so a hostile or buggy peer cannot write `shares` or node-local state.
+    /// `created_at` is the replicated event's signed timestamp; the record is applied only if it is
+    /// strictly newer than the highest already applied for this d-tag (rollback/replay guard). Returns
+    /// `true` if applied, `false` if ignored as stale.
     pub fn apply_replicated_record(
         &self,
         table: &str,
         record_id: &str,
         encrypted: &[u8],
-    ) -> Result<()> {
-        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
+        created_at: u64,
+    ) -> Result<bool> {
         let (table_name, key) = Self::replicated_key(table, record_id)?;
+        if !self.accept_state_version(table, record_id, created_at)? {
+            return Ok(false);
+        }
+        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
         backend.put(table_name, &key, encrypted)?;
-        Ok(())
+        Ok(true)
     }
 
-    /// Apply a replicated delete (tombstone) from a peer. Never notifies the publisher.
-    pub fn apply_replicated_delete(&self, table: &str, record_id: &str) -> Result<()> {
-        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
+    /// Apply a replicated delete (tombstone) from a peer. Never notifies the publisher. Same rollback
+    /// guard as `apply_replicated_record`; returns `true` if applied, `false` if ignored as stale.
+    pub fn apply_replicated_delete(
+        &self,
+        table: &str,
+        record_id: &str,
+        created_at: u64,
+    ) -> Result<bool> {
         let (table_name, key) = Self::replicated_key(table, record_id)?;
+        if !self.accept_state_version(table, record_id, created_at)? {
+            return Ok(false);
+        }
+        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
         backend.delete(table_name, &key)?;
-        Ok(())
+        Ok(true)
+    }
+
+    /// keep-state rollback guard. Returns `true` (and records the new high-water-mark) if `created_at`
+    /// is strictly newer than the highest previously applied for this record's d-tag; `false` if it is
+    /// stale or a replay and must be ignored. `created_at` lives in the SIGNED event, so a malicious
+    /// relay cannot forge a newer one, and persisting the mark keeps the guard across restarts.
+    fn accept_state_version(&self, table: &str, record_id: &str, created_at: u64) -> Result<bool> {
+        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
+        // Lazily ensure the table exists so a vault created before this guard migrates transparently.
+        backend.create_table(STATE_VERSIONS_TABLE)?;
+        let vkey = format!("{table}:{record_id}").into_bytes();
+        if let Some(prev) = backend.get(STATE_VERSIONS_TABLE, &vkey)? {
+            let prev_ts = u64::from_be_bytes(prev.as_slice().try_into().map_err(|_| {
+                KeepError::Other("corrupt keep-state version high-water-mark".to_string())
+            })?);
+            if created_at <= prev_ts {
+                return Ok(false);
+            }
+        }
+        backend.put(STATE_VERSIONS_TABLE, &vkey, &created_at.to_be_bytes())?;
+        Ok(true)
     }
 
     /// Resolve a replicated `(table, record_id)` to its backend table and raw key: maps the logical
@@ -416,6 +453,7 @@ impl Storage {
         backend.create_table(RELAY_CONFIGS_TABLE)?;
         backend.create_table(CONFIG_TABLE)?;
         backend.create_table(HEALTH_STATUS_TABLE)?;
+        backend.create_table(STATE_VERSIONS_TABLE)?;
 
         Ok(Self {
             path: path.to_path_buf(),
@@ -1626,39 +1664,90 @@ mod tests {
 
         // Applying the replicated bytes reconstructs a loadable record (same vault key decrypts them).
         storage
-            .apply_replicated_record("keys", &hex::encode(record.id), &encrypted)
+            .apply_replicated_record("keys", &hex::encode(record.id), &encrypted, 1)
             .unwrap();
         assert_eq!(storage.load_key(&record.id).unwrap().name, "replicated");
 
         // A non-replicable table (shares / node-local / unknown) is refused, so a peer cannot write it.
         assert!(storage
-            .apply_replicated_record("shares", &hex::encode(record.id), &encrypted)
+            .apply_replicated_record("shares", &hex::encode(record.id), &encrypted, 1)
             .is_err());
         assert!(storage
-            .apply_replicated_record("bogus", &hex::encode(record.id), &encrypted)
+            .apply_replicated_record("bogus", &hex::encode(record.id), &encrypted, 1)
             .is_err());
 
         // A descriptor key of the wrong length is refused: the listing/lookup path fails closed on any
         // non-36-byte descriptor row, so accepting one would poison list_descriptors for the vault.
         assert!(storage
-            .apply_replicated_record("descriptors", &hex::encode([0u8; 20]), &encrypted)
+            .apply_replicated_record("descriptors", &hex::encode([0u8; 20]), &encrypted, 1)
             .is_err());
         assert!(storage
-            .apply_replicated_delete("descriptors", &hex::encode([0u8; 20]))
+            .apply_replicated_delete("descriptors", &hex::encode([0u8; 20]), 1)
             .is_err());
         // A correctly-sized 36-byte descriptor key is accepted.
         assert!(storage
-            .apply_replicated_record("descriptors", &hex::encode([0u8; 36]), &encrypted)
+            .apply_replicated_record("descriptors", &hex::encode([0u8; 36]), &encrypted, 1)
             .is_ok());
 
         // A replicated delete removes it, and never echoes to the publisher: the only recorded delete
         // is the earlier real delete_key, not this apply.
         let deletes_before = publisher.deletes.lock().unwrap().len();
         storage
-            .apply_replicated_delete("keys", &hex::encode(record.id))
+            .apply_replicated_delete("keys", &hex::encode(record.id), 2)
             .unwrap();
         assert!(storage.load_key(&record.id).is_err());
         assert_eq!(publisher.deletes.lock().unwrap().len(), deletes_before);
+    }
+
+    #[test]
+    fn replicated_apply_rejects_stale_created_at() {
+        // The rollback guard: an event not strictly newer than the highest applied for its d-tag is
+        // ignored, so an untrusted relay cannot replay a stale record/delete to roll a standby back.
+        // created_at is the SIGNED event timestamp and cannot be forged to look newer.
+        let dir = tempdir().unwrap();
+        let storage =
+            Storage::create(&dir.path().join("v"), "passwordX", Argon2Params::TESTING).unwrap();
+
+        let publisher = std::sync::Arc::new(RecordingPublisher::default());
+        storage.set_state_publisher(publisher.clone());
+        let mk = |name: &str| {
+            KeyRecord::new(
+                [9u8; 32],
+                crate::keys::KeyType::Nostr,
+                name.into(),
+                vec![1, 2, 3],
+            )
+        };
+        storage.store_key(&mk("v1")).unwrap();
+        let enc_v1 = publisher.last_bytes.lock().unwrap().clone();
+        storage.store_key(&mk("v2")).unwrap();
+        let enc_v2 = publisher.last_bytes.lock().unwrap().clone();
+        let id = hex::encode([9u8; 32]);
+
+        // Apply v2 at created_at=100.
+        assert!(storage
+            .apply_replicated_record("keys", &id, &enc_v2, 100)
+            .unwrap());
+        assert_eq!(storage.load_key(&[9u8; 32]).unwrap().name, "v2");
+
+        // An older replay is rejected and does NOT roll the record back to v1.
+        assert!(!storage
+            .apply_replicated_record("keys", &id, &enc_v1, 50)
+            .unwrap());
+        assert_eq!(storage.load_key(&[9u8; 32]).unwrap().name, "v2");
+        // The SAME created_at is also rejected (idempotent, no rollback).
+        assert!(!storage
+            .apply_replicated_record("keys", &id, &enc_v1, 100)
+            .unwrap());
+        assert_eq!(storage.load_key(&[9u8; 32]).unwrap().name, "v2");
+
+        // A strictly-newer delete IS applied, and a stale record cannot resurrect the deleted row.
+        assert!(storage.apply_replicated_delete("keys", &id, 200).unwrap());
+        assert!(storage.load_key(&[9u8; 32]).is_err());
+        assert!(!storage
+            .apply_replicated_record("keys", &id, &enc_v1, 150)
+            .unwrap());
+        assert!(storage.load_key(&[9u8; 32]).is_err());
     }
 
     #[test]
@@ -1696,13 +1785,13 @@ mod tests {
         a.store_key(&record).unwrap();
         let encrypted = publisher.last_bytes.lock().unwrap().clone();
 
-        b.apply_replicated_record("keys", &hex::encode(record.id), &encrypted)
+        b.apply_replicated_record("keys", &hex::encode(record.id), &encrypted, 1)
             .unwrap();
         assert_eq!(b.load_key(&record.id).unwrap().name, "shared");
 
         // Sanity: WITHOUT the shared key, a third vault cannot decrypt the same bytes.
         let c = Storage::create(&dir.path().join("c"), "passwordC", Argon2Params::TESTING).unwrap();
-        c.apply_replicated_record("keys", &hex::encode(record.id), &encrypted)
+        c.apply_replicated_record("keys", &hex::encode(record.id), &encrypted, 1)
             .unwrap();
         assert!(c.load_key(&record.id).is_err());
     }

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -8,8 +8,8 @@ use std::path::{Path, PathBuf};
 use tracing::{debug, trace, warn};
 
 use crate::backend::{
-    RedbBackend, StorageBackend, CONFIG_TABLE, DESCRIPTORS_TABLE, HEALTH_STATUS_TABLE, KEYS_TABLE,
-    RELAY_CONFIGS_TABLE, SHARES_TABLE, STATE_VERSIONS_TABLE,
+    AtomicOp, RedbBackend, StorageBackend, CONFIG_TABLE, DESCRIPTORS_TABLE, HEALTH_STATUS_TABLE,
+    KEYS_TABLE, RELAY_CONFIGS_TABLE, SHARES_TABLE, STATE_VERSIONS_TABLE,
 };
 use crate::crypto::{self, Argon2Params, EncryptedData, SecretKey, SALT_SIZE};
 use crate::error::{KeepError, Result, StorageError};
@@ -314,8 +314,22 @@ impl Storage {
             return Ok(false);
         }
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
-        backend.put(table_name, &key, encrypted)?;
-        self.advance_state_version(&vkey, created_at)?;
+        // Write the data row and advance the high-water-mark in ONE atomic transaction: if these were
+        // two writes a crash between them would strand the mark BEHIND the data, and an untrusted relay
+        // could then replay an intermediate validly-signed version to roll the record back.
+        let ts = created_at.to_be_bytes();
+        backend.write_atomic(&[
+            AtomicOp {
+                table: table_name,
+                key: &key,
+                value: Some(encrypted),
+            },
+            AtomicOp {
+                table: STATE_VERSIONS_TABLE,
+                key: &vkey,
+                value: Some(&ts),
+            },
+        ])?;
         Ok(true)
     }
 
@@ -333,8 +347,20 @@ impl Storage {
             return Ok(false);
         }
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
-        backend.delete(table_name, &key)?;
-        self.advance_state_version(&vkey, created_at)?;
+        // Tombstone and mark advance in one atomic transaction; see `apply_replicated_record`.
+        let ts = created_at.to_be_bytes();
+        backend.write_atomic(&[
+            AtomicOp {
+                table: table_name,
+                key: &key,
+                value: None,
+            },
+            AtomicOp {
+                table: STATE_VERSIONS_TABLE,
+                key: &vkey,
+                value: Some(&ts),
+            },
+        ])?;
         Ok(true)
     }
 
@@ -368,13 +394,23 @@ impl Storage {
         Ok(true)
     }
 
-    /// Persist the high-water-mark. Called AFTER the data write, so a failed data write never advances
-    /// the mark and strands a version: the same event replayed later still applies (the guard tolerates
-    /// an idempotent re-apply) instead of being permanently rejected as stale.
-    fn advance_state_version(&self, vkey: &[u8], created_at: u64) -> Result<()> {
+    /// The highest keep-state high-water-mark persisted in this vault, or 0 if none. A promoted standby
+    /// (restarted as active) seeds its publisher's per-d-tag monotonic floor from this so a fresh publish
+    /// is strictly newer than every mark standbys already applied. Fails closed to 0 only on an empty or
+    /// absent table; a corrupt (non-8-byte) entry propagates a decode error, consistent with
+    /// `state_version_is_newer`.
+    pub fn max_state_version(&self) -> Result<u64> {
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
-        backend.put(STATE_VERSIONS_TABLE, vkey, &created_at.to_be_bytes())?;
-        Ok(())
+        // The read path cannot create the table (redb read txns cannot), so ensure it exists first.
+        backend.create_table(STATE_VERSIONS_TABLE)?;
+        let mut max = 0u64;
+        for (_, v) in backend.list(STATE_VERSIONS_TABLE)? {
+            let ts = u64::from_be_bytes(v.as_slice().try_into().map_err(|_| {
+                KeepError::Other("corrupt keep-state version high-water-mark".to_string())
+            })?);
+            max = max.max(ts);
+        }
+        Ok(max)
     }
 
     /// Resolve a replicated `(table, record_id)` to its backend table and raw key: maps the logical
@@ -1770,6 +1806,44 @@ mod tests {
             .apply_replicated_record("keys", &id, &enc_v1, 150)
             .unwrap());
         assert!(storage.load_key(&[9u8; 32]).is_err());
+    }
+
+    #[test]
+    fn apply_replicated_record_fails_closed_on_corrupt_high_water_mark() {
+        // A non-8-byte high-water-mark cannot be decoded to a u64: the guard must propagate the decode
+        // error (fail closed) rather than silently treating it as first-sync and applying the event.
+        let dir = tempdir().unwrap();
+        let storage =
+            Storage::create(&dir.path().join("v"), "passwordX", Argon2Params::TESTING).unwrap();
+
+        let record = KeyRecord::new(
+            [3u8; 32],
+            crate::keys::KeyType::Nostr,
+            "corrupt".into(),
+            vec![1, 2, 3],
+        );
+        let id = hex::encode([3u8; 32]);
+        let vkey = Storage::state_version_key(KEYS_TABLE, &[3u8; 32]);
+        storage
+            .backend
+            .as_ref()
+            .unwrap()
+            .put(STATE_VERSIONS_TABLE, &vkey, &[1, 2, 3])
+            .unwrap();
+
+        let publisher = std::sync::Arc::new(RecordingPublisher::default());
+        storage.set_state_publisher(publisher.clone());
+        storage.store_key(&record).unwrap();
+        let encrypted = publisher.last_bytes.lock().unwrap().clone();
+        storage.delete_key(&record.id).unwrap();
+
+        let err = storage
+            .apply_replicated_record("keys", &id, &encrypted, 100)
+            .unwrap_err();
+        assert!(
+            matches!(&err, KeepError::Other(m) if m == "corrupt keep-state version high-water-mark"),
+            "got {err:?}"
+        );
     }
 
     #[test]

--- a/keep-frost-net/src/state_event.rs
+++ b/keep-frost-net/src/state_event.rs
@@ -92,6 +92,12 @@ pub fn parse_state_event(keys: &Keys, event: &Event) -> Result<Option<StateRecor
     if event.kind != Kind::Custom(KEEP_STATE_KIND) {
         return Ok(None);
     }
+    // Verify the id + signature here rather than trusting the relay pool to have done it: the entire
+    // rollback guard -- authorship AND the unforgeable created_at -- rests on the event being genuinely
+    // signed by the shared identity, so make this function sound on its own regardless of the caller.
+    if event.verify().is_err() {
+        return Ok(None);
+    }
     // Authenticate authorship against the shared cluster identity, not just the subscription filter:
     // relays are untrusted and can deliver events the filter should have excluded. Without this, a
     // tombstone signed by any keypair would be accepted and delete standby records (records are also

--- a/keep-frost-net/src/state_event.rs
+++ b/keep-frost-net/src/state_event.rs
@@ -33,6 +33,7 @@ pub fn state_record_event(
     table: &str,
     record_id: &str,
     content: &[u8],
+    created_at: u64,
 ) -> Result<Event> {
     let ciphertext = nip44::encrypt(
         keys.secret_key(),
@@ -42,15 +43,24 @@ pub fn state_record_event(
     )
     .map_err(|e| FrostNetError::Crypto(e.to_string()))?;
 
+    // `created_at` is caller-controlled (strictly monotonic per d-tag) so the relay's created_at-based
+    // addressable dedup always retains the latest write and the consumer's rollback guard never rejects
+    // a legitimate same-second update (e.g. a record and its immediate delete).
     EventBuilder::new(Kind::Custom(KEEP_STATE_KIND), ciphertext)
         .tag(Tag::identifier(d_tag(table, record_id)))
         .tag(Tag::custom(TagKind::custom("t"), [table.to_string()]))
+        .custom_created_at(Timestamp::from(created_at))
         .sign_with_keys(keys)
         .map_err(|e| FrostNetError::Nostr(e.to_string()))
 }
 
 /// Build a tombstone (delete) event for a record: same `d`-tag, empty content, a `deleted` marker tag.
-pub fn state_tombstone_event(keys: &Keys, table: &str, record_id: &str) -> Result<Event> {
+pub fn state_tombstone_event(
+    keys: &Keys,
+    table: &str,
+    record_id: &str,
+    created_at: u64,
+) -> Result<Event> {
     EventBuilder::new(Kind::Custom(KEEP_STATE_KIND), "")
         .tag(Tag::identifier(d_tag(table, record_id)))
         .tag(Tag::custom(TagKind::custom("t"), [table.to_string()]))
@@ -58,6 +68,7 @@ pub fn state_tombstone_event(keys: &Keys, table: &str, record_id: &str) -> Resul
             TagKind::custom("deleted"),
             Vec::<String>::new(),
         ))
+        .custom_created_at(Timestamp::from(created_at))
         .sign_with_keys(keys)
         .map_err(|e| FrostNetError::Nostr(e.to_string()))
 }
@@ -69,6 +80,9 @@ pub struct StateRecord {
     pub record_id: String,
     /// The decrypted record bytes, or `None` for a tombstone (delete).
     pub content: Option<Vec<u8>>,
+    /// The event's signed `created_at` (unix seconds). The consumer uses it as a per-d-tag
+    /// high-water-mark to reject stale/replayed events (rollback protection).
+    pub created_at: u64,
 }
 
 /// Parse + decrypt a keep-state event authored by the shared identity (`keys`). Returns `Ok(None)` if
@@ -114,6 +128,7 @@ pub fn parse_state_event(keys: &Keys, event: &Event) -> Result<Option<StateRecor
         table: table.to_string(),
         record_id: record_id.to_string(),
         content,
+        created_at: event.created_at.as_secs(),
     }))
 }
 
@@ -125,7 +140,7 @@ mod tests {
     fn record_event_round_trips() {
         let keys = Keys::generate();
         let content = b"vault-encrypted-record-bytes\x00\x01\x02";
-        let event = state_record_event(&keys, "keys", "abcd1234", content).unwrap();
+        let event = state_record_event(&keys, "keys", "abcd1234", content, 1000).unwrap();
 
         assert_eq!(event.kind, Kind::Custom(KEEP_STATE_KIND));
         assert_eq!(event.tags.identifier(), Some("keep:keys:abcd1234"));
@@ -134,12 +149,13 @@ mod tests {
         assert_eq!(parsed.table, "keys");
         assert_eq!(parsed.record_id, "abcd1234");
         assert_eq!(parsed.content.as_deref(), Some(content.as_slice()));
+        assert_eq!(parsed.created_at, 1000);
     }
 
     #[test]
     fn tombstone_has_no_content() {
         let keys = Keys::generate();
-        let event = state_tombstone_event(&keys, "descriptors", "deadbeef:3").unwrap();
+        let event = state_tombstone_event(&keys, "descriptors", "deadbeef:3", 1000).unwrap();
         let parsed = parse_state_event(&keys, &event).unwrap().unwrap();
         assert_eq!(parsed.table, "descriptors");
         // record_id keeps the remainder past the second ':', so a versioned id survives intact.
@@ -162,11 +178,11 @@ mod tests {
         // the subscription filter is relay-enforced and untrusted, so authorship is verified here.
         let ours = Keys::generate();
         let attacker = Keys::generate();
-        let forged = state_tombstone_event(&attacker, "keys", "abcd1234").unwrap();
+        let forged = state_tombstone_event(&attacker, "keys", "abcd1234", 1000).unwrap();
         assert_eq!(parse_state_event(&ours, &forged).unwrap(), None);
 
         // The same holds for a record event built under a foreign identity.
-        let forged_rec = state_record_event(&attacker, "keys", "abcd1234", b"x").unwrap();
+        let forged_rec = state_record_event(&attacker, "keys", "abcd1234", b"x", 1000).unwrap();
         assert_eq!(parse_state_event(&ours, &forged_rec).unwrap(), None);
     }
 
@@ -198,7 +214,7 @@ mod tests {
         let mut notifications = subscriber.notifications();
 
         let content = b"encrypted-record-bytes";
-        let event = state_record_event(&keys, "keys", "abc123", content).unwrap();
+        let event = state_record_event(&keys, "keys", "abc123", content, 1000).unwrap();
         publisher.send_event(&event).await.unwrap();
 
         let received = tokio::time::timeout(std::time::Duration::from_secs(5), async {

--- a/keep-web/src/state_replication.rs
+++ b/keep-web/src/state_replication.rs
@@ -14,7 +14,13 @@
 //! untrusted relay cannot replay a stale record/tombstone to roll a synced standby back. Residual risks
 //! it does NOT cover (untrusted-relay + no-liveness model): a relay may still WITHHOLD a newer record or
 //! a tombstone (keeping a revoked key live), and on FIRST sync it may serve an arbitrarily old but
-//! validly-signed version (TOFU) -- detecting omission needs a signed cluster manifest/epoch (keep-0kzy).
+//! validly-signed version (TOFU) -- detecting omission needs a signed cluster manifest/epoch.
+//!
+//! Operational requirement: the active node's wall clock must be monotonic and must not regress below
+//! any `created_at` it has already published, because each per-d-tag mark only advances, so a forward
+//! clock jump followed by a correction makes the consumer reject legitimate newer writes until wall-clock
+//! catches up. Seeding the publisher floor from stored marks covers a promoted standby, but not a live
+//! active whose own clock regresses.
 use std::sync::Arc;
 
 use nostr_sdk::prelude::*;
@@ -108,18 +114,49 @@ fn now_secs() -> u64 {
         .unwrap_or(0)
 }
 
+/// Compute the strictly-monotonic per-d-tag `created_at` for the next publish. `last` is the in-memory
+/// per-d-tag high-water-mark, seeded at startup from the persisted floor (see `spawn_publisher`). A new
+/// slot starts at `floor`; each write returns `now` unless that is not strictly greater than the last
+/// timestamp, in which case it bumps to `last + 1` (`saturating_add` so it cannot overflow).
+fn next_ts(
+    last: &mut std::collections::HashMap<String, u64>,
+    dtag: &str,
+    floor: u64,
+    now: u64,
+) -> u64 {
+    let slot = last.entry(dtag.to_string()).or_insert(floor);
+    let ts = now.max(slot.saturating_add(1));
+    *slot = ts;
+    ts
+}
+
 async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys) {
     let (tx, mut rx) = mpsc::unbounded_channel::<Change>();
     keep.lock()
         .await
         .set_state_publisher(Arc::new(ChannelPublisher { tx }));
 
+    // Seed the per-d-tag monotonic floor from the highest mark this node has already persisted. On a
+    // promoted standby (restarted as active) whose stored marks were inflated above wall-clock
+    // (same-second bumps) or under inter-node clock skew, starting from 0 could publish a created_at
+    // <= a mark standbys already applied and be rejected; seeding guarantees the first publish for any
+    // d-tag is strictly greater than every previously-applied mark.
+    let floor = match keep.lock().await.max_state_version() {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                "keep-state: could not read persisted high-water floor, seeding from 0: {e}"
+            );
+            0
+        }
+    };
+
     tokio::spawn(async move {
-        // Strictly-monotonic created_at per d-tag: a record and its immediate delete (or two rapid
-        // writes) must not collide on the same second, or the relay's created_at dedup could keep the
-        // wrong one and the standby's rollback guard would reject the newer as "not newer". Bump to
-        // last+1 when wall-clock has not advanced. In-memory is fine: on restart the first write to a
-        // d-tag reverts to wall-clock, which the relay + consumer already order correctly.
+        // `last_ts` is an in-memory per-d-tag high-water-mark seeded from `floor` (the persisted mark).
+        // Within a run it guarantees strict per-d-tag monotonicity of created_at: a record and its
+        // immediate delete (or two rapid writes) must not collide on the same second, or the relay's
+        // created_at dedup could keep the wrong one and the standby's rollback guard would reject the
+        // newer as "not newer". Same-second writes bump to last+1; otherwise wall-clock is used.
         let mut last_ts: std::collections::HashMap<String, u64> = std::collections::HashMap::new();
         while let Some(change) = rx.recv().await {
             let dtag = match &change {
@@ -127,9 +164,7 @@ async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys)
                     format!("{table}:{id}")
                 }
             };
-            let slot = last_ts.entry(dtag).or_insert(0);
-            let ts = now_secs().max(*slot + 1);
-            *slot = ts;
+            let ts = next_ts(&mut last_ts, &dtag, floor, now_secs());
             let event = match &change {
                 Change::Record {
                     table,
@@ -228,6 +263,24 @@ mod tests {
     use keep_core::crypto::Argon2Params;
     use keep_core::{Keep, RelayConfig};
     use nostr_relay_builder::MockRelay;
+    use std::collections::HashMap;
+
+    #[test]
+    fn next_ts_is_strictly_monotonic_per_dtag() {
+        let mut last: HashMap<String, u64> = HashMap::new();
+
+        // (a) first write for a d-tag with floor 0 returns wall-clock.
+        assert_eq!(next_ts(&mut last, "keys:a", 0, 100), 100);
+        // (b) a second write in the same wall-clock second bumps to last+1.
+        assert_eq!(next_ts(&mut last, "keys:a", 0, 100), 101);
+        // (c) a later write with wall-clock advanced past the mark uses wall-clock.
+        assert_eq!(next_ts(&mut last, "keys:a", 0, 500), 500);
+        // (d) an independent d-tag has its own slot and does not interfere.
+        assert_eq!(next_ts(&mut last, "keys:b", 0, 100), 100);
+        assert_eq!(next_ts(&mut last, "keys:a", 0, 500), 501);
+        // (e) a seeded floor above wall-clock produces floor+1 (the promotion case).
+        assert_eq!(next_ts(&mut last, "keys:c", 1_000, 100), 1_001);
+    }
 
     // Full end-to-end: an ACTIVE keep-web node writes vault state, it flows through a live relay, and a
     // STANDBY node reconstructs it AND reads it back decrypted. The two vaults share the data key (the

--- a/keep-web/src/state_replication.rs
+++ b/keep-web/src/state_replication.rs
@@ -8,6 +8,13 @@
 //! reconstructs each record into its own storage, so a promoted standby serves the same keep secrets.
 //! Single-writer: the active publishes, the standby consumes; roles flip on promotion (the node is
 //! restarted with the new `KEEP_STATE_ROLE`).
+//!
+//! Rollback protection: each event carries the signed `created_at`, and the consumer keeps a persisted
+//! per-d-tag high-water-mark (keep-core `state_versions`), rejecting anything not strictly newer, so an
+//! untrusted relay cannot replay a stale record/tombstone to roll a synced standby back. Residual risks
+//! it does NOT cover (untrusted-relay + no-liveness model): a relay may still WITHHOLD a newer record or
+//! a tombstone (keeping a revoked key live), and on FIRST sync it may serve an arbitrarily old but
+//! validly-signed version (TOFU) -- detecting omission needs a signed cluster manifest/epoch (keep-0kzy).
 use std::sync::Arc;
 
 use nostr_sdk::prelude::*;

--- a/keep-web/src/state_replication.rs
+++ b/keep-web/src/state_replication.rs
@@ -94,6 +94,13 @@ pub async fn spawn(
     Ok(())
 }
 
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
 async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys) {
     let (tx, mut rx) = mpsc::unbounded_channel::<Change>();
     keep.lock()
@@ -101,14 +108,28 @@ async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys)
         .set_state_publisher(Arc::new(ChannelPublisher { tx }));
 
     tokio::spawn(async move {
+        // Strictly-monotonic created_at per d-tag: a record and its immediate delete (or two rapid
+        // writes) must not collide on the same second, or the relay's created_at dedup could keep the
+        // wrong one and the standby's rollback guard would reject the newer as "not newer". Bump to
+        // last+1 when wall-clock has not advanced. In-memory is fine: on restart the first write to a
+        // d-tag reverts to wall-clock, which the relay + consumer already order correctly.
+        let mut last_ts: std::collections::HashMap<String, u64> = std::collections::HashMap::new();
         while let Some(change) = rx.recv().await {
+            let dtag = match &change {
+                Change::Record { table, id, .. } | Change::Delete { table, id } => {
+                    format!("{table}:{id}")
+                }
+            };
+            let slot = last_ts.entry(dtag).or_insert(0);
+            let ts = now_secs().max(*slot + 1);
+            *slot = ts;
             let event = match &change {
                 Change::Record {
                     table,
                     id,
                     encrypted,
-                } => state_record_event(&identity, table, id, encrypted),
-                Change::Delete { table, id } => state_tombstone_event(&identity, table, id),
+                } => state_record_event(&identity, table, id, encrypted, ts),
+                Change::Delete { table, id } => state_tombstone_event(&identity, table, id, ts),
             };
             match event {
                 Ok(ev) => {
@@ -159,13 +180,30 @@ async fn spawn_consumer(
                     Ok(Some(rec)) => {
                         let k = keep.lock().await;
                         let outcome = match rec.content {
-                            Some(bytes) => {
-                                k.apply_replicated_record(&rec.table, &rec.record_id, &bytes)
-                            }
-                            None => k.apply_replicated_delete(&rec.table, &rec.record_id),
+                            Some(bytes) => k.apply_replicated_record(
+                                &rec.table,
+                                &rec.record_id,
+                                &bytes,
+                                rec.created_at,
+                            ),
+                            None => k.apply_replicated_delete(
+                                &rec.table,
+                                &rec.record_id,
+                                rec.created_at,
+                            ),
                         };
-                        if let Err(e) = outcome {
-                            tracing::warn!(table = %rec.table, "keep-state apply failed: {e}");
+                        match outcome {
+                            Ok(true) => {}
+                            // Not strictly newer than what we already applied: a stale or replayed event
+                            // (rollback attempt from an untrusted relay). Ignore it, but record it.
+                            Ok(false) => tracing::warn!(
+                                table = %rec.table,
+                                created_at = rec.created_at,
+                                "keep-state: ignored stale/replayed event (rollback guard)"
+                            ),
+                            Err(e) => {
+                                tracing::warn!(table = %rec.table, "keep-state apply failed: {e}")
+                            }
                         }
                     }
                     Ok(None) => {}


### PR DESCRIPTION
Closes keep-ol4n (P2): the keep-state replication consumer applied whatever the relay delivered with no ordering check, so an untrusted relay could replay a stale record/tombstone to roll a standby back, and a same-second record-then-delete could converge to the wrong event.

## Why created_at, not a version tag
Per NIP-01, relays store an addressable event (kind 30078) by keeping the one with the **latest `created_at`**, breaking same-second ties by **lowest event-id**, and they **ignore any custom tag**. So a `version`/`seq` tag would be inert , the relay would still discard the "older" event before the consumer ever sees it. `created_at` is already in the **signed** event (a malicious relay can't forge it) and is exactly what the relay orders on, so it's the right mechanism.

## The fix
- **Publisher** (`keep-web`) , stamps a **strictly-monotonic `created_at` per d-tag**: if two writes to the same record land in the same second (a record and its immediate delete), the second is bumped to `last+1`. This removes same-second ties, so the relay always retains the true latest write, and the consumer's own guard never rejects a legitimate update.
- **Consumer** (`keep-web` + `keep-core`) , threads the event's `created_at` through `parse_state_event` → `apply_replicated_record/_delete`, which now consult a **persisted per-d-tag high-water-mark** (new `state_versions` redb table) and **reject anything not strictly newer**, returning `false` (logged) instead of applying. Persisted, so a restart doesn't re-open the rollback window against a relay that later turns malicious.

## Tests
`replicated_apply_rejects_stale_created_at` (keep-core): a stale replay is rejected and does **not** roll the record back; the same `created_at` is rejected (idempotent); a strictly-newer delete applies; and a stale record can't resurrect a deleted row. Plus a `created_at` round-trip in keep-frost-net. All keep-core / keep-frost-net / keep-web suites (incl. the replication e2e) pass; clippy clean.

Migration: the `state_versions` table is created for new vaults and lazily on first apply for existing ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replicated state updates now carry timestamps, improving ordering for synced records and deletes.
  * State records now retain a visible creation time for better tracking and consistency.

* **Bug Fixes**
  * Added protection against stale or replayed replicated changes, reducing rollback issues.
  * Improved event timestamp handling to avoid duplicate or out-of-order replication when clocks don’t advance.
  * Standby sync now clearly ignores outdated events and reports apply failures more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->