### PR TITLE
Freeze OPRF holder on a verified duress beacon

### DIFF
--- a/keep-desktop/src/frost.rs
+++ b/keep-desktop/src/frost.rs
@@ -808,6 +808,17 @@ pub(crate) async fn frost_event_listener(
                             new_version,
                         ));
                     }
+                    // A verified duress beacon froze this node: surface it
+                    // prominently (co-signing and OPRF evals are now refused).
+                    Ok(KfpNodeEvent::DuressFrozen { beacon_pubkey }) => {
+                        log!(
+                            EventLogType::Error,
+                            format!(
+                                "DURESS: co-signing frozen by beacon {}",
+                                truncate_peer_string(&beacon_pubkey.to_string())
+                            )
+                        );
+                    }
                     // Threshold-OPRF unlock events are not surfaced in the
                     // desktop UI yet (KeepNode appliance flow).
                     Ok(KfpNodeEvent::OprfEvalRequested { .. })

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -752,6 +752,13 @@ pub enum KfpNodeEvent {
         session_id: [u8; 32],
         reason: String,
     },
+    /// A verified duress beacon froze this holder: it now refuses OPRF
+    /// evaluations (fail-closed) until an out-of-band operator clear. In-memory
+    /// in inc2a; sticky persistence across reboot + the operator clear are
+    /// inc2b/inc2c.
+    DuressFrozen {
+        beacon_pubkey: PublicKey,
+    },
 }
 
 impl std::fmt::Debug for KfpNodeEvent {
@@ -961,12 +968,26 @@ impl std::fmt::Debug for KfpNodeEvent {
                 .field("session_id", &hex::encode(session_id))
                 .field("reason", reason)
                 .finish(),
+            Self::DuressFrozen { beacon_pubkey } => f
+                .debug_struct("DuressFrozen")
+                .field("beacon_pubkey", beacon_pubkey)
+                .finish(),
         }
     }
 }
 
 /// Map key is `(session_id, new_descriptor_hash)`; value is `created_at`.
 pub(crate) type SeenDescriptorMigrates = RwLock<HashMap<([u8; 32], [u8; 32]), u64>>;
+
+/// State recorded when a verified duress beacon freezes this holder. Carries the
+/// beacon identity and nonce so a persistence layer (inc2b) can make the freeze
+/// sticky across reboot and an operator clear (inc2c) can audit what it lifted.
+#[derive(Clone, Debug)]
+pub struct DuressFreeze {
+    pub beacon_pubkey: PublicKey,
+    pub nonce: [u8; 32],
+    pub created_at: u64,
+}
 
 pub struct KfpNode {
     pub(crate) keys: Keys,
@@ -1016,6 +1037,20 @@ pub struct KfpNode {
     /// parallel to `expected_pcrs` for the Nitro path; `None` means TPM quotes
     /// are not configured and appraise to `NotConfigured`.
     tpm_attestation_policy: Option<TpmAttestationPolicy>,
+    /// Pinned duress-beacon pubkey(s) for this group. A received
+    /// `KfpMessage::DuressBeacon` is only actioned if `verify_duress_beacon`
+    /// succeeds against one of these. `None`/empty means duress beacons are not
+    /// configured and are ignored (reaching the arm grants no trust on its own).
+    duress_beacon_pins: Option<Vec<PublicKey>>,
+    /// Set once a valid, fresh, unseen duress beacon is verified: this holder is
+    /// FROZEN and refuses OPRF evaluations (fail-closed). In-memory only in
+    /// inc2a; sticky persistence across reboot + the operator clear are
+    /// inc2b/inc2c.
+    duress_freeze: RwLock<Option<DuressFreeze>>,
+    /// Nonce-dedup for duress beacons: `verify_duress_beacon` only bounds the
+    /// replay WINDOW, so this drops repeats (and same-beacon re-broadcasts)
+    /// within it. Keyed by the beacon nonce.
+    seen_duress_nonces: RwLock<HashSet<[u8; 32]>>,
     /// Producer side: when set, every announce carries a fresh TPM quote bound to
     /// it. `None` means this node attaches no TPM attestation to its announces.
     announce_attestor: Option<Arc<dyn AnnounceAttestor>>,
@@ -1283,6 +1318,9 @@ impl KfpNode {
             audit_log,
             expected_pcrs: None,
             tpm_attestation_policy: None,
+            duress_beacon_pins: None,
+            duress_freeze: RwLock::new(None),
+            seen_duress_nonces: RwLock::new(HashSet::new()),
             announce_attestor: None,
             announce_task: std::sync::Mutex::new(None),
             seen_xpub_announces: RwLock::new(HashSet::new()),
@@ -1362,6 +1400,80 @@ impl KfpNode {
 
     pub fn set_tpm_attestation_policy(&mut self, policy: TpmAttestationPolicy) {
         self.tpm_attestation_policy = Some(policy);
+    }
+
+    /// Pin the group's duress-beacon pubkey(s). A received duress beacon is only
+    /// actioned (freeze) if it verifies against one of these. Without a pin,
+    /// beacons are ignored.
+    pub fn with_duress_beacon_pins(mut self, pins: Vec<PublicKey>) -> Self {
+        self.duress_beacon_pins = Some(pins);
+        self
+    }
+
+    pub fn set_duress_beacon_pins(&mut self, pins: Vec<PublicKey>) {
+        self.duress_beacon_pins = Some(pins);
+    }
+
+    /// Whether this holder is currently duress-frozen (refusing OPRF evals).
+    pub fn is_duress_frozen(&self) -> bool {
+        self.duress_freeze.read().is_some()
+    }
+
+    /// The active duress freeze, if any (for alerting / persistence).
+    pub fn duress_freeze(&self) -> Option<DuressFreeze> {
+        self.duress_freeze.read().clone()
+    }
+
+    /// Verify a received duress beacon against this holder's pinned beacon
+    /// pubkey(s) and, on a valid + fresh + unseen beacon, FREEZE: refuse OPRF
+    /// evaluations and emit a `DuressFrozen` alert. Reaching this without a pin,
+    /// or with a beacon that fails verification (wrong signer, wrong group,
+    /// stale) or is a replay, is a no-op , receipt alone grants no trust.
+    /// In-memory only (inc2a); sticky persistence + operator clear are
+    /// inc2b/inc2c.
+    fn handle_duress_beacon(&self, event: &Event) -> Result<()> {
+        let pins = match self.duress_beacon_pins.as_deref() {
+            Some(pins) if !pins.is_empty() => pins,
+            _ => return Ok(()),
+        };
+        let verified = pins.iter().find_map(|pin| {
+            crate::event::verify_duress_beacon(
+                event,
+                pin,
+                &self.group_pubkey,
+                self.replay_window_secs,
+            )
+            .ok()
+            .map(|payload| (*pin, payload))
+        });
+        let (beacon_pubkey, payload) = match verified {
+            Some(v) => v,
+            None => return Ok(()),
+        };
+        // Nonce-dedup: verify only bounds the replay window; drop repeats (and
+        // same-beacon re-broadcasts) within it.
+        if !self.seen_duress_nonces.write().insert(payload.nonce) {
+            return Ok(());
+        }
+        // Freeze , idempotent: keep the first freeze so its audit trail is stable.
+        {
+            let mut freeze = self.duress_freeze.write();
+            if freeze.is_none() {
+                *freeze = Some(DuressFreeze {
+                    beacon_pubkey,
+                    nonce: payload.nonce,
+                    created_at: payload.created_at,
+                });
+            }
+        }
+        warn!(
+            beacon = %beacon_pubkey,
+            "DURESS BEACON verified: freezing OPRF evaluations (fail-closed)"
+        );
+        let _ = self
+            .event_tx
+            .send(KfpNodeEvent::DuressFrozen { beacon_pubkey });
+        Ok(())
     }
 
     /// Attach a TPM quote, produced by `attestor`, to every announce this node
@@ -1460,6 +1572,14 @@ impl KfpNode {
         request: OprfEvalRequestPayload,
     ) -> Result<()> {
         self.handle_oprf_eval_request(from, request).await
+    }
+
+    /// Test-only: drive the holder-side duress-beacon handler directly, so tests
+    /// can assert the freeze/no-freeze outcome without a relay round-trip.
+    #[doc(hidden)]
+    #[cfg(any(test, feature = "testing"))]
+    pub fn test_handle_duress_beacon(&self, event: &Event) -> Result<()> {
+        self.handle_duress_beacon(event)
     }
 
     /// Test-only: drive the holder-side OPRF enrollment handler directly. Lets the
@@ -2201,10 +2321,11 @@ impl KfpNode {
             }
             KfpMessage::DuressBeacon(_) => {
                 // Reaches here WITHOUT the trusted-peer gate (the beacon key is not
-                // a peer; see the exemption above). inc1a ignores it. inc2 (sxb)
-                // MUST call `verify_duress_beacon` against this holder's PINNED
-                // beacon pubkey before acting -- reaching this arm grants no trust
-                // on its own -- then fail-closed freeze co-signing.
+                // a peer; see the exemption above). `handle_duress_beacon`
+                // self-gates via `verify_duress_beacon` against this holder's
+                // PINNED beacon pubkey , reaching this arm grants no trust on its
+                // own , then fail-closed freezes OPRF evaluations.
+                self.handle_duress_beacon(event)?;
             }
             KfpMessage::PsbtPropose(payload) => {
                 self.handle_psbt_propose(event.pubkey, payload).await?;
@@ -2670,6 +2791,82 @@ mod tests {
 
         let node = result.unwrap();
         assert_eq!(node.share_index(), 1);
+    }
+
+    async fn duress_test_node() -> KfpNode {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .ok();
+        let mock = MockRelay::run().await.unwrap();
+        let relay_url = mock.url().await.to_string();
+        let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+        let (mut shares, _) = dealer.generate("duress-test").unwrap();
+        KfpNode::new(shares.remove(0), vec![relay_url])
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn duress_beacon_freezes_only_for_pinned_signer_and_dedups() {
+        let mut node = duress_test_node().await;
+        let group = *node.group_pubkey();
+        let beacon = Keys::generate();
+        let wrong = Keys::generate();
+        node.set_duress_beacon_pins(vec![beacon.public_key()]);
+
+        // A beacon from an unpinned key does NOT freeze (receipt grants no trust).
+        let ev_wrong = KfpEventBuilder::duress_beacon(&wrong, &group, &[1u8; 32]).unwrap();
+        node.handle_duress_beacon(&ev_wrong).unwrap();
+        assert!(
+            !node.is_duress_frozen(),
+            "beacon from an unpinned key must not freeze"
+        );
+
+        // A beacon from the pinned key freezes and records its identity + nonce.
+        let ev = KfpEventBuilder::duress_beacon(&beacon, &group, &[1u8; 32]).unwrap();
+        node.handle_duress_beacon(&ev).unwrap();
+        assert!(node.is_duress_frozen(), "pinned beacon must freeze");
+        let f = node.duress_freeze().unwrap();
+        assert_eq!(f.beacon_pubkey, beacon.public_key());
+        assert_eq!(f.nonce, [1u8; 32]);
+
+        // A later valid beacon (fresh nonce) keeps the FIRST freeze (idempotent,
+        // stable audit trail); re-handling the same event is a dedup no-op.
+        let ev2 = KfpEventBuilder::duress_beacon(&beacon, &group, &[2u8; 32]).unwrap();
+        node.handle_duress_beacon(&ev2).unwrap();
+        node.handle_duress_beacon(&ev).unwrap();
+        assert_eq!(
+            node.duress_freeze().unwrap().nonce,
+            [1u8; 32],
+            "freeze must remain the first beacon"
+        );
+    }
+
+    #[tokio::test]
+    async fn duress_beacon_ignored_when_no_pin_configured() {
+        let node = duress_test_node().await;
+        let group = *node.group_pubkey();
+        let beacon = Keys::generate();
+        // No pin set: a well-formed beacon is ignored (not configured).
+        let ev = KfpEventBuilder::duress_beacon(&beacon, &group, &[9u8; 32]).unwrap();
+        node.handle_duress_beacon(&ev).unwrap();
+        assert!(!node.is_duress_frozen());
+    }
+
+    #[tokio::test]
+    async fn duress_beacon_for_other_group_does_not_freeze() {
+        let mut node = duress_test_node().await;
+        let beacon = Keys::generate();
+        node.set_duress_beacon_pins(vec![beacon.public_key()]);
+        // Correct signer, WRONG group , verify_duress_beacon rejects the group,
+        // so no freeze.
+        let other_group = [7u8; 32];
+        let ev = KfpEventBuilder::duress_beacon(&beacon, &other_group, &[3u8; 32]).unwrap();
+        node.handle_duress_beacon(&ev).unwrap();
+        assert!(
+            !node.is_duress_frozen(),
+            "a beacon for a different group must not freeze this holder"
+        );
     }
 
     #[tokio::test]

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1042,15 +1042,13 @@ pub struct KfpNode {
     /// succeeds against one of these. `None`/empty means duress beacons are not
     /// configured and are ignored (reaching the arm grants no trust on its own).
     duress_beacon_pins: Option<Vec<PublicKey>>,
-    /// Set once a valid, fresh, unseen duress beacon is verified: this holder is
-    /// FROZEN and refuses OPRF evaluations (fail-closed). In-memory only in
-    /// inc2a; sticky persistence across reboot + the operator clear are
+    /// Set once a valid, fresh duress beacon is verified: this holder is FROZEN
+    /// and refuses co-signing and OPRF evaluations (fail-closed). The freeze is
+    /// also the dedup , once set, `handle_duress_beacon` short-circuits, so a
+    /// re-broadcast neither re-alerts nor does redundant verify work. In-memory
+    /// only in inc2a; sticky persistence across reboot + the operator clear are
     /// inc2b/inc2c.
     duress_freeze: RwLock<Option<DuressFreeze>>,
-    /// Nonce-dedup for duress beacons: `verify_duress_beacon` only bounds the
-    /// replay WINDOW, so this drops repeats (and same-beacon re-broadcasts)
-    /// within it. Keyed by the beacon nonce.
-    seen_duress_nonces: RwLock<HashSet<[u8; 32]>>,
     /// Producer side: when set, every announce carries a fresh TPM quote bound to
     /// it. `None` means this node attaches no TPM attestation to its announces.
     announce_attestor: Option<Arc<dyn AnnounceAttestor>>,
@@ -1320,7 +1318,6 @@ impl KfpNode {
             tpm_attestation_policy: None,
             duress_beacon_pins: None,
             duress_freeze: RwLock::new(None),
-            seen_duress_nonces: RwLock::new(HashSet::new()),
             announce_attestor: None,
             announce_task: std::sync::Mutex::new(None),
             seen_xpub_announces: RwLock::new(HashSet::new()),
@@ -1432,6 +1429,13 @@ impl KfpNode {
     /// In-memory only (inc2a); sticky persistence + operator clear are
     /// inc2b/inc2c.
     fn handle_duress_beacon(&self, event: &Event) -> Result<()> {
+        // Already frozen: nothing more to do. Short-circuits BEFORE the signature
+        // verify, so a flood of beacon-key events cannot force repeated Schnorr
+        // checks once the holder is frozen, and stops `seen_duress_nonces` from
+        // growing after the freeze.
+        if self.is_duress_frozen() {
+            return Ok(());
+        }
         let pins = match self.duress_beacon_pins.as_deref() {
             Some(pins) if !pins.is_empty() => pins,
             _ => return Ok(()),
@@ -1450,29 +1454,28 @@ impl KfpNode {
             Some(v) => v,
             None => return Ok(()),
         };
-        // Nonce-dedup: verify only bounds the replay window; drop repeats (and
-        // same-beacon re-broadcasts) within it.
-        if !self.seen_duress_nonces.write().insert(payload.nonce) {
-            return Ok(());
-        }
-        // Freeze , idempotent: keep the first freeze so its audit trail is stable.
-        {
-            let mut freeze = self.duress_freeze.write();
-            if freeze.is_none() {
-                *freeze = Some(DuressFreeze {
-                    beacon_pubkey,
-                    nonce: payload.nonce,
-                    created_at: payload.created_at,
-                });
-            }
-        }
+        // Freeze. The frozen short-circuit above makes this the first beacon we
+        // act on (serial event handling, no concurrent writer), so a plain set is
+        // correct; a re-broadcast is dropped by that short-circuit, not here.
+        *self.duress_freeze.write() = Some(DuressFreeze {
+            beacon_pubkey,
+            nonce: payload.nonce,
+            created_at: payload.created_at,
+        });
         warn!(
             beacon = %beacon_pubkey,
-            "DURESS BEACON verified: freezing OPRF evaluations (fail-closed)"
+            "DURESS BEACON verified: freezing co-signing and OPRF evaluations (fail-closed)"
         );
-        let _ = self
+        if self
             .event_tx
-            .send(KfpNodeEvent::DuressFrozen { beacon_pubkey });
+            .send(KfpNodeEvent::DuressFrozen { beacon_pubkey })
+            .is_err()
+        {
+            // The freeze itself already holds (state set above); only the operator
+            // alert was dropped because no subscriber is listening. Surface it so a
+            // missing alert is at least visible in the logs.
+            warn!("DuressFrozen alert dropped: no active event subscriber");
+        }
         Ok(())
     }
 

--- a/keep-frost-net/src/node/oprf.rs
+++ b/keep-frost-net/src/node/oprf.rs
@@ -36,6 +36,17 @@ impl KfpNode {
             return Ok(());
         }
 
+        // Fail closed under duress: a verified duress beacon freezes this holder,
+        // so it answers NO evaluations until an out-of-band operator clear
+        // (inc2c). This is the load-bearing coercion behavior , withholding the
+        // OPRF share drops the box below threshold.
+        if self.is_duress_frozen() {
+            debug!("Refusing OPRF eval request: holder is duress-frozen");
+            return Err(FrostNetError::PolicyViolation(
+                "holder is duress-frozen; OPRF evaluations refused".into(),
+            ));
+        }
+
         if !request
             .participants
             .contains(&self.share.metadata.identifier)

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -859,6 +859,15 @@ impl KfpNode {
         signer: SignerId,
         merged_psbt: Vec<u8>,
     ) -> Result<()> {
+        // Fail closed under duress: a verified duress beacon freezes co-signing,
+        // so a coerced holder does not contribute a PSBT signature toward a spend.
+        if self.is_duress_frozen() {
+            debug!("Refusing PSBT signature contribution: holder is duress-frozen");
+            return Err(FrostNetError::PolicyViolation(
+                "holder is duress-frozen; co-signing refused".into(),
+            ));
+        }
+
         let (share_index, fingerprint) = match &signer {
             SignerId::Share(i) => (Some(*i), None),
             SignerId::Fingerprint(fp) => (None, Some(fp.clone())),

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -396,6 +396,15 @@ impl KfpNode {
             return Ok(());
         }
 
+        // Fail closed under duress: a verified duress beacon freezes co-signing
+        // too, so a coerced holder cannot be forced to co-sign a spend.
+        if self.is_duress_frozen() {
+            debug!("Rejecting sign request: holder is duress-frozen");
+            return Err(FrostNetError::PolicyViolation(
+                "holder is duress-frozen; co-signing refused".into(),
+            ));
+        }
+
         if !request
             .participants
             .contains(&self.share.metadata.identifier)
@@ -1972,6 +1981,28 @@ mod gate_tests {
         let group = *node.group_pubkey();
         let req = SignRequestPayload::new([1u8; 32], group, vec![0u8; 32], "test", vec![2, 3]);
         assert!(node.handle_sign_request(from, req).await.is_ok());
+    }
+
+    /// A duress-frozen holder refuses to co-sign: a fresh sign request for its
+    /// own group is rejected with a `PolicyViolation`. The freeze check sits
+    /// before the participant/replay/policy gates, so it trips first (fail
+    /// closed) , a coerced holder cannot be forced to contribute a signature.
+    #[tokio::test]
+    async fn handle_sign_request_refused_when_duress_frozen() {
+        let (mut node, _relay) = test_node().await;
+        let group = *node.group_pubkey();
+        let beacon = Keys::generate();
+        node.set_duress_beacon_pins(vec![beacon.public_key()]);
+        let ev = crate::event::KfpEventBuilder::duress_beacon(&beacon, &group, &[8u8; 32]).unwrap();
+        node.handle_duress_beacon(&ev).unwrap();
+        assert!(node.is_duress_frozen(), "node must be frozen");
+
+        let from = Keys::generate().public_key();
+        let req = SignRequestPayload::new([1u8; 32], group, vec![0u8; 32], "test", vec![1]);
+        assert!(matches!(
+            node.handle_sign_request(from, req).await,
+            Err(FrostNetError::PolicyViolation(_))
+        ));
     }
 
     /// A stale sign request (created_at outside the replay window) is rejected.

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -2538,6 +2538,55 @@ async fn test_oprf_eval_declined_by_hook_sends_no_share() {
     );
 }
 
+/// Coercion resistance: a duress-frozen holder refuses OPRF evaluations
+/// outright. After a verified duress beacon freezes it, `handle_oprf_eval_request`
+/// fails closed for an otherwise-Verified, in-budget requester, so the box cannot
+/// reach quorum. This is the load-bearing inc2 behavior (holder withholds its
+/// share -> box drops below threshold).
+#[tokio::test]
+async fn test_duress_frozen_holder_refuses_oprf_eval() {
+    let mock_relay = MockRelay::run().await.expect("relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let dealer = TrustedDealer::new(ThresholdConfig::two_of_three());
+    let (mut shares, _pkg) = dealer.generate("test-oprf-duress").unwrap();
+    let _ = shares.remove(0); // id 1 (box is synthetic)
+    let holder_share = shares.remove(0); // id 2 = holder
+
+    let oprf = split_oprf_key_2of3();
+    let mut holder = KfpNode::new(holder_share, vec![relay])
+        .await
+        .expect("holder");
+    holder.set_oprf_key_share(oprf[1]);
+
+    // Pin a beacon key and freeze the holder with a valid beacon for its group.
+    let beacon = nostr_sdk::Keys::generate();
+    holder.set_duress_beacon_pins(vec![beacon.public_key()]);
+    let ev =
+        keep_frost_net::KfpEventBuilder::duress_beacon(&beacon, holder.group_pubkey(), &[5u8; 32])
+            .expect("beacon");
+    holder
+        .test_handle_duress_beacon(&ev)
+        .expect("handle beacon");
+    assert!(holder.is_duress_frozen(), "holder must be frozen");
+
+    // A Verified, in-budget requester whose eval would otherwise be gated only by
+    // the approval hook is now refused BEFORE any of that, purely on the freeze.
+    let (box_pubkey, payload, _blinded) = make_oprf_request(&holder);
+    holder.test_inject_peer(
+        keep_frost_net::Peer::new(box_pubkey, 1)
+            .with_attestation_status(keep_frost_net::AttestationStatus::Verified),
+    );
+    let result = holder
+        .test_handle_oprf_eval_request(box_pubkey, payload)
+        .await;
+    let err = result.expect_err("a duress-frozen holder must refuse evals");
+    assert!(
+        err.to_string().contains("duress"),
+        "refusal must be the duress freeze, got: {err}"
+    );
+}
+
 /// Gate (attestation): a requester whose peer is NOT `Verified` (default
 /// `NotProvided`) is rejected with `UntrustedPeer` before any partial is
 /// produced, and the holder emits no `OprfEvalRequested`.


### PR DESCRIPTION
## Summary

Cluster-side (holder) response to a duress beacon, the counterpart to the holder-side duress mode merged in #722/#723/#724. A holder now verifies received duress beacons against a pinned beacon pubkey and, on a valid one, freezes and refuses OPRF evaluations, so a coerced holder's box drops below threshold.

## Behavior

- New config: `KfpNode::set_duress_beacon_pins` / `with_duress_beacon_pins` pin the group's duress-beacon pubkey(s) (parallel to the TPM attestation policy).
- On a `KfpMessage::DuressBeacon` event (already exempt from the trusted-peer gate, since the beacon key is not a peer), `handle_duress_beacon` self-gates via `verify_duress_beacon` against each pinned pubkey + this node's group + the replay window. Reaching the dispatcher arm grants no trust on its own.
- On a valid, fresh, unseen beacon: record an in-memory freeze (`DuressFreeze` with beacon pubkey, nonce, timestamp) and emit a `KfpNodeEvent::DuressFrozen` alert.
- Nonce-dedup drops repeats and same-beacon re-broadcasts within the replay window (verify only bounds the window).
- While frozen, `handle_oprf_eval_request` fails closed with a policy violation before any share work.
- The freeze is idempotent: a later valid beacon keeps the first freeze for a stable audit trail.

## Scope

In-memory only. Sticky persistence across reboot, wiring keep-web/frost-gate to refuse, pinning the beacon pubkey from serve config, the Argent-style delayed/cancelable operator clear, and the VM nixosTest are follow-on increments. The self-labeling beacon wire form remains the documented release gate to close before any deployed path.

## Tests

- `duress_beacon_freezes_only_for_pinned_signer_and_dedups` (unpinned signer does not freeze; pinned does; dedup/idempotency)
- `duress_beacon_ignored_when_no_pin_configured`
- `duress_beacon_for_other_group_does_not_freeze`
- `test_duress_frozen_holder_refuses_oprf_eval` (a Verified, in-budget requester is refused purely on the freeze)

`cargo build`, `cargo clippy --all-targets`, `cargo fmt`, and the full keep-frost-net suite (407 lib tests) pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added duress-beacon support, allowing configured nodes to enter a frozen state when receiving a valid beacon.
  * Added APIs to configure beacon keys and check or retrieve the active freeze status.
  * Added events reporting successful duress freezes.

* **Bug Fixes**
  * Frozen nodes now reject OPRF evaluation requests, preventing cryptographic operations while under duress.
  * Added validation for beacon ownership, group membership, replay protection, and duplicate freeze attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->