### PR TITLE
Add Android cross-compile and UniFFI bindgen job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,73 @@ jobs:
       - run: cargo build --release
       - run: cargo test --workspace --lib --bins
 
+  android:
+    # keep-mobile is a workspace member, so the jobs above compile it for the host
+    # target only. Its `cfg(target_os = "android")` logging branch and the
+    # android-only tracing-android dependency are built by nothing here, and no
+    # other job runs uniffi-bindgen. Both would otherwise break first in the
+    # Android app repository, which pins this repo at a commit and so lags main.
+    #
+    # NDK, cargo-ndk, and Rust versions must stay in sync with that repository's
+    # build-rust.sh, which builds the shipped library from these same sources.
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft != true && github.event_name != 'schedule'
+    env:
+      NDK_VERSION: "29.0.14206865"
+      CARGO_NDK_VERSION: "4.1.2"
+      ANDROID_TARGET: aarch64-linux-android
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install dependencies
+        run: |
+          # GitHub-hosted runners preload third-party apt repos (Microsoft, Google)
+          # whose mirrors intermittently serve invalid InRelease files, which fails
+          # `apt-get update`. None of them provide the packages below, so drop them.
+          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure* /etc/apt/sources.list.d/*google*
+          sudo apt-get update
+          # aws-lc-sys (via rustls) compiles bundled C through the NDK's cmake
+          # toolchain, which only reliably supports the Ninja generator.
+          sudo apt-get install -y ninja-build
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+      - uses: android-actions/setup-android@v4
+      - name: Install Android NDK
+        run: sdkmanager --install "ndk;$NDK_VERSION"
+      # rust-toolchain.toml pins the channel, so the Android target has to be added
+      # to that exact toolchain rather than to whatever `stable` resolves to.
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.89.0"
+          targets: aarch64-linux-android
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: android
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-ndk@${{ env.CARGO_NDK_VERSION }}
+      - name: Cross-compile keep-mobile for Android
+        working-directory: keep-mobile
+        run: |
+          NDK_DIR="$ANDROID_HOME/ndk/$NDK_VERSION"
+          if [ ! -d "$NDK_DIR" ]; then
+            echo "pinned NDK $NDK_VERSION not found at $NDK_DIR" >&2
+            exit 1
+          fi
+          # Runners preinstall a different NDK and set ANDROID_NDK_ROOT, which
+          # cargo-ndk would silently prefer. Force every var it consults.
+          export ANDROID_NDK_HOME="$NDK_DIR" ANDROID_NDK_ROOT="$NDK_DIR" ANDROID_NDK="$NDK_DIR"
+          export CMAKE_GENERATOR=Ninja AWS_LC_SYS_CMAKE_BUILDER=1
+          cargo ndk -t "$ANDROID_TARGET" -P 33 -o "$RUNNER_TEMP/jniLibs" build --release --locked
+      - name: Generate Kotlin bindings
+        working-directory: keep-mobile
+        run: |
+          cargo run --locked --features cli --bin uniffi-bindgen generate \
+            --library "$RUNNER_TEMP/jniLibs/arm64-v8a/libkeep_mobile.so" \
+            --language kotlin --no-format --out-dir "$RUNNER_TEMP/kotlin"
+          test -f "$RUNNER_TEMP/kotlin/io/privkey/keep/uniffi/keep_mobile.kt"
+
   msrv:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Problem

`keep-mobile` is a workspace member, so `cargo build` and `cargo clippy` already compile it, but only for the host target. Two things are therefore never exercised by CI:

- The `cfg(target_os = "android")` branch in `keep-mobile/src/lib.rs`, along with its android-only `tracing-android` dependency. That dependency is declared under `[target.'cfg(target_os = "android")'.dependencies]`, so on a host build it is not even resolved. Nothing type-checks that code path.
- Kotlin binding generation. No job runs `uniffi-bindgen`, so a crate that builds fine as a cdylib can still fail to produce bindings.

Both failures currently surface first in the downstream Android app repository rather than here. That repository pins this one at a commit SHA, so its CI validates the pinned commit and not `main`. Breakage introduced on `main` stays invisible until someone bumps the pin, and whoever does bumps it across however many commits have accumulated.

This is the same shape as the existing `build-windows` gap, where a target that CI does not build goes green on a pull request and red afterwards.

## Change

Adds an `android` job that cross-compiles `keep-mobile` for `aarch64-linux-android` with `cargo-ndk`, then runs `uniffi-bindgen` to generate the Kotlin bindings and asserts the expected package landed. No Gradle and no emulator, so the job stays cheap; the downstream repository still owns Gradle assembly, unit tests, lint, and instrumented tests.

The NDK, `cargo-ndk`, and Rust versions match the downstream `build-rust.sh`, which builds the shipped library from these same sources. `CMAKE_GENERATOR=Ninja` and `AWS_LC_SYS_CMAKE_BUILDER=1` are set because `aws-lc-sys`, pulled in via `rustls`, compiles bundled C through the NDK cmake toolchain, which only reliably supports the Ninja generator. The job also forces `ANDROID_NDK_HOME`, `ANDROID_NDK_ROOT`, and `ANDROID_NDK` to the pinned NDK, since runners preinstall a different one and set `ANDROID_NDK_ROOT`, which `cargo-ndk` would otherwise prefer.

The Android target is added to the exact toolchain named in `rust-toolchain.toml` rather than to whatever `stable` resolves to, because that file pins the channel used by every `cargo` invocation.

## Verification

Both steps were run locally against this commit's tree, using the same pinned NDK `29.0.14206865` and `cargo-ndk 4.1.2`:

- `cargo ndk -t aarch64-linux-android -P 33 -o <out> build --release --locked` from `keep-mobile` exits 0 in about 2m14s and emits `arm64-v8a/libkeep_mobile.so`.
- `uniffi-bindgen generate --library <that .so> --language kotlin --no-format` exits 0 and writes `io/privkey/keep/uniffi/keep_mobile.kt`.

`--no-format` is passed because bindgen otherwise shells out to `ktlint` and emits a warning when it is absent, which would make the step's output depend on what happens to be installed on the runner.

## Follow-up

This job builds a single ABI. The downstream repository builds `aarch64-linux-android` and `x86_64-linux-android`; a second ABI here would mostly re-test the same Rust and is not obviously worth the runner minutes.

It also does not compile the generated Kotlin. Catching a broken Kotlin call site still requires building the Android app against `main`, which only the downstream repository can do.
