### PR TITLE
keep-frost-net: gate OPRF/enroll oracles on fresh attestation, not a sticky Verified

### DIFF
--- a/keep-frost-net/src/node/enroll.rs
+++ b/keep-frost-net/src/node/enroll.rs
@@ -21,7 +21,6 @@ use zeroize::Zeroizing;
 use crate::enroll_session::derive_oprf_enroll_session_id;
 use crate::error::{FrostNetError, Result};
 use crate::event::KfpEventBuilder;
-use crate::peer::AttestationStatus;
 use crate::protocol::*;
 
 use super::{KfpNode, KfpNodeEvent, OprfShareSealAck};
@@ -277,9 +276,12 @@ impl KfpNode {
                     payload.dealer_index
                 ))
             })?;
-            if !matches!(peer.attestation_status, AttestationStatus::Verified) {
+            // Fresh Verified, like the eval oracle: a sticky verdict must not
+            // let a stolen network identity deal an enrollment share from
+            // un-attested hardware after the attested announce has gone stale.
+            if !peer.is_attestation_fresh(peers.offline_threshold()) {
                 return Err(FrostNetError::UntrustedPeer(format!(
-                    "OPRF enrollment dealer share {} attestation not Verified ({:?})",
+                    "OPRF enrollment dealer share {} attestation not fresh-Verified ({:?})",
                     payload.dealer_index, peer.attestation_status
                 )));
             }

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1433,6 +1433,9 @@ impl KfpNode {
     #[cfg(any(test, feature = "testing"))]
     pub fn test_set_peer_attestation(&self, share_index: u16, status: AttestationStatus) {
         if let Some(peer) = self.peers.write().get_peer_mut(share_index) {
+            if matches!(status, AttestationStatus::Verified) {
+                peer.last_attested = Some(std::time::Instant::now());
+            }
             peer.attestation_status = status;
         }
     }

--- a/keep-frost-net/src/node/oprf.rs
+++ b/keep-frost-net/src/node/oprf.rs
@@ -19,8 +19,6 @@ use crate::event::KfpEventBuilder;
 use crate::oprf_session::derive_oprf_session_id;
 use crate::protocol::*;
 
-use crate::peer::AttestationStatus;
-
 use super::{KfpNode, KfpNodeEvent};
 
 impl KfpNode {
@@ -88,9 +86,14 @@ impl KfpNode {
                         request.requester_share_index
                     ))
                 })?;
-            if !matches!(peer.attestation_status, AttestationStatus::Verified) {
+            // Require a Verified status that is still FRESH: an attested
+            // announce within the offline window. A bare `Verified` is sticky
+            // (a failing re-announce is rejected before it can downgrade the
+            // entry), so gating on freshness stops a stolen network identity
+            // replayed from un-attested hardware from trading on a stale verdict.
+            if !peer.is_attestation_fresh(peers.offline_threshold()) {
                 return Err(FrostNetError::UntrustedPeer(format!(
-                    "OPRF requester share {} attestation not Verified ({:?})",
+                    "OPRF requester share {} attestation not fresh-Verified ({:?})",
                     request.requester_share_index, peer.attestation_status
                 )));
             }

--- a/keep-frost-net/src/peer.rs
+++ b/keep-frost-net/src/peer.rs
@@ -66,6 +66,13 @@ pub struct Peer {
     pub status: PeerStatus,
     pub protocol_version: u8,
     pub attestation_status: AttestationStatus,
+    /// Last time this peer was admitted with `Verified` attestation. Stamped
+    /// only by a successful attested announce (via `with_attestation_status`),
+    /// never by a ping/pong or a re-announce that failed attestation, so unlike
+    /// `last_seen` it cannot be refreshed without producing fresh evidence. The
+    /// OPRF/enrollment oracle gates on this so a `Verified` verdict expires
+    /// instead of being honored indefinitely on credit.
+    pub last_attested: Option<Instant>,
     pub recovery_xpubs: Vec<AnnouncedXpub>,
 }
 
@@ -82,11 +89,15 @@ impl Peer {
             status: PeerStatus::Online,
             protocol_version: crate::KFP_VERSION,
             attestation_status: AttestationStatus::NotProvided,
+            last_attested: None,
             recovery_xpubs: Vec::new(),
         }
     }
 
     pub fn with_attestation_status(mut self, status: AttestationStatus) -> Self {
+        if matches!(status, AttestationStatus::Verified) {
+            self.last_attested = Some(Instant::now());
+        }
         self.attestation_status = status;
         self
     }
@@ -96,6 +107,23 @@ impl Peer {
             self.attestation_status,
             AttestationStatus::Verified | AttestationStatus::NotConfigured
         )
+    }
+
+    /// Whether this peer's attestation is `Verified` AND that verdict is still
+    /// fresh (its last attested announce was received within `window`). The OPRF
+    /// and enrollment oracles require this rather than a bare `Verified` so a
+    /// verdict ages out instead of being honored indefinitely on credit: an
+    /// attacker on un-attested hardware cannot forge a fresh Verified announce
+    /// (the AK is TPM-resident), so once the real box stops emitting valid
+    /// attested announces the verdict expires. Freshness is measured from
+    /// announce RECEIPT, so the honored lifetime after the box goes silent is
+    /// bounded by `window` PLUS the announce admission window
+    /// (`ANNOUNCE_MAX_AGE_SECS`), within which a captured announce could be
+    /// replayed to refresh the stamp; gating on the signed quote time instead
+    /// would remove that slack at the cost of wall-clock skew sensitivity.
+    pub fn is_attestation_fresh(&self, window: Duration) -> bool {
+        matches!(self.attestation_status, AttestationStatus::Verified)
+            && self.last_attested.is_some_and(|t| t.elapsed() < window)
     }
 
     pub fn with_name(mut self, name: &str) -> Self {
@@ -177,6 +205,13 @@ impl PeerManager {
                 // announce does not wipe the liveness signal the pre-round check
                 // relies on.
                 peer.last_pong = existing.last_pong;
+                // Keep the freshest attestation stamp: a Verified re-announce
+                // brings a newer `last_attested`; an announce that carried none
+                // must not wipe a prior verdict (its staleness is judged by the
+                // gate's window, not by presence).
+                if peer.last_attested.is_none() {
+                    peer.last_attested = existing.last_attested;
+                }
             }
             self.peers.insert(peer.share_index, peer);
         }
@@ -391,5 +426,57 @@ mod tests {
             parse_announce_interval(Some("99999".into())),
             Duration::from_secs(99999)
         );
+    }
+
+    #[test]
+    fn attestation_fresh_requires_verified_and_recent() {
+        let keys = Keys::generate();
+        let peer =
+            Peer::new(keys.public_key(), 2).with_attestation_status(AttestationStatus::Verified);
+        // A just-Verified peer is fresh within a normal window.
+        assert!(peer.last_attested.is_some());
+        assert!(peer.is_attestation_fresh(Duration::from_secs(60)));
+        // A zero window makes no verdict fresh (elapsed is never < 0); this
+        // stands in for a verdict that has aged past the offline window, at
+        // which point the oracle must refuse.
+        assert!(!peer.is_attestation_fresh(Duration::ZERO));
+    }
+
+    #[test]
+    fn attestation_fresh_false_for_unverified_or_unstamped() {
+        let keys = Keys::generate();
+        let w = Duration::from_secs(60);
+        // Never attested.
+        assert!(!Peer::new(keys.public_key(), 2).is_attestation_fresh(w));
+        // NotConfigured counts as "attested" for the permissive is_attested()
+        // path but must NOT satisfy the strict oracle gate; Failed never does.
+        assert!(!Peer::new(keys.public_key(), 2)
+            .with_attestation_status(AttestationStatus::NotConfigured)
+            .is_attestation_fresh(w));
+        assert!(!Peer::new(keys.public_key(), 2)
+            .with_attestation_status(AttestationStatus::Failed("x".into()))
+            .is_attestation_fresh(w));
+        // A Verified status with no stamp (defensive: unreachable via the
+        // builder) is never honored on credit.
+        let mut peer =
+            Peer::new(keys.public_key(), 2).with_attestation_status(AttestationStatus::Verified);
+        peer.last_attested = None;
+        assert!(!peer.is_attestation_fresh(w));
+    }
+
+    #[test]
+    fn re_announce_without_stamp_preserves_prior_attestation() {
+        // A Verified announce stamps last_attested; a later announce that
+        // carries no stamp must not wipe the prior verdict (its staleness is
+        // judged by the gate's window, not by presence).
+        let mut pm = PeerManager::new(1);
+        let keys = Keys::generate();
+        pm.add_peer(
+            Peer::new(keys.public_key(), 2).with_attestation_status(AttestationStatus::Verified),
+        );
+        let stamped = pm.get_peer(2).unwrap().last_attested;
+        assert!(stamped.is_some());
+        pm.add_peer(Peer::new(keys.public_key(), 2));
+        assert_eq!(pm.get_peer(2).unwrap().last_attested, stamped);
     }
 }


### PR DESCRIPTION
## Problem

The OPRF eval oracle (`node/oprf.rs`) and the OPRF enrollment dealer gate (`node/enroll.rs`) admitted a requester on a bare `AttestationStatus::Verified`. That verdict is **sticky and unbounded**:

- A re-announce that fails attestation is rejected with `Err` before `add_peer`, so it never downgrades an existing `Verified` entry.
- `remove_stale_peers` had no caller, so peer entries live for the whole holder-process lifetime.
- The eval request carries no fresh attestation, and the gate checked no freshness/liveness.

So once a peer was admitted `Verified`, that status persisted forever. An attacker who obtains a box's Nostr identity key but cannot produce a TPM quote (the AK is TPM-resident, restricted, non-exportable) could answer OPRF evaluations from their own un-attested hardware against the stale `Verified` entry; a quorum of those reconstructs the vault's LUKS key. The fresh-quote requirement the gate exists to enforce was satisfied on credit.

## Fix

Bind the oracle gates on attestation **freshness**, not a bare status:

- Add `Peer::last_attested`, stamped only when a peer is admitted with `Verified` attestation (via `with_attestation_status`), never by a ping/pong or a re-announce that failed attestation. This mirrors the existing `last_pong` field, which is tracked separately from `last_seen` for the same reason (a signal that cannot be refreshed without the real event).
- Add `Peer::is_attestation_fresh(window)` = `Verified` and `last_attested` within `window`.
- Both oracle gates now require `is_attestation_fresh(offline_threshold())`. The window is the peer offline threshold (two announce intervals, 40s by default): a live box re-announces every interval with a fresh quote and stays fresh, while a status frozen at an attacker's stolen identity expires once the box stops emitting valid attested announces.
- `last_attested` is preserved across re-announces that carry no stamp, so a benign non-attesting path cannot wipe a prior verdict (staleness is judged by the window, not by presence).

This bounds the attacker's window from unbounded to the offline threshold after the real box's last valid attested announce, and closes it entirely once the box is offline.

## Tests

- `attestation_fresh_requires_verified_and_recent`, `attestation_fresh_false_for_unverified_or_unstamped`, `re_announce_without_stamp_preserves_prior_attestation`.
- Existing OPRF integration tests keep passing: the test injector `test_set_peer_attestation` now stamps `last_attested` for `Verified`, matching a legitimately just-attested peer.
- Full `keep-frost-net` suite green; clippy clean on default and `testing` features.

Found by an end-to-end security review of the attestation and OPRF-unlock keystone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Peer verification now includes a freshness check, helping ensure only recently verified peers can join sensitive flows.

* **Bug Fixes**
  * Enrollment and OPRF requests now reject stale attestations with clearer trust-related errors.
  * Re-announced peers keep their previous verification timestamp instead of losing it.
  * Test helpers now correctly mark peers as recently attested when setting them to verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->