### PR TITLE
Wire duress detection and fail-closed beacon into frost network serve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4572,6 +4572,7 @@ dependencies = [
  "serialport",
  "sha2 0.10.9",
  "shellexpand",
+ "subtle",
  "tempfile",
  "tokio",
  "toml 1.1.2+spec-1.1.0",

--- a/keep-cli/Cargo.toml
+++ b/keep-cli/Cargo.toml
@@ -55,6 +55,7 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "6.0"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
 secrecy = "0.10"
+subtle = "2.5"
 
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -610,6 +610,18 @@ pub(crate) enum FrostNetworkCommands {
         /// `attestation-provision`. Needs the tpm-attestation build feature.
         #[arg(long, value_name = "TCTI")]
         tpm_tcti: Option<String>,
+        /// Coercion resistance: the pinned duress-beacon npub from
+        /// `duress-provision`. When set (with --duress-beacon-salt), entering the
+        /// duress credential at the password prompt fails closed (the vault stays
+        /// locked, no OPRF share is loaded, so the box drops below threshold) and
+        /// publishes a signed duress beacon, indistinguishable from a normal start.
+        #[arg(long, value_name = "NPUB", requires = "duress_beacon_salt")]
+        duress_beacon_pubkey: Option<String>,
+        /// Coercion resistance: the hex salt printed by `duress-provision`, used to
+        /// re-derive and detect the duress credential. Set together with
+        /// --duress-beacon-pubkey.
+        #[arg(long, value_name = "HEX", requires = "duress_beacon_pubkey")]
+        duress_beacon_salt: Option<String>,
     },
     Peers {
         #[arg(short, long)]

--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -83,6 +83,102 @@ pub fn cmd_frost_network_duress_provision(out: &Output) -> Result<()> {
     Ok(())
 }
 
+/// Constant-time equality of two x-only pubkeys, so duress detection does not
+/// leak (via timing) whether the entered password matched the pinned beacon key.
+/// The dominating cost is the Argon2 re-derivation (which runs for every serve
+/// regardless), so the paths are timing-indistinguishable.
+fn ct_pubkey_eq(a: &PublicKey, b: &PublicKey) -> bool {
+    let (a, b) = (a.to_bytes(), b.to_bytes());
+    let mut diff = 0u8;
+    for i in 0..a.len() {
+        diff |= a[i] ^ b[i];
+    }
+    diff == 0
+}
+
+/// If `password` is the duress credential, return the beacon `Keys`; otherwise
+/// `None`. Re-derives the beacon key from the entered password (same HIGH params
+/// as provisioning) and constant-time-compares its pubkey to the pinned
+/// `beacon_pubkey`. A single Argon2 derivation, run for EVERY serve unlock, so a
+/// normal password and the duress credential are indistinguishable by timing.
+pub(crate) fn match_duress(
+    password: &str,
+    salt: &[u8; SALT_SIZE],
+    beacon_pubkey: &PublicKey,
+) -> Result<Option<Keys>> {
+    let candidate = derive_beacon_key(password, salt, DURESS_BEACON_ARGON2)?;
+    if ct_pubkey_eq(&candidate.public_key(), beacon_pubkey) {
+        Ok(Some(candidate))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Parse the serve-side duress config: the pinned beacon `npub` and the hex salt.
+pub(crate) fn parse_duress_config(
+    beacon_npub: &str,
+    salt_hex: &str,
+) -> Result<(PublicKey, [u8; SALT_SIZE])> {
+    let pubkey = PublicKey::from_bech32(beacon_npub.trim())
+        .map_err(|e| KeepError::invalid_input(format!("--duress-beacon-pubkey: {e}")))?;
+    let raw = hex::decode(salt_hex.trim())
+        .map_err(|e| KeepError::invalid_input(format!("--duress-beacon-salt not hex: {e}")))?;
+    let salt: [u8; SALT_SIZE] = raw.try_into().map_err(|_| {
+        KeepError::invalid_input("--duress-beacon-salt must be 32 bytes".to_string())
+    })?;
+    Ok((pubkey, salt))
+}
+
+/// The duress serve path: fail CLOSED (never unlock the vault or load the OPRF
+/// share, so this holder answers no evaluations and the box drops below
+/// threshold) and publish ONE signed duress beacon, then stay resident so the
+/// holder looks online but simply never answers. Reached only when the entered
+/// password derived the pinned beacon key.
+///
+/// The screen mirrors a normal serve start using data knowable without the vault
+/// (group, relay). The `Share`/`Threshold`/`Attestation` lines a normal serve
+/// derives from the unlocked share are the DOCUMENTED residual: full byte-level
+/// output and on-wire indistinguishability is a follow-up (deep-research open
+/// question, tracked with the inc2 wire-format release gate). The load-bearing
+/// coercion property is that the box stays locked , this fail-closed path plus the
+/// inc2 sticky freeze , invariant to which password was entered.
+pub(crate) async fn run_duress_serve(
+    out: &Output,
+    beacon: &Keys,
+    group_pubkey: &[u8; 32],
+    relay: &str,
+) -> Result<()> {
+    let group_npub = keep_core::keys::bytes_to_npub(group_pubkey);
+    out.newline();
+    out.header("FROST Network Node");
+    out.field("Group", &group_npub);
+    out.field("Relay", relay);
+    out.newline();
+
+    let client = Client::new(beacon.clone());
+    client
+        .add_relay(relay)
+        .await
+        .map_err(|e| KeepError::runtime(format!("add relay: {e}")))?;
+    client.connect().await;
+
+    let nonce: [u8; 32] = keep_core::entropy::try_random_bytes()?;
+    let event = keep_frost_net::KfpEventBuilder::duress_beacon(beacon, group_pubkey, &nonce)
+        .map_err(|e| KeepError::runtime(format!("build duress beacon: {e}")))?;
+    client
+        .send_event(&event)
+        .await
+        .map_err(|e| KeepError::runtime(format!("publish duress beacon: {e}")))?;
+
+    out.info("Starting FROST coordination node...");
+
+    // Stay resident so the holder appears online but answers no evaluation
+    // requests (fail-closed). Nothing here is duress-specific on screen.
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -102,6 +198,34 @@ mod tests {
         let a = derive_beacon_key("correct horse battery staple", &salt, P).unwrap();
         let b = derive_beacon_key("correct horse battery staple", &salt, P).unwrap();
         assert_eq!(a.public_key(), b.public_key());
+    }
+
+    #[test]
+    fn ct_pubkey_eq_matches_std_eq() {
+        let salt = [3u8; SALT_SIZE];
+        let a = derive_beacon_key("x", &salt, P).unwrap().public_key();
+        let b = derive_beacon_key("x", &salt, P).unwrap().public_key();
+        let c = derive_beacon_key("y", &salt, P).unwrap().public_key();
+        assert!(ct_pubkey_eq(&a, &b));
+        assert!(!ct_pubkey_eq(&a, &c));
+    }
+
+    #[test]
+    fn parse_duress_config_roundtrips_and_rejects_bad_input() {
+        let salt = [5u8; SALT_SIZE];
+        let npub = derive_beacon_key("dur", &salt, P)
+            .unwrap()
+            .public_key()
+            .to_bech32()
+            .unwrap();
+        let salt_hex = hex::encode(salt);
+        let (pk, parsed_salt) = parse_duress_config(&npub, &salt_hex).unwrap();
+        assert_eq!(parsed_salt, salt);
+        assert_eq!(pk.to_bech32().unwrap(), npub);
+        // A too-short salt is rejected (not silently zero-padded).
+        assert!(parse_duress_config(&npub, "00ff").is_err());
+        // A non-npub pubkey is rejected.
+        assert!(parse_duress_config("not-an-npub", &salt_hex).is_err());
     }
 
     #[test]

--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -10,6 +10,8 @@ use keep_core::crypto::{derive_key, Argon2Params, SALT_SIZE};
 use keep_core::error::{KeepError, Result};
 use nostr_sdk::prelude::*;
 use secrecy::ExposeSecret;
+use subtle::ConstantTimeEq;
+use tracing::debug;
 
 use crate::commands::get_duress_credential;
 use crate::output::Output;
@@ -78,22 +80,29 @@ pub fn cmd_frost_network_duress_provision(out: &Output) -> Result<()> {
     out.newline();
     out.info(
         "Register the beacon pubkey with the cluster (like an attestation AK pin) and set both \
-         values on `serve`. Do NOT store the duress credential anywhere.",
+         values on `serve`. Treat the pinned pubkey as PROTECTED, not merely pinned: anyone who \
+         learns it can grind the credential offline. Do NOT store the duress credential anywhere.",
     );
     Ok(())
 }
 
-/// Constant-time equality of two x-only pubkeys, so duress detection does not
-/// leak (via timing) whether the entered password matched the pinned beacon key.
-/// The dominating cost is the Argon2 re-derivation (which runs for every serve
-/// regardless), so the paths are timing-indistinguishable.
+/// Constant-time equality of two x-only pubkeys (via the workspace's `subtle`,
+/// the same primitive used for CT comparisons elsewhere in the tree), so duress
+/// detection does not leak by timing whether the entered password matched the
+/// pinned beacon key.
 fn ct_pubkey_eq(a: &PublicKey, b: &PublicKey) -> bool {
-    let (a, b) = (a.to_bytes(), b.to_bytes());
-    let mut diff = 0u8;
-    for i in 0..a.len() {
-        diff |= a[i] ^ b[i];
-    }
-    diff == 0
+    a.to_bytes().ct_eq(&b.to_bytes()).into()
+}
+
+/// Spend the same KDF cost a genuine vault unlock would (the vault's own Argon2
+/// params) and discard the result, so a duress start is wall-clock-
+/// indistinguishable from a real unlock. The vault is NEVER unlocked here; this
+/// only reproduces the missing second derivation that `keep.unlock` performs on
+/// the normal path (the duress path returns before it). The derived key is held
+/// in `keep_core`'s mlocked, drop-zeroized box.
+pub(crate) fn equalize_unlock_cost(params: Argon2Params, salt: &[u8; SALT_SIZE]) -> Result<()> {
+    let _ = derive_key(b"duress-unlock-cost-equalizer", salt, params)?;
+    Ok(())
 }
 
 /// If `password` is the duress credential, return the beacon `Keys`; otherwise
@@ -129,19 +138,37 @@ pub(crate) fn parse_duress_config(
     Ok((pubkey, salt))
 }
 
+/// Build a single signed duress beacon event for `group_pubkey` with a fresh
+/// random nonce. Split from the transport so the beacon's construction is unit-
+/// testable without a live relay.
+pub(crate) fn build_duress_event(beacon: &Keys, group_pubkey: &[u8; 32]) -> Result<Event> {
+    let nonce: [u8; 32] = keep_core::entropy::try_random_bytes()?;
+    keep_frost_net::KfpEventBuilder::duress_beacon(beacon, group_pubkey, &nonce)
+        .map_err(|e| KeepError::runtime(format!("build beacon: {e}")))
+}
+
+/// How long to wait for the best-effort beacon publish before giving up and
+/// staying resident, so a black-holed relay cannot hang the duress start.
+const BEACON_PUBLISH_TIMEOUT_SECS: u64 = 10;
+
 /// The duress serve path: fail CLOSED (never unlock the vault or load the OPRF
 /// share, so this holder answers no evaluations and the box drops below
-/// threshold) and publish ONE signed duress beacon, then stay resident so the
-/// holder looks online but simply never answers. Reached only when the entered
-/// password derived the pinned beacon key.
+/// threshold), best-effort publish ONE signed duress beacon, then stay resident
+/// so the holder looks online but simply never answers. Reached only when the
+/// entered password derived the pinned beacon key.
+///
+/// Beacon delivery is BEST-EFFORT and must never change observable behavior: a
+/// coercer can black-hole the network, so a failed connect/publish neither aborts
+/// nor prints anything (least of all the word "duress"). The box stays resident
+/// and fail-closed regardless , the vault is already never unlocked.
 ///
 /// The screen mirrors a normal serve start using data knowable without the vault
 /// (group, relay). The `Share`/`Threshold`/`Attestation` lines a normal serve
-/// derives from the unlocked share are the DOCUMENTED residual: full byte-level
-/// output and on-wire indistinguishability is a follow-up (deep-research open
-/// question, tracked with the inc2 wire-format release gate). The load-bearing
-/// coercion property is that the box stays locked , this fail-closed path plus the
-/// inc2 sticky freeze , invariant to which password was entered.
+/// derives from the unlocked share, and full on-wire indistinguishability of the
+/// beacon, are the DOCUMENTED residuals (tracked with the inc2 wire-format
+/// release gate). The load-bearing coercion property is that the box stays locked
+/// , this fail-closed path plus the inc2 sticky freeze , invariant to which
+/// password was entered.
 pub(crate) async fn run_duress_serve(
     out: &Output,
     beacon: &Keys,
@@ -154,23 +181,28 @@ pub(crate) async fn run_duress_serve(
     out.field("Group", &group_npub);
     out.field("Relay", relay);
     out.newline();
-
-    let client = Client::new(beacon.clone());
-    client
-        .add_relay(relay)
-        .await
-        .map_err(|e| KeepError::runtime(format!("add relay: {e}")))?;
-    client.connect().await;
-
-    let nonce: [u8; 32] = keep_core::entropy::try_random_bytes()?;
-    let event = keep_frost_net::KfpEventBuilder::duress_beacon(beacon, group_pubkey, &nonce)
-        .map_err(|e| KeepError::runtime(format!("build duress beacon: {e}")))?;
-    client
-        .send_event(&event)
-        .await
-        .map_err(|e| KeepError::runtime(format!("publish duress beacon: {e}")))?;
-
     out.info("Starting FROST coordination node...");
+
+    // Best-effort alert. Any failure is swallowed (logged only at debug, never on
+    // screen and never mentioning duress) so the observable path is identical to
+    // a normal start whose relay happens to be unreachable.
+    let client = Client::new(beacon.clone());
+    if client.add_relay(relay).await.is_ok() {
+        client.connect().await;
+        match build_duress_event(beacon, group_pubkey) {
+            Ok(event) => {
+                let send = tokio::time::timeout(
+                    std::time::Duration::from_secs(BEACON_PUBLISH_TIMEOUT_SECS),
+                    client.send_event(&event),
+                )
+                .await;
+                if let Ok(Err(e)) = send {
+                    debug!(error = %e, "beacon publish failed; staying resident");
+                }
+            }
+            Err(e) => debug!(error = %e, "beacon build failed; staying resident"),
+        }
+    }
 
     // Stay resident so the holder appears online but answers no evaluation
     // requests (fail-closed). Nothing here is duress-specific on screen.
@@ -208,6 +240,20 @@ mod tests {
         let c = derive_beacon_key("y", &salt, P).unwrap().public_key();
         assert!(ct_pubkey_eq(&a, &b));
         assert!(!ct_pubkey_eq(&a, &c));
+    }
+
+    #[test]
+    fn build_duress_event_produces_a_verifiable_beacon() {
+        let salt = [1u8; SALT_SIZE];
+        let beacon = derive_beacon_key("the-duress-word", &salt, P).unwrap();
+        let group = [42u8; 32];
+        let event = build_duress_event(&beacon, &group).unwrap();
+        // The beacon verifies against the beacon pubkey and the expected group.
+        keep_frost_net::verify_duress_beacon(&event, &beacon.public_key(), &group, 3600)
+            .expect("freshly built beacon must verify");
+        // Two builds use fresh nonces, so their events differ (replay-distinct).
+        let again = build_duress_event(&beacon, &group).unwrap();
+        assert_ne!(event.id, again.id);
     }
 
     #[test]

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -70,6 +70,8 @@ pub fn cmd_frost_network_serve(
     oprf_dealer: Option<u16>,
     oprf_auto_approve: bool,
     tpm_tcti: Option<&str>,
+    duress_beacon_pubkey: Option<&str>,
+    duress_beacon_salt: Option<&str>,
 ) -> Result<()> {
     debug!(group = group_npub, relay, share = ?share_index, refuse_raw_sign, require_structured_sign, "starting FROST network node");
 
@@ -95,6 +97,33 @@ pub fn cmd_frost_network_serve(
 
     let mut keep = Keep::open(path)?;
     let password = get_password("Enter password")?;
+
+    // Coercion resistance: when a duress beacon is configured, re-derive its key
+    // from the entered password. On a match, take the fail-closed duress path ,
+    // NEVER unlock the vault, NEVER load the OPRF share (so this holder answers no
+    // evaluations and the box drops below threshold), publish one signed beacon,
+    // and stay resident. The re-derivation runs on EVERY unlock, so a normal
+    // password and the duress credential are timing-indistinguishable. Both config
+    // values must be set together; a partial config fails closed.
+    match (duress_beacon_pubkey, duress_beacon_salt) {
+        (Some(npub), Some(salt_hex)) => {
+            let (beacon_pubkey, salt) = duress::parse_duress_config(npub, salt_hex)?;
+            if let Some(beacon) =
+                duress::match_duress(password.expose_secret(), &salt, &beacon_pubkey)?
+            {
+                let group_pubkey = keep_core::keys::npub_to_bytes(group_npub)?;
+                let rt = tokio::runtime::Runtime::new()
+                    .map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
+                return rt.block_on(duress::run_duress_serve(out, &beacon, &group_pubkey, relay));
+            }
+        }
+        (None, None) => {}
+        _ => {
+            return Err(KeepError::invalid_input(
+                "--duress-beacon-pubkey and --duress-beacon-salt must be set together",
+            ));
+        }
+    }
 
     let spinner = out.spinner("Unlocking vault...");
     keep.unlock(password.expose_secret())?;

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -95,33 +95,40 @@ pub fn cmd_frost_network_serve(
     // `attestation-provision`). Built before unlocking so it fails fast.
     let attestor = attestation::optional_announce_attestor(out, tpm_tcti)?;
 
-    let mut keep = Keep::open(path)?;
-    let password = get_password("Enter password")?;
-
-    // Coercion resistance: when a duress beacon is configured, re-derive its key
-    // from the entered password. On a match, take the fail-closed duress path ,
-    // NEVER unlock the vault, NEVER load the OPRF share (so this holder answers no
-    // evaluations and the box drops below threshold), publish one signed beacon,
-    // and stay resident. The re-derivation runs on EVERY unlock, so a normal
-    // password and the duress credential are timing-indistinguishable. Both config
-    // values must be set together; a partial config fails closed.
-    match (duress_beacon_pubkey, duress_beacon_salt) {
-        (Some(npub), Some(salt_hex)) => {
-            let (beacon_pubkey, salt) = duress::parse_duress_config(npub, salt_hex)?;
-            if let Some(beacon) =
-                duress::match_duress(password.expose_secret(), &salt, &beacon_pubkey)?
-            {
-                let group_pubkey = keep_core::keys::npub_to_bytes(group_npub)?;
-                let rt = tokio::runtime::Runtime::new()
-                    .map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
-                return rt.block_on(duress::run_duress_serve(out, &beacon, &group_pubkey, relay));
-            }
-        }
-        (None, None) => {}
+    // Coercion resistance: resolve the duress-beacon config up front (fail closed
+    // on a partial or malformed config) so a misconfiguration surfaces BEFORE the
+    // operator is prompted for a password, never after. Both flags must be set
+    // together (clap also enforces this).
+    let duress_cfg = match (duress_beacon_pubkey, duress_beacon_salt) {
+        (Some(npub), Some(salt_hex)) => Some(duress::parse_duress_config(npub, salt_hex)?),
+        (None, None) => None,
         _ => {
             return Err(KeepError::invalid_input(
                 "--duress-beacon-pubkey and --duress-beacon-salt must be set together",
             ));
+        }
+    };
+
+    let mut keep = Keep::open(path)?;
+    let password = get_password("Enter password")?;
+
+    // When a duress beacon is configured, re-derive its key from the entered
+    // password. On a match, take the fail-closed duress path , NEVER unlock the
+    // vault, NEVER load the OPRF share (so this holder answers no evaluations and
+    // the box drops below threshold), publish one signed beacon, and stay
+    // resident. To keep a coerced start wall-clock- and screen-indistinguishable
+    // from a genuine one, mirror the normal path's "Unlocking vault..." spinner
+    // and spend an equal-cost KDF (the vault's own params) before diverging.
+    if let Some((beacon_pubkey, salt)) = duress_cfg {
+        if let Some(beacon) = duress::match_duress(password.expose_secret(), &salt, &beacon_pubkey)?
+        {
+            let spinner = out.spinner("Unlocking vault...");
+            duress::equalize_unlock_cost(keep.argon2_params(), &salt)?;
+            spinner.finish();
+            let group_pubkey = keep_core::keys::npub_to_bytes(group_npub)?;
+            let rt = tokio::runtime::Runtime::new()
+                .map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
+            return rt.block_on(duress::run_duress_serve(out, &beacon, &group_pubkey, relay));
         }
     }
 

--- a/keep-cli/src/commands/mod.rs
+++ b/keep-cli/src/commands/mod.rs
@@ -77,6 +77,11 @@ pub fn get_password_with_confirm(prompt: &str, confirm: &str) -> Result<SecretSt
     Ok(SecretString::from(pw))
 }
 
+/// Minimum length for a duress credential. A crude entropy proxy: because the
+/// pinned beacon pubkey is shared cluster-wide, a short credential is cheaply
+/// grindable offline even behind Argon2id.
+const MIN_DURESS_CREDENTIAL_LEN: usize = 12;
+
 /// Read a DURESS credential (coercion resistance). Prompt + confirm, or the
 /// `KEEP_DURESS_PASSWORD` env var , NEVER `KEEP_PASSWORD`, so an exported vault
 /// password cannot silently become the duress trigger (which would make every
@@ -97,10 +102,20 @@ pub fn get_duress_credential(prompt: &str, confirm: &str) -> Result<SecretString
             })?;
         SecretString::from(pw)
     };
-    if cred.expose_secret().trim().is_empty() {
+    let trimmed_len = cred.expose_secret().trim().chars().count();
+    if trimmed_len == 0 {
         return Err(KeepError::invalid_input(
             "duress credential must not be empty",
         ));
+    }
+    // The pinned beacon pubkey is shared cluster-wide, so the duress credential is
+    // offline-grindable if it leaks. Argon2id (HIGH) raises that cost, but a floor
+    // on length is a cheap defense against a trivially short, low-entropy choice.
+    if trimmed_len < MIN_DURESS_CREDENTIAL_LEN {
+        return Err(KeepError::invalid_input(format!(
+            "duress credential must be at least {MIN_DURESS_CREDENTIAL_LEN} characters \
+             (its pinned pubkey is shared with the cluster and offline-grindable)"
+        )));
     }
     if let Some(vault) = password_from_env("KEEP_PASSWORD") {
         if cred.expose_secret() == vault.expose_secret() {

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -324,6 +324,8 @@ fn dispatch_frost_network(
             oprf_dealer,
             oprf_auto_approve,
             tpm_tcti,
+            duress_beacon_pubkey,
+            duress_beacon_salt,
         } => {
             let relay = relay.as_deref().unwrap_or(default_relay);
             commands::frost_network::cmd_frost_network_serve(
@@ -341,6 +343,8 @@ fn dispatch_frost_network(
                 oprf_dealer,
                 oprf_auto_approve,
                 tpm_tcti.as_deref(),
+                duress_beacon_pubkey.as_deref(),
+                duress_beacon_salt.as_deref(),
             )
         }
         FrostNetworkCommands::Peers { group, relay } => {

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -275,6 +275,12 @@ impl Keep {
         self.storage.is_unlocked()
     }
 
+    /// The vault's Argon2id parameters (from the header, readable before unlock).
+    /// Non-secret; used to reproduce an unlock's KDF cost without unlocking.
+    pub fn argon2_params(&self) -> crate::crypto::Argon2Params {
+        self.storage.argon2_params()
+    }
+
     /// Generate a new Nostr keypair and store it.
     ///
     /// # Example

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -712,6 +712,13 @@ impl Storage {
         self.data_key.is_some()
     }
 
+    /// The vault's Argon2id parameters (from the header, readable before unlock).
+    /// These are non-secret; callers use them to reproduce an unlock's KDF cost
+    /// (e.g. a timing equalizer) without unlocking the vault.
+    pub fn argon2_params(&self) -> Argon2Params {
+        self.header.argon2_params()
+    }
+
     /// The data encryption key, if unlocked.
     pub fn data_key(&self) -> Option<&SecretKey> {
         self.data_key.as_ref()


### PR DESCRIPTION
## Summary

Wires duress detection into `keep frost network serve`, completing the holder-side coercion-resistance path started in #722 (protocol/beacon primitives) and #723 (duress-credential provisioning).

A holder provisions a duress credential distinct from the vault password via `duress-provision`, which prints a beacon pubkey (pinned with the cluster) and a salt. The operator configures the pinned pubkey and salt on `serve`. When the entered password derives the pinned beacon key, the node takes a fail-closed path instead of unlocking.

## Behavior

New serve flags (must be set together; clap enforces the pairing):

- `--duress-beacon-pubkey <NPUB>`
- `--duress-beacon-salt <HEX>`

On every unlock, the entered password is run through the same Argon2id (HIGH) derivation used at provisioning and its pubkey is constant-time compared to the pinned one. A normal password and the duress credential are therefore indistinguishable by timing (both pay the KDF). On a match:

- the vault is never unlocked and no OPRF key share is loaded, so this holder answers no evaluation requests and the box drops below threshold (fail closed);
- one signed duress beacon is published to the relay;
- the process stays resident and the screen mirrors a normal serve start using data knowable without the vault (group, relay).

## Scope / residuals

The `Share`/`Threshold`/`Attestation` lines a normal serve derives from the unlocked share are a documented output residual; full byte-level output and on-wire indistinguishability is a follow-up tracked with the wire-format release gate. The load-bearing property here is that the box stays locked, invariant to which password was entered. Cluster-side beacon verification, sticky freeze, and a delayed/cancelable operator clear are the next increment.

## Tests

- `ct_pubkey_eq` matches standard equality on matching/non-matching keys
- `parse_duress_config` round-trips a pubkey/salt and rejects a short salt and a non-npub
- existing derive-key determinism/variance tests

`cargo build`, `cargo clippy`, `cargo fmt`, and the full `keep-cli` suite pass.
