### PR TITLE
Release v0.7.1: fix duress emit flag to --group-total

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "keep-agent"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "keep-bitcoin"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bitcoin",
  "getrandom 0.4.3",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "keep-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "keep-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aes 0.9.1",
  "argon2",
@@ -4636,7 +4636,7 @@ dependencies = [
 
 [[package]]
 name = "keep-desktop"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4669,14 +4669,14 @@ dependencies = [
 
 [[package]]
 name = "keep-enclave"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "keep-enclave-host",
 ]
 
 [[package]]
 name = "keep-enclave-host"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -4707,7 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "keep-frost-net"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "keep-mobile"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4778,7 +4778,7 @@ dependencies = [
 
 [[package]]
 name = "keep-nip46"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bitflags 2.13.0",
  "chrono",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "keep-web"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "axum",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -638,7 +638,11 @@ pub(crate) enum FrostNetworkCommands {
         /// group member, so the emitter needs the member count up front , a coerced
         /// holder never unlocks the vault to read it. Public group data (not a
         /// secret); required with --duress-beacon-pubkey.
-        #[arg(long, value_name = "N", requires = "duress_beacon_pubkey")]
+        #[arg(
+            long = "group-total",
+            value_name = "N",
+            requires = "duress_beacon_pubkey"
+        )]
         duress_group_total: Option<u16>,
         /// Coercion resistance: a group holder's duress-beacon npub to TRUST.
         /// Repeatable. Receiving a verified beacon signed by any pinned key freezes
@@ -1029,6 +1033,43 @@ mod tests {
             panic!("expected bitcoin sign command");
         };
         assert_eq!(psbt, "/tmp/unsigned.psbt");
+    }
+
+    #[test]
+    fn frost_serve_accepts_group_total_flag() {
+        // Regression: the duress emit path requires `--group-total`, and the field
+        // name would otherwise derive `--duress-group-total`, which mismatches the
+        // docs, the error strings, and the nixosTest. Assert the flag parses and
+        // binds, so a rename can never silently break the coerced-holder emit.
+        let cli = Cli::try_parse_from([
+            "keep",
+            "frost",
+            "network",
+            "serve",
+            "--group",
+            "npub1group",
+            "--duress-beacon-pubkey",
+            "npub1beacon",
+            "--duress-beacon-salt",
+            "00",
+            "--group-total",
+            "3",
+        ])
+        .expect("parse serve with --group-total");
+
+        let Commands::Frost { command } = cli.command else {
+            panic!("expected frost command");
+        };
+        let FrostCommands::Network { command } = command else {
+            panic!("expected frost network command");
+        };
+        let FrostNetworkCommands::Serve {
+            duress_group_total, ..
+        } = command
+        else {
+            panic!("expected frost network serve command");
+        };
+        assert_eq!(duress_group_total, Some(3));
     }
 
     #[test]


### PR DESCRIPTION
Patch release. In v0.7.0 the duress emit flag derived its name from the field (`--duress-group-total`) while the help text, the fail-closed validation errors, and the end-to-end test all reference `--group-total`, so the documented invocation was rejected with "unexpected argument". Pin the flag to `--group-total` and add a parse regression test that binds it, so the coerced-holder emit path matches its own docs. No behavior change beyond the flag name.