### PR TITLE
keep-cli: duress-provision command + beacon-key derivation (coercion inc1b)

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -617,6 +617,10 @@ pub(crate) enum FrostNetworkCommands {
         #[arg(short, long)]
         relay: Option<String>,
     },
+    /// Provision a duress credential: derive and print the duress-beacon pubkey
+    /// (to pin with the cluster) and salt (to configure on `serve`). The
+    /// credential is never stored. Coercion resistance (inc1b).
+    DuressProvision,
     /// Author an attestation-config from observed announces (trust-on-first-use).
     AttestationProvision {
         #[arg(short, long, help = "FROST group npub")]

--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+//! Duress-mode keying and provisioning (coercion resistance, inc1b).
+//!
+//! A duress credential distinct from the vault password lets a coerced holder
+//! fail closed and emit a signed duress beacon. This module derives the
+//! dedicated beacon keypair from that credential and provisions it.
+
+use keep_core::crypto::{derive_key, Argon2Params, SALT_SIZE};
+use keep_core::error::{KeepError, Result};
+use nostr_sdk::prelude::*;
+use secrecy::ExposeSecret;
+
+use crate::commands::get_duress_credential;
+use crate::output::Output;
+
+/// Argon2id parameters for the duress-beacon key: HIGH (512 MiB / 6 iters), NOT
+/// the vault default. The beacon's only protection against a leaked (cluster-
+/// shared) pinned pubkey is the KDF cost , unlike the vault password it does not
+/// also sit behind an encrypted-blob threshold , and it is derived rarely (once
+/// at provision, once per serve start), so the extra cost is free UX-wise and
+/// materially raises the offline brute-force cost of a low-entropy credential.
+/// `serve` MUST use the same params or its re-derivation will not match.
+const DURESS_BEACON_ARGON2: Argon2Params = Argon2Params::HIGH;
+
+/// Derive the duress-beacon nostr keypair from a duress credential and salt via
+/// the same vetted Argon2id path the vault uses (`keep_core::crypto::derive_key`),
+/// so no new key-derivation crypto is introduced. Deterministic: the same
+/// `(credential, salt)` always yields the same key. That determinism is what lets
+/// `serve` detect duress (re-derive from the entered password, compare the pubkey
+/// to the pinned one) and what lets the cluster pin the pubkey at provisioning.
+///
+/// SECURITY: a duress credential is typically low-entropy (human-memorable).
+/// Argon2id raises the offline brute-force cost but does not eliminate it, so the
+/// derived pubkey (shared with the cluster) is sensitive: an attacker who learns
+/// it can grind the credential space to recover the beacon key and forge freeze
+/// alerts. Use a strong duress credential and treat the pinned pubkey as protected.
+pub(crate) fn derive_beacon_key(
+    credential: &str,
+    salt: &[u8; SALT_SIZE],
+    params: Argon2Params,
+) -> Result<Keys> {
+    let derived = derive_key(credential.as_bytes(), salt, params)?;
+    let bytes = derived.decrypt()?;
+    let secret = SecretKey::from_slice(&bytes[..])
+        .map_err(|e| KeepError::invalid_input(format!("derive beacon key: {e}")))?;
+    Ok(Keys::new(secret))
+}
+
+/// `keep frost network duress-provision`: interactively provision a duress
+/// credential and print the beacon pubkey (to pin with the cluster) plus the salt
+/// (to configure on `serve`). Purely local , it derives, prints, and forgets. The
+/// credential itself is NEVER stored (serve re-derives from the entered password
+/// and compares the pubkey), so a coercer inspecting config finds only a pubkey
+/// and a salt, not the duress trigger.
+pub fn cmd_frost_network_duress_provision(out: &Output) -> Result<()> {
+    out.header("Duress Provisioning");
+    out.warn(
+        "Choose a DURESS credential DISTINCT from your vault password. Entering it at `serve` \
+         triggers duress mode: the holder fails closed (withholds its OPRF share so the box drops \
+         below threshold) and publishes a signed alert. Make it memorable and secret; it is never \
+         stored.",
+    );
+    let credential = get_duress_credential("Enter duress credential", "Confirm duress credential")?;
+    let salt: [u8; SALT_SIZE] = keep_core::entropy::try_random_bytes()?;
+    let beacon = derive_beacon_key(credential.expose_secret(), &salt, DURESS_BEACON_ARGON2)?;
+    let npub = beacon
+        .public_key()
+        .to_bech32()
+        .map_err(|e| KeepError::runtime(format!("encode beacon npub: {e}")))?;
+
+    out.newline();
+    out.field("Beacon pubkey (pin with the cluster)", &npub);
+    out.field(
+        "Salt (configure on serve: --duress-beacon-salt)",
+        &hex::encode(salt),
+    );
+    out.newline();
+    out.info(
+        "Register the beacon pubkey with the cluster (like an attestation AK pin) and set both \
+         values on `serve`. Do NOT store the duress credential anywhere.",
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tests use fast params (keep_core's Argon2Params::TESTING is cfg(test)-gated
+    // and not reachable here); production uses DURESS_BEACON_ARGON2 (HIGH).
+    // Determinism/variance hold for any fixed params.
+    const P: Argon2Params = Argon2Params {
+        memory_kib: 1024,
+        iterations: 1,
+        parallelism: 1,
+    };
+
+    #[test]
+    fn derive_beacon_key_is_deterministic() {
+        let salt = [7u8; SALT_SIZE];
+        let a = derive_beacon_key("correct horse battery staple", &salt, P).unwrap();
+        let b = derive_beacon_key("correct horse battery staple", &salt, P).unwrap();
+        assert_eq!(a.public_key(), b.public_key());
+    }
+
+    #[test]
+    fn derive_beacon_key_varies_by_credential_and_salt() {
+        let salt = [7u8; SALT_SIZE];
+        let base = derive_beacon_key("cred-a", &salt, P).unwrap().public_key();
+        // A different credential yields a different beacon key.
+        assert_ne!(
+            base,
+            derive_beacon_key("cred-b", &salt, P).unwrap().public_key()
+        );
+        // A different salt yields a different beacon key.
+        assert_ne!(
+            base,
+            derive_beacon_key("cred-a", &[9u8; SALT_SIZE], P)
+                .unwrap()
+                .public_key()
+        );
+    }
+}

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -20,10 +20,12 @@ use super::get_password;
 
 mod attestation;
 mod dkg;
+mod duress;
 mod hardware;
 
 pub use attestation::cmd_frost_network_attestation_provision;
 pub use dkg::{cmd_frost_network_dkg, cmd_frost_network_group_create};
+pub use duress::cmd_frost_network_duress_provision;
 pub use hardware::{cmd_frost_network_nonce_precommit, cmd_frost_network_sign_hardware};
 
 /// Fixed OPRF unlock input (the design's fixed label). Both provisioning and

--- a/keep-cli/src/commands/mod.rs
+++ b/keep-cli/src/commands/mod.rs
@@ -15,7 +15,7 @@ pub mod vault;
 pub mod wallet;
 
 use dialoguer::{theme::ColorfulTheme, Confirm, Password};
-use secrecy::SecretString;
+use secrecy::{ExposeSecret, SecretString};
 use tracing::debug;
 
 use keep_core::error::{KeepError, Result};
@@ -75,6 +75,41 @@ pub fn get_password_with_confirm(prompt: &str, confirm: &str) -> Result<SecretSt
             )))
         })?;
     Ok(SecretString::from(pw))
+}
+
+/// Read a DURESS credential (coercion resistance). Prompt + confirm, or the
+/// `KEEP_DURESS_PASSWORD` env var , NEVER `KEEP_PASSWORD`, so an exported vault
+/// password cannot silently become the duress trigger (which would make every
+/// normal unlock fail closed). Refuses an empty/whitespace-only credential, and,
+/// when `KEEP_PASSWORD` is also set, refuses a credential equal to it.
+pub fn get_duress_credential(prompt: &str, confirm: &str) -> Result<SecretString> {
+    let cred = if let Some(pw) = password_from_env("KEEP_DURESS_PASSWORD") {
+        pw
+    } else {
+        let pw = Password::with_theme(&ColorfulTheme::default())
+            .with_prompt(prompt)
+            .with_confirmation(confirm, "Credentials don't match")
+            .interact()
+            .map_err(|e| {
+                KeepError::StorageErr(keep_core::error::StorageError::io(format!(
+                    "read password: {e}"
+                )))
+            })?;
+        SecretString::from(pw)
+    };
+    if cred.expose_secret().trim().is_empty() {
+        return Err(KeepError::invalid_input(
+            "duress credential must not be empty",
+        ));
+    }
+    if let Some(vault) = password_from_env("KEEP_PASSWORD") {
+        if cred.expose_secret() == vault.expose_secret() {
+            return Err(KeepError::invalid_input(
+                "duress credential must be DISTINCT from the vault password (KEEP_PASSWORD)",
+            ));
+        }
+    }
+    Ok(cred)
 }
 
 pub fn get_new_password_with_confirm(prompt: &str, confirm: &str) -> Result<SecretString> {

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -347,6 +347,9 @@ fn dispatch_frost_network(
             let relay = relay.as_deref().unwrap_or(default_relay);
             commands::frost_network::cmd_frost_network_peers(out, path, &group, relay)
         }
+        FrostNetworkCommands::DuressProvision => {
+            commands::frost_network::cmd_frost_network_duress_provision(out)
+        }
         FrostNetworkCommands::AttestationProvision {
             group,
             relay,


### PR DESCRIPTION
Second step of the coercion-resistance feature (keep-node 9cx / inc1b). Builds on the merged beacon primitive (#722). Adds the duress-beacon **keying** and the **provisioning** command; the serve-side duress detection + fail-closed + emit is the next step (inc1b-b).

## Keying (no new crypto)
`derive_beacon_key(credential, salt)` derives the dedicated duress-beacon nostr keypair from the duress credential via the SAME vetted Argon2id path the vault uses (`keep_core::crypto::derive_key`), then builds a `Keys` exactly like `derive_member_keys` does (`SecretKey::from_slice` -> `Keys::new`). Deterministic: the same `(credential, salt)` always yields the same key , which is what lets `serve` (inc1b-b) detect duress by re-deriving from the entered password and comparing the pubkey to the pinned one, and what lets the cluster pin the pubkey at provisioning.

Grounded in the deep-research: the research found no reference implementation of an authenticated duress beacon derived from a duress credential, and recommended building it from standard primitives , this reuses keep's Argon2id + nostr Schnorr, inventing nothing.

## Provisioning
`keep frost network duress-provision`: interactively takes a duress credential (distinct from the vault password), generates a random 32-byte salt, derives the beacon key, and prints the beacon **pubkey** (to pin with the cluster, like a TPM AK pin) and the **salt** (to configure on serve). The credential is NEVER stored , serve re-derives from the entered password , so a coercer inspecting config finds only a pubkey and a salt, not the duress trigger (mitigates the research's config-exposure pitfall).

## Security caveats (documented in code)
Per the research: a low-entropy duress credential is offline-brute-forceable if the pinned pubkey leaks (Argon2id raises the cost, doesn't eliminate it). The doc-comment flags the pinned pubkey as sensitive and calls for a strong credential; this is carried into inc2 tracking too.

Tests: `derive_beacon_key_is_deterministic`, `derive_beacon_key_varies_by_credential_and_salt`. keep-cli build + clippy green. Security-review requested (coercion-sensitive).

## Review fixes (security-review + pr-review)
- Beacon derivation uses `Argon2Params::HIGH` (512 MiB / 6 iters), not the vault default: the beacon's only protection against a leakable (cluster-shared) pinned pubkey is the KDF cost, and it derives rarely. `serve` must use the same params (documented).
- New `get_duress_credential` reads a DURESS-specific path (`KEEP_DURESS_PASSWORD`, never `KEEP_PASSWORD`), refuses an empty/whitespace credential, and refuses a credential equal to the vault password when `KEEP_PASSWORD` is set , closing the silent "duress == vault password -> every unlock self-DoSes" footgun both reviews flagged.
- KDF parameterized so tests run fast; `derive_beacon_key` is `pub(crate)`.
