### PR TITLE
keep-frost-net: attestation-gate the ECDH oracle like OPRF/enroll

### DIFF
--- a/keep-frost-net/src/node/ecdh.rs
+++ b/keep-frost-net/src/node/ecdh.rs
@@ -50,6 +50,27 @@ impl KfpNode {
             )));
         }
 
+        // Attestation gate, matching the OPRF/enroll oracles (the #621 ship-gate
+        // this responder was missing): a quorum of these partials combines to
+        // the group's ECDH shared secret with an attacker-chosen recipient, so
+        // answer only a requester whose measured boot is freshly Verified. A
+        // stolen network identity replayed from un-attested hardware must not
+        // extract group ECDH secrets, even though policy (`can_receive_from`)
+        // still lists its pubkey. Fresh-Verified (not a bare `Verified`) so a
+        // stale verdict is not honored on credit; see `is_attestation_fresh`.
+        {
+            let peers = self.peers.read();
+            let peer = peers.get_peer_by_pubkey(&from).ok_or_else(|| {
+                FrostNetError::UntrustedPeer(format!("ECDH requester {from} not announced"))
+            })?;
+            if !peer.is_attestation_fresh(peers.offline_threshold()) {
+                return Err(FrostNetError::UntrustedPeer(format!(
+                    "ECDH requester {from} attestation not fresh-Verified ({:?})",
+                    peer.attestation_status
+                )));
+            }
+        }
+
         info!(
             session_id = %hex::encode(request.session_id),
             "Received ECDH request"
@@ -493,6 +514,38 @@ mod gate_tests {
         assert!(matches!(
             node.handle_ecdh_complete(from, payload).await,
             Err(FrostNetError::Session(_))
+        ));
+    }
+
+    /// A requester that is not a known peer at all is refused: the ECDH oracle
+    /// exposes the group's shared secret, so an unannounced pubkey cannot invoke
+    /// it. Fresh `created_at` passes the replay gate so the attestation gate is
+    /// what trips.
+    #[tokio::test]
+    async fn handle_ecdh_request_rejects_unannounced_requester() {
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        let group = *node.group_pubkey();
+        let req = EcdhRequestPayload::new([1u8; 32], group, BAD_RECIPIENT, vec![1]);
+        assert!(matches!(
+            node.handle_ecdh_request(from, req).await,
+            Err(FrostNetError::UntrustedPeer(_))
+        ));
+    }
+
+    /// A known but unattested (default `NotProvided`) requester is refused,
+    /// matching the OPRF/enroll oracles. Reaching the attestation gate proves
+    /// group/participant/replay/policy all passed first.
+    #[tokio::test]
+    async fn handle_ecdh_request_rejects_unattested_requester() {
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        node.test_inject_peer(crate::peer::Peer::new(from, 2));
+        let group = *node.group_pubkey();
+        let req = EcdhRequestPayload::new([1u8; 32], group, BAD_RECIPIENT, vec![1]);
+        assert!(matches!(
+            node.handle_ecdh_request(from, req).await,
+            Err(FrostNetError::UntrustedPeer(_))
         ));
     }
 }

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -1706,6 +1706,15 @@ async fn test_ecdh_request_completes_with_one_cosigner() {
     let secp = bitcoin::secp256k1::Secp256k1::new();
     let recipient_pubkey: [u8; 33] = recipient_secret.public_key(&secp).serialize();
 
+    // The ECDH oracle now requires the requester to be fresh-Verified (matching
+    // the OPRF/enroll oracles). These nodes run without an attestation policy,
+    // so mark the requester (share index 1) Verified on the responder, exactly
+    // as the OPRF round-trip test does. Let the post-discovery reciprocal
+    // announces flush first (a re-announce would reset the status); re-announces
+    // are then 20s apart, covering the sub-second request window.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    node2.test_set_peer_attestation(1, keep_frost_net::AttestationStatus::Verified);
+
     let request_result = timeout(
         Duration::from_secs(45),
         node1.request_ecdh(&recipient_pubkey),


### PR DESCRIPTION
## Problem

The threshold-ECDH responder `handle_ecdh_request` (`keep-frost-net/src/node/ecdh.rs`) was gated on group membership, participant set, replay window, and `can_receive_from` policy, but **not on attestation** , unlike the OPRF eval and enrollment oracles, which carry the attestation + rate-limit + approval ship-gate. The message loop dispatches `EcdhRequest` to it (mod.rs), so it is a live oracle.

Each holder returns `compute_partial_ecdh(signing_share, recipient_pubkey)`, and a quorum combines to `group_secret · recipient_pubkey` , the group's ECDH shared secret with a **caller-chosen** recipient. Naming a victim's pubkey as the recipient yields the shared secret the group would use with that victim (enabling decryption/impersonation of group↔victim communication); it reveals nothing only when the caller already knows the recipient's private key.

Because the only gate on the caller was `can_receive_from` (keyed on pubkey), an attacker who obtains a co-signer's Nostr identity key but cannot produce a TPM quote could invoke the oracle from un-attested hardware and extract group ECDH secrets , the same stolen-network-identity class fixed for the OPRF oracle in #714.

## Fix

Apply the same attestation gate the OPRF/enroll oracles use, adapted to the ECDH request (which identifies the requester by the event sender rather than a share index in the payload):

- After the policy check, look up the requester peer by pubkey (`get_peer_by_pubkey`) and require `is_attestation_fresh(offline_threshold())` , a `Verified` verdict still within the freshness window (from #714). An unannounced or non-fresh-Verified requester is refused with `UntrustedPeer`.
- Consistent with the OPRF oracle, this fail-closes on a node with no attestation policy (peers are never `Verified`), so a node exposing this oracle must configure attestation , which the appliance deployment does.

## Scope note

This gates the responder oracle, the identified gap. `request_ecdh` (the initiator) is not wired into any shipped keep-cli/keep-web/keep-node command yet, so the live blast radius is limited today, but the oracle responds to any peer, so the gate is the right fix now. Rate-limit and an approval hook (the other two thirds of the OPRF ship-gate) are not added here; if ECDH becomes a shipped feature they should be considered for parity.

## Tests

- `handle_ecdh_request_rejects_unannounced_requester` and `handle_ecdh_request_rejects_unattested_requester` (new unit gate tests, mirroring the OPRF ones).
- `test_ecdh_request_completes_with_one_cosigner` (existing round-trip) updated to mark the requester Verified before the request, matching the OPRF round-trip test.
- Full `keep-frost-net` suite green (default + `testing`); clippy clean.

Found by the end-to-end security review of the attestation/OPRF-unlock keystone.
