### PR TITLE
keep: zeroize the shared vault data key through the create chain (keep-1pmw/7n1i)

### DIFF
--- a/keep-core/src/crypto.rs
+++ b/keep-core/src/crypto.rs
@@ -344,9 +344,11 @@ impl SecretKey {
         if slice.len() != KEY_SIZE {
             return Err(CryptoError::invalid_key("invalid key length").into());
         }
-        let mut bytes = [0u8; KEY_SIZE];
+        // Zeroize the staging buffer: `Self::new` wipes its own by-value copy, but this local would
+        // otherwise linger un-zeroized in the stack frame after the call.
+        let mut bytes = Zeroizing::new([0u8; KEY_SIZE]);
         bytes.copy_from_slice(slice);
-        Self::new(bytes)
+        Self::new(*bytes)
     }
 
     pub fn try_clone(&self) -> Result<Self> {

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -182,7 +182,7 @@ impl Keep {
         path: &Path,
         password: &str,
         params: Argon2Params,
-        data_key: [u8; crypto::KEY_SIZE],
+        data_key: Zeroizing<[u8; crypto::KEY_SIZE]>,
     ) -> Result<Self> {
         let storage = Storage::create_with_shared_data_key(path, password, params, data_key)?;
         Ok(Self {

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -521,8 +521,8 @@ impl Storage {
         // The data key encrypts every record and is normally random per vault. A cluster can instead
         // seed the SAME data key on every node (keep-state replication), so a standby decrypts records
         // the active shipped: each node still wraps it under its OWN password+salt in its own header.
-        // `from_slice` reads the seed straight out of the zeroizing buffer, avoiding a bare `[u8; 32]`
-        // stack copy of the raw key that would outlive the seed.
+        // `from_slice` stages the seed in its own zeroizing buffer (and `SecretKey::new` wipes its
+        // by-value copy), so no un-zeroized bare `[u8; 32]` of the raw key outlives this call.
         let data_key = match shared_data_key {
             Some(k) => SecretKey::from_slice(k.as_slice())?,
             None => SecretKey::generate()?,

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -487,7 +487,7 @@ impl Storage {
         path: &Path,
         password: &str,
         params: Argon2Params,
-        data_key: [u8; crypto::KEY_SIZE],
+        data_key: Zeroizing<[u8; crypto::KEY_SIZE]>,
     ) -> Result<Self> {
         create_storage_dir(path)?;
         let db_path = path.join("keep.db");
@@ -513,7 +513,7 @@ impl Storage {
         password: &str,
         params: Argon2Params,
         backend: Box<dyn StorageBackend>,
-        shared_data_key: Option<[u8; crypto::KEY_SIZE]>,
+        shared_data_key: Option<Zeroizing<[u8; crypto::KEY_SIZE]>>,
     ) -> Result<Self> {
         validate_new_password(password)?;
 
@@ -521,8 +521,10 @@ impl Storage {
         // The data key encrypts every record and is normally random per vault. A cluster can instead
         // seed the SAME data key on every node (keep-state replication), so a standby decrypts records
         // the active shipped: each node still wraps it under its OWN password+salt in its own header.
+        // `from_slice` reads the seed straight out of the zeroizing buffer, avoiding a bare `[u8; 32]`
+        // stack copy of the raw key that would outlive the seed.
         let data_key = match shared_data_key {
-            Some(k) => SecretKey::new(k)?,
+            Some(k) => SecretKey::from_slice(k.as_slice())?,
             None => SecretKey::generate()?,
         };
         let master_key = crypto::derive_key(password.as_bytes(), &header.salt, params)?;
@@ -1992,21 +1994,21 @@ mod tests {
         // Two independent vaults with DIFFERENT passwords but the SAME seeded data key: a record
         // encrypted by one must decrypt in the other. This is the cluster invariant keep-state
         // replication relies on (the standby reads what the active shipped).
-        let shared: [u8; 32] = crypto::random_bytes();
+        let shared: Zeroizing<[u8; 32]> = Zeroizing::new(crypto::random_bytes());
         let dir = tempdir().unwrap();
 
         let a = Storage::create_with_shared_data_key(
             &dir.path().join("a"),
             "passwordA",
             Argon2Params::TESTING,
-            shared,
+            shared.clone(),
         )
         .unwrap();
         let b = Storage::create_with_shared_data_key(
             &dir.path().join("b"),
             "differentB",
             Argon2Params::TESTING,
-            shared,
+            shared.clone(),
         )
         .unwrap();
 

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -69,7 +69,8 @@ fn read_secret_file(path: &str) -> Result<String, Box<dyn std::error::Error>> {
 /// `Err` when set but malformed so a misconfigured cluster node fails loudly instead
 /// of silently creating a non-replicable vault.
 fn shared_data_key_from_env() -> Result<Option<Zeroizing<[u8; 32]>>, Box<dyn std::error::Error>> {
-    let Some(hex_key) = secret_from("KEEP_STORAGE_KEY")? else {
+    // Zeroize our copy of the hex on drop; it decodes to the raw record-encryption key.
+    let Some(hex_key) = secret_from("KEEP_STORAGE_KEY")?.map(Zeroizing::new) else {
         return Ok(None);
     };
     Ok(Some(parse_shared_data_key(&hex_key)?))
@@ -185,7 +186,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         &vault_path,
                         &password,
                         keep_core::crypto::Argon2Params::DEFAULT,
-                        *key,
+                        key,
                     )?
                 }
                 None => {


### PR DESCRIPTION
Closes keep-1pmw and keep-7n1i (duplicates).

The shared vault data key (`KEEP_STORAGE_KEY`) existed as several un-zeroized plaintext copies on the create path, inconsistent with the codebase's mlock/zeroize posture. keep-web already zeroized the hex-decode `Vec` and the `[u8; 32]` it built, but:
- the hex `String` read from env was a plain `String`,
- `*key` dereferenced the `Zeroizing<[u8; 32]>` into a **bare `[u8; 32]` copy** passed by value into `Keep::create_with_shared_data_key`,
- that copy was threaded `[u8; 32]`-by-value through `Storage::create_with_shared_data_key` → `create_inner`, and only the innermost `SecretKey::new` local was zeroized.

## Change
- `Keep`/`Storage::create_with_shared_data_key` and `create_inner` now take `Zeroizing<[u8; 32]>`, so every hop is wiped on drop.
- `create_inner` builds the `SecretKey` with `SecretKey::from_slice(k.as_slice())` , reads the seed straight out of the zeroizing buffer, with no intermediate bare-array stack copy.
- keep-web passes the `Zeroizing` key through by value (no `*key` deref) and wraps the env hex `String` in `Zeroizing`.

No behavior change; the raw record-encryption key now only ever lives in zeroized buffers plus the mlock'd `SecretKey`. keep-core (348) + keep-web pass; clippy clean.

Follow-up (filed): `secret_from` itself returns a plain `String` and makes un-zeroized internal copies for *every* secret (password, token, storage key); hardening it to `Zeroizing<String>` is a separate, broader change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Sensitive shared vault key material is now cleared from memory more reliably after use.
  * Environment-provided key values are also handled more safely during startup and setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->