### PR TITLE
attestation: fail closed on unverifiable enclave evidence and all-zero TPM policies

### DIFF
--- a/keep-cli/src/commands/frost_network/attestation.rs
+++ b/keep-cli/src/commands/frost_network/attestation.rs
@@ -117,6 +117,16 @@ fn parse_tpm_policy(text: &str) -> Result<TpmAttestationPolicy> {
             reference_pcrs.len()
         )));
     }
+    // A fully zeroed reference set is theater: every PCR unextended means no
+    // measured boot happened, so the policy would "verify" a completely
+    // unmeasured TPM. Mirror the Nitro all-zero PCR0 rejection. A mix of zero
+    // and non-zero slots is legitimate (unused PCRs read zero), so reject only
+    // when EVERY reference PCR is zero.
+    if reference_pcrs.iter().all(|d| d.iter().all(|&b| b == 0)) {
+        return Err(err(
+            "attestation `reference_pcrs` are all zeros (an unmeasured TPM); refusing to pin a policy that verifies nothing",
+        ));
+    }
 
     if cfg.peer.is_empty() {
         return Err(err(
@@ -572,7 +582,7 @@ mod tests {
     fn rejects_no_peers() {
         let cfg = r#"
             selection = "00000001000b03010000"
-            reference_pcrs = ["0000000000000000000000000000000000000000000000000000000000000000"]
+            reference_pcrs = ["cf2b0db7514f320c315130275a960f6e6ed80744c754c687069d7a9f55d704f0"]
         "#;
         assert!(parse_tpm_policy(cfg).is_err());
     }
@@ -581,7 +591,7 @@ mod tests {
     fn rejects_bad_ak() {
         let cfg = r#"
             selection = "00000001000b03010000"
-            reference_pcrs = ["0000000000000000000000000000000000000000000000000000000000000000"]
+            reference_pcrs = ["cf2b0db7514f320c315130275a960f6e6ed80744c754c687069d7a9f55d704f0"]
             [[peer]]
             index = 2
             ak = "0400"
@@ -595,7 +605,7 @@ mod tests {
         let cfg = format!(
             r#"
             selection = "{ONE_PCR_SELECTION}"
-            reference_pcrs = ["0000000000000000000000000000000000000000000000000000000000000000"]
+            reference_pcrs = ["cf2b0db7514f320c315130275a960f6e6ed80744c754c687069d7a9f55d704f0"]
             [[peer]]
             index = 2
             ak = "04{}"
@@ -628,6 +638,25 @@ mod tests {
             ak = "04f533789fb86ad512ca3e930df08cd16396d14c30c79c46a88839b574a3dfb3271b3db55b2abdc884e40898e95dfffd2c7e8554526d4e1f651779bab1f81300cb"
         "#;
         assert!(parse_tpm_policy(cfg).is_err());
+    }
+
+    #[test]
+    fn rejects_all_zero_reference_set() {
+        // A fully zeroed reference set (an unmeasured TPM) is refused even when
+        // count and peer are otherwise valid. A mix with a non-zero slot (the
+        // VALID fixture) is accepted, so this pins the all-zero-only case.
+        let cfg = r#"
+            selection = "00000001000b03010000"
+            reference_pcrs = ["0000000000000000000000000000000000000000000000000000000000000000"]
+            [[peer]]
+            index = 2
+            ak = "04f533789fb86ad512ca3e930df08cd16396d14c30c79c46a88839b574a3dfb3271b3db55b2abdc884e40898e95dfffd2c7e8554526d4e1f651779bab1f81300cb"
+        "#;
+        let e = parse_tpm_policy(cfg).unwrap_err().to_string();
+        assert!(
+            e.contains("all zeros"),
+            "expected all-zeros rejection, got: {e}"
+        );
     }
 
     #[test]

--- a/keep-frost-net/src/attestation.rs
+++ b/keep-frost-net/src/attestation.rs
@@ -1,13 +1,16 @@
 // SPDX-FileCopyrightText: © 2026 PrivKey LLC
 // SPDX-License-Identifier: MIT
 use sha2::{Digest, Sha256};
-#[cfg(not(feature = "nitro-attestation"))]
-use subtle::ConstantTimeEq;
 
 use crate::error::{FrostNetError, Result};
 use crate::protocol::EnclaveAttestation;
 
+// Only the Nitro document verifier checks an enclave attestation's timestamp;
+// the non-Nitro build fails closed before any timestamp check, so these are
+// gated to avoid dead-code warnings there.
+#[cfg(feature = "nitro-attestation")]
 pub const ATTESTATION_MAX_AGE_SECS: u64 = 300;
+#[cfg(feature = "nitro-attestation")]
 pub const ATTESTATION_MAX_FUTURE_SECS: u64 = 30;
 
 #[derive(Clone, Debug)]
@@ -108,19 +111,27 @@ pub fn verify_peer_attestation(
     Ok(())
 }
 
+/// Without the `nitro-attestation` feature there is no Nitro document verifier
+/// compiled in, so a peer's enclave attestation cannot be cryptographically
+/// verified. Fail closed: refuse it. The previous stub compared only the
+/// attacker-supplied PCR *claims* against the (public) expected values and
+/// returned `Ok`, which any forger could satisfy by echoing the expected PCRs.
+/// A node that cannot verify Nitro evidence must reject it, never admit it on
+/// trust.
 #[cfg(not(feature = "nitro-attestation"))]
 pub fn verify_peer_attestation(
-    attestation: &EnclaveAttestation,
-    expected_pcrs: &ExpectedPcrs,
+    _attestation: &EnclaveAttestation,
+    _expected_pcrs: &ExpectedPcrs,
     _group_pubkey: &[u8; 32],
 ) -> Result<()> {
-    verify_pcr(&attestation.pcr0, 0, &expected_pcrs.pcr0)?;
-    verify_pcr(&attestation.pcr1, 1, &expected_pcrs.pcr1)?;
-    verify_pcr(&attestation.pcr2, 2, &expected_pcrs.pcr2)?;
-    verify_attestation_timestamp_ms(attestation.timestamp)?;
-    Ok(())
+    Err(FrostNetError::Attestation(
+        "enclave (Nitro) attestation cannot be verified: this build lacks the \
+         nitro-attestation feature"
+            .into(),
+    ))
 }
 
+#[cfg(feature = "nitro-attestation")]
 pub(crate) fn verify_attestation_timestamp_ms(timestamp_ms: u64) -> Result<()> {
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -144,25 +155,6 @@ pub(crate) fn verify_attestation_timestamp_ms(timestamp_ms: u64) -> Result<()> {
         )));
     }
 
-    Ok(())
-}
-
-#[cfg(not(feature = "nitro-attestation"))]
-fn verify_pcr(actual: &[u8], index: u32, expected: &[u8; 48]) -> Result<()> {
-    if actual.len() != 48 {
-        return Err(FrostNetError::PcrMismatch {
-            pcr: index,
-            expected: hex::encode(expected),
-            actual: format!("invalid length: {}", actual.len()),
-        });
-    }
-    if !bool::from(actual.ct_eq(expected)) {
-        return Err(FrostNetError::PcrMismatch {
-            pcr: index,
-            expected: hex::encode(expected),
-            actual: hex::encode(actual),
-        });
-    }
     Ok(())
 }
 
@@ -236,8 +228,12 @@ mod tests {
     mod non_nitro_tests {
         use super::*;
 
+        /// Without the nitro-attestation feature there is no document verifier,
+        /// so verify_peer_attestation fails closed for ANY input, including one
+        /// whose claimed PCRs and timestamp are otherwise valid, rather than the
+        /// old stub that returned Ok on a matching (forgeable) PCR claim.
         #[test]
-        fn test_verify_peer_attestation_success() {
+        fn verify_peer_attestation_fails_closed_without_nitro() {
             let attestation = EnclaveAttestation::new(
                 vec![],
                 vec![0u8; 48],
@@ -246,94 +242,14 @@ mod tests {
                 vec![],
                 current_timestamp_ms(),
             );
+            // PCRs and timestamp all "match"/are fresh; the old stub returned Ok.
             let expected = ExpectedPcrs::new([0u8; 48], [1u8; 48], [2u8; 48]);
-            let group_pubkey = [0u8; 32];
-            assert!(verify_peer_attestation(&attestation, &expected, &group_pubkey).is_ok());
-        }
-
-        #[test]
-        fn test_verify_peer_attestation_mismatch() {
-            let attestation = EnclaveAttestation::new(
-                vec![],
-                vec![0u8; 48],
-                vec![99u8; 48],
-                vec![2u8; 48],
-                vec![],
-                current_timestamp_ms(),
-            );
-            let expected = ExpectedPcrs::new([0u8; 48], [1u8; 48], [2u8; 48]);
-            let group_pubkey = [0u8; 32];
-            let result = verify_peer_attestation(&attestation, &expected, &group_pubkey);
-            assert!(result.is_err());
+            let result = verify_peer_attestation(&attestation, &expected, &[0u8; 32]);
             match result.unwrap_err() {
-                FrostNetError::PcrMismatch { pcr, .. } => assert_eq!(pcr, 1),
-                _ => panic!("Expected PcrMismatch error"),
-            }
-        }
-
-        #[test]
-        fn test_verify_peer_attestation_invalid_length() {
-            let attestation = EnclaveAttestation::new(
-                vec![],
-                vec![0u8; 32],
-                vec![1u8; 48],
-                vec![2u8; 48],
-                vec![],
-                current_timestamp_ms(),
-            );
-            let expected = ExpectedPcrs::new([0u8; 48], [1u8; 48], [2u8; 48]);
-            let group_pubkey = [0u8; 32];
-            let result = verify_peer_attestation(&attestation, &expected, &group_pubkey);
-            assert!(result.is_err());
-            match result.unwrap_err() {
-                FrostNetError::PcrMismatch { pcr, actual, .. } => {
-                    assert_eq!(pcr, 0);
-                    assert!(actual.contains("invalid length"));
+                FrostNetError::Attestation(msg) => {
+                    assert!(msg.contains("nitro-attestation"))
                 }
-                _ => panic!("Expected PcrMismatch error"),
-            }
-        }
-
-        #[test]
-        fn test_verify_peer_attestation_timestamp_too_old() {
-            let old_timestamp = current_timestamp_ms() - (ATTESTATION_MAX_AGE_SECS + 60) * 1000;
-            let attestation = EnclaveAttestation::new(
-                vec![],
-                vec![0u8; 48],
-                vec![1u8; 48],
-                vec![2u8; 48],
-                vec![],
-                old_timestamp,
-            );
-            let expected = ExpectedPcrs::new([0u8; 48], [1u8; 48], [2u8; 48]);
-            let group_pubkey = [0u8; 32];
-            let result = verify_peer_attestation(&attestation, &expected, &group_pubkey);
-            assert!(result.is_err());
-            match result.unwrap_err() {
-                FrostNetError::Attestation(msg) => assert!(msg.contains("too old")),
-                e => panic!("Expected Attestation error, got {:?}", e),
-            }
-        }
-
-        #[test]
-        fn test_verify_peer_attestation_timestamp_in_future() {
-            let future_timestamp =
-                current_timestamp_ms() + (ATTESTATION_MAX_FUTURE_SECS + 60) * 1000;
-            let attestation = EnclaveAttestation::new(
-                vec![],
-                vec![0u8; 48],
-                vec![1u8; 48],
-                vec![2u8; 48],
-                vec![],
-                future_timestamp,
-            );
-            let expected = ExpectedPcrs::new([0u8; 48], [1u8; 48], [2u8; 48]);
-            let group_pubkey = [0u8; 32];
-            let result = verify_peer_attestation(&attestation, &expected, &group_pubkey);
-            assert!(result.is_err());
-            match result.unwrap_err() {
-                FrostNetError::Attestation(msg) => assert!(msg.contains("future")),
-                e => panic!("Expected Attestation error, got {:?}", e),
+                e => panic!("Expected fail-closed Attestation error, got {:?}", e),
             }
         }
     }


### PR DESCRIPTION
Two fail-closed hardening items from the attestation keystone security review.

## 1. Non-Nitro `verify_peer_attestation` no longer fails open

`keep-frost-net/src/attestation.rs`. Built without the `nitro-attestation` feature, `verify_peer_attestation` had no Nitro document verifier, so it compared only the peer's *claimed* `pcr0/1/2` against the (public) expected values and returned `Ok` , trivially forgeable by echoing the expected PCRs. It is not in the shipped build (`nitro-attestation` is a default feature), but keep-mobile and the fuzz crate both build keep-frost-net with `default-features = false`, so the fail-open path is compiled there.

A `compile_error!` guard (the review's first suggestion) would break those two non-default builds. Instead the stub now **fails closed**: a build that cannot cryptographically verify enclave evidence rejects it rather than admitting it on trust. Removed the now-unused `verify_pcr` and the non-Nitro `subtle` import; gated the Nitro-only timestamp helper and its two constants behind the feature so the non-Nitro build has no dead code. Replaced the five obsolete stub tests with one asserting fail-closed for otherwise-valid input.

## 2. `parse_tpm_policy` rejects a fully-zeroed reference set

`keep-cli/src/commands/frost_network/attestation.rs`. A TPM policy whose `reference_pcrs` are *all* zero pins an unmeasured TPM (every PCR unextended) , it would look "enforced" yet verify a completely unmeasured boot. The policy loader now refuses it, mirroring the Nitro all-zero-PCR0 rejection.

The guard rejects only the **all-zero set**, not any individual zero PCR: a real policy legitimately mixes zero and non-zero slots (unused PCRs read zero), as the existing `VALID` fixture shows (five zero slots plus one real digest). Updated three fixtures that used an all-zero placeholder PCR to a non-zero value so they still exercise their intended (no-peers / bad-AK / off-curve-AK) checks rather than tripping the new guard; added a test for the all-zero-set rejection.

## Tests

- keep-frost-net: clean on default (Nitro) and `--no-default-features` (clippy + tests, both configs); full lib suite green.
- keep-cli: attestation suite green including the new all-zero-set test.
