### PR TITLE
tui: sanitize app/action/detail in the activity-log pane

### DIFF
--- a/keep-cli/src/tui.rs
+++ b/keep-cli/src/tui.rs
@@ -214,19 +214,30 @@ impl Tui {
                 } else {
                     Color::Red
                 };
+                // `app`/`action`/`detail` carry attacker-influenced strings (the
+                // client's declared app name, the requested method). Sanitize
+                // them like the approval prompt so a newline/bidi sequence cannot
+                // corrupt or spoof a log line. Per-column caps keep one entry from
+                // dominating the pane.
                 let mut spans = vec![
                     Span::styled(
                         format!("[{}] ", entry.timestamp),
                         Style::default().fg(Color::DarkGray),
                     ),
                     Span::styled(format!("{symbol} "), Style::default().fg(color)),
-                    Span::styled(&entry.app, Style::default().fg(Color::White)),
+                    Span::styled(
+                        sanitize_prompt_field(&entry.app, 32),
+                        Style::default().fg(Color::White),
+                    ),
                     Span::raw(" "),
-                    Span::styled(&entry.action, Style::default().fg(Color::Gray)),
+                    Span::styled(
+                        sanitize_prompt_field(&entry.action, 48),
+                        Style::default().fg(Color::Gray),
+                    ),
                 ];
                 if let Some(ref detail) = entry.detail {
                     spans.push(Span::styled(
-                        format!(" ({detail})"),
+                        format!(" ({})", sanitize_prompt_field(detail, 64)),
                         Style::default().fg(Color::DarkGray),
                     ));
                 }


### PR DESCRIPTION
Follow-up from the #719 review. The NIP-46 signer TUI's activity-log pane (`draw_logs`) rendered `entry.app`, `entry.action`, and `entry.detail` unbounded and unsanitized. `app` is the client's declared app name and `action` is the requested method , both attacker-influenced , so a newline or bidi/zero-width sequence could corrupt a log line or spoof the log.

Lower severity than the approval popup (the log is not the decision line), but the same class. Fix: route all three through the shared `sanitize_prompt_field` (strips bidi/format/zero-width + control chars) with per-column display caps (app 32, action 48, detail 64), reusing the same choke-point sanitizer introduced in #719 rather than a new one.

keep-cli builds + clippy clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log display safety by sanitizing and shortening user-controlled text before it appears in the activity pane.
  * Prevented overly long entries from overflowing the interface by applying fixed display limits to log fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->