### PR TITLE
Release v0.7.2: duress-provision anti-brick guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "keep-agent"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "keep-bitcoin"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bitcoin",
  "getrandom 0.4.3",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "keep-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "keep-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aes 0.9.1",
  "argon2",
@@ -4636,7 +4636,7 @@ dependencies = [
 
 [[package]]
 name = "keep-desktop"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4669,14 +4669,14 @@ dependencies = [
 
 [[package]]
 name = "keep-enclave"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "keep-enclave-host",
 ]
 
 [[package]]
 name = "keep-enclave-host"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -4707,7 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "keep-frost-net"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "keep-mobile"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -4778,7 +4778,7 @@ dependencies = [
 
 [[package]]
 name = "keep-nip46"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bitflags 2.13.0",
  "chrono",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "keep-web"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "axum",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"


### PR DESCRIPTION
Version bump to 0.7.2. Patch release: duress-provision now rejects a duress credential equal to the vault password (#734), which would otherwise make every normal unlock take the fail-closed duress path and permanently brick the holder. Adds a rate-limit-free `Keep::password_matches` pre-flight primitive used by the guard. Lets keep-node adopt the fix.