### PR TITLE
duress-provision: reject a duress credential equal to the vault password (anti-brick)

### DIFF
--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -63,18 +63,21 @@ enum DuressVaultCheck {
     VaultUnavailable(String),
 }
 
-/// Test whether `candidate` is the vault password by attempting to unlock the vault
-/// at `path` with it. Split from the command so the anti-brick check is unit-testable
-/// without an interactive prompt.
+/// Test whether `candidate` is the vault password at `path`, via the read-only
+/// [`keep_core::Keep::password_matches`] pre-flight check (NOT an unlock): it does
+/// not touch the rate limiter, so this guard can neither self-inflict a lockout nor
+/// be silently skipped when the vault is in backoff. A candidate that could not be
+/// tested (crypto error, or the vault could not be opened) is reported as
+/// `VaultUnavailable` , the caller warns rather than treating "unknown" as "distinct"
+/// and letting the footgun through. Split out so the check is unit-testable.
 fn check_duress_vs_vault(path: &Path, candidate: &str) -> DuressVaultCheck {
-    match keep_core::Keep::open(path) {
-        Ok(mut keep) => {
-            if keep.unlock(candidate).is_ok() {
-                DuressVaultCheck::EqualsVaultPassword
-            } else {
-                DuressVaultCheck::Distinct
-            }
-        }
+    let keep = match keep_core::Keep::open(path) {
+        Ok(k) => k,
+        Err(e) => return DuressVaultCheck::VaultUnavailable(e.to_string()),
+    };
+    match keep.password_matches(candidate) {
+        Ok(true) => DuressVaultCheck::EqualsVaultPassword,
+        Ok(false) => DuressVaultCheck::Distinct,
         Err(e) => DuressVaultCheck::VaultUnavailable(e.to_string()),
     }
 }

--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -53,13 +53,40 @@ pub(crate) fn derive_beacon_key(
     Ok(Keys::new(secret))
 }
 
+/// Outcome of testing a candidate duress credential against the vault at a path.
+enum DuressVaultCheck {
+    /// The candidate does NOT unlock the vault: safe, distinct from the vault password.
+    Distinct,
+    /// The candidate unlocks the vault, i.e. it IS the vault password (the brick footgun).
+    EqualsVaultPassword,
+    /// The vault could not be opened (e.g. it does not exist yet); check skipped.
+    VaultUnavailable(String),
+}
+
+/// Test whether `candidate` is the vault password by attempting to unlock the vault
+/// at `path` with it. Split from the command so the anti-brick check is unit-testable
+/// without an interactive prompt.
+fn check_duress_vs_vault(path: &Path, candidate: &str) -> DuressVaultCheck {
+    match keep_core::Keep::open(path) {
+        Ok(mut keep) => {
+            if keep.unlock(candidate).is_ok() {
+                DuressVaultCheck::EqualsVaultPassword
+            } else {
+                DuressVaultCheck::Distinct
+            }
+        }
+        Err(e) => DuressVaultCheck::VaultUnavailable(e.to_string()),
+    }
+}
+
 /// `keep frost network duress-provision`: interactively provision a duress
 /// credential and print the beacon pubkey (to pin with the cluster) plus the salt
-/// (to configure on `serve`). Purely local , it derives, prints, and forgets. The
-/// credential itself is NEVER stored (serve re-derives from the entered password
-/// and compares the pubkey), so a coercer inspecting config finds only a pubkey
-/// and a salt, not the duress trigger.
-pub fn cmd_frost_network_duress_provision(out: &Output) -> Result<()> {
+/// (to configure on `serve`). It derives, prints, and forgets; the credential is
+/// NEVER stored (serve re-derives from the entered password and compares the
+/// pubkey), so a coercer inspecting config finds only a pubkey and a salt, not the
+/// duress trigger. It does touch the vault at `path` once, read-only, to reject a
+/// duress credential equal to the vault password (see below).
+pub fn cmd_frost_network_duress_provision(out: &Output, path: &Path) -> Result<()> {
     out.header("Duress Provisioning");
     out.warn(
         "Choose a DURESS credential DISTINCT from your vault password. Entering it at `serve` \
@@ -68,6 +95,30 @@ pub fn cmd_frost_network_duress_provision(out: &Output) -> Result<()> {
          stored.",
     );
     let credential = get_duress_credential("Enter duress credential", "Confirm duress credential")?;
+
+    // Reject a duress credential that IS the vault password. At `serve`, match_duress
+    // runs before unlock, so if the two are equal every NORMAL unlock takes the
+    // fail-closed duress path and normal operation is permanently bricked. The
+    // KEEP_PASSWORD env case is caught in get_duress_credential; this catches the
+    // interactive case by testing the candidate against the ACTUAL vault (robust even
+    // when the vault password is complex). If the vault cannot be opened (e.g.
+    // provisioning before it exists), warn rather than silently allow the footgun.
+    match check_duress_vs_vault(path, credential.expose_secret()) {
+        DuressVaultCheck::EqualsVaultPassword => {
+            return Err(KeepError::invalid_input(
+                "duress credential must be DISTINCT from the vault password: it unlocks this \
+                 vault, so at `serve` every normal unlock would take the fail-closed duress \
+                 path and permanently brick normal operation",
+            ))
+        }
+        DuressVaultCheck::VaultUnavailable(e) => out.warn(&format!(
+            "could not open the vault at the configured path to verify the duress credential \
+             differs from the vault password ({e}); make sure it does, or a normal unlock will \
+             fail closed"
+        )),
+        DuressVaultCheck::Distinct => {}
+    }
+
     let salt: [u8; SALT_SIZE] = keep_core::entropy::try_random_bytes()?;
     let beacon = derive_beacon_key(credential.expose_secret(), &salt, DURESS_BEACON_ARGON2)?;
     let npub = beacon
@@ -552,6 +603,32 @@ mod tests {
         let a = derive_beacon_key("correct horse battery staple", &salt, P).unwrap();
         let b = derive_beacon_key("correct horse battery staple", &salt, P).unwrap();
         assert_eq!(a.public_key(), b.public_key());
+    }
+
+    #[test]
+    fn duress_provision_rejects_credential_equal_to_vault_password() {
+        let dir = tempfile::tempdir().unwrap();
+        // Keep::create requires a non-existent path (it creates the vault dir).
+        let vault = dir.path().join("vault");
+        let vault_pw = "the-real-vault-password";
+        // Fast params so the test is quick; unlock reads the stored params back.
+        keep_core::Keep::create_with_params(&vault, vault_pw, P).unwrap();
+
+        // The vault password IS detected , the brick footgun the guard blocks.
+        assert!(matches!(
+            check_duress_vs_vault(&vault, vault_pw),
+            DuressVaultCheck::EqualsVaultPassword
+        ));
+        // A distinct credential is allowed through.
+        assert!(matches!(
+            check_duress_vs_vault(&vault, "a-different-duress-credential"),
+            DuressVaultCheck::Distinct
+        ));
+        // A path with no vault skips the check (the caller warns) rather than hard-failing.
+        assert!(matches!(
+            check_duress_vs_vault(&dir.path().join("nope"), vault_pw),
+            DuressVaultCheck::VaultUnavailable(_)
+        ));
     }
 
     #[test]

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -358,7 +358,7 @@ fn dispatch_frost_network(
             commands::frost_network::cmd_frost_network_peers(out, path, &group, relay)
         }
         FrostNetworkCommands::DuressProvision => {
-            commands::frost_network::cmd_frost_network_duress_provision(out)
+            commands::frost_network::cmd_frost_network_duress_provision(out, path)
         }
         FrostNetworkCommands::DuressClear {
             state_file,

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -261,6 +261,18 @@ impl Keep {
         self.storage.verify_password(password)
     }
 
+    /// Read-only pre-flight check of whether `password` is this vault's password,
+    /// WITHOUT touching the rate limiter, audit log, keyring, or unlock state.
+    /// `Ok(true)` = matches, `Ok(false)` = wrong password, `Err` = could not check.
+    /// Unlike [`Self::verify_password`] it does not record a rate-limit attempt and
+    /// is not blocked by an active backoff, so a pre-flight check cannot self-inflict
+    /// a lockout nor be silently skipped. Because it does not rate-limit, use it only
+    /// on local, operator-driven paths (e.g. the duress-provision anti-brick guard),
+    /// never as a remote or automated unlock oracle.
+    pub fn password_matches(&self, password: &str) -> Result<bool> {
+        self.storage.password_matches(password)
+    }
+
     /// Lock and clear all keys from memory.
     pub fn lock(&mut self) {
         self.audit_event(AuditEventType::VaultLock, |e| e);

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -653,6 +653,38 @@ impl Storage {
         }
     }
 
+    /// Check whether `password` decrypts the vault header, WITHOUT touching the
+    /// rate limiter, the audit log, the keyring, or the unlock state. Returns
+    /// `Ok(true)` if it matches, `Ok(false)` if it is simply the wrong password,
+    /// and `Err` only if the check could not be performed (a crypto/KDF error).
+    ///
+    /// This is a read-only pre-flight primitive, NOT an unlock path. Unlike
+    /// [`Self::verify_password`] / [`Self::unlock`] it deliberately bypasses the
+    /// rate limiter: it neither consumes a real-unlock attempt (so a pre-flight
+    /// check cannot self-inflict a lockout) nor is defeated by an active backoff
+    /// (so it cannot be silently skipped when the vault is rate-limited). Because
+    /// it does not rate-limit, callers MUST keep it on a local, operator-driven
+    /// path (it needs the vault file already, same as an offline attacker) and
+    /// MUST NOT expose it as a remote or automated unlock oracle.
+    pub(crate) fn password_matches(&self, password: &str) -> Result<bool> {
+        validate_password_max_len(password)?;
+        let master_key = crypto::derive_key(
+            password.as_bytes(),
+            &self.header.salt,
+            self.header.argon2_params(),
+        )?;
+        let header_key = crypto::derive_subkey(&master_key, b"keep-header-key")?;
+        let encrypted = EncryptedData {
+            nonce: self.header.nonce,
+            ciphertext: self.header.encrypted_data_key.to_vec(),
+        };
+        match crypto::decrypt(&encrypted, &header_key) {
+            Ok(_) => Ok(true),
+            Err(KeepError::DecryptionFailed) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
     fn unlock_inner(&mut self, password: &str) -> Result<()> {
         validate_password_max_len(password)?;
 
@@ -1922,6 +1954,32 @@ mod tests {
                 .apply_replicated_record("keys", &id, &enc, now + MAX_FUTURE_SKEW_SECS, now)
                 .unwrap(),
             ReplicatedApply::Applied
+        );
+    }
+
+    #[test]
+    fn password_matches_is_rate_limit_free() {
+        let dir = tempdir().unwrap();
+        let storage = Storage::create(
+            &dir.path().join("v"),
+            "rightpassword",
+            Argon2Params::TESTING,
+        )
+        .unwrap();
+
+        // Correct classification: right password matches, wrong password does not.
+        assert!(storage.password_matches("rightpassword").unwrap());
+        assert!(!storage.password_matches("wrongpassword").unwrap());
+
+        // Hammer wrong passwords well past MAX_ATTEMPTS (5): password_matches must
+        // record no failures, so the rate limiter never trips. If it did, the real
+        // verify below would return RateLimited before decrypting.
+        for _ in 0..8 {
+            assert!(!storage.password_matches("nope").unwrap());
+        }
+        assert!(
+            storage.verify_password("rightpassword").is_ok(),
+            "password_matches must not touch the rate limiter (a pre-flight check cannot self-lock the vault)"
         );
     }
 


### PR DESCRIPTION
## duress-provision: reject a duress credential equal to the vault password

Closes a permanent-brick footgun in the coercion feature. At `serve`, `match_duress` runs **before** the vault unlock, so if a holder's duress credential equals their vault password, entering the vault password takes the fail-closed duress path on **every normal unlock** , normal operation is bricked until re-provisioned.

`get_duress_credential` already rejects this when `KEEP_PASSWORD` is set in the env, but the **interactive** path had nothing to compare against (provisioning can't see the vault password), leaving only a `warn()`.

### Fix

`duress-provision` now tests the chosen credential against the **actual vault** at `--path`: it attempts an unlock and rejects if it succeeds (the credential *is* the vault password). This is robust , it checks the real password without asking the user to re-type it and works regardless of password complexity. If the vault can't be opened (e.g. provisioning before it exists), it warns rather than silently allowing the footgun. The check is split into a small `check_duress_vs_vault` helper so it's unit-testable.

### Tests

New unit test creates a fast-params vault and asserts the guard: the vault password is detected (`EqualsVaultPassword`), a distinct credential passes (`Distinct`), and a missing vault degrades to `VaultUnavailable` (warn, not fail). All duress tests pass; `clippy`/`fmt` clean.

Ref: keep-node-t38.1 (security-review PR #724, Low). No behavior change on the happy path (distinct credentials); only the equal-to-vault-password case is now rejected up front instead of at serve.
