### PR TITLE
Release 0.6.0: coercion beacon delivery fixes + version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "keep-agent"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "keep-bitcoin"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitcoin",
  "getrandom 0.4.3",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "keep-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "keep-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aes 0.9.1",
  "argon2",
@@ -4636,7 +4636,7 @@ dependencies = [
 
 [[package]]
 name = "keep-desktop"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4669,14 +4669,14 @@ dependencies = [
 
 [[package]]
 name = "keep-enclave"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "keep-enclave-host",
 ]
 
 [[package]]
 name = "keep-enclave-host"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -4707,7 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "keep-frost-net"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "keep-mobile"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4778,7 +4778,7 @@ dependencies = [
 
 [[package]]
 name = "keep-nip46"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitflags 2.13.0",
  "chrono",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "keep-web"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "axum",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"

--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -453,8 +453,15 @@ pub(crate) async fn run_duress_serve(
                         client.send_event(&event),
                     )
                     .await;
-                    if let Ok(Err(e)) = send {
-                        debug!(error = %e, "beacon publish failed; staying resident");
+                    match send {
+                        Ok(Ok(output)) => debug!(
+                            id = %output.id(),
+                            success = output.success.len(),
+                            failed = output.failed.len(),
+                            "beacon publish sent"
+                        ),
+                        Ok(Err(e)) => debug!(error = %e, "beacon publish failed; staying resident"),
+                        Err(_) => debug!("beacon publish timed out; staying resident"),
                     }
                 }
                 Err(e) => debug!(error = %e, "beacon build failed; staying resident"),

--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -457,6 +457,12 @@ pub(crate) async fn run_duress_serve(
             // the first one they verify and short-circuit the rest, so the repeat
             // is idempotent for them. This loop also keeps the process resident so
             // the holder looks online but answers no evaluations (fail-closed).
+            //
+            // The first send may still race the relay's NIP-42 auth (the wait above
+            // is for `Connected`, not `Authenticated`); the interval retry covers a
+            // rejected first publish. RELEASE GATE: the fixed re-broadcast cadence
+            // is itself a relay-observable duress signature (distinct from the wire
+            // FORMAT gate); traffic-shape indistinguishability is part of that gate.
             loop {
                 match build_duress_event(beacon, group_pubkey) {
                     Ok(event) => {

--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -155,6 +155,11 @@ pub(crate) fn build_duress_event(beacon: &Keys, group_pubkey: &[u8; 32]) -> Resu
 /// staying resident, so a black-holed relay cannot hang the duress start.
 const BEACON_PUBLISH_TIMEOUT_SECS: u64 = 10;
 
+/// Interval between duress-beacon re-broadcasts. The beacon is re-published (with
+/// a fresh nonce) on this cadence so a holder that was offline, reconnecting, or
+/// slow to subscribe when the first one fired still receives one and freezes.
+const BEACON_REPUBLISH_INTERVAL_SECS: u64 = 30;
+
 /// Default delay before a `duress-clear --initiate` may be executed: a generous
 /// window for out-of-band intervention (`--cancel`) if the clear was coerced.
 pub const DEFAULT_DURESS_CLEAR_DELAY_SECS: u64 = 24 * 60 * 60;
@@ -421,11 +426,8 @@ pub(crate) async fn run_duress_serve(
     // screen and never mentioning duress) so the observable path is identical to
     // a normal start whose relay happens to be unreachable.
     let client = Client::new(beacon.clone());
-    let added = client.add_relay(relay).await;
-    tracing::warn!(ok = added.is_ok(), err = ?added.as_ref().err().map(|e| e.to_string()), "DIAG add_relay");
-    if added.is_ok() {
+    if client.add_relay(relay).await.is_ok() {
         client.connect().await;
-        tracing::warn!("DIAG connect returned");
         // connect() returns immediately, so wait for the relay to actually connect
         // before publishing; otherwise send_event races the WebSocket + NIP-42
         // handshake and the best-effort publish silently drops (mirrors
@@ -446,36 +448,46 @@ pub(crate) async fn run_duress_serve(
             },
         )
         .await;
-        tracing::warn!(connected = connected.is_ok(), "DIAG connection wait done");
         if connected.is_err() {
             debug!("relay not connected; beacon not published, staying resident");
         } else {
-            match build_duress_event(beacon, group_pubkey) {
-                Ok(event) => {
-                    let send = tokio::time::timeout(
-                        std::time::Duration::from_secs(BEACON_PUBLISH_TIMEOUT_SECS),
-                        client.send_event(&event),
-                    )
-                    .await;
-                    match send {
-                        Ok(Ok(output)) => tracing::warn!(
-                            id = %output.id(),
-                            success = output.success.len(),
-                            failed = output.failed.len(),
-                            failed_detail = ?output.failed,
-                            "DIAG beacon publish sent"
-                        ),
-                        Ok(Err(e)) => tracing::warn!(error = %e, "DIAG beacon publish failed"),
-                        Err(_) => tracing::warn!("DIAG beacon publish timed out"),
+            // Re-broadcast the beacon on an interval (fresh nonce each time), not
+            // once: a one-shot alert would miss any holder that is briefly offline,
+            // reconnecting, or slow to subscribe when it fires. Holders freeze on
+            // the first one they verify and short-circuit the rest, so the repeat
+            // is idempotent for them. This loop also keeps the process resident so
+            // the holder looks online but answers no evaluations (fail-closed).
+            loop {
+                match build_duress_event(beacon, group_pubkey) {
+                    Ok(event) => {
+                        let send = tokio::time::timeout(
+                            std::time::Duration::from_secs(BEACON_PUBLISH_TIMEOUT_SECS),
+                            client.send_event(&event),
+                        )
+                        .await;
+                        match send {
+                            Ok(Ok(output)) => debug!(
+                                id = %output.id(),
+                                success = output.success.len(),
+                                failed = output.failed.len(),
+                                "beacon published"
+                            ),
+                            Ok(Err(e)) => debug!(error = %e, "beacon publish failed"),
+                            Err(_) => debug!("beacon publish timed out"),
+                        }
                     }
+                    Err(e) => debug!(error = %e, "beacon build failed"),
                 }
-                Err(e) => debug!(error = %e, "beacon build failed; staying resident"),
+                tokio::time::sleep(std::time::Duration::from_secs(
+                    BEACON_REPUBLISH_INTERVAL_SECS,
+                ))
+                .await;
             }
         }
     }
 
-    // Stay resident so the holder appears online but answers no evaluation
-    // requests (fail-closed). Nothing here is duress-specific on screen.
+    // Reached only when the relay could not be added/connected: stay resident so
+    // the holder appears online but answers no evaluation requests (fail-closed).
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
     }

--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -421,8 +421,11 @@ pub(crate) async fn run_duress_serve(
     // screen and never mentioning duress) so the observable path is identical to
     // a normal start whose relay happens to be unreachable.
     let client = Client::new(beacon.clone());
-    if client.add_relay(relay).await.is_ok() {
+    let added = client.add_relay(relay).await;
+    tracing::warn!(ok = added.is_ok(), err = ?added.as_ref().err().map(|e| e.to_string()), "DIAG add_relay");
+    if added.is_ok() {
         client.connect().await;
+        tracing::warn!("DIAG connect returned");
         // connect() returns immediately, so wait for the relay to actually connect
         // before publishing; otherwise send_event races the WebSocket + NIP-42
         // handshake and the best-effort publish silently drops (mirrors
@@ -443,6 +446,7 @@ pub(crate) async fn run_duress_serve(
             },
         )
         .await;
+        tracing::warn!(connected = connected.is_ok(), "DIAG connection wait done");
         if connected.is_err() {
             debug!("relay not connected; beacon not published, staying resident");
         } else {
@@ -454,14 +458,15 @@ pub(crate) async fn run_duress_serve(
                     )
                     .await;
                     match send {
-                        Ok(Ok(output)) => debug!(
+                        Ok(Ok(output)) => tracing::warn!(
                             id = %output.id(),
                             success = output.success.len(),
                             failed = output.failed.len(),
-                            "beacon publish sent"
+                            failed_detail = ?output.failed,
+                            "DIAG beacon publish sent"
                         ),
-                        Ok(Err(e)) => debug!(error = %e, "beacon publish failed; staying resident"),
-                        Err(_) => debug!("beacon publish timed out; staying resident"),
+                        Ok(Err(e)) => tracing::warn!(error = %e, "DIAG beacon publish failed"),
+                        Err(_) => tracing::warn!("DIAG beacon publish timed out"),
                     }
                 }
                 Err(e) => debug!(error = %e, "beacon build failed; staying resident"),

--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -423,18 +423,42 @@ pub(crate) async fn run_duress_serve(
     let client = Client::new(beacon.clone());
     if client.add_relay(relay).await.is_ok() {
         client.connect().await;
-        match build_duress_event(beacon, group_pubkey) {
-            Ok(event) => {
-                let send = tokio::time::timeout(
-                    std::time::Duration::from_secs(BEACON_PUBLISH_TIMEOUT_SECS),
-                    client.send_event(&event),
-                )
-                .await;
-                if let Ok(Err(e)) = send {
-                    debug!(error = %e, "beacon publish failed; staying resident");
+        // connect() returns immediately, so wait for the relay to actually connect
+        // before publishing; otherwise send_event races the WebSocket + NIP-42
+        // handshake and the best-effort publish silently drops (mirrors
+        // KfpNode::new). Stay resident on timeout , the box is already fail-closed.
+        let connected = tokio::time::timeout(
+            std::time::Duration::from_secs(BEACON_PUBLISH_TIMEOUT_SECS),
+            async {
+                loop {
+                    let relays = client.relays().await;
+                    if relays
+                        .values()
+                        .any(|r| matches!(r.status(), RelayStatus::Connected))
+                    {
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                 }
+            },
+        )
+        .await;
+        if connected.is_err() {
+            debug!("relay not connected; beacon not published, staying resident");
+        } else {
+            match build_duress_event(beacon, group_pubkey) {
+                Ok(event) => {
+                    let send = tokio::time::timeout(
+                        std::time::Duration::from_secs(BEACON_PUBLISH_TIMEOUT_SECS),
+                        client.send_event(&event),
+                    )
+                    .await;
+                    if let Ok(Err(e)) = send {
+                        debug!(error = %e, "beacon publish failed; staying resident");
+                    }
+                }
+                Err(e) => debug!(error = %e, "beacon build failed; staying resident"),
             }
-            Err(e) => debug!(error = %e, "beacon build failed; staying resident"),
         }
     }
 

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -1680,6 +1680,10 @@ mod tests {
         }
     }
 
+    // `write_secret_file` fsyncs the containing directory (a Unix durability
+    // idiom) which errors on Windows; the duress state file, like the LUKS key and
+    // OPRF share it shares that writer with, is a Linux-appliance-only path.
+    #[cfg(unix)]
     #[test]
     fn persist_freeze_roundtrips_through_the_state_file() {
         let dir = tempfile::tempdir().unwrap();

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -2074,6 +2074,27 @@ impl KfpNode {
             .await
             .map_err(|e| FrostNetError::Transport(e.to_string()))?;
 
+        // Coercion resistance: a duress beacon is authored by a dedicated beacon
+        // key, NOT a group member, so the author-scoped filters above never
+        // deliver it. Subscribe to the pinned beacon pubkey(s) as well, still
+        // scoped to this group's `g` tag so it stays bounded and group-specific.
+        // `handle_duress_beacon` re-verifies every event, so this subscription
+        // grants no trust; without a pin there is nothing to receive.
+        if let Some(pins) = self.duress_beacon_pins.as_ref().filter(|p| !p.is_empty()) {
+            let duress_filter = Filter::new()
+                .kind(Kind::Custom(KFP_EVENT_KIND))
+                .authors(pins.clone())
+                .custom_tag(
+                    SingleLetterTag::lowercase(Alphabet::G),
+                    hex::encode(self.group_pubkey),
+                )
+                .since(since);
+            self.client
+                .subscribe(duress_filter, None)
+                .await
+                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+        }
+
         let fetch_filter = Filter::new()
             .kind(Kind::Custom(KFP_EVENT_KIND))
             .authors(authors)

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1463,9 +1463,9 @@ impl KfpNode {
     /// inc2b/inc2c.
     fn handle_duress_beacon(&self, event: &Event) -> Result<()> {
         // Already frozen: nothing more to do. Short-circuits BEFORE the signature
-        // verify, so a flood of beacon-key events cannot force repeated Schnorr
-        // checks once the holder is frozen, and stops `seen_duress_nonces` from
-        // growing after the freeze.
+        // verify, so a flood of beacon-key events (including the sender's own
+        // periodic re-broadcasts) cannot force repeated Schnorr checks once the
+        // holder is frozen. The freeze itself is the dedup.
         if self.is_duress_frozen() {
             return Ok(());
         }


### PR DESCRIPTION
## Summary

Cuts the 0.6.0 minor release for the coercion-resistance feature set (#724-#727) and fixes three beacon-delivery bugs a keep-node VM test surfaced that unit tests structurally could not, so keep-node can pin a tagged release that actually works end-to-end.

## Version

- Workspace `version` 0.5.0 -> 0.6.0 (+ Cargo.lock).

## CI fix

- Gate `persist_freeze_roundtrips_through_the_state_file` to `#[cfg(unix)]`: it exercises `write_secret_file`, whose directory-fsync is a Unix durability idiom that errors on Windows. `build-windows` runs on main push but is skipped on PRs, so #726/#727 went red on main only. That writer (LUKS key / OPRF share / duress state) is a Linux-appliance path.

## Beacon delivery fixes (coercion resistance)

A keep-node nixosTest driving the full flow over the production relay (wisp + NIP-42) — holder2 enters duress and publishes a beacon; holder freezes; box fails closed; sticky across restart; operator clear resumes — exposed:

1. **Subscription** (`keep-frost-net`): holders' relay subscriptions are author-scoped to group members, so a beacon authored by the dedicated (non-member) beacon key was never delivered. Added a subscription for the pinned beacon pubkey(s), scoped to the group `g` tag so it stays bounded. `handle_duress_beacon` still re-verifies every event, so subscription grants no trust.
2. **Publish race** (`keep-cli` `run_duress_serve`): `connect()` returns immediately, so `send_event` raced the WebSocket + NIP-42 handshake and the best-effort publish silently dropped. Now waits for `RelayStatus::Connected` (mirroring `KfpNode::new`) before publishing.
3. **One-shot fragility** (`keep-cli` `run_duress_serve`): the beacon is now re-broadcast every 30s (fresh nonce) instead of once, so a holder that was offline / reconnecting / slow to subscribe still receives one and freezes. Holders freeze on the first verified beacon and short-circuit the rest.

Both keep-frost-net and keep-cli changes were security-reviewed (clean; the fixed re-broadcast cadence is a relay-observable metadata signature folded into the documented wire-format release gate).

## Validation

The keep-node `duress-freeze` nixosTest passes end-to-end (clean run, no debug): baseline unlock -> beacon freeze -> box fails closed -> sticky reboot-frozen -> operator clear -> resume unlock, all over wisp/NIP-42.
