### PR TITLE
Retry duress beacon relay connection (fixes silent no-alert on slow hosts); v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "keep-agent"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "keep-bitcoin"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bitcoin",
  "getrandom 0.4.3",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "keep-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "keep-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aes 0.9.1",
  "argon2",
@@ -4636,7 +4636,7 @@ dependencies = [
 
 [[package]]
 name = "keep-desktop"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4669,14 +4669,14 @@ dependencies = [
 
 [[package]]
 name = "keep-enclave"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "keep-enclave-host",
 ]
 
 [[package]]
 name = "keep-enclave-host"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -4707,7 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "keep-frost-net"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "keep-mobile"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4778,7 +4778,7 @@ dependencies = [
 
 [[package]]
 name = "keep-nip46"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bitflags 2.13.0",
  "chrono",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "keep-web"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "axum",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"

--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -428,67 +428,59 @@ pub(crate) async fn run_duress_serve(
     let client = Client::new(beacon.clone());
     if client.add_relay(relay).await.is_ok() {
         client.connect().await;
-        // connect() returns immediately, so wait for the relay to actually connect
-        // before publishing; otherwise send_event races the WebSocket + NIP-42
-        // handshake and the best-effort publish silently drops (mirrors
-        // KfpNode::new). Stay resident on timeout , the box is already fail-closed.
-        let connected = tokio::time::timeout(
-            std::time::Duration::from_secs(BEACON_PUBLISH_TIMEOUT_SECS),
-            async {
-                loop {
-                    let relays = client.relays().await;
-                    if relays
-                        .values()
-                        .any(|r| matches!(r.status(), RelayStatus::Connected))
-                    {
-                        break;
-                    }
-                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                }
-            },
-        )
-        .await;
-        if connected.is_err() {
-            debug!("relay not connected; beacon not published, staying resident");
-        } else {
-            // Re-broadcast the beacon on an interval (fresh nonce each time), not
-            // once: a one-shot alert would miss any holder that is briefly offline,
-            // reconnecting, or slow to subscribe when it fires. Holders freeze on
-            // the first one they verify and short-circuit the rest, so the repeat
-            // is idempotent for them. This loop also keeps the process resident so
-            // the holder looks online but answers no evaluations (fail-closed).
-            //
-            // The first send may still race the relay's NIP-42 auth (the wait above
-            // is for `Connected`, not `Authenticated`); the interval retry covers a
-            // rejected first publish. RELEASE GATE: the fixed re-broadcast cadence
-            // is itself a relay-observable duress signature (distinct from the wire
-            // FORMAT gate); traffic-shape indistinguishability is part of that gate.
-            loop {
-                match build_duress_event(beacon, group_pubkey) {
-                    Ok(event) => {
-                        let send = tokio::time::timeout(
-                            std::time::Duration::from_secs(BEACON_PUBLISH_TIMEOUT_SECS),
-                            client.send_event(&event),
-                        )
-                        .await;
-                        match send {
-                            Ok(Ok(output)) => debug!(
-                                id = %output.id(),
-                                success = output.success.len(),
-                                failed = output.failed.len(),
-                                "beacon published"
-                            ),
-                            Ok(Err(e)) => debug!(error = %e, "beacon publish failed"),
-                            Err(_) => debug!("beacon publish timed out"),
-                        }
-                    }
-                    Err(e) => debug!(error = %e, "beacon build failed"),
-                }
-                tokio::time::sleep(std::time::Duration::from_secs(
-                    BEACON_REPUBLISH_INTERVAL_SECS,
-                ))
-                .await;
+        // Re-broadcast the beacon on an interval (fresh nonce each time), not once:
+        // a one-shot alert would miss any holder that is briefly offline,
+        // reconnecting, or slow to subscribe when it fires. Holders freeze on the
+        // first one they verify and short-circuit the rest, so the repeat is
+        // idempotent for them. This loop also keeps the process resident so the
+        // holder looks online but answers no evaluations (fail-closed).
+        //
+        // connect() returns immediately, so we RE-CHECK the connection each pass
+        // rather than gating on a single fixed window: on a slow or contended host
+        // the WebSocket + NIP-42 handshake can take longer than any one timeout,
+        // and a one-shot give-up would leave the box resident but silent (no holder
+        // ever freezes , a coerced holder on a slow box would fail to alert). We
+        // only build+send once a relay is Connected; otherwise poll briefly and
+        // retry, which also recovers if the connection later drops. The send itself
+        // may still race NIP-42 auth (Connected != Authenticated); the interval
+        // retry covers a rejected first publish. RELEASE GATE: the fixed cadence is
+        // itself a relay-observable duress signature (distinct from the wire FORMAT
+        // gate); traffic-shape indistinguishability is part of that gate.
+        loop {
+            let connected = client
+                .relays()
+                .await
+                .values()
+                .any(|r| matches!(r.status(), RelayStatus::Connected));
+            if !connected {
+                // Not connected yet (or dropped); check again shortly.
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                continue;
             }
+            match build_duress_event(beacon, group_pubkey) {
+                Ok(event) => {
+                    let send = tokio::time::timeout(
+                        std::time::Duration::from_secs(BEACON_PUBLISH_TIMEOUT_SECS),
+                        client.send_event(&event),
+                    )
+                    .await;
+                    match send {
+                        Ok(Ok(output)) => debug!(
+                            id = %output.id(),
+                            success = output.success.len(),
+                            failed = output.failed.len(),
+                            "beacon published"
+                        ),
+                        Ok(Err(e)) => debug!(error = %e, "beacon publish failed"),
+                        Err(_) => debug!("beacon publish timed out"),
+                    }
+                }
+                Err(e) => debug!(error = %e, "beacon build failed"),
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(
+                BEACON_REPUBLISH_INTERVAL_SECS,
+            ))
+            .await;
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes a real robustness bug in the duress beacon publisher (`run_duress_serve`) that also turned the keep-node `duress-freeze` nixosTest red on main.

## Bug

`run_duress_serve` waited up to a single 10s window for the relay to reach `RelayStatus::Connected`, and on timeout gave up publishing entirely (logged at debug, fell through to the resident idle loop). `connect()` returns immediately, so on a slow or contended host the bare beacon client's WebSocket + NIP-42 handshake can exceed that window — after which **no beacon is ever published and no holder freezes**. A coerced holder on a slow/contended box would silently fail to alert.

This is why the `duress-freeze` VM test passes locally (fast connect) but timed out at the "DURESS BEACON verified" wait on the contended CI runner.

## Fix

Fold the connection check into the re-broadcast loop: re-check `Connected` each pass, publish only when connected, otherwise poll briefly (1s) and retry — indefinitely. No one-shot give-up, and it also recovers if the connection later drops. The send still races NIP-42 auth (`Connected` != `Authenticated`); the interval retry covers a rejected first publish, as before.

## Version

0.6.0 -> 0.6.1 (patch), so keep-node can pin the fix.

## Validation

Builds, clippy, fmt, keep-cli tests pass. End-to-end validation is the keep-node `duress-freeze` nixosTest, which will run against v0.6.1 with the full CI matrix in the follow-up keep-node PR.
