### PR TITLE
Persist duress freeze across reboot; wire beacon pins into serve

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -622,6 +622,21 @@ pub(crate) enum FrostNetworkCommands {
         /// --duress-beacon-pubkey.
         #[arg(long, value_name = "HEX", requires = "duress_beacon_pubkey")]
         duress_beacon_salt: Option<String>,
+        /// Coercion resistance: a group holder's duress-beacon npub to TRUST.
+        /// Repeatable. Receiving a verified beacon signed by any pinned key freezes
+        /// this node: it refuses co-signing and OPRF evaluations (fail-closed) until
+        /// an out-of-band operator clear. These are OTHER holders' beacon pubkeys
+        /// (from their `duress-provision`), distinct from this node's own
+        /// --duress-beacon-pubkey trigger.
+        #[arg(long = "duress-beacon-pin", value_name = "NPUB")]
+        duress_beacon_pins: Vec<String>,
+        /// Coercion resistance: file that makes a duress freeze STICKY across
+        /// reboot. On a freeze the state is written here; at startup an existing
+        /// file re-freezes the node before it serves, so a restart cannot silently
+        /// resume answering. Only an out-of-band operator clear (removing/clearing
+        /// this file) lifts the freeze.
+        #[arg(long, value_name = "FILE")]
+        duress_state_file: Option<PathBuf>,
     },
     Peers {
         #[arg(short, long)]

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -634,7 +634,9 @@ pub(crate) enum FrostNetworkCommands {
         /// reboot. On a freeze the state is written here; at startup an existing
         /// file re-freezes the node before it serves, so a restart cannot silently
         /// resume answering. Only an out-of-band operator clear (removing/clearing
-        /// this file) lifts the freeze.
+        /// this file) lifts the freeze. MUST be passed on every start: omitting it
+        /// on a later start resumes un-frozen. Place it in a root-owned,
+        /// non-writable directory so a non-owner cannot delete the marker.
         #[arg(long, value_name = "FILE")]
         duress_state_file: Option<PathBuf>,
     },

--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -6,8 +6,11 @@
 //! fail closed and emit a signed duress beacon. This module derives the
 //! dedicated beacon keypair from that credential and provisions it.
 
+use std::path::Path;
+
 use keep_core::crypto::{derive_key, Argon2Params, SALT_SIZE};
 use keep_core::error::{KeepError, Result};
+use keep_frost_net::DuressFreeze;
 use nostr_sdk::prelude::*;
 use secrecy::ExposeSecret;
 use subtle::ConstantTimeEq;
@@ -151,6 +154,42 @@ pub(crate) fn build_duress_event(beacon: &Keys, group_pubkey: &[u8; 32]) -> Resu
 /// staying resident, so a black-holed relay cannot hang the duress start.
 const BEACON_PUBLISH_TIMEOUT_SECS: u64 = 10;
 
+/// Parse the trusted duress-beacon pins (other holders' beacon npubs) that, when
+/// one signs a received beacon, freeze THIS node. A malformed npub is fatal , the
+/// operator meant to trust a specific key.
+pub(crate) fn parse_beacon_pins(pins: &[String]) -> Result<Vec<PublicKey>> {
+    pins.iter()
+        .map(|p| {
+            PublicKey::from_bech32(p.trim())
+                .map_err(|e| KeepError::invalid_input(format!("--duress-beacon-pin {p}: {e}")))
+        })
+        .collect()
+}
+
+/// Read a persisted duress freeze at boot. `None` if the file is absent (normal:
+/// not frozen). An existing but unparseable file is FATAL, not silently ignored:
+/// a corrupt freeze marker must fail the node closed rather than let it resume
+/// answering, which is the whole point of the sticky freeze.
+pub(crate) fn read_persisted_freeze(path: &Path) -> Result<Option<DuressFreeze>> {
+    match std::fs::read(path) {
+        Ok(bytes) => {
+            let freeze = serde_json::from_slice(&bytes).map_err(|e| {
+                KeepError::invalid_input(format!(
+                    "duress state file {} is present but unparseable ({e}); \
+                     refusing to start un-frozen",
+                    path.display()
+                ))
+            })?;
+            Ok(Some(freeze))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(KeepError::runtime(format!(
+            "read duress state file {}: {e}",
+            path.display()
+        ))),
+    }
+}
+
 /// The duress serve path: fail CLOSED (never unlock the vault or load the OPRF
 /// share, so this holder answers no evaluations and the box drops below
 /// threshold), best-effort publish ONE signed duress beacon, then stay resident
@@ -254,6 +293,35 @@ mod tests {
         // Two builds use fresh nonces, so their events differ (replay-distinct).
         let again = build_duress_event(&beacon, &group).unwrap();
         assert_ne!(event.id, again.id);
+    }
+
+    #[test]
+    fn parse_beacon_pins_parses_and_rejects() {
+        let k = Keys::generate();
+        let npub = k.public_key().to_bech32().unwrap();
+        assert_eq!(parse_beacon_pins(&[npub]).unwrap(), vec![k.public_key()]);
+        assert!(parse_beacon_pins(&["not-an-npub".to_string()]).is_err());
+    }
+
+    #[test]
+    fn read_persisted_freeze_roundtrips_and_fails_closed_on_corrupt() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("duress.state");
+        // Absent -> None (not frozen).
+        assert!(read_persisted_freeze(&path).unwrap().is_none());
+        // A valid persisted freeze round-trips.
+        let f = DuressFreeze {
+            beacon_pubkey: Keys::generate().public_key(),
+            nonce: [3u8; 32],
+            created_at: 99,
+        };
+        std::fs::write(&path, serde_json::to_vec(&f).unwrap()).unwrap();
+        let got = read_persisted_freeze(&path).unwrap().unwrap();
+        assert_eq!(got.created_at, 99);
+        assert_eq!(got.nonce, [3u8; 32]);
+        // A present-but-corrupt file fails closed (Err), never silently un-frozen.
+        std::fs::write(&path, b"garbage").unwrap();
+        assert!(read_persisted_freeze(&path).is_err());
     }
 
     #[test]

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 
 use nostr_sdk::prelude::*;
 use secrecy::ExposeSecret;
-use tracing::debug;
+use tracing::{debug, error};
 use zeroize::Zeroize;
 
 use keep_core::error::{FrostError, KeepError, NetworkError, Result};
@@ -72,6 +72,8 @@ pub fn cmd_frost_network_serve(
     tpm_tcti: Option<&str>,
     duress_beacon_pubkey: Option<&str>,
     duress_beacon_salt: Option<&str>,
+    duress_beacon_pins: &[String],
+    duress_state_file: Option<&Path>,
 ) -> Result<()> {
     debug!(group = group_npub, relay, share = ?share_index, refuse_raw_sign, require_structured_sign, "starting FROST network node");
 
@@ -107,6 +109,13 @@ pub fn cmd_frost_network_serve(
                 "--duress-beacon-pubkey and --duress-beacon-salt must be set together",
             ));
         }
+    };
+    // Trusted beacon pins + any persisted sticky freeze, resolved up front so a
+    // bad pin or a corrupt state file fails the node before it prompts or serves.
+    let duress_pins = duress::parse_beacon_pins(duress_beacon_pins)?;
+    let persisted_freeze = match duress_state_file {
+        Some(p) => duress::read_persisted_freeze(p)?,
+        None => None,
     };
 
     let mut keep = Keep::open(path)?;
@@ -176,6 +185,8 @@ pub fn cmd_frost_network_serve(
     };
     // Where an enrolled share is sealed, owned so the event loop can move it.
     let oprf_seal_path = oprf_share_file.map(|p| p.to_path_buf());
+    // Owned so the async event loop can move the persister closure that writes it.
+    let duress_state_path = duress_state_file.map(|p| p.to_path_buf());
 
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
@@ -199,6 +210,33 @@ pub fn cmd_frost_network_serve(
             );
         } else {
             out.field("Attestation", "DISABLED (--insecure-no-attestation)");
+        }
+        // Coercion resistance: trust the group's beacon pins so a verified beacon
+        // freezes this node, persist the freeze durably (so a restart stays
+        // frozen), and re-apply any freeze a previous run persisted before serving.
+        if !duress_pins.is_empty() {
+            let count = duress_pins.len();
+            node.set_duress_beacon_pins(duress_pins);
+            out.field("Duress beacons", &format!("{count} pinned"));
+        }
+        if let Some(state_path) = duress_state_path.clone() {
+            node.set_duress_persister(Arc::new(move |freeze| {
+                match serde_json::to_vec(freeze) {
+                    Ok(bytes) => {
+                        if let Err(e) = write_secret_file(&state_path, &bytes) {
+                            error!(error = %e, path = %state_path.display(), "failed to persist duress freeze");
+                        }
+                    }
+                    Err(e) => error!(error = %e, "failed to serialize duress freeze"),
+                }
+            }));
+        }
+        if let Some(freeze) = persisted_freeze {
+            node.restore_duress_freeze(freeze);
+            out.field(
+                "Duress",
+                "FROZEN (persisted; co-signing + OPRF refused until operator clear)",
+            );
         }
         if refuse_raw_sign || require_structured_sign || oprf_auto_approve {
             node.set_hooks(Arc::new(keep_frost_net::ServeHooks {

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -113,8 +113,19 @@ pub fn cmd_frost_network_serve(
     // Trusted beacon pins + any persisted sticky freeze, resolved up front so a
     // bad pin or a corrupt state file fails the node before it prompts or serves.
     let duress_pins = duress::parse_beacon_pins(duress_beacon_pins)?;
+    if !duress_pins.is_empty() && duress_state_file.is_none() {
+        out.warn(
+            "--duress-beacon-pin set without --duress-state-file: a duress freeze will NOT survive \
+             a restart (non-durable). Set --duress-state-file to make it sticky.",
+        );
+    }
+    // Probe the state path up front (fail closed if a freeze could not be
+    // persisted) before reading any freeze it already holds.
     let persisted_freeze = match duress_state_file {
-        Some(p) => duress::read_persisted_freeze(p)?,
+        Some(p) => {
+            probe_duress_state(out, p)?;
+            duress::read_persisted_freeze(p)?
+        }
         None => None,
     };
 
@@ -221,13 +232,11 @@ pub fn cmd_frost_network_serve(
         }
         if let Some(state_path) = duress_state_path.clone() {
             node.set_duress_persister(Arc::new(move |freeze| {
-                match serde_json::to_vec(freeze) {
-                    Ok(bytes) => {
-                        if let Err(e) = write_secret_file(&state_path, &bytes) {
-                            error!(error = %e, path = %state_path.display(), "failed to persist duress freeze");
-                        }
-                    }
-                    Err(e) => error!(error = %e, "failed to serialize duress freeze"),
+                // Synchronous fsync so the freeze is durable BEFORE the alert
+                // broadcasts; the in-memory freeze is already set, so on failure
+                // the box stays frozen this run and only loses durability (logged).
+                if let Err(e) = persist_freeze(&state_path, freeze) {
+                    error!(error = %e, path = %state_path.display(), "failed to persist duress freeze");
                 }
             }));
         }
@@ -1251,6 +1260,59 @@ fn write_secret_file(path: &Path, bytes: &[u8]) -> Result<()> {
     Ok(())
 }
 
+/// Serialize and durably write a duress freeze to `path` (atomic temp + fsync +
+/// rename via [`write_secret_file`]). Split out so the persist round-trip and its
+/// error path are unit-testable.
+fn persist_freeze(path: &Path, freeze: &keep_frost_net::DuressFreeze) -> Result<()> {
+    let bytes = serde_json::to_vec(freeze)
+        .map_err(|e| KeepError::Runtime(format!("serialize duress freeze: {e}")))?;
+    write_secret_file(path, &bytes)
+}
+
+/// Validate a `--duress-state-file` at startup so a misconfigured path fails the
+/// node UP FRONT rather than silently at freeze time (when durability matters
+/// most). Writes, fsyncs, and removes a probe sibling to confirm the path is
+/// writable; a failure is fatal. Also WARNS if the containing directory is group/
+/// world-writable without the sticky bit, since removing a file needs only
+/// directory write, so a non-owner could `unlink` the freeze marker and silently
+/// unfreeze on the next boot. The appliance MUST place this in a root-owned,
+/// non-writable directory.
+fn probe_duress_state(out: &Output, path: &Path) -> Result<()> {
+    let mut probe = path.as_os_str().to_owned();
+    probe.push(".probe");
+    let probe = std::path::PathBuf::from(probe);
+    write_secret_file(&probe, b"probe").map_err(|e| {
+        KeepError::invalid_input(format!(
+            "--duress-state-file {} is not writable ({e}); refusing to start because a duress \
+             freeze could not be made durable",
+            path.display()
+        ))
+    })?;
+    let _ = std::fs::remove_file(&probe);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let dir = match path.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p,
+            _ => Path::new("."),
+        };
+        if let Ok(md) = std::fs::metadata(dir) {
+            let mode = md.mode();
+            // group/world write with no sticky bit lets a non-owner unlink the file.
+            if mode & 0o022 != 0 && mode & 0o1000 == 0 {
+                out.warn(&format!(
+                    "duress state directory {} is group/world-writable without the sticky bit: a \
+                     non-owner could delete the freeze marker and silently unfreeze on reboot. \
+                     Place --duress-state-file in a root-owned, non-writable directory.",
+                    dir.display()
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Reconstruct a LUKS key from a threshold-OPRF quorum and write the 32 raw key
 /// bytes to STDOUT (and nothing else), so a boot gate can pipe it to
 /// `cryptsetup open --key-file -`. All human/progress output goes to STDERR via
@@ -1605,6 +1667,33 @@ mod tests {
         assert!(!auto_approve_conflicts(true, false));
         assert!(!auto_approve_conflicts(false, true));
         assert!(!auto_approve_conflicts(false, false));
+    }
+
+    fn sample_freeze() -> keep_frost_net::DuressFreeze {
+        keep_frost_net::DuressFreeze {
+            beacon_pubkey: nostr_sdk::Keys::generate().public_key(),
+            nonce: [7u8; 32],
+            created_at: 42,
+        }
+    }
+
+    #[test]
+    fn persist_freeze_roundtrips_through_the_state_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("duress.state");
+        let f = sample_freeze();
+        persist_freeze(&path, &f).unwrap();
+        let back = duress::read_persisted_freeze(&path).unwrap().unwrap();
+        assert_eq!(back.created_at, 42);
+        assert_eq!(back.nonce, [7u8; 32]);
+        assert_eq!(back.beacon_pubkey, f.beacon_pubkey);
+    }
+
+    #[test]
+    fn persist_freeze_errors_when_the_directory_is_unwritable() {
+        // A parent directory that does not exist cannot be written atomically.
+        let path = Path::new("/keep-nonexistent-dir-xyz-77/duress.state");
+        assert!(persist_freeze(path, &sample_freeze()).is_err());
     }
 
     #[test]

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -326,6 +326,8 @@ fn dispatch_frost_network(
             tpm_tcti,
             duress_beacon_pubkey,
             duress_beacon_salt,
+            duress_beacon_pins,
+            duress_state_file,
         } => {
             let relay = relay.as_deref().unwrap_or(default_relay);
             commands::frost_network::cmd_frost_network_serve(
@@ -345,6 +347,8 @@ fn dispatch_frost_network(
                 tpm_tcti.as_deref(),
                 duress_beacon_pubkey.as_deref(),
                 duress_beacon_salt.as_deref(),
+                &duress_beacon_pins,
+                duress_state_file.as_deref(),
             )
         }
         FrostNetworkCommands::Peers { group, relay } => {

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -111,10 +111,11 @@ pub use enroll_session::{
 pub use error::{FrostNetError, Result};
 pub use event::{verify_duress_beacon, KfpEventBuilder};
 pub use node::{
-    DescriptorLookupUnavailable, HealthCheckResult, KeepDescriptorLookup, KfpNode, KfpNodeEvent,
-    NoOpHooks, OprfShareSealAck, PeerPolicy, PersistedDescriptorLookup, PsbtSessionSnapshot,
-    RefuseRawAndRequireStructuredHooks, RefuseRawSignatureHooks, RequireStructuredPayloadHooks,
-    ServeHooks, SessionInfo, SigningHooks, SuccessorLookup,
+    DescriptorLookupUnavailable, DuressFreeze, DuressPersister, HealthCheckResult,
+    KeepDescriptorLookup, KfpNode, KfpNodeEvent, NoOpHooks, OprfShareSealAck, PeerPolicy,
+    PersistedDescriptorLookup, PsbtSessionSnapshot, RefuseRawAndRequireStructuredHooks,
+    RefuseRawSignatureHooks, RequireStructuredPayloadHooks, ServeHooks, SessionInfo, SigningHooks,
+    SuccessorLookup,
 };
 pub use nonce_pool::{NonceId, NoncePool, DEFAULT_POOL_TARGET, MAX_POOL_ENTRIES};
 pub use nonce_store::{FileNonceStore, MemoryNonceStore, NonceStore};

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -980,14 +980,22 @@ impl std::fmt::Debug for KfpNodeEvent {
 pub(crate) type SeenDescriptorMigrates = RwLock<HashMap<([u8; 32], [u8; 32]), u64>>;
 
 /// State recorded when a verified duress beacon freezes this holder. Carries the
-/// beacon identity and nonce so a persistence layer (inc2b) can make the freeze
-/// sticky across reboot and an operator clear (inc2c) can audit what it lifted.
-#[derive(Clone, Debug)]
+/// beacon identity and nonce so a persistence layer can make the freeze sticky
+/// across reboot and an operator clear (inc2c) can audit what it lifted. Serde-
+/// serializable so `serve` can persist it to a state file and restore it on boot.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct DuressFreeze {
     pub beacon_pubkey: PublicKey,
     pub nonce: [u8; 32],
     pub created_at: u64,
 }
+
+/// Injected sink that durably records a duress freeze the moment it happens, so a
+/// restart cannot silently resume serving. Called synchronously inside the beacon
+/// handler (right after the freeze is set) rather than off the event bus, so the
+/// persist cannot be lost to broadcast lag. Must be best-effort and non-panicking;
+/// implementations log their own failures.
+pub type DuressPersister = Arc<dyn Fn(&DuressFreeze) + Send + Sync>;
 
 pub struct KfpNode {
     pub(crate) keys: Keys,
@@ -1049,6 +1057,9 @@ pub struct KfpNode {
     /// only in inc2a; sticky persistence across reboot + the operator clear are
     /// inc2b/inc2c.
     duress_freeze: RwLock<Option<DuressFreeze>>,
+    /// Optional durable sink for the freeze (see [`DuressPersister`]). `None`
+    /// means the freeze is in-memory only (lost on restart).
+    duress_persister: Option<DuressPersister>,
     /// Producer side: when set, every announce carries a fresh TPM quote bound to
     /// it. `None` means this node attaches no TPM attestation to its announces.
     announce_attestor: Option<Arc<dyn AnnounceAttestor>>,
@@ -1318,6 +1329,7 @@ impl KfpNode {
             tpm_attestation_policy: None,
             duress_beacon_pins: None,
             duress_freeze: RwLock::new(None),
+            duress_persister: None,
             announce_attestor: None,
             announce_task: std::sync::Mutex::new(None),
             seen_xpub_announces: RwLock::new(HashSet::new()),
@@ -1411,6 +1423,27 @@ impl KfpNode {
         self.duress_beacon_pins = Some(pins);
     }
 
+    /// Install a durable sink that records the freeze the moment a beacon fires,
+    /// making the freeze survive a restart. See [`DuressPersister`].
+    pub fn set_duress_persister(&mut self, persister: DuressPersister) {
+        self.duress_persister = Some(persister);
+    }
+
+    /// Restore a freeze persisted by a previous run (called at boot BEFORE
+    /// serving). Fails closed: the holder starts frozen and refuses co-signing
+    /// and OPRF evals until an out-of-band operator clear. Does NOT re-invoke the
+    /// persister (the state is already durable) and is a no-op if already frozen.
+    pub fn restore_duress_freeze(&self, freeze: DuressFreeze) {
+        let mut guard = self.duress_freeze.write();
+        if guard.is_none() {
+            warn!(
+                beacon = %freeze.beacon_pubkey,
+                "Restored persisted DURESS freeze: refusing co-signing and OPRF evaluations until operator clear"
+            );
+            *guard = Some(freeze);
+        }
+    }
+
     /// Whether this holder is currently duress-frozen (refusing OPRF evals).
     pub fn is_duress_frozen(&self) -> bool {
         self.duress_freeze.read().is_some()
@@ -1457,11 +1490,17 @@ impl KfpNode {
         // Freeze. The frozen short-circuit above makes this the first beacon we
         // act on (serial event handling, no concurrent writer), so a plain set is
         // correct; a re-broadcast is dropped by that short-circuit, not here.
-        *self.duress_freeze.write() = Some(DuressFreeze {
+        let freeze = DuressFreeze {
             beacon_pubkey,
             nonce: payload.nonce,
             created_at: payload.created_at,
-        });
+        };
+        *self.duress_freeze.write() = Some(freeze.clone());
+        // Durably record the freeze (if configured) BEFORE alerting, so a crash
+        // between freeze and alert still leaves the box frozen on the next boot.
+        if let Some(persister) = &self.duress_persister {
+            persister(&freeze);
+        }
         warn!(
             beacon = %beacon_pubkey,
             "DURESS BEACON verified: freezing co-signing and OPRF evaluations (fail-closed)"
@@ -2843,6 +2882,40 @@ mod tests {
             [1u8; 32],
             "freeze must remain the first beacon"
         );
+    }
+
+    #[tokio::test]
+    async fn duress_persister_invoked_on_freeze() {
+        let mut node = duress_test_node().await;
+        let group = *node.group_pubkey();
+        let beacon = Keys::generate();
+        node.set_duress_beacon_pins(vec![beacon.public_key()]);
+        let captured = Arc::new(RwLock::new(None));
+        let sink = captured.clone();
+        node.set_duress_persister(Arc::new(move |f: &DuressFreeze| {
+            *sink.write() = Some(f.clone());
+        }));
+
+        let ev = KfpEventBuilder::duress_beacon(&beacon, &group, &[4u8; 32]).unwrap();
+        node.handle_duress_beacon(&ev).unwrap();
+
+        let got = captured.read().clone().expect("persister must be invoked");
+        assert_eq!(got.beacon_pubkey, beacon.public_key());
+        assert_eq!(got.nonce, [4u8; 32]);
+    }
+
+    #[tokio::test]
+    async fn restore_duress_freeze_starts_frozen() {
+        let node = duress_test_node().await;
+        assert!(!node.is_duress_frozen());
+        let beacon = Keys::generate();
+        node.restore_duress_freeze(DuressFreeze {
+            beacon_pubkey: beacon.public_key(),
+            nonce: [1u8; 32],
+            created_at: 123,
+        });
+        assert!(node.is_duress_frozen(), "restore must fail closed (frozen)");
+        assert_eq!(node.duress_freeze().unwrap().created_at, 123);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Makes a duress freeze sticky across reboot and wires the trusted beacon pins into `keep frost network serve`, closing the "restart silently resumes serving" gap flagged in the #725 review. This is the keep-repo half of inc2b; the appliance path (state-file location + reboot nixosTest) and the operator clear follow.

## Behavior

New serve flags:

- `--duress-beacon-pin <NPUB>` (repeatable): the group's duress-beacon pubkeys this node trusts. A verified beacon signed by any pinned key freezes the node (refuses co-signing and OPRF evaluations, fail-closed). These are OTHER holders' beacon keys, distinct from this node's own `--duress-beacon-pubkey` trigger.
- `--duress-state-file <FILE>`: makes a freeze durable. On a freeze the state is written atomically; at startup an existing file re-freezes the node before it serves. Only an out-of-band operator clear (removing/clearing the file) lifts it.

Mechanism (keep-frost-net):

- `DuressFreeze` is now serde-serializable.
- `KfpNode::set_duress_persister` installs a durable sink (`DuressPersister`) called synchronously inside the beacon handler right after the freeze is set, so the persist cannot be lost to broadcast lag. Persist runs before the alert, so a crash between freeze and alert still leaves the box frozen next boot.
- `KfpNode::restore_duress_freeze` re-applies a persisted freeze at boot (fail-closed, no re-persist, no-op if already frozen).

serve wiring:

- Pins and any persisted freeze are parsed up front, so a bad pin or a corrupt state file fails the node before it prompts or serves.
- A present-but-unparseable state file is fatal (refuse to start un-frozen), never silently ignored.
- The persister writes atomically via the existing `write_secret_file` (temp + fsync + rename + dir fsync), durable across a crash.

## Tests

keep-frost-net: `duress_persister_invoked_on_freeze`, `restore_duress_freeze_starts_frozen`.
keep-cli: `parse_beacon_pins_parses_and_rejects`, `read_persisted_freeze_roundtrips_and_fails_closed_on_corrupt`.

`cargo check --workspace --all-targets`, clippy `--all-targets`, fmt, and the full keep-frost-net (410) + keep-cli (20) suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional duress beacon pinning for FROST network serving.
  * Added persistent duress freeze state that can be restored after restarts.
  * Nodes now save freeze state before broadcasting duress alerts.
  * Added validation for configured state-file paths and malformed beacon keys.

* **Bug Fixes**
  * Prevented startup from proceeding silently when an existing freeze-state file is unreadable or invalid.

* **Tests**
  * Added coverage for beacon parsing, freeze persistence, restoration, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->