### PR TITLE
keep-frost-net: add the duress beacon event primitive (inc1a of coercion resistance)

### DIFF
--- a/keep-frost-net/src/event.rs
+++ b/keep-frost-net/src/event.rs
@@ -58,6 +58,33 @@ impl KfpEventBuilder {
             .map_err(|e| FrostNetError::Nostr(e.to_string()))
     }
 
+    /// Build a holder's duress beacon: a normal KFP event signed by the holder's
+    /// dedicated duress-beacon `keys` (NOT the vault-derived identity, which
+    /// duress mode never unlocks). `nonce` must be freshly random. The cluster
+    /// authenticates it against the pinned beacon pubkey (see
+    /// [`verify_duress_beacon`]), so no proof-of-share is needed or possible.
+    ///
+    /// RELEASE GATE: this wire form is self-labeling (`t=duress_beacon` tag,
+    /// `type=duress_beacon` content, `g` group tag), so a relay-level adversary
+    /// can filter and silently drop the beacon. That is acceptable for this inert
+    /// primitive, but this MUST NOT reach a deployed path before the inc2
+    /// indistinguishability work (identify-by-pinned-pubkey, encrypted look-alike
+    /// content, constant cadence) lands.
+    pub fn duress_beacon(keys: &Keys, group_pubkey: &[u8; 32], nonce: &[u8; 32]) -> Result<Event> {
+        let payload = DuressBeaconPayload::new(*group_pubkey, *nonce);
+        let content = KfpMessage::DuressBeacon(payload).to_json()?;
+
+        EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), content)
+            .custom_created_at(Timestamp::tweaked(TIMESTAMP_TWEAK_RANGE))
+            .tag(Tag::custom(
+                TagKind::custom("g"),
+                [hex::encode(group_pubkey)],
+            ))
+            .tag(Tag::custom(TagKind::custom("t"), ["duress_beacon"]))
+            .sign_with_keys(keys)
+            .map_err(|e| FrostNetError::Nostr(e.to_string()))
+    }
+
     pub fn sign_request(
         keys: &Keys,
         recipient: &PublicKey,
@@ -553,6 +580,55 @@ impl KfpEventBuilder {
     }
 }
 
+/// Verify an inbound event is an authentic, fresh duress beacon for `group_pubkey`,
+/// signed by the pinned beacon key. Returns the payload on success.
+///
+/// Authenticity IS the pinned signing key: the beacon carries no proof-of-share
+/// (duress mode never unlocks the vault), so it is trusted only when signed by
+/// the beacon pubkey the cluster pinned out of band for that holder. Also checks
+/// the Nostr signature, the decoded group, and `created_at` freshness. Nonce
+/// replay dedup is the caller's job (track seen nonces within the window); this
+/// only bounds the window.
+pub fn verify_duress_beacon(
+    event: &Event,
+    expected_beacon_pubkey: &PublicKey,
+    group_pubkey: &[u8; 32],
+    window_secs: u64,
+) -> Result<DuressBeaconPayload> {
+    if event.kind != Kind::Custom(KFP_EVENT_KIND) {
+        return Err(FrostNetError::Protocol("not a KFP event".into()));
+    }
+    if &event.pubkey != expected_beacon_pubkey {
+        return Err(FrostNetError::UntrustedPeer(
+            "duress beacon not signed by the pinned beacon key".into(),
+        ));
+    }
+    if event.verify().is_err() {
+        return Err(FrostNetError::UntrustedPeer(
+            "duress beacon signature invalid".into(),
+        ));
+    }
+    let payload = match KfpMessage::from_json(&event.content)? {
+        KfpMessage::DuressBeacon(p) => p,
+        _ => {
+            return Err(FrostNetError::Protocol(
+                "event is not a duress beacon".into(),
+            ))
+        }
+    };
+    if &payload.group_pubkey != group_pubkey {
+        return Err(FrostNetError::Protocol(
+            "duress beacon group mismatch".into(),
+        ));
+    }
+    if !payload.is_within_replay_window(window_secs) {
+        return Err(FrostNetError::ReplayDetected(
+            "duress beacon outside replay window".into(),
+        ));
+    }
+    Ok(payload)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -672,5 +748,65 @@ mod tests {
             }
             _ => panic!("expected SignRequest"),
         }
+    }
+
+    #[test]
+    fn duress_beacon_roundtrips_and_verifies() {
+        let beacon_keys = Keys::generate();
+        let group = [7u8; 32];
+        let nonce = [9u8; 32];
+        let event = KfpEventBuilder::duress_beacon(&beacon_keys, &group, &nonce).unwrap();
+
+        assert_eq!(event.kind, Kind::Custom(KFP_EVENT_KIND));
+        let payload = verify_duress_beacon(&event, &beacon_keys.public_key(), &group, 300).unwrap();
+        assert_eq!(payload.group_pubkey, group);
+        assert_eq!(payload.nonce, nonce);
+    }
+
+    #[test]
+    fn duress_beacon_rejects_wrong_signer() {
+        // Signed by a different key than the pinned beacon key: authorship rejected.
+        // This is the load-bearing authenticity check (the beacon has no proof-of-share).
+        let beacon_keys = Keys::generate();
+        let attacker = Keys::generate();
+        let group = [7u8; 32];
+        let event = KfpEventBuilder::duress_beacon(&beacon_keys, &group, &[1u8; 32]).unwrap();
+        let err = verify_duress_beacon(&event, &attacker.public_key(), &group, 300).unwrap_err();
+        assert!(matches!(err, FrostNetError::UntrustedPeer(_)));
+    }
+
+    #[test]
+    fn duress_beacon_rejects_group_mismatch() {
+        let beacon_keys = Keys::generate();
+        let event = KfpEventBuilder::duress_beacon(&beacon_keys, &[1u8; 32], &[2u8; 32]).unwrap();
+        let err =
+            verify_duress_beacon(&event, &beacon_keys.public_key(), &[9u8; 32], 300).unwrap_err();
+        assert!(matches!(err, FrostNetError::Protocol(_)));
+    }
+
+    #[test]
+    fn duress_beacon_payload_freshness_window() {
+        let mut p = DuressBeaconPayload::new([0u8; 32], [0u8; 32]);
+        assert!(p.is_within_replay_window(300));
+        p.created_at = 1; // ancient
+        assert!(!p.is_within_replay_window(300));
+    }
+
+    #[test]
+    fn verify_duress_beacon_rejects_stale_end_to_end() {
+        // A beacon whose SIGNED payload created_at is far in the past is rejected
+        // by the verifier's freshness check (drives ReplayDetected through
+        // verify_duress_beacon, not just the payload helper).
+        let beacon_keys = Keys::generate();
+        let group = [7u8; 32];
+        let mut payload = DuressBeaconPayload::new(group, [1u8; 32]);
+        payload.created_at = 1; // ancient
+        let content = KfpMessage::DuressBeacon(payload).to_json().unwrap();
+        let event = EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), content)
+            .tag(Tag::custom(TagKind::custom("t"), ["duress_beacon"]))
+            .sign_with_keys(&beacon_keys)
+            .unwrap();
+        let err = verify_duress_beacon(&event, &beacon_keys.public_key(), &group, 300).unwrap_err();
+        assert!(matches!(err, FrostNetError::ReplayDetected(_)));
     }
 }

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -109,7 +109,7 @@ pub use enroll_session::{
     OprfEnrollSessionState,
 };
 pub use error::{FrostNetError, Result};
-pub use event::KfpEventBuilder;
+pub use event::{verify_duress_beacon, KfpEventBuilder};
 pub use node::{
     DescriptorLookupUnavailable, HealthCheckResult, KeepDescriptorLookup, KfpNode, KfpNodeEvent,
     NoOpHooks, OprfShareSealAck, PeerPolicy, PersistedDescriptorLookup, PsbtSessionSnapshot,
@@ -126,15 +126,15 @@ pub use peer::{AttestationStatus, Peer, PeerManager, PeerStatus};
 pub use protocol::{
     AnnouncePayload, AnnouncedXpub, CommitmentPayload, DescriptorAckPayload,
     DescriptorContributePayload, DescriptorFinalizePayload, DescriptorNackPayload,
-    DescriptorProposePayload, EcdhCompletePayload, EcdhRequestPayload, EcdhSharePayload,
-    EnclaveAttestation, ErrorPayload, KeySlot, KfpMessage, NonceCommitmentPayload, NonceRef,
-    OprfEnrollAckPayload, OprfEnrollPayload, OprfEvalRequestPayload, OprfEvalSharePayload,
-    PingPayload, PolicyTier, PongPayload, PreExchangedCommitment, PsbtAbortPayload,
-    PsbtFinalizePayload, PsbtInputInfo, PsbtOutputInfo, PsbtProposePayload, PsbtSignPayload,
-    RefreshCompletePayload, RefreshRequestPayload, RefreshRound1Payload, RefreshRound2Payload,
-    SignRequestPayload, SignatureCompletePayload, SignatureSharePayload, TpmQuoteEvidence,
-    WalletPolicy, XpubAnnouncePayload, DEFAULT_REPLAY_WINDOW_SECS,
-    DESCRIPTOR_ACK_PHASE_TIMEOUT_SECS, DESCRIPTOR_ACK_TIMEOUT_SECS,
+    DescriptorProposePayload, DuressBeaconPayload, EcdhCompletePayload, EcdhRequestPayload,
+    EcdhSharePayload, EnclaveAttestation, ErrorPayload, KeySlot, KfpMessage,
+    NonceCommitmentPayload, NonceRef, OprfEnrollAckPayload, OprfEnrollPayload,
+    OprfEvalRequestPayload, OprfEvalSharePayload, PingPayload, PolicyTier, PongPayload,
+    PreExchangedCommitment, PsbtAbortPayload, PsbtFinalizePayload, PsbtInputInfo, PsbtOutputInfo,
+    PsbtProposePayload, PsbtSignPayload, RefreshCompletePayload, RefreshRequestPayload,
+    RefreshRound1Payload, RefreshRound2Payload, SignRequestPayload, SignatureCompletePayload,
+    SignatureSharePayload, TpmQuoteEvidence, WalletPolicy, XpubAnnouncePayload,
+    DEFAULT_REPLAY_WINDOW_SECS, DESCRIPTOR_ACK_PHASE_TIMEOUT_SECS, DESCRIPTOR_ACK_TIMEOUT_SECS,
     DESCRIPTOR_CONTRIBUTION_TIMEOUT_SECS, DESCRIPTOR_FINALIZE_TIMEOUT_SECS,
     DESCRIPTOR_SESSION_MAX_TIMEOUT_SECS, DESCRIPTOR_SESSION_TIMEOUT_SECS, KFP_EVENT_KIND,
     KFP_VERSION, MAX_CAPABILITIES, MAX_CAPABILITY_LENGTH, MAX_COMMITMENT_SIZE,

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -2090,6 +2090,12 @@ impl KfpNode {
         // including `OprfEnrollAck`, is deliberately absent so it still requires a trusted peer
         // (defense in depth), matching `EcdhShare` / `SignatureShare` / `OprfEvalShare` /
         // `DescriptorAck`. Do NOT add `OprfEnrollAck` here: that would exempt it from the gate.
+        //
+        // `DuressBeacon` MUST be exempt: a duress beacon is signed by a dedicated duress-beacon
+        // key that never unlocks the vault and is by construction NOT a cluster peer, so the
+        // trusted-peer check would drop every authentic beacon before it reaches its arm. Its
+        // authenticity comes from `verify_duress_beacon` against the pinned beacon pubkey instead,
+        // which the arm (inc2) MUST call before acting -- the exemption grants NO trust on its own.
         if !matches!(
             msg,
             KfpMessage::Announce(_)
@@ -2097,6 +2103,7 @@ impl KfpNode {
                 | KfpMessage::EcdhRequest(_)
                 | KfpMessage::OprfEvalRequest(_)
                 | KfpMessage::OprfEnroll(_)
+                | KfpMessage::DuressBeacon(_)
         ) && !self.peers.read().is_trusted_peer(&event.pubkey)
         {
             debug!(from = %event.pubkey, "Rejecting message from untrusted peer");
@@ -2191,6 +2198,13 @@ impl KfpNode {
             }
             KfpMessage::XpubAnnounce(payload) => {
                 self.handle_xpub_announce(event.pubkey, payload).await?;
+            }
+            KfpMessage::DuressBeacon(_) => {
+                // Reaches here WITHOUT the trusted-peer gate (the beacon key is not
+                // a peer; see the exemption above). inc1a ignores it. inc2 (sxb)
+                // MUST call `verify_duress_beacon` against this holder's PINNED
+                // beacon pubkey before acting -- reaching this arm grants no trust
+                // on its own -- then fail-closed freeze co-signing.
             }
             KfpMessage::PsbtPropose(payload) => {
                 self.handle_psbt_propose(event.pubkey, payload).await?;

--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -132,6 +132,7 @@ pub enum KfpMessage {
     DescriptorNack(DescriptorNackPayload),
     DescriptorMigrate(DescriptorMigratePayload),
     XpubAnnounce(XpubAnnouncePayload),
+    DuressBeacon(DuressBeaconPayload),
     PsbtPropose(PsbtProposePayload),
     PsbtSign(PsbtSignPayload),
     PsbtFinalize(PsbtFinalizePayload),
@@ -168,6 +169,7 @@ impl KfpMessage {
             KfpMessage::DescriptorNack(_) => "descriptor_nack",
             KfpMessage::DescriptorMigrate(_) => "descriptor_migrate",
             KfpMessage::XpubAnnounce(_) => "xpub_announce",
+            KfpMessage::DuressBeacon(_) => "duress_beacon",
             KfpMessage::PsbtPropose(_) => "psbt_propose",
             KfpMessage::PsbtSign(_) => "psbt_sign",
             KfpMessage::PsbtFinalize(_) => "psbt_finalize",
@@ -226,6 +228,7 @@ impl KfpMessage {
             KfpMessage::DescriptorNack(p) => Some(&p.group_pubkey),
             KfpMessage::DescriptorMigrate(p) => Some(&p.group_pubkey),
             KfpMessage::XpubAnnounce(p) => Some(&p.group_pubkey),
+            KfpMessage::DuressBeacon(p) => Some(&p.group_pubkey),
             KfpMessage::PsbtPropose(p) => Some(&p.group_pubkey),
             KfpMessage::PsbtSign(p) => Some(&p.group_pubkey),
             KfpMessage::PsbtFinalize(p) => Some(&p.group_pubkey),
@@ -951,6 +954,40 @@ impl XpubAnnouncePayload {
             group_pubkey,
             share_index,
             recovery_xpubs,
+            created_at: Timestamp::now().as_secs(),
+        }
+    }
+
+    pub fn is_within_replay_window(&self, window_secs: u64) -> bool {
+        within_replay_window(self.created_at, window_secs)
+    }
+}
+
+/// A holder's duress signal. Published when the holder is unlocked with its
+/// DURESS credential instead of the real vault password: the holder withholds
+/// its OPRF share (the box drops below threshold, fail-closed) and emits this.
+///
+/// It is signed (as a Nostr event) by the holder's dedicated duress-beacon key,
+/// whose public key the cluster pins out of band, NOT by the vault-derived
+/// identity (which duress mode never unlocks). Authenticity therefore comes from
+/// the pinned signing key, so a network attacker cannot forge one. The random
+/// `nonce` plus `created_at` bound replay: a captured beacon cannot be
+/// re-published as a fresh signal. It carries no secret and (beyond the group id
+/// every KFP event already tags) no sensitive data.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct DuressBeaconPayload {
+    #[serde(with = "hex_bytes")]
+    pub group_pubkey: [u8; 32],
+    #[serde(with = "hex_bytes")]
+    pub nonce: [u8; 32],
+    pub created_at: u64,
+}
+
+impl DuressBeaconPayload {
+    pub fn new(group_pubkey: [u8; 32], nonce: [u8; 32]) -> Self {
+        Self {
+            group_pubkey,
+            nonce,
             created_at: Timestamp::now().as_secs(),
         }
     }


### PR DESCRIPTION
First increment (inc1a) of the coercion-resistance feature (keep-node t38 / 9cx). This adds only the **authenticated, replay-protected duress-beacon event primitive** in keep-frost-net; the serve-side duress detection + share-withholding is inc1b, and the cluster verify + fail-closed freeze is inc2 (sxb).

## Design grounding (deep-research verified)
The overall model , fail-closed lock + authenticated alert + sticky freeze , was verified against Clark & Hengartner "Panic Passwords" (USENIX HotSec 2008) as a faithful 2P-lock/panic-lock instantiation (invariant locking, indistinguishable submissions, iteration-attack resistance), NOT a panic-reveal decoy. The research found NO reference implementation of an authenticated distress beacon derived from a duress credential without the primary secret, so this is built from standard vetted primitives, not invented:
- The beacon is a normal Nostr Schnorr-signed `KfpMessage::DuressBeacon` (same mechanism as every KFP event).
- Authenticity is the **pinned beacon pubkey**: the holder signs with a dedicated duress-beacon key whose pubkey the cluster pins out of band (like the TPM AK pins). The beacon carries no proof-of-share (duress mode never unlocks the vault), so `verify_duress_beacon` trusts it only when `event.pubkey == expected_beacon_pubkey`, the Nostr signature checks out, the group matches, and `created_at` is within the replay window. Nonce dedup is the caller's (inc2).
- Replay is bounded by a random 32-byte nonce + `created_at`.

## Scope / follow-ups (documented, not baked-in-wrong)
- The dispatcher ignores inbound beacons for now (arm added); inc2 wires verify-against-pinned-key + freeze.
- On-wire byte-indistinguishability (identify-by-pinned-pubkey only, encrypted look-alike content, constant cadence) is a documented follow-up per the research's open question #1 (no precedent). The load-bearing coercion indistinguishability is the identical serve output + box-stays-locked invariant, delivered in inc1b/inc2.

## Tests
`duress_beacon_roundtrips_and_verifies`, `duress_beacon_rejects_wrong_signer` (authorship , the load-bearing check), `duress_beacon_rejects_group_mismatch`, `duress_beacon_payload_freshness_window`. Full keep-frost-net suite (403) + clippy green.

Security-review requested before merge (coercion-sensitive), per the bead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for duress beacons in KFP messages, including creation and verification of signed beacon events.
  * Beacons now carry group identification, a nonce, and a creation timestamp for freshness checks.

* **Bug Fixes**
  * Added validation to reject beacons with the wrong signer, mismatched group, invalid signature, or expired replay window.
  * Nodes now explicitly ignore duress beacon messages where they are not meant to be processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->