### PR TITLE
keep-web: honor KEEP_STATE_IDENTITY_FILE to keep the cluster nsec off the process env

### DIFF
--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -30,7 +30,7 @@ fn env_or(key: &str, default: &str) -> String {
 /// keeps the secret off the process environment (which leaks via /proc,
 /// container inspection, and crash dumps). Warns if the file is group/world
 /// accessible.
-fn secret_from(key: &str) -> Result<Option<String>, Box<dyn std::error::Error>> {
+pub(crate) fn secret_from(key: &str) -> Result<Option<String>, Box<dyn std::error::Error>> {
     if let Ok(path) = std::env::var(format!("{key}_FILE")) {
         let path = path.trim();
         if !path.is_empty() {

--- a/keep-web/src/state_replication.rs
+++ b/keep-web/src/state_replication.rs
@@ -95,10 +95,17 @@ fn requeue(pending: &StdMutex<HashMap<String, Change>>, dtag: String, change: Ch
 
 /// Load the shared cluster identity from `KEEP_STATE_IDENTITY` (an `nsec1...` bech32 or a 64-char hex
 /// secret key). This key is a cluster secret distributed out-of-band to every node, like the shared
-/// Vaultwarden JWT key.
+/// Vaultwarden JWT key. Read via `secret_from` so `KEEP_STATE_IDENTITY_FILE` is honored, keeping the
+/// raw nsec off the process environment (which leaks via /proc/<pid>/environ, child inheritance, and
+/// core dumps), matching how the password, auth token, and storage key are already delivered.
 pub fn load_state_identity() -> Result<Keys, String> {
-    let raw = std::env::var("KEEP_STATE_IDENTITY")
-        .map_err(|_| "KEEP_STATE_RELAY is set but KEEP_STATE_IDENTITY is missing".to_string())?;
+    let raw = zeroize::Zeroizing::new(
+        crate::secret_from("KEEP_STATE_IDENTITY")
+            .map_err(|e| format!("reading KEEP_STATE_IDENTITY: {e}"))?
+            .ok_or_else(|| {
+                "KEEP_STATE_RELAY is set but KEEP_STATE_IDENTITY[_FILE] is missing".to_string()
+            })?,
+    );
     Keys::parse(raw.trim()).map_err(|e| format!("invalid KEEP_STATE_IDENTITY: {e}"))
 }
 


### PR DESCRIPTION
Upstream half of keep-node's dv5. `load_state_identity` read the shared cluster identity (an `nsec1...` secret) from the raw `KEEP_STATE_IDENTITY` env var, so on the appliance the cluster nsec sat in the daemon's process environment , readable via `/proc/<pid>/environ` (service UID + root), inherited by child processes, and surfaceable in core dumps.

The password, auth token, and storage key already avoid this by reading through `secret_from`, which prefers `{KEY}_FILE` (a path to a 0400 credential file) over the env var. This routes `KEEP_STATE_IDENTITY` through the same helper, so `KEEP_STATE_IDENTITY_FILE` is now honored and keep-node can deliver the nsec as a systemd credential path instead of exporting its plaintext into the environment. The raw value is also wrapped in `Zeroizing` so the in-memory copy is scrubbed after parsing.

Behavior is unchanged when only `KEEP_STATE_IDENTITY` (no `_FILE`) is set, so existing deployments keep working; the error message now notes `[_FILE]`.

keep-web builds + clippy clean. Follow-up (keep-node): switch the keep-web unit to `KEEP_STATE_IDENTITY_FILE`/`KEEP_STORAGE_KEY_FILE = "%d/..."` and drop the ExecStart export wrappers, once this lands in a keep release the module consumes.
