### PR TITLE
Add delayed, cancelable operator clear for the duress freeze

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -276,6 +276,17 @@ pub(crate) enum ExportFormat {
     Bech32,
 }
 
+/// The step of a delayed, cancelable duress-freeze clear (see `DuressClear`).
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum DuressClearAction {
+    /// Start the delay window; the box stays frozen.
+    Initiate,
+    /// Abort a pending clear during the window.
+    Cancel,
+    /// Lift the freeze once the delay has elapsed.
+    Execute,
+}
+
 #[derive(Subcommand)]
 pub(crate) enum WalletCommands {
     /// List stored wallet descriptors
@@ -650,6 +661,22 @@ pub(crate) enum FrostNetworkCommands {
     /// (to pin with the cluster) and salt (to configure on `serve`). The
     /// credential is never stored. Coercion resistance (inc1b).
     DuressProvision,
+    /// Clear a sticky duress freeze via a delayed, cancelable operator action
+    /// (Argent-style): `initiate` starts a delay window (box stays frozen),
+    /// `cancel` aborts it, `execute` lifts the freeze once the delay elapses.
+    /// A running `serve` stays frozen until restarted.
+    DuressClear {
+        /// The `--duress-state-file` the node was served with.
+        #[arg(long, value_name = "FILE")]
+        state_file: PathBuf,
+        /// Which step of the delayed clear to perform.
+        #[arg(value_enum)]
+        action: DuressClearAction,
+        /// For `initiate`: seconds to wait before the clear may be executed.
+        #[arg(long, value_name = "SECS",
+            default_value_t = crate::commands::frost_network::DEFAULT_DURESS_CLEAR_DELAY_SECS)]
+        delay_secs: u64,
+    },
     /// Author an attestation-config from observed announces (trust-on-first-use).
     AttestationProvision {
         #[arg(short, long, help = "FROST group npub")]

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -664,7 +664,10 @@ pub(crate) enum FrostNetworkCommands {
     /// Clear a sticky duress freeze via a delayed, cancelable operator action
     /// (Argent-style): `initiate` starts a delay window (box stays frozen),
     /// `cancel` aborts it, `execute` lifts the freeze once the delay elapses.
-    /// A running `serve` stays frozen until restarted.
+    /// A running `serve` stays frozen until restarted. The delay defends only the
+    /// CLI-confined coercion case; the real boundary is filesystem permissions,
+    /// the state directory MUST be root-owned and not operator-writable, since a
+    /// party with directory write can delete the freeze file directly.
     DuressClear {
         /// The `--duress-state-file` the node was served with.
         #[arg(long, value_name = "FILE")]

--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -6,7 +6,8 @@
 //! fail closed and emit a signed duress beacon. This module derives the
 //! dedicated beacon keypair from that credential and provisions it.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use keep_core::crypto::{derive_key, Argon2Params, SALT_SIZE};
 use keep_core::error::{KeepError, Result};
@@ -154,6 +155,143 @@ pub(crate) fn build_duress_event(beacon: &Keys, group_pubkey: &[u8; 32]) -> Resu
 /// staying resident, so a black-holed relay cannot hang the duress start.
 const BEACON_PUBLISH_TIMEOUT_SECS: u64 = 10;
 
+/// Default delay before a `duress-clear --initiate` may be executed: a generous
+/// window for out-of-band intervention (`--cancel`) if the clear was coerced.
+pub const DEFAULT_DURESS_CLEAR_DELAY_SECS: u64 = 24 * 60 * 60;
+
+/// A pending, delayed operator clear (Argent guardian-recovery pattern): the box
+/// stays frozen until `--execute` runs after `requested_at + delay_secs`, and any
+/// operator can `--cancel` during the window.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct ClearPending {
+    requested_at: u64,
+    delay_secs: u64,
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// The pending-clear marker lives beside the freeze state file.
+fn clear_marker_path(state_file: &Path) -> PathBuf {
+    let mut p = state_file.as_os_str().to_owned();
+    p.push(".clear-pending");
+    PathBuf::from(p)
+}
+
+/// `keep frost network duress-clear`: lift a sticky duress freeze via a distinct,
+/// delayed, cancelable operator action rather than a bare file delete, so a
+/// coerced clear can be intervened on before it takes effect. Actions:
+/// `initiate` (start the delay; box stays frozen), `cancel` (abort the window),
+/// `execute` (lift the freeze once the delay elapses). `serve` is unchanged; the
+/// marker is consulted only here.
+pub fn cmd_frost_network_duress_clear(
+    out: &Output,
+    state_file: &Path,
+    action: crate::cli::DuressClearAction,
+    delay_secs: u64,
+) -> Result<()> {
+    use crate::cli::DuressClearAction::*;
+    match action {
+        Initiate => {
+            clear_initiate(state_file, delay_secs)?;
+            out.warn(&format!(
+                "Duress clear INITIATED. The box stays FROZEN for {delay_secs}s, then run \
+                 `duress-clear ... execute`. Cancel any time with `duress-clear ... cancel`."
+            ));
+        }
+        Cancel => {
+            if clear_cancel(state_file)? {
+                out.info("Pending duress clear cancelled; the box remains frozen.");
+            } else {
+                out.info("No pending duress clear to cancel.");
+            }
+        }
+        Execute => {
+            clear_execute(state_file, now_secs())?;
+            out.info(
+                "Duress freeze CLEARED. Restart `serve` (or reboot) to resume normal operation.",
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Arm a delayed clear. Requires an active freeze (refuse to arm against nothing)
+/// and records the request time + delay in the marker beside the state file.
+fn clear_initiate(state_file: &Path, delay_secs: u64) -> Result<()> {
+    if read_persisted_freeze(state_file)?.is_none() {
+        return Err(KeepError::invalid_input(format!(
+            "no duress freeze at {}: nothing to clear",
+            state_file.display()
+        )));
+    }
+    let pending = ClearPending {
+        requested_at: now_secs(),
+        delay_secs,
+    };
+    let bytes = serde_json::to_vec(&pending)
+        .map_err(|e| KeepError::runtime(format!("serialize clear marker: {e}")))?;
+    let marker = clear_marker_path(state_file);
+    std::fs::write(&marker, &bytes)
+        .map_err(|e| KeepError::runtime(format!("write {}: {e}", marker.display())))
+}
+
+/// Abort a pending clear. Returns whether a marker was actually present.
+fn clear_cancel(state_file: &Path) -> Result<bool> {
+    match std::fs::remove_file(clear_marker_path(state_file)) {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(KeepError::runtime(format!("remove clear marker: {e}"))),
+    }
+}
+
+/// Execute a pending clear if its delay has elapsed by `now`. Removes the freeze
+/// state file (absent = not frozen) and the marker. A running `serve` stays frozen
+/// until restarted. Errors if no clear is pending or the delay has not elapsed.
+fn clear_execute(state_file: &Path, now: u64) -> Result<()> {
+    let marker = clear_marker_path(state_file);
+    let pending: ClearPending = match std::fs::read(&marker) {
+        Ok(bytes) => serde_json::from_slice(&bytes).map_err(|e| {
+            KeepError::invalid_input(format!(
+                "clear marker {} unparseable: {e}",
+                marker.display()
+            ))
+        })?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(KeepError::invalid_input(
+                "no pending duress clear; run `duress-clear ... initiate` first",
+            ));
+        }
+        Err(e) => {
+            return Err(KeepError::runtime(format!(
+                "read {}: {e}",
+                marker.display()
+            )))
+        }
+    };
+    let ready_at = pending.requested_at.saturating_add(pending.delay_secs);
+    if now < ready_at {
+        return Err(KeepError::invalid_input(format!(
+            "clear delay not elapsed; {}s remaining. Cancel with `duress-clear ... cancel`.",
+            ready_at - now
+        )));
+    }
+    if let Err(e) = std::fs::remove_file(state_file) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            return Err(KeepError::runtime(format!(
+                "remove {}: {e}",
+                state_file.display()
+            )));
+        }
+    }
+    let _ = std::fs::remove_file(&marker);
+    Ok(())
+}
+
 /// Parse the trusted duress-beacon pins (other holders' beacon npubs) that, when
 /// one signs a received beacon, freeze THIS node. A malformed npub is fatal , the
 /// operator meant to trust a specific key.
@@ -293,6 +431,58 @@ mod tests {
         // Two builds use fresh nonces, so their events differ (replay-distinct).
         let again = build_duress_event(&beacon, &group).unwrap();
         assert_ne!(event.id, again.id);
+    }
+
+    fn write_freeze(path: &Path) {
+        let f = DuressFreeze {
+            beacon_pubkey: Keys::generate().public_key(),
+            nonce: [1u8; 32],
+            created_at: 10,
+        };
+        std::fs::write(path, serde_json::to_vec(&f).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn clear_initiate_requires_an_active_freeze() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("d.state");
+        // No freeze -> initiate refuses.
+        assert!(clear_initiate(&path, 100).is_err());
+        write_freeze(&path);
+        clear_initiate(&path, 100).unwrap();
+        assert!(clear_marker_path(&path).exists(), "marker must be written");
+    }
+
+    #[test]
+    fn clear_execute_gated_by_delay_then_lifts_freeze() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("d.state");
+        write_freeze(&path);
+        // Execute with no pending clear -> error.
+        assert!(clear_execute(&path, 1_000).is_err());
+        // Initiate with a 100s delay at t=1000 (marker records now_secs()).
+        clear_initiate(&path, 100).unwrap();
+        let started = now_secs();
+        // Before the delay elapses -> refused, freeze intact.
+        assert!(clear_execute(&path, started + 50).is_err());
+        assert!(path.exists(), "freeze file must remain while gated");
+        // After the delay -> clears the freeze file and the marker.
+        clear_execute(&path, started + 100).unwrap();
+        assert!(!path.exists(), "freeze file must be removed");
+        assert!(!clear_marker_path(&path).exists(), "marker must be removed");
+    }
+
+    #[test]
+    fn clear_cancel_aborts_a_pending_clear() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("d.state");
+        write_freeze(&path);
+        assert!(!clear_cancel(&path).unwrap(), "no marker yet");
+        clear_initiate(&path, 100).unwrap();
+        assert!(clear_cancel(&path).unwrap(), "marker existed");
+        // After cancel, execute is refused (no pending clear) and freeze intact.
+        assert!(clear_execute(&path, now_secs() + 10_000).is_err());
+        assert!(path.exists(), "freeze must survive a cancelled clear");
     }
 
     #[test]

--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -159,20 +159,35 @@ const BEACON_PUBLISH_TIMEOUT_SECS: u64 = 10;
 /// window for out-of-band intervention (`--cancel`) if the clear was coerced.
 pub const DEFAULT_DURESS_CLEAR_DELAY_SECS: u64 = 24 * 60 * 60;
 
+/// Non-overridable floor on the clear delay. The cancelable window is the whole
+/// point of the delayed clear, so `--delay-secs` cannot dial it below this and
+/// nullify the ability to intervene.
+pub const MIN_DURESS_CLEAR_DELAY_SECS: u64 = 60 * 60;
+
 /// A pending, delayed operator clear (Argent guardian-recovery pattern): the box
 /// stays frozen until `--execute` runs after `requested_at + delay_secs`, and any
-/// operator can `--cancel` during the window.
+/// operator can `--cancel` during the window. `freeze_nonce` binds the clear to
+/// the SPECIFIC freeze it was armed against, so a clear armed during one freeze
+/// cannot lift a later, different freeze the operator never reviewed.
 #[derive(serde::Serialize, serde::Deserialize)]
 struct ClearPending {
     requested_at: u64,
     delay_secs: u64,
+    freeze_nonce: [u8; 32],
 }
 
-fn now_secs() -> u64 {
+/// Wall-clock unix seconds. Fails CLOSED (an `Err`, not a silent 0) so arming a
+/// clear against a broken clock cannot later pass the delay gate the moment the
+/// clock is fixed. NOTE: `execute` trusts this local wall clock; a forward clock
+/// jump (manual or loose NTP) collapses the delay. That is acceptable only under
+/// the documented boundary , the state directory is root-owned and not
+/// operator-writable, so the same party that could step the clock could also just
+/// delete the freeze file directly.
+fn now_secs() -> Result<u64> {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
-        .unwrap_or(0)
+        .map_err(|e| KeepError::runtime(format!("system clock is before the UNIX epoch: {e}")))
 }
 
 /// The pending-clear marker lives beside the freeze state file.
@@ -182,12 +197,18 @@ fn clear_marker_path(state_file: &Path) -> PathBuf {
     PathBuf::from(p)
 }
 
-/// `keep frost network duress-clear`: lift a sticky duress freeze via a distinct,
-/// delayed, cancelable operator action rather than a bare file delete, so a
-/// coerced clear can be intervened on before it takes effect. Actions:
-/// `initiate` (start the delay; box stays frozen), `cancel` (abort the window),
-/// `execute` (lift the freeze once the delay elapses). `serve` is unchanged; the
-/// marker is consulted only here.
+/// `keep frost network duress-clear`: lift a sticky duress freeze via a delayed,
+/// cancelable operator action. Actions: `initiate` (start the delay; box stays
+/// frozen), `cancel` (abort the window), `execute` (lift the freeze once the delay
+/// elapses). `serve` is unchanged; the marker is consulted only here.
+///
+/// SCOPE / boundary: the delay defends only the CLI-confined coercion case , an
+/// operator who is socially/remotely coerced but confined to running the
+/// sanctioned CLI. It is NOT a control against a party with write access to the
+/// state directory: such a party can forge the marker OR simply delete the freeze
+/// file directly (the same capability), bypassing the delay entirely. The real
+/// security boundary is filesystem permissions: the state directory MUST be
+/// root-owned and not operator-writable (see the `--duress-state-file` warning).
 pub fn cmd_frost_network_duress_clear(
     out: &Output,
     state_file: &Path,
@@ -195,9 +216,10 @@ pub fn cmd_frost_network_duress_clear(
     delay_secs: u64,
 ) -> Result<()> {
     use crate::cli::DuressClearAction::*;
+    let now = now_secs()?;
     match action {
         Initiate => {
-            clear_initiate(state_file, delay_secs)?;
+            clear_initiate(state_file, delay_secs, now)?;
             out.warn(&format!(
                 "Duress clear INITIATED. The box stays FROZEN for {delay_secs}s, then run \
                  `duress-clear ... execute`. Cancel any time with `duress-clear ... cancel`."
@@ -211,7 +233,7 @@ pub fn cmd_frost_network_duress_clear(
             }
         }
         Execute => {
-            clear_execute(state_file, now_secs())?;
+            clear_execute(state_file, now)?;
             out.info(
                 "Duress freeze CLEARED. Restart `serve` (or reboot) to resume normal operation.",
             );
@@ -220,21 +242,32 @@ pub fn cmd_frost_network_duress_clear(
     Ok(())
 }
 
-/// Arm a delayed clear. Requires an active freeze (refuse to arm against nothing)
-/// and records the request time + delay in the marker beside the state file.
-fn clear_initiate(state_file: &Path, delay_secs: u64) -> Result<()> {
-    if read_persisted_freeze(state_file)?.is_none() {
+/// Arm a delayed clear. Enforces the non-overridable delay floor, requires an
+/// active freeze (refuse to arm against nothing), and binds the marker to that
+/// freeze's `nonce` so it can only ever clear THIS freeze, not a later one.
+fn clear_initiate(state_file: &Path, delay_secs: u64, now: u64) -> Result<()> {
+    if delay_secs < MIN_DURESS_CLEAR_DELAY_SECS {
         return Err(KeepError::invalid_input(format!(
-            "no duress freeze at {}: nothing to clear",
-            state_file.display()
+            "--delay-secs must be at least {MIN_DURESS_CLEAR_DELAY_SECS}s: the cancelable window is \
+             the point of the delayed clear and cannot be dialed to zero"
         )));
     }
+    let freeze = read_persisted_freeze(state_file)?.ok_or_else(|| {
+        KeepError::invalid_input(format!(
+            "no duress freeze at {}: nothing to clear",
+            state_file.display()
+        ))
+    })?;
     let pending = ClearPending {
-        requested_at: now_secs(),
+        requested_at: now,
         delay_secs,
+        freeze_nonce: freeze.nonce,
     };
     let bytes = serde_json::to_vec(&pending)
         .map_err(|e| KeepError::runtime(format!("serialize clear marker: {e}")))?;
+    // Non-atomic + default perms is acceptable: the marker carries no secret, a
+    // torn write fails `execute` closed (unparseable -> error, box stays frozen),
+    // and the state dir's permissions are the real boundary.
     let marker = clear_marker_path(state_file);
     std::fs::write(&marker, &bytes)
         .map_err(|e| KeepError::runtime(format!("write {}: {e}", marker.display())))
@@ -249,9 +282,11 @@ fn clear_cancel(state_file: &Path) -> Result<bool> {
     }
 }
 
-/// Execute a pending clear if its delay has elapsed by `now`. Removes the freeze
+/// Execute a pending clear if its delay has elapsed by `now` AND the currently
+/// active freeze is the same one the clear was armed against. Removes the freeze
 /// state file (absent = not frozen) and the marker. A running `serve` stays frozen
-/// until restarted. Errors if no clear is pending or the delay has not elapsed.
+/// until restarted. Errors if no clear is pending, the freeze changed, or the
+/// delay has not elapsed.
 fn clear_execute(state_file: &Path, now: u64) -> Result<()> {
     let marker = clear_marker_path(state_file);
     let pending: ClearPending = match std::fs::read(&marker) {
@@ -273,6 +308,26 @@ fn clear_execute(state_file: &Path, now: u64) -> Result<()> {
             )))
         }
     };
+    // Bind to the freeze: only clear the exact freeze this was armed against. A
+    // NEW duress event during the window overwrites the state file with a fresh
+    // nonce, so a stale pending clear (or a leftover marker) can never lift it ,
+    // that freeze needs its own initiate + cancel window.
+    match read_persisted_freeze(state_file)? {
+        Some(freeze) if freeze.nonce == pending.freeze_nonce => {}
+        Some(_) => {
+            return Err(KeepError::invalid_input(
+                "the active duress freeze changed since this clear was initiated; \
+                 re-initiate to review and clear the current freeze",
+            ));
+        }
+        None => {
+            // Already un-frozen; drop the now-meaningless marker.
+            let _ = std::fs::remove_file(&marker);
+            return Err(KeepError::invalid_input(
+                "no active duress freeze; nothing to clear",
+            ));
+        }
+    }
     let ready_at = pending.requested_at.saturating_add(pending.delay_secs);
     if now < ready_at {
         return Err(KeepError::invalid_input(format!(
@@ -288,6 +343,8 @@ fn clear_execute(state_file: &Path, now: u64) -> Result<()> {
             )));
         }
     }
+    // A leftover marker is harmless now: it is bound to this freeze's nonce, which
+    // no longer exists, so it can never match a future freeze.
     let _ = std::fs::remove_file(&marker);
     Ok(())
 }
@@ -433,24 +490,41 @@ mod tests {
         assert_ne!(event.id, again.id);
     }
 
-    fn write_freeze(path: &Path) {
+    fn write_freeze_nonce(path: &Path, nonce: [u8; 32]) {
         let f = DuressFreeze {
             beacon_pubkey: Keys::generate().public_key(),
-            nonce: [1u8; 32],
+            nonce,
             created_at: 10,
         };
         std::fs::write(path, serde_json::to_vec(&f).unwrap()).unwrap();
     }
+    fn write_freeze(path: &Path) {
+        write_freeze_nonce(path, [1u8; 32]);
+    }
+
+    // A delay comfortably above the floor, used as a fixed value in tests.
+    const TEST_DELAY: u64 = 2 * MIN_DURESS_CLEAR_DELAY_SECS;
 
     #[test]
     fn clear_initiate_requires_an_active_freeze() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("d.state");
         // No freeze -> initiate refuses.
-        assert!(clear_initiate(&path, 100).is_err());
+        assert!(clear_initiate(&path, TEST_DELAY, 1000).is_err());
         write_freeze(&path);
-        clear_initiate(&path, 100).unwrap();
+        clear_initiate(&path, TEST_DELAY, 1000).unwrap();
         assert!(clear_marker_path(&path).exists(), "marker must be written");
+    }
+
+    #[test]
+    fn clear_initiate_rejects_delay_below_the_floor() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("d.state");
+        write_freeze(&path);
+        // 0 (or anything below the floor) is refused: the window cannot be nulled.
+        assert!(clear_initiate(&path, 0, 1000).is_err());
+        assert!(clear_initiate(&path, MIN_DURESS_CLEAR_DELAY_SECS - 1, 1000).is_err());
+        clear_initiate(&path, MIN_DURESS_CLEAR_DELAY_SECS, 1000).unwrap();
     }
 
     #[test]
@@ -459,17 +533,34 @@ mod tests {
         let path = dir.path().join("d.state");
         write_freeze(&path);
         // Execute with no pending clear -> error.
-        assert!(clear_execute(&path, 1_000).is_err());
-        // Initiate with a 100s delay at t=1000 (marker records now_secs()).
-        clear_initiate(&path, 100).unwrap();
-        let started = now_secs();
+        assert!(clear_execute(&path, 1000).is_err());
+        // Initiate at t=1000; ready at 1000 + TEST_DELAY.
+        clear_initiate(&path, TEST_DELAY, 1000).unwrap();
+        let ready = 1000 + TEST_DELAY;
         // Before the delay elapses -> refused, freeze intact.
-        assert!(clear_execute(&path, started + 50).is_err());
+        assert!(clear_execute(&path, ready - 1).is_err());
         assert!(path.exists(), "freeze file must remain while gated");
-        // After the delay -> clears the freeze file and the marker.
-        clear_execute(&path, started + 100).unwrap();
+        // At/after the delay -> clears the freeze file and the marker.
+        clear_execute(&path, ready).unwrap();
         assert!(!path.exists(), "freeze file must be removed");
         assert!(!clear_marker_path(&path).exists(), "marker must be removed");
+    }
+
+    #[test]
+    fn clear_execute_refuses_when_the_freeze_changed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("d.state");
+        write_freeze_nonce(&path, [1u8; 32]);
+        clear_initiate(&path, TEST_DELAY, 1000).unwrap();
+        // A NEW duress event overwrites the freeze during the window.
+        write_freeze_nonce(&path, [2u8; 32]);
+        // Even well past the delay, execute refuses: the clear was armed against a
+        // different freeze, so the fresh one is NOT lifted.
+        assert!(clear_execute(&path, 1000 + TEST_DELAY + 10_000).is_err());
+        assert!(
+            path.exists(),
+            "a stale clear must not lift a newer, different freeze"
+        );
     }
 
     #[test]
@@ -478,10 +569,10 @@ mod tests {
         let path = dir.path().join("d.state");
         write_freeze(&path);
         assert!(!clear_cancel(&path).unwrap(), "no marker yet");
-        clear_initiate(&path, 100).unwrap();
+        clear_initiate(&path, TEST_DELAY, 1000).unwrap();
         assert!(clear_cancel(&path).unwrap(), "marker existed");
         // After cancel, execute is refused (no pending clear) and freeze intact.
-        assert!(clear_execute(&path, now_secs() + 10_000).is_err());
+        assert!(clear_execute(&path, 10_000_000).is_err());
         assert!(path.exists(), "freeze must survive a cancelled clear");
     }
 

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -25,7 +25,10 @@ mod hardware;
 
 pub use attestation::cmd_frost_network_attestation_provision;
 pub use dkg::{cmd_frost_network_dkg, cmd_frost_network_group_create};
-pub use duress::cmd_frost_network_duress_provision;
+pub use duress::{
+    cmd_frost_network_duress_clear, cmd_frost_network_duress_provision,
+    DEFAULT_DURESS_CLEAR_DELAY_SECS,
+};
 pub use hardware::{cmd_frost_network_nonce_precommit, cmd_frost_network_sign_hardware};
 
 /// Fixed OPRF unlock input (the design's fixed label). Both provisioning and

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -358,6 +358,16 @@ fn dispatch_frost_network(
         FrostNetworkCommands::DuressProvision => {
             commands::frost_network::cmd_frost_network_duress_provision(out)
         }
+        FrostNetworkCommands::DuressClear {
+            state_file,
+            action,
+            delay_secs,
+        } => commands::frost_network::cmd_frost_network_duress_clear(
+            out,
+            &state_file,
+            action,
+            delay_secs,
+        ),
         FrostNetworkCommands::AttestationProvision {
             group,
             relay,


### PR DESCRIPTION
## Summary

Adds a delayed, cancelable operator clear for a sticky duress freeze (Argent guardian-recovery pattern). Lifting a freeze becomes a distinct, gated CLI action with a mandatory delay window during which any operator can cancel.

## Behavior

`keep frost network duress-clear --state-file <FILE> <action>`:

- `initiate [--delay-secs N]` (default 24h, hard floor 1h): requires an active freeze; writes a `<state-file>.clear-pending` marker recording the request time, delay, and the freeze's nonce. The box stays FROZEN.
- `cancel`: removes the marker, aborting an in-progress clear (the intervention window).
- `execute`: lifts the freeze (removes the state file + marker) only if the delay has elapsed AND the currently active freeze is the same one the clear was armed against.

`serve` is unchanged; the marker is consulted only by `duress-clear`. A running `serve` stays frozen until restarted, which is fail-closed.

## Security scope (important)

The delay defends only the **CLI-confined coercion case**: an operator who is socially/remotely coerced but confined to running the sanctioned CLI, giving an out-of-band party a window to `cancel`. It is **not** a control against a party with write access to the state directory: such a party can forge the marker or simply delete the freeze file directly (same capability), bypassing the delay. The real security boundary is **filesystem permissions**, the state directory must be root-owned and not operator-writable (as `serve`'s `--duress-state-file` warns). This scope is documented on the command and its help text.

Hardening from review:
- **Non-overridable delay floor** (1h): `--delay-secs 0` can no longer nullify the cancel window.
- **Freeze binding**: the marker records the freeze nonce; a new duress event during the window cannot be lifted by a stale clear armed against the old freeze.
- **Fail-closed clock**: a broken clock at `initiate` errors rather than arming a window that a later valid clock would pass instantly. (`execute` still trusts the local wall clock; a forward clock jump collapses the delay, acceptable only under the root-owned-dir boundary above.)

## Tests

- `clear_initiate_requires_an_active_freeze`
- `clear_initiate_rejects_delay_below_the_floor`
- `clear_execute_gated_by_delay_then_lifts_freeze`
- `clear_execute_refuses_when_the_freeze_changed`
- `clear_cancel_aborts_a_pending_clear`

Pure `clear_initiate`/`clear_cancel`/`clear_execute` with time injected. `cargo check --workspace`, clippy `--all-targets`, fmt, and the keep-cli suite pass.

## Follow-on

A comprehensive nixosTest (freeze -> reboot-frozen -> clear -> resume), the `docs/SECURITY.md` update, and the beacon wire-format release gate remain before any deployed duress claim.
