### PR TITLE
keep-frost-net: in-attempt holder failover for OPRF unlock

### DIFF
--- a/keep-frost-net/src/node/oprf.rs
+++ b/keep-frost-net/src/node/oprf.rs
@@ -19,7 +19,32 @@ use crate::event::KfpEventBuilder;
 use crate::oprf_session::derive_oprf_session_id;
 use crate::protocol::*;
 
+use super::signing::MAX_FAILOVER_ATTEMPTS;
 use super::{KfpNode, KfpNodeEvent};
+
+/// Failure of a single OPRF unlock round. `non_responders` carries the sampled
+/// holders that never deposited a partial (populated only on a timeout), so the
+/// failover loop can exclude them from the next round.
+struct OprfRoundError {
+    error: FrostNetError,
+    non_responders: Vec<u16>,
+}
+
+impl OprfRoundError {
+    /// A fatal round error with no failover hint (not a holder-silence timeout).
+    fn fatal(error: FrostNetError) -> Self {
+        Self {
+            error,
+            non_responders: Vec::new(),
+        }
+    }
+}
+
+impl From<FrostNetError> for OprfRoundError {
+    fn from(error: FrostNetError) -> Self {
+        Self::fatal(error)
+    }
+}
 
 impl KfpNode {
     /// Holder side: evaluate a box's blinded element with this node's dedicated
@@ -247,20 +272,110 @@ impl KfpNode {
     /// the FROST threshold to `finalize_luks_key`); a mismatch makes every
     /// finalize fail. The node with FROST identifier `i` must hold the OPRF share
     /// at vsss index `i`.
+    /// Threshold OPRF unlock with in-attempt holder failover.
+    ///
+    /// A single unlock samples `threshold-1` holders and waits one timeout for
+    /// their partials. On timeout with fewer than `threshold` partials, the
+    /// holders that never answered are excluded and a fresh round re-samples
+    /// from the remaining eligible holders, up to `MAX_FAILOVER_ATTEMPTS`. This
+    /// fails over to a live holder in seconds instead of failing the boot closed
+    /// when one holder is momentarily unreachable (the real target: a
+    /// geo-distributed holder on a flaky network). Mirrors the FROST signing
+    /// failover (`signing.rs`).
+    ///
+    /// Failover keys off a `Timeout` (silence) ONLY. A holder that answers but
+    /// rejects (duress-frozen, unattested, rate-limited, or approval-denied)
+    /// simply sends nothing, so it is indistinguishable from unreachable and is
+    /// correctly excluded. A holder whose partial reaches the box but fails to
+    /// combine surfaces as `Session`/`OprfUnlockFailed`, which is a real
+    /// cryptographic rejection and is surfaced to the caller unchanged (retrying
+    /// a different holder would combine to the same key, so it cannot help and
+    /// must not mask a misbehaving holder). Re-sampling never re-hits an excluded
+    /// holder, so no holder's per-requester rate limit or attestation gate is
+    /// bypassed; each round contacts each holder at most once for the same fixed
+    /// blinded input, so it is not a grinding vector.
     pub async fn request_oprf_unlock(
         &self,
         input: &[u8],
         volume_id: &str,
         epoch: u32,
     ) -> Result<Zeroizing<[u8; 32]>> {
-        let oprf_share = self.oprf_key_share.as_ref().ok_or_else(|| {
-            FrostNetError::Crypto("Node has no OPRF key share; cannot initiate unlock".into())
-        })?;
+        // Fail fast once if this node holds no OPRF share, before any round.
+        if self.oprf_key_share.is_none() {
+            return Err(FrostNetError::Crypto(
+                "Node has no OPRF key share; cannot initiate unlock".into(),
+            ));
+        }
+
+        let mut excluded: Vec<u16> = Vec::new();
+        for attempt in 0..MAX_FAILOVER_ATTEMPTS {
+            let last = attempt + 1 == MAX_FAILOVER_ATTEMPTS;
+            match self
+                .oprf_unlock_round(input, volume_id, epoch, &excluded)
+                .await
+            {
+                Ok(key) => return Ok(key),
+                Err(OprfRoundError {
+                    error: FrostNetError::Timeout(_),
+                    non_responders,
+                }) if !last => {
+                    if non_responders.is_empty() {
+                        warn!(
+                            attempt,
+                            "OPRF unlock round timed out with no identifiable non-responders; re-sampling and retrying"
+                        );
+                    } else {
+                        warn!(
+                            excluded = ?non_responders,
+                            attempt,
+                            "OPRF unlock round timed out; excluding unresponsive holders and retrying"
+                        );
+                        excluded.extend(non_responders);
+                    }
+                }
+                Err(OprfRoundError {
+                    error: FrostNetError::InsufficientPeers { .. },
+                    ..
+                }) if !excluded.is_empty() => {
+                    // Failover exhausted the eligible holder set (each retry
+                    // excludes more until fewer than threshold remain). Surface
+                    // the aggregate timeout, not InsufficientPeers, which would
+                    // wrongly suggest the group was undersized.
+                    warn!(
+                        attempt,
+                        "OPRF failover exhausted the eligible holder set; surfacing aggregate timeout"
+                    );
+                    break;
+                }
+                Err(OprfRoundError { error, .. }) => return Err(error),
+            }
+        }
+        Err(FrostNetError::Timeout(
+            "OPRF unlock request timed out after failover".into(),
+        ))
+    }
+
+    /// One OPRF unlock round: sample (excluding `excluded`), blind, send, and
+    /// wait one timeout. On timeout, the returned `non_responders` are the
+    /// sampled holders that never deposited a partial, so the caller can exclude
+    /// them and fail over.
+    async fn oprf_unlock_round(
+        &self,
+        input: &[u8],
+        volume_id: &str,
+        epoch: u32,
+        excluded: &[u16],
+    ) -> std::result::Result<Zeroizing<[u8; 32]>, OprfRoundError> {
+        let oprf_share = self
+            .oprf_key_share
+            .as_ref()
+            .expect("caller checked oprf_key_share is present");
 
         let threshold = self.share.metadata.threshold;
 
-        let (participants, participant_peers) =
-            self.select_eligible_peers(threshold as usize, &[])?;
+        let (participants, participant_peers) = self
+            .select_eligible_peers(threshold as usize, excluded)
+            .map_err(OprfRoundError::fatal)?;
 
         let (client, blinded) = keep_core::oprf::unlock::blind(input)
             .map_err(|e| FrostNetError::Crypto(e.to_string()))?;
@@ -325,7 +440,7 @@ impl KfpNode {
         .await;
         if let Err(e) = send_result {
             self.oprf_sessions.write().complete_session(&session_id);
-            return Err(e);
+            return Err(OprfRoundError::fatal(e));
         }
 
         // Single-participant (threshold=1) or quorum already met by our own
@@ -337,7 +452,7 @@ impl KfpNode {
                     Ok(key) => key,
                     Err(e) => {
                         oprf_sessions.complete_session(&session_id);
-                        return Err(e);
+                        return Err(OprfRoundError::fatal(e));
                     }
                 },
                 _ => None,
@@ -398,11 +513,42 @@ impl KfpNode {
                 "OPRF unlock request timed out".into(),
             )),
         };
-        // Tear down the session on any non-success exit so it does not linger
-        // until cleanup_expired reaps it (matches request_ecdh).
-        if result.is_err() {
-            self.oprf_sessions.write().complete_session(&session_id);
+        match result {
+            Ok(key) => Ok(key),
+            Err(error) => {
+                // On a timeout, identify the sampled holders that never
+                // deposited a partial so the caller can exclude them and fail
+                // over to other eligible holders. Read responders BEFORE tearing
+                // the session down. A non-timeout error (a real cryptographic
+                // rejection or a transport fault) carries no non-responders, so
+                // the caller surfaces it unchanged.
+                let non_responders = if matches!(error, FrostNetError::Timeout(_)) {
+                    let sessions = self.oprf_sessions.read();
+                    match sessions.get_session(&session_id) {
+                        Some(s) => {
+                            let responded: std::collections::HashSet<u16> =
+                                s.responders().into_iter().collect();
+                            participants
+                                .iter()
+                                .copied()
+                                .filter(|p| {
+                                    *p != self.share.metadata.identifier && !responded.contains(p)
+                                })
+                                .collect()
+                        }
+                        None => Vec::new(),
+                    }
+                } else {
+                    Vec::new()
+                };
+                // Tear the session down on any non-success exit so it does not
+                // linger until cleanup_expired reaps it (matches request_ecdh).
+                self.oprf_sessions.write().complete_session(&session_id);
+                Err(OprfRoundError {
+                    error,
+                    non_responders,
+                })
+            }
         }
-        result
     }
 }

--- a/keep-frost-net/src/node/oprf.rs
+++ b/keep-frost-net/src/node/oprf.rs
@@ -290,10 +290,12 @@ impl KfpNode {
     /// combine surfaces as `Session`/`OprfUnlockFailed`, which is a real
     /// cryptographic rejection and is surfaced to the caller unchanged (retrying
     /// a different holder would combine to the same key, so it cannot help and
-    /// must not mask a misbehaving holder). Re-sampling never re-hits an excluded
-    /// holder, so no holder's per-requester rate limit or attestation gate is
-    /// bypassed; each round contacts each holder at most once for the same fixed
-    /// blinded input, so it is not a grinding vector.
+    /// must not mask a misbehaving holder). Re-sampling never re-hits an
+    /// *excluded* (non-responding) holder; a holder that did respond may be
+    /// re-sampled in a later round, but the loop is capped at
+    /// `MAX_FAILOVER_ATTEMPTS` and every holder independently enforces its
+    /// per-requester rate limit and attestation gate on each eval, so failover
+    /// cannot drive a holder past its budget. Not a grinding vector.
     pub async fn request_oprf_unlock(
         &self,
         input: &[u8],

--- a/keep-frost-net/src/oprf_session.rs
+++ b/keep-frost-net/src/oprf_session.rs
@@ -157,6 +157,13 @@ impl OprfUnlockSession {
         self.partials.len() >= self.threshold
     }
 
+    /// Share indices that have deposited a partial into this session so far.
+    /// Used by the unlock requester to identify non-responding holders on a
+    /// timeout, so it can exclude them and fail over to other eligible holders.
+    pub fn responders(&self) -> Vec<u16> {
+        self.partials.keys().copied().collect()
+    }
+
     /// Derive the LUKS key once a quorum of partials is present. Below quorum
     /// returns `Ok(None)`; a finalize failure marks the session `Failed` and
     /// surfaces the error.

--- a/keep-frost-net/tests/multinode_test.rs
+++ b/keep-frost-net/tests/multinode_test.rs
@@ -2443,6 +2443,136 @@ async fn test_oprf_unlock_completes_with_one_holder() {
     );
 }
 
+/// Failover: in a 2-of-3, one holder is persistently silent (its default
+/// approval hook DENIES, so it clears attestation + rate limit but returns no
+/// partial, which is indistinguishable from unreachable from the box's side).
+/// The box samples `threshold-1 = 1` holder at random; when it lands on the
+/// silent one it must exclude it and re-sample the live holder WITHIN the same
+/// unlock, instead of failing the boot closed. This is the geo-distributed
+/// flaky-holder case. A short session timeout keeps each failover round quick.
+///
+/// With failover, every iteration derives a key (immediate when the live holder
+/// is sampled, else after one failover round), so this test is deterministically
+/// green. A regression that drops failover fails any iteration that samples the
+/// silent holder, i.e. with probability `1 - 0.5^6` across the loop.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_oprf_unlock_fails_over_when_one_holder_silent() {
+    use std::sync::Arc;
+
+    let mock_relay = MockRelay::run().await.expect("Failed to start mock relay");
+    let relay = mock_relay.url().await.to_string();
+
+    let config = ThresholdConfig::two_of_three();
+    let dealer = TrustedDealer::new(config);
+    let (mut shares, _pkg) = dealer.generate("test-oprf-failover").unwrap();
+    let share1 = shares.remove(0); // FROST id 1 = box
+    let share2 = shares.remove(0); // FROST id 2 = silent holder
+    let share3 = shares.remove(0); // FROST id 3 = live holder
+
+    let oprf = split_oprf_key_2of3();
+
+    // Short session timeout so a failover round costs ~3s, not the 30s default.
+    let short = Some(Duration::from_secs(3));
+    let mut node1 = KfpNode::with_nonce_store(share1, vec![relay.clone()], None, None, short)
+        .await
+        .expect("box node");
+    node1.set_oprf_key_share(oprf[0]);
+    // node2 keeps the DEFAULT approval hook, which DENIES: it clears every prior
+    // gate but returns no partial, so from the box it is silent.
+    let mut node2 = KfpNode::with_nonce_store(share2, vec![relay.clone()], None, None, short)
+        .await
+        .expect("silent holder node");
+    node2.set_oprf_key_share(oprf[1]);
+    let mut node3 = KfpNode::with_nonce_store(share3, vec![relay], None, None, short)
+        .await
+        .expect("live holder node");
+    node3.set_oprf_key_share(oprf[2]);
+    node3.set_hooks(Arc::new(ApproveOprfHooks));
+
+    let mut rx1 = node1.subscribe();
+    let shutdown1 = node1.take_shutdown_handle();
+    let shutdown2 = node2.take_shutdown_handle();
+    let shutdown3 = node3.take_shutdown_handle();
+
+    let node1 = Arc::new(node1);
+    let node2 = Arc::new(node2);
+    let node3 = Arc::new(node3);
+    let node1_run = Arc::clone(&node1);
+    let node2_run = Arc::clone(&node2);
+    let node3_run = Arc::clone(&node3);
+    let node1_handle = tokio::spawn(async move {
+        let _ = node1_run.run().await;
+    });
+    let node2_handle = tokio::spawn(async move {
+        let _ = node2_run.run().await;
+    });
+    let node3_handle = tokio::spawn(async move {
+        let _ = node3_run.run().await;
+    });
+
+    // The box must discover BOTH holders so either can be sampled.
+    let mut discovered = 0u32;
+    let discovery = timeout(Duration::from_secs(45), async {
+        while discovered < 2 {
+            if let Ok(KfpNodeEvent::PeerDiscovered { .. }) = rx1.recv().await {
+                discovered += 1;
+            }
+        }
+    })
+    .await;
+    if discovery.is_err() {
+        graceful_shutdown(shutdown1, node1_handle).await;
+        graceful_shutdown(shutdown2, node2_handle).await;
+        graceful_shutdown(shutdown3, node3_handle).await;
+        panic!("Peer discovery timed out: box discovered {discovered}/2 holders");
+    }
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let mut first_key: Option<[u8; 32]> = None;
+    for i in 0..6 {
+        // Re-assert the box as Verified on both holders before each unlock; a
+        // periodic re-announce can otherwise reset attestation between rounds.
+        node2.test_set_peer_attestation(1, keep_frost_net::AttestationStatus::Verified);
+        node3.test_set_peer_attestation(1, keep_frost_net::AttestationStatus::Verified);
+
+        let key = match timeout(
+            Duration::from_secs(30),
+            node1.request_oprf_unlock(OPRF_INPUT, "vault0", 1),
+        )
+        .await
+        {
+            Ok(Ok(k)) => k,
+            Ok(Err(e)) => {
+                graceful_shutdown(shutdown1, node1_handle).await;
+                graceful_shutdown(shutdown2, node2_handle).await;
+                graceful_shutdown(shutdown3, node3_handle).await;
+                panic!(
+                    "unlock iteration {i} failed (a failover regression fails closed here): {e}"
+                );
+            }
+            Err(_) => {
+                graceful_shutdown(shutdown1, node1_handle).await;
+                graceful_shutdown(shutdown2, node2_handle).await;
+                graceful_shutdown(shutdown3, node3_handle).await;
+                panic!("unlock iteration {i} timed out");
+            }
+        };
+        assert_eq!(key.len(), 32, "iteration {i}: LUKS key must be 32 bytes");
+        let bytes: [u8; 32] = *key;
+        match first_key {
+            None => first_key = Some(bytes),
+            Some(k0) => assert_eq!(
+                k0, bytes,
+                "iteration {i}: every unlock must derive the same key regardless of which holder answered"
+            ),
+        }
+    }
+
+    graceful_shutdown(shutdown1, node1_handle).await;
+    graceful_shutdown(shutdown2, node2_handle).await;
+    graceful_shutdown(shutdown3, node3_handle).await;
+}
+
 /// Build a well-formed OPRF eval request for `holder` from a synthetic box at
 /// FROST share index 1, returning the box pubkey, the request payload (with a
 /// real blinded element), and the raw blinded bytes for box-side partials.


### PR DESCRIPTION
## What

Add in-attempt holder failover to `request_oprf_unlock`. A single unlock samples `threshold-1` holders and waits one timeout; on a timeout with fewer than `threshold` partials, the holders that never answered are excluded and a fresh round re-samples from the remaining eligible holders, up to `MAX_FAILOVER_ATTEMPTS` (the constant the FROST signing failover already uses).

## Why

Today `select_eligible_peers(threshold, &[])` samples once and never re-samples. In a 2-of-3 (box + 1 of 2 holders), if the single sampled holder is momentarily unreachable the whole unlock fails closed and the box does not boot until a manual retry — even though the other holder would have answered. This is the geo-distributed-holder-on-a-flaky-network case. Failover recovers in seconds instead.

## Design (grounded in the existing signing failover)

- Mirrors `signing.rs`'s `MAX_FAILOVER_ATTEMPTS` loop with an `excluded` set; the OPRF sampler already takes the `exclude` arg (previously called with `&[]`).
- **Failover keys off `Timeout` (silence) ONLY.** A holder that answers-but-rejects (duress-frozen, unattested, rate-limited, approval-denied) sends nothing, so it is correctly treated as unreachable and excluded. A holder whose partial reaches the box but fails to combine surfaces as `Session`/`OprfUnlockFailed` — a real cryptographic rejection — and is returned to the caller unchanged (retrying a different holder would combine to the same key, so it cannot help and must not mask a misbehaving holder).
- **Cryptographically safe by the combine invariant**: any threshold-subset of valid partials combines to the *identical* LUKS key (the sampled set is not baked into the combine; proven by `session_finalizes_matching_other_quorum`). A fresh round re-blinds and re-derives the session id from the new participant set.
- **Not a grinding vector**: `exclude` guarantees a re-sample never re-hits a holder; each holder gates + rate-limits independently and answers at most once per attempt for the same fixed blinded input.
- A genuinely undersized group still surfaces `InsufficientPeers` on the first round (the exclude set is empty there); only *failover-exhausted* rounds convert to the aggregate timeout.

Adds `OprfUnlockSession::responders()` to identify non-responders on timeout.

## Verification

New test `test_oprf_unlock_fails_over_when_one_holder_silent` (2-of-3, one holder persistently silent via the default DENY hook, short session timeout, 6-iteration loop):
- **Passes** deterministically (every iteration derives the same 32-byte key, immediate or via failover) — ran 3x, no flake, ~10-16s.
- **Negative control**: with the failover loop disabled (single round), it fails at the first iteration that samples the silent holder ("timed out after failover") — so it genuinely guards the behavior.
- clippy clean; `responders()` unit tests + all 17 other OPRF multinode tests pass (no regression).

Addresses keep-node-02a.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OPRF unlocks now automatically retry when a holder times out.
  * Unresponsive holders are excluded from subsequent attempts, improving unlock reliability.
  * Unlock sessions are properly cleaned up after failed attempts.
  * Unlock operations continue to produce consistent LUKS keys when a holder is unavailable.

* **Tests**
  * Added coverage for failover when a holder remains silent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->