### PR TITLE
Metadata-private duress beacon (NIP-59 gift wrap) with robust delivery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ secrecy = "0.10"
 subtle = "2.5"
 
 # Nostr
-nostr-sdk = { version = "0.44", features = ["nip04", "nip44"] }
+nostr-sdk = { version = "0.44", features = ["nip04", "nip44", "nip59"] }
 
 # Async
 tokio = { version = "1", features = ["full", "signal"] }

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -633,6 +633,13 @@ pub(crate) enum FrostNetworkCommands {
         /// --duress-beacon-pubkey.
         #[arg(long, value_name = "HEX", requires = "duress_beacon_pubkey")]
         duress_beacon_salt: Option<String>,
+        /// Coercion resistance: the group's total share count (e.g. 3 for a 2-of-3).
+        /// The duress beacon is gift-wrapped (NIP-59, metadata-private) to every
+        /// group member, so the emitter needs the member count up front , a coerced
+        /// holder never unlocks the vault to read it. Public group data (not a
+        /// secret); required with --duress-beacon-pubkey.
+        #[arg(long, value_name = "N", requires = "duress_beacon_pubkey")]
+        duress_group_total: Option<u16>,
         /// Coercion resistance: a group holder's duress-beacon npub to TRUST.
         /// Repeatable. Receiving a verified beacon signed by any pinned key freezes
         /// this node: it refuses co-signing and OPRF evaluations (fail-closed) until

--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -142,15 +142,6 @@ pub(crate) fn parse_duress_config(
     Ok((pubkey, salt))
 }
 
-/// Build a single signed duress beacon event for `group_pubkey` with a fresh
-/// random nonce. Split from the transport so the beacon's construction is unit-
-/// testable without a live relay.
-pub(crate) fn build_duress_event(beacon: &Keys, group_pubkey: &[u8; 32]) -> Result<Event> {
-    let nonce: [u8; 32] = keep_core::entropy::try_random_bytes()?;
-    keep_frost_net::KfpEventBuilder::duress_beacon(beacon, group_pubkey, &nonce)
-        .map_err(|e| KeepError::runtime(format!("build beacon: {e}")))
-}
-
 /// How long to wait for the best-effort beacon publish before giving up and
 /// staying resident, so a black-holed relay cannot hang the duress start.
 const BEACON_PUBLISH_TIMEOUT_SECS: u64 = 10;
@@ -159,6 +150,11 @@ const BEACON_PUBLISH_TIMEOUT_SECS: u64 = 10;
 /// a fresh nonce) on this cadence so a holder that was offline, reconnecting, or
 /// slow to subscribe when the first one fired still receives one and freezes.
 const BEACON_REPUBLISH_INTERVAL_SECS: u64 = 30;
+
+/// Fast retry interval used until the FIRST fully-accepted broadcast, so the beacon
+/// delivers within seconds once the relay's NIP-42 auth completes (rather than
+/// waiting a full re-broadcast interval on the initial auth race).
+const BEACON_INITIAL_RETRY_SECS: u64 = 2;
 
 /// Default delay before a `duress-clear --initiate` may be executed: a generous
 /// window for out-of-band intervention (`--cancel`) if the clear was coerced.
@@ -412,6 +408,7 @@ pub(crate) async fn run_duress_serve(
     out: &Output,
     beacon: &Keys,
     group_pubkey: &[u8; 32],
+    total_shares: u16,
     relay: &str,
 ) -> Result<()> {
     let group_npub = keep_core::keys::bytes_to_npub(group_pubkey);
@@ -428,24 +425,22 @@ pub(crate) async fn run_duress_serve(
     let client = Client::new(beacon.clone());
     if client.add_relay(relay).await.is_ok() {
         client.connect().await;
-        // Re-broadcast the beacon on an interval (fresh nonce each time), not once:
-        // a one-shot alert would miss any holder that is briefly offline,
-        // reconnecting, or slow to subscribe when it fires. Holders freeze on the
-        // first one they verify and short-circuit the rest, so the repeat is
-        // idempotent for them. This loop also keeps the process resident so the
-        // holder looks online but answers no evaluations (fail-closed).
+        // Broadcast the beacon (one NIP-59 gift wrap per group member) and
+        // re-broadcast on an interval with a fresh nonce, not once: a one-shot
+        // alert would miss any holder briefly offline, reconnecting, or slow to
+        // subscribe. Holders freeze on the first wrap they verify and short-circuit
+        // the rest, so repeats are idempotent. The loop keeps the process resident
+        // (fail-closed: never unlocks, never answers evals).
         //
-        // connect() returns immediately, so we RE-CHECK the connection each pass
-        // rather than gating on a single fixed window: on a slow or contended host
-        // the WebSocket + NIP-42 handshake can take longer than any one timeout,
-        // and a one-shot give-up would leave the box resident but silent (no holder
-        // ever freezes , a coerced holder on a slow box would fail to alert). We
-        // only build+send once a relay is Connected; otherwise poll briefly and
-        // retry, which also recovers if the connection later drops. The send itself
-        // may still race NIP-42 auth (Connected != Authenticated); the interval
-        // retry covers a rejected first publish. RELEASE GATE: the fixed cadence is
-        // itself a relay-observable duress signature (distinct from the wire FORMAT
-        // gate); traffic-shape indistinguishability is part of that gate.
+        // Delivery is `Output`-driven: connect() returns immediately and a send can
+        // race the relay's NIP-42 auth (which completes shortly after connect but
+        // isn't exposed as a status), so we RETRY FAST until a broadcast is actually
+        // ACCEPTED (the relay appears in `output.success`) , covering the auth race
+        // and any connection settling , then relax to the re-broadcast cadence. A
+        // one-shot give-up would leave a coerced holder on a slow box silent.
+        // RELEASE GATE: the re-broadcast cadence is a relay-observable duress
+        // signature; traffic-shape indistinguishability is part of the gate.
+        let mut delivered = false;
         loop {
             let connected = client
                 .relays()
@@ -453,34 +448,26 @@ pub(crate) async fn run_duress_serve(
                 .values()
                 .any(|r| matches!(r.status(), RelayStatus::Connected));
             if !connected {
-                // Not connected yet (or dropped); check again shortly.
                 tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                 continue;
             }
-            match build_duress_event(beacon, group_pubkey) {
-                Ok(event) => {
-                    let send = tokio::time::timeout(
-                        std::time::Duration::from_secs(BEACON_PUBLISH_TIMEOUT_SECS),
-                        client.send_event(&event),
-                    )
-                    .await;
-                    match send {
-                        Ok(Ok(output)) => debug!(
-                            id = %output.id(),
-                            success = output.success.len(),
-                            failed = output.failed.len(),
-                            "beacon published"
-                        ),
-                        Ok(Err(e)) => debug!(error = %e, "beacon publish failed"),
-                        Err(_) => debug!("beacon publish timed out"),
+            let broadcast_ok =
+                match broadcast_beacon(&client, beacon, group_pubkey, total_shares).await {
+                    Ok(ok) => ok,
+                    Err(e) => {
+                        debug!(error = %e, "beacon broadcast build failed");
+                        false
                     }
-                }
-                Err(e) => debug!(error = %e, "beacon build failed"),
+                };
+            if broadcast_ok {
+                delivered = true;
             }
-            tokio::time::sleep(std::time::Duration::from_secs(
-                BEACON_REPUBLISH_INTERVAL_SECS,
-            ))
-            .await;
+            let interval = if delivered {
+                BEACON_REPUBLISH_INTERVAL_SECS
+            } else {
+                BEACON_INITIAL_RETRY_SECS
+            };
+            tokio::time::sleep(std::time::Duration::from_secs(interval)).await;
         }
     }
 
@@ -489,6 +476,49 @@ pub(crate) async fn run_duress_serve(
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
     }
+}
+
+/// Build a fresh-nonce gift-wrapped beacon for every group member and publish each
+/// to `client`. Returns whether EVERY wrap was accepted by the relay (relay in
+/// `output.success`) , i.e. the relay is authenticated and delivering , so the
+/// caller can retry fast until the first fully-accepted broadcast. Never errors on
+/// a send failure (best-effort); only a build/entropy failure is an `Err`.
+async fn broadcast_beacon(
+    client: &Client,
+    beacon: &Keys,
+    group_pubkey: &[u8; 32],
+    total_shares: u16,
+) -> Result<bool> {
+    let nonce: [u8; 32] = keep_core::entropy::try_random_bytes()?;
+    let wraps = keep_frost_net::KfpEventBuilder::duress_beacon_broadcast(
+        beacon,
+        group_pubkey,
+        total_shares,
+        &nonce,
+    )
+    .await
+    .map_err(|e| KeepError::runtime(format!("build beacon: {e}")))?;
+    if wraps.is_empty() {
+        return Ok(false);
+    }
+    let mut all_ok = true;
+    for wrap in &wraps {
+        let sent = tokio::time::timeout(
+            std::time::Duration::from_secs(BEACON_PUBLISH_TIMEOUT_SECS),
+            client.send_event(wrap),
+        )
+        .await;
+        match sent {
+            Ok(Ok(output)) if !output.success.is_empty() => {}
+            _ => all_ok = false,
+        }
+    }
+    debug!(
+        wraps = wraps.len(),
+        accepted = all_ok,
+        "duress beacon broadcast"
+    );
+    Ok(all_ok)
 }
 
 #[cfg(test)]
@@ -520,20 +550,6 @@ mod tests {
         let c = derive_beacon_key("y", &salt, P).unwrap().public_key();
         assert!(ct_pubkey_eq(&a, &b));
         assert!(!ct_pubkey_eq(&a, &c));
-    }
-
-    #[test]
-    fn build_duress_event_produces_a_verifiable_beacon() {
-        let salt = [1u8; SALT_SIZE];
-        let beacon = derive_beacon_key("the-duress-word", &salt, P).unwrap();
-        let group = [42u8; 32];
-        let event = build_duress_event(&beacon, &group).unwrap();
-        // The beacon verifies against the beacon pubkey and the expected group.
-        keep_frost_net::verify_duress_beacon(&event, &beacon.public_key(), &group, 3600)
-            .expect("freshly built beacon must verify");
-        // Two builds use fresh nonces, so their events differ (replay-distinct).
-        let again = build_duress_event(&beacon, &group).unwrap();
-        assert_ne!(event.id, again.id);
     }
 
     fn write_freeze_nonce(path: &Path, nonce: [u8; 32]) {

--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -422,7 +422,15 @@ pub(crate) async fn run_duress_serve(
     // Best-effort alert. Any failure is swallowed (logged only at debug, never on
     // screen and never mentioning duress) so the observable path is identical to
     // a normal start whose relay happens to be unreachable.
-    let client = Client::new(beacon.clone());
+    //
+    // The transport client is signed by an EPHEMERAL key, NOT the beacon key: the
+    // relay auto-authenticates (NIP-42), so a beacon-keyed client would sign the
+    // AUTH with the stable, cluster-pinned beacon pubkey , handing a relay-level
+    // adversary exactly the fixed author the gift-wrap redesign removed (it could
+    // then correlate or silently drop the duress broadcast by that pubkey). The
+    // wraps authenticate via their own seal, not the client key, so a throwaway
+    // AUTH identity loses nothing.
+    let client = Client::new(Keys::generate());
     if client.add_relay(relay).await.is_ok() {
         client.connect().await;
         // Broadcast the beacon (one NIP-59 gift wrap per group member) and
@@ -479,10 +487,13 @@ pub(crate) async fn run_duress_serve(
 }
 
 /// Build a fresh-nonce gift-wrapped beacon for every group member and publish each
-/// to `client`. Returns whether EVERY wrap was accepted by the relay (relay in
-/// `output.success`) , i.e. the relay is authenticated and delivering , so the
-/// caller can retry fast until the first fully-accepted broadcast. Never errors on
-/// a send failure (best-effort); only a build/entropy failure is an `Err`.
+/// to `client`. Returns whether AT LEAST ONE wrap was accepted by the relay (relay
+/// in `output.success`) , which proves NIP-42 auth completed and the relay is
+/// delivering, so the caller can stop fast-retrying. Keying the relax on "any
+/// accepted" (not "all") avoids spinning at the fast cadence forever , amplifying
+/// the relay-observable duress signature , when one specific recipient's wrap is
+/// persistently rejected (relay size/rate limit) while the rest deliver. Never
+/// errors on a send failure (best-effort); only a build/entropy failure is an `Err`.
 async fn broadcast_beacon(
     client: &Client,
     beacon: &Keys,
@@ -501,24 +512,25 @@ async fn broadcast_beacon(
     if wraps.is_empty() {
         return Ok(false);
     }
-    let mut all_ok = true;
+    let mut any_ok = false;
     for wrap in &wraps {
         let sent = tokio::time::timeout(
             std::time::Duration::from_secs(BEACON_PUBLISH_TIMEOUT_SECS),
             client.send_event(wrap),
         )
         .await;
-        match sent {
-            Ok(Ok(output)) if !output.success.is_empty() => {}
-            _ => all_ok = false,
+        if let Ok(Ok(output)) = sent {
+            if !output.success.is_empty() {
+                any_ok = true;
+            }
         }
     }
     debug!(
         wraps = wraps.len(),
-        accepted = all_ok,
+        any_accepted = any_ok,
         "duress beacon broadcast"
     );
-    Ok(all_ok)
+    Ok(any_ok)
 }
 
 #[cfg(test)]

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -117,6 +117,15 @@ pub fn cmd_frost_network_serve(
                     "--group-total is required with --duress-beacon-pubkey/--duress-beacon-salt",
                 )
             })?;
+            // A zero total derives no recipients, so the beacon would broadcast to
+            // nobody , the coerced holder would look resident but silently alert no
+            // one (fail-open). Reject it here, before the prompt, with the rest of
+            // the fail-closed config checks.
+            if total == 0 {
+                return Err(KeepError::invalid_input(
+                    "--group-total must be at least 1 (the group's share count)",
+                ));
+            }
             let (pubkey, salt) = duress::parse_duress_config(npub, salt_hex)?;
             Some((pubkey, salt, total))
         }

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -77,6 +77,7 @@ pub fn cmd_frost_network_serve(
     duress_beacon_salt: Option<&str>,
     duress_beacon_pins: &[String],
     duress_state_file: Option<&Path>,
+    duress_group_total: Option<u16>,
 ) -> Result<()> {
     debug!(group = group_npub, relay, share = ?share_index, refuse_raw_sign, require_structured_sign, "starting FROST network node");
 
@@ -105,7 +106,20 @@ pub fn cmd_frost_network_serve(
     // operator is prompted for a password, never after. Both flags must be set
     // together (clap also enforces this).
     let duress_cfg = match (duress_beacon_pubkey, duress_beacon_salt) {
-        (Some(npub), Some(salt_hex)) => Some(duress::parse_duress_config(npub, salt_hex)?),
+        (Some(npub), Some(salt_hex)) => {
+            // The beacon is gift-wrapped to every group member, so the emitter must
+            // know the member count up front (a coerced holder never unlocks the
+            // vault to read it). Require --group-total with the emit config; fail
+            // closed here, before the password prompt, so a misconfig never leaks by
+            // surfacing only after the operator has already typed the duress word.
+            let total = duress_group_total.ok_or_else(|| {
+                KeepError::invalid_input(
+                    "--group-total is required with --duress-beacon-pubkey/--duress-beacon-salt",
+                )
+            })?;
+            let (pubkey, salt) = duress::parse_duress_config(npub, salt_hex)?;
+            Some((pubkey, salt, total))
+        }
         (None, None) => None,
         _ => {
             return Err(KeepError::invalid_input(
@@ -142,7 +156,7 @@ pub fn cmd_frost_network_serve(
     // resident. To keep a coerced start wall-clock- and screen-indistinguishable
     // from a genuine one, mirror the normal path's "Unlocking vault..." spinner
     // and spend an equal-cost KDF (the vault's own params) before diverging.
-    if let Some((beacon_pubkey, salt)) = duress_cfg {
+    if let Some((beacon_pubkey, salt, group_total)) = duress_cfg {
         if let Some(beacon) = duress::match_duress(password.expose_secret(), &salt, &beacon_pubkey)?
         {
             let spinner = out.spinner("Unlocking vault...");
@@ -151,7 +165,13 @@ pub fn cmd_frost_network_serve(
             let group_pubkey = keep_core::keys::npub_to_bytes(group_npub)?;
             let rt = tokio::runtime::Runtime::new()
                 .map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
-            return rt.block_on(duress::run_duress_serve(out, &beacon, &group_pubkey, relay));
+            return rt.block_on(duress::run_duress_serve(
+                out,
+                &beacon,
+                &group_pubkey,
+                group_total,
+                relay,
+            ));
         }
     }
 

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -326,6 +326,7 @@ fn dispatch_frost_network(
             tpm_tcti,
             duress_beacon_pubkey,
             duress_beacon_salt,
+            duress_group_total,
             duress_beacon_pins,
             duress_state_file,
         } => {
@@ -349,6 +350,7 @@ fn dispatch_frost_network(
                 duress_beacon_salt.as_deref(),
                 &duress_beacon_pins,
                 duress_state_file.as_deref(),
+                duress_group_total,
             )
         }
         FrostNetworkCommands::Peers { group, relay } => {

--- a/keep-frost-net/Cargo.toml
+++ b/keep-frost-net/Cargo.toml
@@ -20,7 +20,7 @@ keep-bitcoin = { path = "../keep-bitcoin" }
 keep-core = { path = "../keep-core", features = ["oprf"] }
 keep-enclave-host = { path = "../keep-enclave/host", optional = true }
 
-nostr-sdk = { version = "0.44", features = ["nip04", "nip44"] }
+nostr-sdk = { version = "0.44", features = ["nip04", "nip44", "nip59"] }
 frost-secp256k1-tr = "3.0"
 rand = "0.10"
 k256 = { version = "0.13.4", features = ["schnorr"] }

--- a/keep-frost-net/src/event.rs
+++ b/keep-frost-net/src/event.rs
@@ -62,26 +62,29 @@ impl KfpEventBuilder {
     /// dedicated duress-beacon `keys` (NOT the vault-derived identity, which
     /// duress mode never unlocks). `nonce` must be freshly random. The cluster
     /// authenticates it against the pinned beacon pubkey (see
-    /// [`verify_duress_beacon`]), so no proof-of-share is needed or possible.
+    /// [`verify_unwrapped_duress_beacon`]), so no proof-of-share is needed.
     ///
-    /// RELEASE GATE: this wire form is self-labeling (`t=duress_beacon` tag,
-    /// `type=duress_beacon` content, `g` group tag), so a relay-level adversary
-    /// can filter and silently drop the beacon. That is acceptable for this inert
-    /// primitive, but this MUST NOT reach a deployed path before the inc2
-    /// indistinguishability work (identify-by-pinned-pubkey, encrypted look-alike
-    /// content, constant cadence) lands.
-    pub fn duress_beacon(keys: &Keys, group_pubkey: &[u8; 32], nonce: &[u8; 32]) -> Result<Event> {
+    /// Metadata-private wire form (NIP-59 gift wrap): the `DuressBeaconPayload` is
+    /// placed in an unsigned rumor authored by the beacon key, sealed by the beacon
+    /// key (authenticity), then gift-wrapped to `recipient` (a group member's
+    /// transport pubkey) with an EPHEMERAL key and a randomized timestamp. To a
+    /// relay it is an ordinary `kind:1059` gift wrap , indistinguishable from a
+    /// private DM, with no duress label, group, nonce, or beacon-key identity
+    /// visible on the wire, and no fixed author to filter on. Broadcast is one wrap
+    /// per group member (the caller wraps to each). Freshness is enforced on the
+    /// payload's own `created_at`, independent of the wrap's tweaked timestamp.
+    pub async fn duress_beacon(
+        beacon_keys: &Keys,
+        group_pubkey: &[u8; 32],
+        nonce: &[u8; 32],
+        recipient: &PublicKey,
+    ) -> Result<Event> {
         let payload = DuressBeaconPayload::new(*group_pubkey, *nonce);
         let content = KfpMessage::DuressBeacon(payload).to_json()?;
-
-        EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), content)
-            .custom_created_at(Timestamp::tweaked(TIMESTAMP_TWEAK_RANGE))
-            .tag(Tag::custom(
-                TagKind::custom("g"),
-                [hex::encode(group_pubkey)],
-            ))
-            .tag(Tag::custom(TagKind::custom("t"), ["duress_beacon"]))
-            .sign_with_keys(keys)
+        let rumor =
+            EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), content).build(beacon_keys.public_key());
+        EventBuilder::gift_wrap(beacon_keys, recipient, rumor, [])
+            .await
             .map_err(|e| FrostNetError::Nostr(e.to_string()))
     }
 
@@ -589,30 +592,32 @@ impl KfpEventBuilder {
 /// the Nostr signature, the decoded group, and `created_at` freshness. Nonce
 /// replay dedup is the caller's job (track seen nonces within the window); this
 /// only bounds the window.
-pub fn verify_duress_beacon(
-    event: &Event,
+/// Verify a duress beacon UNWRAPPED from a NIP-59 gift wrap (via
+/// [`nostr_sdk::nips::nip59::extract_rumor`], which already decrypts and verifies
+/// the gift-wrap + seal signatures). `sender` is the seal author; `rumor` the
+/// inner payload event. Checks the seal author is the pinned beacon pubkey, the
+/// rumor is a `DuressBeacon` for `group_pubkey`, and it is fresh. Replay dedup is
+/// the caller's job; this only bounds the window.
+pub fn verify_unwrapped_duress_beacon(
+    sender: &PublicKey,
+    rumor: &UnsignedEvent,
     expected_beacon_pubkey: &PublicKey,
     group_pubkey: &[u8; 32],
     window_secs: u64,
 ) -> Result<DuressBeaconPayload> {
-    if event.kind != Kind::Custom(KFP_EVENT_KIND) {
-        return Err(FrostNetError::Protocol("not a KFP event".into()));
-    }
-    if &event.pubkey != expected_beacon_pubkey {
+    if sender != expected_beacon_pubkey {
         return Err(FrostNetError::UntrustedPeer(
-            "duress beacon not signed by the pinned beacon key".into(),
+            "duress beacon not sealed by the pinned beacon key".into(),
         ));
     }
-    if event.verify().is_err() {
-        return Err(FrostNetError::UntrustedPeer(
-            "duress beacon signature invalid".into(),
-        ));
+    if rumor.kind != Kind::Custom(KFP_EVENT_KIND) {
+        return Err(FrostNetError::Protocol("not a KFP rumor".into()));
     }
-    let payload = match KfpMessage::from_json(&event.content)? {
+    let payload = match KfpMessage::from_json(&rumor.content)? {
         KfpMessage::DuressBeacon(p) => p,
         _ => {
             return Err(FrostNetError::Protocol(
-                "event is not a duress beacon".into(),
+                "rumor is not a duress beacon".into(),
             ))
         }
     };

--- a/keep-frost-net/src/event.rs
+++ b/keep-frost-net/src/event.rs
@@ -81,11 +81,32 @@ impl KfpEventBuilder {
     ) -> Result<Event> {
         let payload = DuressBeaconPayload::new(*group_pubkey, *nonce);
         let content = KfpMessage::DuressBeacon(payload).to_json()?;
-        let rumor =
-            EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), content).build(beacon_keys.public_key());
+        let rumor = EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), content)
+            .build(beacon_keys.public_key());
         EventBuilder::gift_wrap(beacon_keys, recipient, rumor, [])
             .await
             .map_err(|e| FrostNetError::Nostr(e.to_string()))
+    }
+
+    /// Build one gift-wrapped duress beacon per group member (transport pubkeys
+    /// derived from `group_pubkey` + `total_shares`), so a coerced holder can
+    /// broadcast the beacon metadata-privately to every holder. All wraps carry the
+    /// same `nonce` (one logical beacon) but each is a distinct `kind:1059` to a
+    /// distinct recipient under its own ephemeral key. The caller publishes the
+    /// returned wraps. A coerced holder cannot read its group's size once locked,
+    /// so `total_shares` is supplied out of band (the serve `--group-total`).
+    pub async fn duress_beacon_broadcast(
+        beacon_keys: &Keys,
+        group_pubkey: &[u8; 32],
+        total_shares: u16,
+        nonce: &[u8; 32],
+    ) -> Result<Vec<Event>> {
+        let recipients = crate::node::group_member_pubkeys(group_pubkey, total_shares);
+        let mut wraps = Vec::with_capacity(recipients.len());
+        for recipient in &recipients {
+            wraps.push(Self::duress_beacon(beacon_keys, group_pubkey, nonce, recipient).await?);
+        }
+        Ok(wraps)
     }
 
     pub fn sign_request(
@@ -583,15 +604,6 @@ impl KfpEventBuilder {
     }
 }
 
-/// Verify an inbound event is an authentic, fresh duress beacon for `group_pubkey`,
-/// signed by the pinned beacon key. Returns the payload on success.
-///
-/// Authenticity IS the pinned signing key: the beacon carries no proof-of-share
-/// (duress mode never unlocks the vault), so it is trusted only when signed by
-/// the beacon pubkey the cluster pinned out of band for that holder. Also checks
-/// the Nostr signature, the decoded group, and `created_at` freshness. Nonce
-/// replay dedup is the caller's job (track seen nonces within the window); this
-/// only bounds the window.
 /// Verify a duress beacon UNWRAPPED from a NIP-59 gift wrap (via
 /// [`nostr_sdk::nips::nip59::extract_rumor`], which already decrypts and verifies
 /// the gift-wrap + seal signatures). `sender` is the seal author; `rumor` the
@@ -755,37 +767,83 @@ mod tests {
         }
     }
 
-    #[test]
-    fn duress_beacon_roundtrips_and_verifies() {
+    /// Unwrap a gift wrap as `recipient` (decrypts + verifies the wrap/seal
+    /// signatures) and return the seal author and inner rumor, as the node does.
+    async fn unwrap(recipient: &Keys, wrap: &Event) -> (PublicKey, UnsignedEvent) {
+        let g = nostr_sdk::nips::nip59::extract_rumor(recipient, wrap)
+            .await
+            .expect("gift wrap must unwrap for its recipient");
+        (g.sender, g.rumor)
+    }
+
+    #[tokio::test]
+    async fn duress_beacon_roundtrips_and_verifies() {
         let beacon_keys = Keys::generate();
+        let recipient = Keys::generate();
         let group = [7u8; 32];
         let nonce = [9u8; 32];
-        let event = KfpEventBuilder::duress_beacon(&beacon_keys, &group, &nonce).unwrap();
+        let wrap =
+            KfpEventBuilder::duress_beacon(&beacon_keys, &group, &nonce, &recipient.public_key())
+                .await
+                .unwrap();
 
-        assert_eq!(event.kind, Kind::Custom(KFP_EVENT_KIND));
-        let payload = verify_duress_beacon(&event, &beacon_keys.public_key(), &group, 300).unwrap();
+        // On the wire it is an ordinary kind:1059 gift wrap addressed to the
+        // recipient, authored by an ephemeral key (never the beacon key).
+        assert_eq!(wrap.kind, Kind::GiftWrap);
+        assert_ne!(wrap.pubkey, beacon_keys.public_key());
+
+        let (sender, rumor) = unwrap(&recipient, &wrap).await;
+        let payload =
+            verify_unwrapped_duress_beacon(&sender, &rumor, &beacon_keys.public_key(), &group, 300)
+                .unwrap();
         assert_eq!(payload.group_pubkey, group);
         assert_eq!(payload.nonce, nonce);
     }
 
-    #[test]
-    fn duress_beacon_rejects_wrong_signer() {
-        // Signed by a different key than the pinned beacon key: authorship rejected.
+    #[tokio::test]
+    async fn duress_beacon_rejects_wrong_signer() {
+        // Sealed by a different key than the pinned beacon key: authorship rejected.
         // This is the load-bearing authenticity check (the beacon has no proof-of-share).
         let beacon_keys = Keys::generate();
+        let recipient = Keys::generate();
         let attacker = Keys::generate();
         let group = [7u8; 32];
-        let event = KfpEventBuilder::duress_beacon(&beacon_keys, &group, &[1u8; 32]).unwrap();
-        let err = verify_duress_beacon(&event, &attacker.public_key(), &group, 300).unwrap_err();
+        let wrap = KfpEventBuilder::duress_beacon(
+            &beacon_keys,
+            &group,
+            &[1u8; 32],
+            &recipient.public_key(),
+        )
+        .await
+        .unwrap();
+        let (sender, rumor) = unwrap(&recipient, &wrap).await;
+        let err =
+            verify_unwrapped_duress_beacon(&sender, &rumor, &attacker.public_key(), &group, 300)
+                .unwrap_err();
         assert!(matches!(err, FrostNetError::UntrustedPeer(_)));
     }
 
-    #[test]
-    fn duress_beacon_rejects_group_mismatch() {
+    #[tokio::test]
+    async fn duress_beacon_rejects_group_mismatch() {
         let beacon_keys = Keys::generate();
-        let event = KfpEventBuilder::duress_beacon(&beacon_keys, &[1u8; 32], &[2u8; 32]).unwrap();
-        let err =
-            verify_duress_beacon(&event, &beacon_keys.public_key(), &[9u8; 32], 300).unwrap_err();
+        let recipient = Keys::generate();
+        let wrap = KfpEventBuilder::duress_beacon(
+            &beacon_keys,
+            &[1u8; 32],
+            &[2u8; 32],
+            &recipient.public_key(),
+        )
+        .await
+        .unwrap();
+        let (sender, rumor) = unwrap(&recipient, &wrap).await;
+        let err = verify_unwrapped_duress_beacon(
+            &sender,
+            &rumor,
+            &beacon_keys.public_key(),
+            &[9u8; 32],
+            300,
+        )
+        .unwrap_err();
         assert!(matches!(err, FrostNetError::Protocol(_)));
     }
 
@@ -797,21 +855,26 @@ mod tests {
         assert!(!p.is_within_replay_window(300));
     }
 
-    #[test]
-    fn verify_duress_beacon_rejects_stale_end_to_end() {
-        // A beacon whose SIGNED payload created_at is far in the past is rejected
-        // by the verifier's freshness check (drives ReplayDetected through
-        // verify_duress_beacon, not just the payload helper).
+    #[tokio::test]
+    async fn verify_duress_beacon_rejects_stale_end_to_end() {
+        // A beacon whose inner payload created_at is far in the past is rejected by
+        // the verifier's freshness check (drives ReplayDetected end-to-end through a
+        // real gift wrap + unwrap, independent of the wrap's own tweaked timestamp).
         let beacon_keys = Keys::generate();
+        let recipient = Keys::generate();
         let group = [7u8; 32];
         let mut payload = DuressBeaconPayload::new(group, [1u8; 32]);
         payload.created_at = 1; // ancient
         let content = KfpMessage::DuressBeacon(payload).to_json().unwrap();
-        let event = EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), content)
-            .tag(Tag::custom(TagKind::custom("t"), ["duress_beacon"]))
-            .sign_with_keys(&beacon_keys)
+        let rumor = EventBuilder::new(Kind::Custom(KFP_EVENT_KIND), content)
+            .build(beacon_keys.public_key());
+        let wrap = EventBuilder::gift_wrap(&beacon_keys, &recipient.public_key(), rumor, [])
+            .await
             .unwrap();
-        let err = verify_duress_beacon(&event, &beacon_keys.public_key(), &group, 300).unwrap_err();
+        let (sender, rumor) = unwrap(&recipient, &wrap).await;
+        let err =
+            verify_unwrapped_duress_beacon(&sender, &rumor, &beacon_keys.public_key(), &group, 300)
+                .unwrap_err();
         assert!(matches!(err, FrostNetError::ReplayDetected(_)));
     }
 }

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -109,7 +109,7 @@ pub use enroll_session::{
     OprfEnrollSessionState,
 };
 pub use error::{FrostNetError, Result};
-pub use event::{verify_duress_beacon, KfpEventBuilder};
+pub use event::{verify_unwrapped_duress_beacon, KfpEventBuilder};
 pub use node::{
     DescriptorLookupUnavailable, DuressFreeze, DuressPersister, HealthCheckResult,
     KeepDescriptorLookup, KfpNode, KfpNodeEvent, NoOpHooks, OprfShareSealAck, PeerPolicy,

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1477,6 +1477,18 @@ impl KfpNode {
             Some(pins) if !pins.is_empty() => pins,
             _ => return Ok(()),
         };
+        // Cheap size cap BEFORE the expensive unwrap. Our transport pubkey is
+        // deterministically derivable from the public group data, so anyone with the
+        // group npub can address `kind:1059` floods at us; each would otherwise force
+        // a full ECDH + NIP-44 decrypt + two Schnorr verifies in `extract_rumor` on
+        // the serial notification loop. A real beacon wraps a tiny rumor, so it is far
+        // under this bound; an oversized payload is rejected here for the cost of a
+        // length check. (Full unauthenticated-flood rate limiting is tracked
+        // separately: naive dropping could starve a legitimate beacon.)
+        const MAX_GIFT_WRAP_CONTENT: usize = MAX_MESSAGE_SIZE;
+        if event.content.len() > MAX_GIFT_WRAP_CONTENT {
+            return Ok(());
+        }
         // Unwrap with our keys (the wrap is addressed to us). `extract_rumor`
         // decrypts the gift wrap + seal and verifies both signatures, returning the
         // seal author (`sender`) and the inner rumor.

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1461,11 +1461,16 @@ impl KfpNode {
     /// stale) or is a replay, is a no-op , receipt alone grants no trust.
     /// In-memory only (inc2a); sticky persistence + operator clear are
     /// inc2b/inc2c.
-    fn handle_duress_beacon(&self, event: &Event) -> Result<()> {
-        // Already frozen: nothing more to do. Short-circuits BEFORE the signature
-        // verify, so a flood of beacon-key events (including the sender's own
-        // periodic re-broadcasts) cannot force repeated Schnorr checks once the
-        // holder is frozen. The freeze itself is the dedup.
+    /// Handle a received NIP-59 gift wrap (`kind:1059`): unwrap it with our node
+    /// keys and, if it carries a duress beacon sealed by a PINNED beacon pubkey,
+    /// freeze. Gift wraps that are not for us, not decryptable, or not a duress
+    /// beacon are ignored. This is the metadata-private beacon receive path: the
+    /// beacon has no fixed author or label on the wire, so we cannot filter for it
+    /// by author , every gift wrap to us is unwrapped and re-verified here.
+    async fn handle_gift_wrap(&self, event: &Event) -> Result<()> {
+        // Already frozen: nothing more to do. Short-circuits BEFORE the unwrap so a
+        // flood of gift wraps (including the sender's own re-broadcasts) cannot
+        // force repeated nip44 decrypts once frozen. The freeze itself is the dedup.
         if self.is_duress_frozen() {
             return Ok(());
         }
@@ -1473,9 +1478,17 @@ impl KfpNode {
             Some(pins) if !pins.is_empty() => pins,
             _ => return Ok(()),
         };
+        // Unwrap with our keys (the wrap is addressed to us). `extract_rumor`
+        // decrypts the gift wrap + seal and verifies both signatures, returning the
+        // seal author (`sender`) and the inner rumor.
+        let unwrapped = match nostr_sdk::nips::nip59::extract_rumor(&self.keys, event).await {
+            Ok(u) => u,
+            Err(_) => return Ok(()),
+        };
         let verified = pins.iter().find_map(|pin| {
-            crate::event::verify_duress_beacon(
-                event,
+            crate::event::verify_unwrapped_duress_beacon(
+                &unwrapped.sender,
+                &unwrapped.rumor,
                 pin,
                 &self.group_pubkey,
                 self.replay_window_secs,
@@ -2074,23 +2087,24 @@ impl KfpNode {
             .await
             .map_err(|e| FrostNetError::Transport(e.to_string()))?;
 
-        // Coercion resistance: a duress beacon is authored by a dedicated beacon
-        // key, NOT a group member, so the author-scoped filters above never
-        // deliver it. Subscribe to the pinned beacon pubkey(s) as well, still
-        // scoped to this group's `g` tag so it stays bounded and group-specific.
-        // `handle_duress_beacon` re-verifies every event, so this subscription
-        // grants no trust; without a pin there is nothing to receive.
-        if let Some(pins) = self.duress_beacon_pins.as_ref().filter(|p| !p.is_empty()) {
-            let duress_filter = Filter::new()
-                .kind(Kind::Custom(KFP_EVENT_KIND))
-                .authors(pins.clone())
-                .custom_tag(
-                    SingleLetterTag::lowercase(Alphabet::G),
-                    hex::encode(self.group_pubkey),
-                )
-                .since(since);
+        // Coercion resistance: a duress beacon arrives as a NIP-59 gift wrap
+        // authored by an EPHEMERAL key (not a fixed beacon key or group member), so
+        // it cannot be filtered by author. Subscribe to gift wraps addressed to us
+        // (`kind:1059`, `#p` = our pubkey), which look like ordinary private DMs on
+        // the wire; `handle_gift_wrap` unwraps + re-verifies each against the pinned
+        // beacon key, so this grants no trust. Only when a pin is configured (else
+        // nothing would be actioned). Gift wraps use randomized past timestamps, so
+        // no `.since()` , that would drop legitimately back-dated wraps.
+        if self
+            .duress_beacon_pins
+            .as_ref()
+            .is_some_and(|p| !p.is_empty())
+        {
+            let giftwrap_filter = Filter::new()
+                .kind(Kind::GiftWrap)
+                .pubkey(self.keys.public_key());
             self.client
-                .subscribe(duress_filter, None)
+                .subscribe(giftwrap_filter, None)
                 .await
                 .map_err(|e| FrostNetError::Transport(e.to_string()))?;
         }
@@ -2257,6 +2271,14 @@ impl KfpNode {
             return Ok(());
         }
 
+        // A duress beacon arrives metadata-privately as a NIP-59 gift wrap
+        // (kind:1059) authored by an ephemeral key, not as a KFP event, so it is
+        // routed here before the KFP parse. `handle_gift_wrap` unwraps + re-verifies
+        // it against the pinned beacon key.
+        if event.kind == Kind::GiftWrap {
+            return self.handle_gift_wrap(event).await;
+        }
+
         let msg_type = KfpEventBuilder::get_message_type(event);
         debug!(msg_type = ?msg_type, from = %event.pubkey, "Received event");
 
@@ -2274,11 +2296,10 @@ impl KfpNode {
         // (defense in depth), matching `EcdhShare` / `SignatureShare` / `OprfEvalShare` /
         // `DescriptorAck`. Do NOT add `OprfEnrollAck` here: that would exempt it from the gate.
         //
-        // `DuressBeacon` MUST be exempt: a duress beacon is signed by a dedicated duress-beacon
-        // key that never unlocks the vault and is by construction NOT a cluster peer, so the
-        // trusted-peer check would drop every authentic beacon before it reaches its arm. Its
-        // authenticity comes from `verify_duress_beacon` against the pinned beacon pubkey instead,
-        // which the arm (inc2) MUST call before acting -- the exemption grants NO trust on its own.
+        // A duress beacon no longer arrives as a top-level KFP event , it is a NIP-59
+        // gift wrap handled by `handle_gift_wrap` above , so `DuressBeacon` is NOT
+        // exempt here: a plaintext top-level `DuressBeacon` (legacy/spoofed) is
+        // rejected by the trusted-peer gate like any other non-request message.
         if !matches!(
             msg,
             KfpMessage::Announce(_)
@@ -2286,7 +2307,6 @@ impl KfpNode {
                 | KfpMessage::EcdhRequest(_)
                 | KfpMessage::OprfEvalRequest(_)
                 | KfpMessage::OprfEnroll(_)
-                | KfpMessage::DuressBeacon(_)
         ) && !self.peers.read().is_trusted_peer(&event.pubkey)
         {
             debug!(from = %event.pubkey, "Rejecting message from untrusted peer");
@@ -2383,12 +2403,10 @@ impl KfpNode {
                 self.handle_xpub_announce(event.pubkey, payload).await?;
             }
             KfpMessage::DuressBeacon(_) => {
-                // Reaches here WITHOUT the trusted-peer gate (the beacon key is not
-                // a peer; see the exemption above). `handle_duress_beacon`
-                // self-gates via `verify_duress_beacon` against this holder's
-                // PINNED beacon pubkey , reaching this arm grants no trust on its
-                // own , then fail-closed freezes OPRF evaluations.
-                self.handle_duress_beacon(event)?;
+                // A real duress beacon arrives as a NIP-59 gift wrap (handled in
+                // `handle_gift_wrap`), never as a top-level KFP event. A plaintext
+                // top-level one is legacy/spoofed and only reaches here from a
+                // trusted peer (the gate above); ignore it , beacons must be wrapped.
             }
             KfpMessage::PsbtPropose(payload) => {
                 self.handle_psbt_propose(event.pubkey, payload).await?;

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1045,17 +1045,16 @@ pub struct KfpNode {
     /// parallel to `expected_pcrs` for the Nitro path; `None` means TPM quotes
     /// are not configured and appraise to `NotConfigured`.
     tpm_attestation_policy: Option<TpmAttestationPolicy>,
-    /// Pinned duress-beacon pubkey(s) for this group. A received
-    /// `KfpMessage::DuressBeacon` is only actioned if `verify_duress_beacon`
-    /// succeeds against one of these. `None`/empty means duress beacons are not
-    /// configured and are ignored (reaching the arm grants no trust on its own).
+    /// Pinned duress-beacon pubkey(s) for this group. A gift-wrapped beacon is only
+    /// actioned if `verify_unwrapped_duress_beacon` succeeds against one of these.
+    /// `None`/empty means duress beacons are not configured and are ignored
+    /// (receiving one grants no trust on its own).
     duress_beacon_pins: Option<Vec<PublicKey>>,
     /// Set once a valid, fresh duress beacon is verified: this holder is FROZEN
     /// and refuses co-signing and OPRF evaluations (fail-closed). The freeze is
-    /// also the dedup , once set, `handle_duress_beacon` short-circuits, so a
-    /// re-broadcast neither re-alerts nor does redundant verify work. In-memory
-    /// only in inc2a; sticky persistence across reboot + the operator clear are
-    /// inc2b/inc2c.
+    /// also the dedup , once set, `handle_gift_wrap` short-circuits, so a
+    /// re-broadcast neither re-alerts nor does redundant unwrap/verify work.
+    /// Sticky across reboot via the optional persister + the operator clear.
     duress_freeze: RwLock<Option<DuressFreeze>>,
     /// Optional durable sink for the freeze (see [`DuressPersister`]). `None`
     /// means the freeze is in-memory only (lost on restart).
@@ -1629,12 +1628,21 @@ impl KfpNode {
         self.handle_oprf_eval_request(from, request).await
     }
 
-    /// Test-only: drive the holder-side duress-beacon handler directly, so tests
-    /// can assert the freeze/no-freeze outcome without a relay round-trip.
+    /// Test-only: drive the holder-side gift-wrap (duress-beacon) handler directly,
+    /// so tests can assert the freeze/no-freeze outcome without a relay round-trip.
+    /// The event must be a NIP-59 gift wrap addressed to this node's transport key.
     #[doc(hidden)]
     #[cfg(any(test, feature = "testing"))]
-    pub fn test_handle_duress_beacon(&self, event: &Event) -> Result<()> {
-        self.handle_duress_beacon(event)
+    pub async fn test_handle_gift_wrap(&self, event: &Event) -> Result<()> {
+        self.handle_gift_wrap(event).await
+    }
+
+    /// Test-only: this node's transport public key, so a test can gift-wrap a
+    /// beacon addressed to it.
+    #[doc(hidden)]
+    #[cfg(any(test, feature = "testing"))]
+    pub fn test_transport_pubkey(&self) -> PublicKey {
+        self.keys.public_key()
     }
 
     /// Test-only: drive the holder-side OPRF enrollment handler directly. Lets the
@@ -2829,7 +2837,7 @@ fn derive_keys_from_share(share: &SharePackage) -> Result<Keys> {
 /// Used to scope relay subscriptions to `authors`, which keeps strict relays
 /// happy (they require `authors`/`#p`) and avoids pulling the relay's entire
 /// `kind:24242` stream (shared with Blossom and other groups).
-fn group_member_pubkeys(group_pubkey: &[u8; 32], total_shares: u16) -> Vec<PublicKey> {
+pub(crate) fn group_member_pubkeys(group_pubkey: &[u8; 32], total_shares: u16) -> Vec<PublicKey> {
     (1..=total_shares)
         .filter_map(|i| {
             derive_member_keys(group_pubkey, i)
@@ -2887,6 +2895,14 @@ mod tests {
             .unwrap()
     }
 
+    /// Gift-wrap a duress beacon addressed to `node`'s transport key, as a coerced
+    /// holder would broadcast it, so the test drives the real receive path.
+    async fn wrap_for(node: &KfpNode, beacon: &Keys, group: &[u8; 32], nonce: &[u8; 32]) -> Event {
+        KfpEventBuilder::duress_beacon(beacon, group, nonce, &node.keys.public_key())
+            .await
+            .unwrap()
+    }
+
     #[tokio::test]
     async fn duress_beacon_freezes_only_for_pinned_signer_and_dedups() {
         let mut node = duress_test_node().await;
@@ -2896,16 +2912,16 @@ mod tests {
         node.set_duress_beacon_pins(vec![beacon.public_key()]);
 
         // A beacon from an unpinned key does NOT freeze (receipt grants no trust).
-        let ev_wrong = KfpEventBuilder::duress_beacon(&wrong, &group, &[1u8; 32]).unwrap();
-        node.handle_duress_beacon(&ev_wrong).unwrap();
+        let ev_wrong = wrap_for(&node, &wrong, &group, &[1u8; 32]).await;
+        node.handle_gift_wrap(&ev_wrong).await.unwrap();
         assert!(
             !node.is_duress_frozen(),
             "beacon from an unpinned key must not freeze"
         );
 
         // A beacon from the pinned key freezes and records its identity + nonce.
-        let ev = KfpEventBuilder::duress_beacon(&beacon, &group, &[1u8; 32]).unwrap();
-        node.handle_duress_beacon(&ev).unwrap();
+        let ev = wrap_for(&node, &beacon, &group, &[1u8; 32]).await;
+        node.handle_gift_wrap(&ev).await.unwrap();
         assert!(node.is_duress_frozen(), "pinned beacon must freeze");
         let f = node.duress_freeze().unwrap();
         assert_eq!(f.beacon_pubkey, beacon.public_key());
@@ -2913,9 +2929,9 @@ mod tests {
 
         // A later valid beacon (fresh nonce) keeps the FIRST freeze (idempotent,
         // stable audit trail); re-handling the same event is a dedup no-op.
-        let ev2 = KfpEventBuilder::duress_beacon(&beacon, &group, &[2u8; 32]).unwrap();
-        node.handle_duress_beacon(&ev2).unwrap();
-        node.handle_duress_beacon(&ev).unwrap();
+        let ev2 = wrap_for(&node, &beacon, &group, &[2u8; 32]).await;
+        node.handle_gift_wrap(&ev2).await.unwrap();
+        node.handle_gift_wrap(&ev).await.unwrap();
         assert_eq!(
             node.duress_freeze().unwrap().nonce,
             [1u8; 32],
@@ -2935,8 +2951,8 @@ mod tests {
             *sink.write() = Some(f.clone());
         }));
 
-        let ev = KfpEventBuilder::duress_beacon(&beacon, &group, &[4u8; 32]).unwrap();
-        node.handle_duress_beacon(&ev).unwrap();
+        let ev = wrap_for(&node, &beacon, &group, &[4u8; 32]).await;
+        node.handle_gift_wrap(&ev).await.unwrap();
 
         let got = captured.read().clone().expect("persister must be invoked");
         assert_eq!(got.beacon_pubkey, beacon.public_key());
@@ -2963,8 +2979,8 @@ mod tests {
         let group = *node.group_pubkey();
         let beacon = Keys::generate();
         // No pin set: a well-formed beacon is ignored (not configured).
-        let ev = KfpEventBuilder::duress_beacon(&beacon, &group, &[9u8; 32]).unwrap();
-        node.handle_duress_beacon(&ev).unwrap();
+        let ev = wrap_for(&node, &beacon, &group, &[9u8; 32]).await;
+        node.handle_gift_wrap(&ev).await.unwrap();
         assert!(!node.is_duress_frozen());
     }
 
@@ -2973,11 +2989,11 @@ mod tests {
         let mut node = duress_test_node().await;
         let beacon = Keys::generate();
         node.set_duress_beacon_pins(vec![beacon.public_key()]);
-        // Correct signer, WRONG group , verify_duress_beacon rejects the group,
-        // so no freeze.
+        // Correct signer, WRONG group , verify_unwrapped_duress_beacon rejects the
+        // group, so no freeze.
         let other_group = [7u8; 32];
-        let ev = KfpEventBuilder::duress_beacon(&beacon, &other_group, &[3u8; 32]).unwrap();
-        node.handle_duress_beacon(&ev).unwrap();
+        let ev = wrap_for(&node, &beacon, &other_group, &[3u8; 32]).await;
+        node.handle_gift_wrap(&ev).await.unwrap();
         assert!(
             !node.is_duress_frozen(),
             "a beacon for a different group must not freeze this holder"

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -1993,8 +1993,15 @@ mod gate_tests {
         let group = *node.group_pubkey();
         let beacon = Keys::generate();
         node.set_duress_beacon_pins(vec![beacon.public_key()]);
-        let ev = crate::event::KfpEventBuilder::duress_beacon(&beacon, &group, &[8u8; 32]).unwrap();
-        node.handle_duress_beacon(&ev).unwrap();
+        let ev = crate::event::KfpEventBuilder::duress_beacon(
+            &beacon,
+            &group,
+            &[8u8; 32],
+            &node.keys.public_key(),
+        )
+        .await
+        .unwrap();
+        node.handle_gift_wrap(&ev).await.unwrap();
         assert!(node.is_duress_frozen(), "node must be frozen");
 
         let from = Keys::generate().public_key();

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -2559,14 +2559,21 @@ async fn test_duress_frozen_holder_refuses_oprf_eval() {
         .expect("holder");
     holder.set_oprf_key_share(oprf[1]);
 
-    // Pin a beacon key and freeze the holder with a valid beacon for its group.
+    // Pin a beacon key and freeze the holder with a valid beacon for its group,
+    // gift-wrapped to the holder's own transport key (the real receive path).
     let beacon = nostr_sdk::Keys::generate();
     holder.set_duress_beacon_pins(vec![beacon.public_key()]);
-    let ev =
-        keep_frost_net::KfpEventBuilder::duress_beacon(&beacon, holder.group_pubkey(), &[5u8; 32])
-            .expect("beacon");
+    let ev = keep_frost_net::KfpEventBuilder::duress_beacon(
+        &beacon,
+        holder.group_pubkey(),
+        &[5u8; 32],
+        &holder.test_transport_pubkey(),
+    )
+    .await
+    .expect("beacon");
     holder
-        .test_handle_duress_beacon(&ev)
+        .test_handle_gift_wrap(&ev)
+        .await
         .expect("handle beacon");
     assert!(holder.is_duress_frozen(), "holder must be frozen");
 


### PR DESCRIPTION
## Metadata-private duress beacon (NIP-59 gift wrap) + robust delivery

Reworks the coercion-resistance duress beacon from a self-labeling, author-identifiable KFP event into a metadata-private NIP-59 gift wrap, and makes its delivery auth-aware so a coerced holder reliably alerts even when its publish races the relay's NIP-42 authentication.

### Why

The prior beacon was a plaintext-tagged `kind` event authored by a fixed beacon key. On the wire that self-labels as duress (a `t=duress_beacon` tag, the group, the nonce) and is filterable by the beacon pubkey, so a relay or network observer could both detect that a duress event occurred and identify the holder. It also published once against `RelayStatus::Connected`, which is not the same as authenticated, so on a fast path the publish could be rejected with `auth-required` and the holder would silently fail to alert.

### What changed

- **Wire form (metadata-private).** The `DuressBeaconPayload` now rides in an unsigned rumor, sealed by the beacon key (authenticity), then gift-wrapped to each recipient under an ephemeral key with a randomized timestamp. To a relay it is an ordinary `kind:1059` gift wrap, indistinguishable from a private DM: no duress label, group, nonce, or beacon-key identity on the wire, and no fixed author to filter on.
- **Broadcast to every member.** `KfpEventBuilder::duress_beacon_broadcast` wraps one beacon per group member (transport pubkeys derived from the public group data), since a gift wrap is addressed to a single recipient. Emit and receive use the same `derive_member_keys` derivation, so each wrap lands on exactly one holder's subscription.
- **Receive path.** Holders subscribe to `kind:1059` `#p`-addressed to them (only when a pin is configured). `handle_gift_wrap` unwraps with the node key, then `verify_unwrapped_duress_beacon` checks the seal author is a pinned beacon key, the rumor is a `DuressBeacon` for this group, and it is fresh. The freeze short-circuits before the unwrap, so a re-broadcast flood does no redundant work.
- **Robust auth-aware delivery.** Emit retries fast (2s) until a broadcast is actually accepted by the relay (the relay appears in the send `Output.success` set), which covers the NIP-42 auth race and connection settling, then relaxes to the 30s re-broadcast cadence. This closes the delivery flakiness that kept `duress-freeze` out of keep-node CI.
- **New `--group-total` serve flag.** A coerced holder never unlocks the vault, so it cannot read its group size; the member count (public group data) is supplied out of band alongside the emit config and validated up front, before the password prompt, to stay indistinguishable from a normal start.

### Tests

Reworked the event, node, and multinode duress tests to the gift-wrap API (build a wrap, unwrap as the recipient, verify): pinned-signer-only freeze + dedup, persister-on-freeze, wrong-signer rejection, group-mismatch rejection, end-to-end staleness, and duress-frozen OPRF-eval refusal. All pass; `fmt`/`clippy` clean.

### Follow-ups (not in this PR)

- keep `0.7.0` release, then keep-node re-pins it, adds `--group-total` to the duress-freeze nixosTest, and re-enables that test in CI to revalidate the full path.
- Traffic-shape indistinguishability (cover traffic + jittered cadence): the fixed re-broadcast cadence is still a relay-observable signature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `--duress-group-total` to configure the total number of shares when serving a duress beacon.
  - Duress beacons are now securely delivered to all group members through protected gift-wrapped messages.
  - Beacon serving retries quickly until relay acceptance, then continues periodic broadcasts.

- **Bug Fixes**
  - Invalid duress configurations now fail immediately.
  - Nodes ignore unauthenticated, incorrectly targeted, stale, or legacy beacon messages.
  - Valid beacons continue to freeze nodes and prevent protected operations as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->