### PR TITLE
keep-state: surface relay created_at rejection instead of silent replication loss (#704)

### DIFF
--- a/keep-bitcoin/src/chain_view.rs
+++ b/keep-bitcoin/src/chain_view.rs
@@ -23,7 +23,7 @@
 //! shape of `REFUSED:` error the destination guard uses, so operators see
 //! the two defenses side by side.
 
-use bitcoin::{OutPoint, Psbt, ScriptBuf, TxOut};
+use bitcoin::{OutPoint, Psbt, TxOut};
 
 /// Read-only view resolving an outpoint's committed `(value, script_pubkey)`
 /// for #502 prevout validation.
@@ -323,7 +323,7 @@ impl ChainView for EsploraChainView {
             .map_err(|e| ChainViewError::Decode(format!("decode scriptpubkey hex: {e}")))?;
         Ok(TxOut {
             value: bitcoin::Amount::from_sat(vout.value),
-            script_pubkey: ScriptBuf::from_bytes(script_bytes),
+            script_pubkey: bitcoin::ScriptBuf::from_bytes(script_bytes),
         })
     }
 }

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -135,11 +135,10 @@ impl Keep {
             .apply_replicated_delete(table, record_id, created_at)
     }
 
-    /// The highest keep-state high-water-mark persisted in this vault (0 if none). A promoted standby
-    /// seeds its publisher's monotonic floor from this so a fresh publish is strictly newer than every
-    /// mark standbys already applied. See [`Storage::max_state_version`].
-    pub fn max_state_version(&self) -> Result<u64> {
-        self.storage.max_state_version()
+    /// The persisted rollback high-water-mark for one replicated record's d-tag (`None` if never
+    /// applied), for seeding the publisher's per-d-tag floor. See [`Storage::state_version`].
+    pub fn state_version(&self, table: &str, record_id: &str) -> Result<Option<u64>> {
+        self.storage.state_version(table, record_id)
     }
 
     /// Create a new Keep with the given password.

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -394,23 +394,23 @@ impl Storage {
         Ok(true)
     }
 
-    /// The highest keep-state high-water-mark persisted in this vault, or 0 if none. A promoted standby
-    /// (restarted as active) seeds its publisher's per-d-tag monotonic floor from this so a fresh publish
-    /// is strictly newer than every mark standbys already applied. Fails closed to 0 only on an empty or
-    /// absent table; a corrupt (non-8-byte) entry propagates a decode error, consistent with
-    /// `state_version_is_newer`.
-    pub fn max_state_version(&self) -> Result<u64> {
+    /// The persisted keep-state high-water-mark for a single replicated record's d-tag, or `None` if it
+    /// has never been applied. A promoted standby seeds its publisher's monotonic floor PER RECORD from
+    /// this (not from a global maximum), so a quiet record is not future-dated to the newest record's
+    /// timestamp. Uses the same key derivation as the consumer's guard, so it reads exactly the mark that
+    /// guard wrote. A corrupt (non-8-byte) entry propagates a decode error.
+    pub fn state_version(&self, table: &str, record_id: &str) -> Result<Option<u64>> {
+        let (table_name, key) = Self::replicated_key(table, record_id)?;
+        let vkey = Self::state_version_key(table_name, &key);
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
         // The read path cannot create the table (redb read txns cannot), so ensure it exists first.
         backend.create_table(STATE_VERSIONS_TABLE)?;
-        let mut max = 0u64;
-        for (_, v) in backend.list(STATE_VERSIONS_TABLE)? {
-            let ts = u64::from_be_bytes(v.as_slice().try_into().map_err(|_| {
-                KeepError::Other("corrupt keep-state version high-water-mark".to_string())
-            })?);
-            max = max.max(ts);
+        match backend.get(STATE_VERSIONS_TABLE, &vkey)? {
+            Some(v) => Ok(Some(u64::from_be_bytes(v.as_slice().try_into().map_err(
+                |_| KeepError::Other("corrupt keep-state version high-water-mark".to_string()),
+            )?))),
+            None => Ok(None),
         }
-        Ok(max)
     }
 
     /// Resolve a replicated `(table, record_id)` to its backend table and raw key: maps the logical
@@ -1806,6 +1806,39 @@ mod tests {
             .apply_replicated_record("keys", &id, &enc_v1, 150)
             .unwrap());
         assert!(storage.load_key(&[9u8; 32]).is_err());
+    }
+
+    #[test]
+    fn state_version_is_per_record_not_global() {
+        // The publisher seeds each d-tag's floor from its OWN mark, so verify the getter returns
+        // per-record marks: a quiet record is not inflated to a busier record's timestamp.
+        let dir = tempdir().unwrap();
+        let storage =
+            Storage::create(&dir.path().join("v"), "passwordP", Argon2Params::TESTING).unwrap();
+        let publisher = std::sync::Arc::new(RecordingPublisher::default());
+        storage.set_state_publisher(publisher.clone());
+        storage
+            .store_key(&KeyRecord::new(
+                [1u8; 32],
+                crate::keys::KeyType::Nostr,
+                "a".into(),
+                vec![1],
+            ))
+            .unwrap();
+        let enc = publisher.last_bytes.lock().unwrap().clone();
+        let a = hex::encode([1u8; 32]);
+        let b = hex::encode([2u8; 32]);
+
+        assert_eq!(storage.state_version("keys", &a).unwrap(), None);
+        storage
+            .apply_replicated_record("keys", &a, &enc, 100)
+            .unwrap();
+        storage
+            .apply_replicated_record("keys", &b, &enc, 500)
+            .unwrap();
+        // Record a's mark stays 100 even though b was applied at 500 (no global-max contamination).
+        assert_eq!(storage.state_version("keys", &a).unwrap(), Some(100));
+        assert_eq!(storage.state_version("keys", &b).unwrap(), Some(500));
     }
 
     #[test]

--- a/keep-web/src/state_replication.rs
+++ b/keep-web/src/state_replication.rs
@@ -119,6 +119,30 @@ fn now_secs() -> u64 {
 /// regression), which a relay enforcing a NIP-11 `created_at_upper_limit` may reject.
 const MAX_FUTURE_DRIFT_SECS: u64 = 60;
 
+/// How a relay pool responded to a publish. `RelayPool::send_event_to` returns `Ok(output)` even when
+/// every relay said no: a relay replying `OK: false` (including NIP-01 `invalid:` prefixes) lands in
+/// `failed`, leaving `success` empty. Classifying on the outer `Result` alone therefore reads a
+/// rejection as a success, which is the silent replication loss this exists to prevent.
+#[derive(Debug, PartialEq, Eq)]
+enum SendOutcome {
+    /// Every relay accepted the event.
+    Accepted,
+    /// At least one relay accepted, but others rejected it.
+    PartiallyRejected,
+    /// No relay accepted it: the record did NOT replicate.
+    NoRelayAccepted,
+}
+
+fn classify_send(out: &Output<EventId>) -> SendOutcome {
+    if out.success.is_empty() {
+        SendOutcome::NoRelayAccepted
+    } else if !out.failed.is_empty() {
+        SendOutcome::PartiallyRejected
+    } else {
+        SendOutcome::Accepted
+    }
+}
+
 /// Compute the strictly-monotonic per-d-tag `created_at` for the next publish. `last` is the in-memory
 /// per-d-tag high-water-mark. Each write returns `now` unless that is not strictly greater than the last
 /// timestamp, in which case it bumps to `last + 1` (`saturating_add` so it cannot overflow).
@@ -203,23 +227,26 @@ async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys)
             };
             match event {
                 Ok(ev) => match client.send_event(&ev).await {
-                    // No relay accepted it -- rejected (e.g. NIP-01 "invalid: created_at too far off")
-                    // or unreachable. It did NOT replicate; log loudly instead of losing it silently.
-                    Ok(out) if out.success.is_empty() => tracing::error!(
-                        dtag = ?dtag,
-                        created_at = ts,
-                        failed = ?out.failed,
-                        "keep-state publish accepted by NO relay; record did not replicate"
-                    ),
-                    // Replicated, but some relay still said no. Not loss today (`spawn` adds exactly one
-                    // relay, so this cannot fire), yet the reasons must never be silently discarded.
-                    Ok(out) if !out.failed.is_empty() => tracing::warn!(
-                        dtag = ?dtag,
-                        created_at = ts,
-                        failed = ?out.failed,
-                        "keep-state publish rejected by some relays"
-                    ),
-                    Ok(_) => {}
+                    Ok(out) => match classify_send(&out) {
+                        // Rejected (e.g. NIP-01 "invalid: event creation date is too far off from the
+                        // current time") or unreachable. It did NOT replicate; log loudly instead of
+                        // losing it silently.
+                        SendOutcome::NoRelayAccepted => tracing::error!(
+                            dtag = ?dtag,
+                            created_at = ts,
+                            failed = ?out.failed,
+                            "keep-state publish accepted by NO relay; record did not replicate"
+                        ),
+                        // Replicated, but some relay still said no. Not loss today (`spawn` adds exactly
+                        // one relay, so this cannot fire), yet the reasons must never be discarded.
+                        SendOutcome::PartiallyRejected => tracing::warn!(
+                            dtag = ?dtag,
+                            created_at = ts,
+                            failed = ?out.failed,
+                            "keep-state publish rejected by some relays"
+                        ),
+                        SendOutcome::Accepted => {}
+                    },
                     Err(e) => tracing::warn!("keep-state publish failed: {e}"),
                 },
                 Err(e) => tracing::warn!("keep-state event build failed: {e}"),
@@ -281,14 +308,20 @@ async fn spawn_consumer(
                             Ok(true) => {}
                             // Not strictly newer than what we already applied: a stale or replayed event
                             // (rollback attempt from an untrusted relay). Ignore it, but record it.
+                            // Debug-format the event-supplied table and record id: neither is charset-
+                            // constrained until `apply_*` checks the allowlist, so Display would let a
+                            // control character forge log lines.
                             Ok(false) => tracing::warn!(
-                                table = %rec.table,
+                                table = ?rec.table,
+                                record_id = ?rec.record_id,
                                 created_at = rec.created_at,
                                 "keep-state: ignored stale/replayed event (rollback guard)"
                             ),
-                            Err(e) => {
-                                tracing::warn!(table = %rec.table, "keep-state apply failed: {e}")
-                            }
+                            Err(e) => tracing::warn!(
+                                table = ?rec.table,
+                                record_id = ?rec.record_id,
+                                "keep-state apply failed: {e}"
+                            ),
                         }
                     }
                     Ok(None) => {}
@@ -307,6 +340,45 @@ mod tests {
     use keep_core::{Keep, RelayConfig};
     use nostr_relay_builder::MockRelay;
     use std::collections::HashMap;
+
+    // A relay that rejects an event (NIP-01 `OK: false`, e.g. an `invalid:` far-future `created_at`)
+    // still leaves `send_event` returning `Ok(output)` -- the rejection only shows up as an empty
+    // `success` set. Pin the classification, because reading `Ok(_)` as success is the silent
+    // replication loss this whole path exists to surface.
+    #[test]
+    fn a_send_no_relay_accepted_is_not_a_success() {
+        let out = |success: &[&str], failed: &[&str]| Output {
+            val: EventId::from_byte_array([0u8; 32]),
+            success: success
+                .iter()
+                .map(|u| RelayUrl::parse(u).unwrap())
+                .collect(),
+            failed: failed
+                .iter()
+                .map(|u| {
+                    (
+                        RelayUrl::parse(u).unwrap(),
+                        "invalid: event creation date is too far off from the current time".into(),
+                    )
+                })
+                .collect(),
+        };
+        let (a, b) = ("wss://a.example", "wss://b.example");
+
+        // Every relay rejected: the record did not replicate, even though the call returned `Ok`.
+        assert_eq!(
+            classify_send(&out(&[], &[a, b])),
+            SendOutcome::NoRelayAccepted
+        );
+        // No relay reachable at all: also did not replicate.
+        assert_eq!(classify_send(&out(&[], &[])), SendOutcome::NoRelayAccepted);
+        // Accepted somewhere, rejected elsewhere: replicated, but the reasons must not be discarded.
+        assert_eq!(
+            classify_send(&out(&[a], &[b])),
+            SendOutcome::PartiallyRejected
+        );
+        assert_eq!(classify_send(&out(&[a, b], &[])), SendOutcome::Accepted);
+    }
 
     #[test]
     fn next_ts_is_strictly_monotonic_per_dtag() {

--- a/keep-web/src/state_replication.rs
+++ b/keep-web/src/state_replication.rs
@@ -114,6 +114,11 @@ fn now_secs() -> u64 {
         .unwrap_or(0)
 }
 
+/// How far ahead of wall-clock a published `created_at` may drift before we warn. Same-second bumps
+/// drift only ~1-2s; a much larger gap means the seeded floor is ahead of wall-clock (a clock
+/// regression), which a relay enforcing a NIP-11 `created_at_upper_limit` may reject.
+const MAX_FUTURE_DRIFT_SECS: u64 = 60;
+
 /// Compute the strictly-monotonic per-d-tag `created_at` for the next publish. `last` is the in-memory
 /// per-d-tag high-water-mark, seeded at startup from the persisted floor (see `spawn_publisher`). A new
 /// slot starts at `floor`; each write returns `now` unless that is not strictly greater than the last
@@ -164,7 +169,19 @@ async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys)
                     format!("{table}:{id}")
                 }
             };
-            let ts = next_ts(&mut last_ts, &dtag, floor, now_secs());
+            let now = now_secs();
+            let ts = next_ts(&mut last_ts, &dtag, floor, now);
+            // A created_at far ahead of wall-clock (a floor seeded after a clock regression, or a long
+            // same-second burst) risks a strict relay rejecting it as too-far-future. Surface the drift
+            // so a rejection below is explainable.
+            if ts > now.saturating_add(MAX_FUTURE_DRIFT_SECS) {
+                tracing::warn!(
+                    dtag = %dtag,
+                    created_at = ts,
+                    now,
+                    "keep-state: created_at is far ahead of wall-clock; a relay enforcing a created_at_upper_limit may reject this event"
+                );
+            }
             let event = match &change {
                 Change::Record {
                     table,
@@ -174,11 +191,18 @@ async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys)
                 Change::Delete { table, id } => state_tombstone_event(&identity, table, id, ts),
             };
             match event {
-                Ok(ev) => {
-                    if let Err(e) = client.send_event(&ev).await {
-                        tracing::warn!("keep-state publish failed: {e}");
-                    }
-                }
+                Ok(ev) => match client.send_event(&ev).await {
+                    // No relay accepted it -- rejected (e.g. NIP-01 "invalid: created_at too far off")
+                    // or unreachable. It did NOT replicate; log loudly instead of losing it silently.
+                    Ok(out) if out.success.is_empty() => tracing::error!(
+                        dtag = %dtag,
+                        created_at = ts,
+                        failed = ?out.failed,
+                        "keep-state publish accepted by NO relay; record did not replicate"
+                    ),
+                    Ok(_) => {}
+                    Err(e) => tracing::warn!("keep-state publish failed: {e}"),
+                },
                 Err(e) => tracing::warn!("keep-state event build failed: {e}"),
             }
         }

--- a/keep-web/src/state_replication.rs
+++ b/keep-web/src/state_replication.rs
@@ -176,7 +176,7 @@ async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys)
             // so a rejection below is explainable.
             if ts > now.saturating_add(MAX_FUTURE_DRIFT_SECS) {
                 tracing::warn!(
-                    dtag = %dtag,
+                    dtag = ?dtag,
                     created_at = ts,
                     now,
                     "keep-state: created_at is far ahead of wall-clock; a relay enforcing a created_at_upper_limit may reject this event"
@@ -195,10 +195,18 @@ async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys)
                     // No relay accepted it -- rejected (e.g. NIP-01 "invalid: created_at too far off")
                     // or unreachable. It did NOT replicate; log loudly instead of losing it silently.
                     Ok(out) if out.success.is_empty() => tracing::error!(
-                        dtag = %dtag,
+                        dtag = ?dtag,
                         created_at = ts,
                         failed = ?out.failed,
                         "keep-state publish accepted by NO relay; record did not replicate"
+                    ),
+                    // Replicated, but some relay still said no. Not loss today (`spawn` adds exactly one
+                    // relay, so this cannot fire), yet the reasons must never be silently discarded.
+                    Ok(out) if !out.failed.is_empty() => tracing::warn!(
+                        dtag = ?dtag,
+                        created_at = ts,
+                        failed = ?out.failed,
+                        "keep-state publish rejected by some relays"
                     ),
                     Ok(_) => {}
                     Err(e) => tracing::warn!("keep-state publish failed: {e}"),
@@ -304,6 +312,26 @@ mod tests {
         assert_eq!(next_ts(&mut last, "keys:a", 0, 500), 501);
         // (e) a seeded floor above wall-clock produces floor+1 (the promotion case).
         assert_eq!(next_ts(&mut last, "keys:c", 1_000, 100), 1_001);
+    }
+
+    // The publisher warns when a computed created_at lands more than `MAX_FUTURE_DRIFT_SECS` ahead of
+    // wall-clock, because a relay enforcing a NIP-11 `created_at_upper_limit` may reject it. Pin both
+    // sides of that threshold: routine same-second bumps must not trip it, a seeded floor must.
+    #[test]
+    fn only_a_far_future_floor_trips_the_drift_threshold() {
+        let mut last: HashMap<String, u64> = HashMap::new();
+        let now = 1_000_000;
+
+        // A burst of same-second writes drifts one second per write, so it stays well inside the
+        // threshold -- the warning cannot false-positive on ordinary collision bumps.
+        for _ in 0..10 {
+            assert!(next_ts(&mut last, "keys:a", 0, now) <= now + MAX_FUTURE_DRIFT_SECS);
+        }
+
+        // A floor seeded above wall-clock (promoted standby, or a clock regression) pushes created_at
+        // past the threshold: exactly the case the warning exists to surface.
+        let ts = next_ts(&mut last, "keys:b", now + MAX_FUTURE_DRIFT_SECS, now);
+        assert!(ts > now + MAX_FUTURE_DRIFT_SECS);
     }
 
     // Full end-to-end: an ACTIVE keep-web node writes vault state, it flows through a live relay, and a

--- a/keep-web/src/state_replication.rs
+++ b/keep-web/src/state_replication.rs
@@ -120,9 +120,13 @@ fn now_secs() -> u64 {
 const MAX_FUTURE_DRIFT_SECS: u64 = 60;
 
 /// Compute the strictly-monotonic per-d-tag `created_at` for the next publish. `last` is the in-memory
-/// per-d-tag high-water-mark, seeded at startup from the persisted floor (see `spawn_publisher`). A new
-/// slot starts at `floor`; each write returns `now` unless that is not strictly greater than the last
+/// per-d-tag high-water-mark. Each write returns `now` unless that is not strictly greater than the last
 /// timestamp, in which case it bumps to `last + 1` (`saturating_add` so it cannot overflow).
+///
+/// `floor` seeds a d-tag's slot ONLY the first time that d-tag is seen (see `spawn_publisher`, which
+/// reads the record's persisted mark lazily and passes a don't-care `0` once the slot is cached). Keep
+/// it that way: applying `floor` to an already-cached slot would let a stale `0` clamp `created_at` back
+/// to wall-clock and silently break the strict per-d-tag monotonicity the rollback guard depends on.
 fn next_ts(
     last: &mut std::collections::HashMap<String, u64>,
     dtag: &str,
@@ -150,6 +154,13 @@ async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys)
         // record, not a global maximum), so a quiet record is not future-dated to the newest record's
         // timestamp -- which is what a promoted standby, whose marks may be inflated above wall-clock,
         // needs to stay strictly greater than what standbys already applied.
+        //
+        // The floor therefore covers only this record's own mark. A record this node never applied seeds
+        // from wall-clock, so if a peer holds a FUTURE-dated mark for it (this node was desynced while a
+        // prior active published it under a fast clock), that peer's rollback guard drops our publish as
+        // "not newer". Accepted deliberately: a global maximum would cover that case only by inflating
+        // every d-tag, which is the drift this seeding exists to remove, and the residual needs a real
+        // clock regression -- already an operational requirement above.
         let mut last_ts: std::collections::HashMap<String, u64> = std::collections::HashMap::new();
         while let Some(change) = rx.recv().await {
             let (table, id) = match &change {
@@ -165,7 +176,7 @@ async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys)
                 match keep.lock().await.state_version(table, id) {
                     Ok(v) => v.unwrap_or(0),
                     Err(e) => {
-                        tracing::warn!(dtag = %dtag, "keep-state: could not read persisted mark for d-tag, seeding from 0: {e}");
+                        tracing::warn!(dtag = ?dtag, "keep-state: could not read persisted mark for d-tag, seeding from 0: {e}");
                         0
                     }
                 }

--- a/keep-web/src/state_replication.rs
+++ b/keep-web/src/state_replication.rs
@@ -141,35 +141,35 @@ async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys)
         .await
         .set_state_publisher(Arc::new(ChannelPublisher { tx }));
 
-    // Seed the per-d-tag monotonic floor from the highest mark this node has already persisted. On a
-    // promoted standby (restarted as active) whose stored marks were inflated above wall-clock
-    // (same-second bumps) or under inter-node clock skew, starting from 0 could publish a created_at
-    // <= a mark standbys already applied and be rejected; seeding guarantees the first publish for any
-    // d-tag is strictly greater than every previously-applied mark.
-    let floor = match keep.lock().await.max_state_version() {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::warn!(
-                "keep-state: could not read persisted high-water floor, seeding from 0: {e}"
-            );
-            0
-        }
-    };
-
     tokio::spawn(async move {
-        // `last_ts` is an in-memory per-d-tag high-water-mark seeded from `floor` (the persisted mark).
-        // Within a run it guarantees strict per-d-tag monotonicity of created_at: a record and its
-        // immediate delete (or two rapid writes) must not collide on the same second, or the relay's
-        // created_at dedup could keep the wrong one and the standby's rollback guard would reject the
-        // newer as "not newer". Same-second writes bump to last+1; otherwise wall-clock is used.
+        // `last_ts` is an in-memory per-d-tag high-water-mark guaranteeing strict per-d-tag monotonicity
+        // of created_at within a run: a record and its immediate delete (or two rapid writes) must not
+        // collide on the same second, or the relay's created_at dedup could keep the wrong one and the
+        // standby's rollback guard would reject the newer as "not newer". Same-second writes bump to
+        // last+1. Each d-tag's floor is seeded on first sight from THAT record's OWN persisted mark (per
+        // record, not a global maximum), so a quiet record is not future-dated to the newest record's
+        // timestamp -- which is what a promoted standby, whose marks may be inflated above wall-clock,
+        // needs to stay strictly greater than what standbys already applied.
         let mut last_ts: std::collections::HashMap<String, u64> = std::collections::HashMap::new();
         while let Some(change) = rx.recv().await {
-            let dtag = match &change {
-                Change::Record { table, id, .. } | Change::Delete { table, id } => {
-                    format!("{table}:{id}")
+            let (table, id) = match &change {
+                Change::Record { table, id, .. } | Change::Delete { table, id } => (table, id),
+            };
+            let dtag = format!("{table}:{id}");
+            let now = now_secs();
+            // Read this record's own persisted mark only on first sight (then cached in last_ts). A read
+            // error seeds 0 (wall-clock); the loud reject path below covers a rejected event.
+            let floor = if last_ts.contains_key(&dtag) {
+                0
+            } else {
+                match keep.lock().await.state_version(table, id) {
+                    Ok(v) => v.unwrap_or(0),
+                    Err(e) => {
+                        tracing::warn!(dtag = %dtag, "keep-state: could not read persisted mark for d-tag, seeding from 0: {e}");
+                        0
+                    }
                 }
             };
-            let now = now_secs();
             let ts = next_ts(&mut last_ts, &dtag, floor, now);
             // A created_at far ahead of wall-clock (a floor seeded after a clock regression, or a long
             // same-second burst) risks a strict relay rejecting it as too-far-future. Surface the drift


### PR DESCRIPTION
Closes #704.

The keep-state publisher future-dates `created_at` to keep it strictly monotonic per d-tag for the standby's rollback guard. Per NIP-01 a relay may reject a `created_at` too far in the future, but the send path only `warn!`ed on a transport `Err` and never inspected the relay's `OK: false` response, so a rejected event **silently failed to replicate**.

Two defects, addressed in order.

## 1. A rejected publish was silently dropped

`client.send_event` returns per-relay success/failed sets. `Relay::send_event` returns `Err` when a relay replies `OK: false` (including `invalid:` prefixes), which `RelayPool::send_event_to` records in `failed` while still returning `Ok(output)` with an empty `success` set. The old code matched only on the outer `Err`, so a NIP-01 rejection looked like success.

- If **no** relay accepted the event, log at `error!` with the d-tag, the `created_at`, and the per-relay failure reasons. The record did not replicate, and now an operator can see that.
- If the event was accepted by at least one relay but rejected by others, log the reasons at `warn!` rather than discarding them. Unreachable while `spawn` configures a single relay, and guarded so it stays correct if that changes.
- Warn when a published `created_at` lands more than `MAX_FUTURE_DRIFT_SECS` (60s) ahead of wall-clock, so a rejection is explainable before it happens.

A relay replying `OK: true` with a `duplicate:` prefix counts as success per NIP-01 and lands in `success`, so it cannot trip the "did not replicate" error.

The classification is a pure `classify_send(&Output<EventId>) -> SendOutcome` rather than an inline match, so the distinction that this PR exists to draw, `Ok(output)` with an empty `success` is a failure, is unit-testable without a live relay.

## 2. The publisher manufactured the drift it was being rejected for

The consumer's rollback guard is **per record**: `apply_replicated_record` keys its high-water-mark on `backend_table + ':' + record_key` and compares `created_at` only against that record's own previous mark.

The publisher, however, seeded *every* d-tag's floor from `max_state_version()`, a single global maximum across all records. A quiet record therefore inherited the newest record's timestamp as its floor, and `ts = max(now, floor + 1)` pushed it into the future for no reason. On a promoted standby whose marks were themselves inflated, this compounded. That is the drift #704 describes.

Replaced `Storage::max_state_version()` with `Storage::state_version(table, record_id) -> Option<u64>`, which reuses the consumer's exact key derivation so the publisher reads precisely the mark the guard wrote. The publisher seeds each d-tag's floor lazily, on first sight, from that record's own mark. In the normal case the mark is below wall-clock, so `ts == now` and there is no drift to reject.

## Log injection

Event-supplied and relay-supplied strings reach the log unvalidated: a record id and table name are only checked against the allowlist inside `apply_*`, and a relay's rejection reason is an arbitrary string. Every such field is now formatted with `Debug` rather than `Display`, at both the publisher and consumer log sites, so a control character cannot forge a log line. The consumer's rollback-guard reject also now records the `record_id`, without which an operator cannot tell which record was dropped.

## Why there is no clamp

#704 lists clamping `created_at` to `now + margin` as an optional follow-on. It is unsound, and is deliberately not implemented. If a record's own mark is at or above `now + margin`, the clamped event is at or below that mark, so the standby's strictly-greater guard drops it. That converts a loud relay rejection into a silent consumer rejection, which is the exact failure this PR exists to remove. The same reasoning rules out clamping the same-second bump: strict monotonicity *is* the rollback protection.

Per-record seeding is the sound form of that bullet. It removes all manufactured drift. What remains is bounded by genuine inter-node clock skew, which the module already documents as an operational requirement, and which now surfaces loudly via the rejection path above rather than silently.

One consequence is recorded in the code: the floor covers only a record's own mark, so a record this node never applied seeds from wall-clock. If a peer holds a future-dated mark for it, that peer's guard drops the publish. Covering that case would require a global maximum, which is the drift being removed.

The consumer applies no upper bound to the `created_at` it persists as a mark, which is a separate hardening tracked in #708.

## Tests

`state_version_is_per_record_not_global` pins that one record's mark stays put while another advances. `only_a_far_future_floor_trips_the_drift_threshold` pins both sides of the drift warning: routine same-second bumps must not trip it, a seeded floor must. `a_send_no_relay_accepted_is_not_a_success` pins the send-outcome classification, including the both-empty case. The existing end-to-end test still drives a real write through a live relay to a standby and back out decrypted.

22 keep-web and 351 keep-core tests pass; fmt and clippy clean.

## Unrelated: one keep-bitcoin warning

`chain_view.rs` imported `ScriptBuf` unconditionally but used it only inside an `esplora-chain-view` block, so a default build warned that the import was unused. Dropping the import would have broken the build with that feature enabled; the single use is now fully qualified as `bitcoin::ScriptBuf`, matching the `bitcoin::Amount` on the adjacent line. Clippy passes under `-D warnings` both with and without the feature, and keep-bitcoin's tests pass in both configurations.

This predates the branch and is unrelated to state replication. It is folded in here rather than split out because it is two lines and was blocking a clean `-D warnings` run.
