### PR TITLE
keep-cli: keep the alt-screen-exit escape off command stdout

### DIFF
--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -78,8 +78,11 @@ fn main() {
     keep_frost_net::install_default_crypto_provider();
 
     ctrlc::set_handler(|| {
-        let _ = crossterm::terminal::disable_raw_mode();
-        let _ = crossterm::execute!(std::io::stdout(), crossterm::terminal::LeaveAlternateScreen);
+        // Restore raw mode, but emit LeaveAlternateScreen only if the TUI actually
+        // entered the alt screen -- otherwise this signal (incl. the SIGTERM the
+        // frost gate sends on a fail-closed oprf-unlock) would leak the escape onto
+        // a command's key-only stdout (keep-node-95y).
+        tui::restore_terminal();
         std::process::exit(130);
     })
     .ok();

--- a/keep-cli/src/panic.rs
+++ b/keep-cli/src/panic.rs
@@ -12,8 +12,9 @@ pub fn install() {
 }
 
 fn cleanup_terminal() {
-    let _ = crossterm::terminal::disable_raw_mode();
-    let _ = crossterm::execute!(std::io::stdout(), crossterm::terminal::LeaveAlternateScreen);
+    // Emit LeaveAlternateScreen only if the TUI entered it, so a panic on a non-TUI
+    // command does not leak the escape onto that command's stdout (keep-node-95y).
+    crate::tui::restore_terminal();
 }
 
 fn log_panic(info: &PanicHookInfo<'_>) {

--- a/keep-cli/src/tui.rs
+++ b/keep-cli/src/tui.rs
@@ -119,8 +119,12 @@ impl Tui {
 
     pub fn run(&mut self) -> io::Result<()> {
         enable_raw_mode()?;
-        stdout().execute(EnterAlternateScreen)?;
+        // Mark the alt screen active BEFORE entering it: a signal in the tiny window
+        // before EnterAlternateScreen then still restores the terminal (an escape
+        // emitted a hair early on a real TUI terminal is harmless), rather than
+        // leaving it stuck in the alt screen.
         ALT_SCREEN_ACTIVE.store(true, Ordering::SeqCst);
+        stdout().execute(EnterAlternateScreen)?;
         let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
 
         while !self.should_quit {

--- a/keep-cli/src/tui.rs
+++ b/keep-cli/src/tui.rs
@@ -15,6 +15,34 @@ use ratatui::{
     prelude::*,
     widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
 };
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// True only while the interactive TUI holds the alternate screen. The signal
+/// handler (`main`) and the panic handler (`panic`) consult this so they emit the
+/// LeaveAlternateScreen escape ONLY when the TUI actually entered it -- never on a
+/// non-TUI command like `frost network oprf-unlock`, whose stdout is contractually
+/// the 32-byte LUKS key and must carry no terminal control bytes (keep-node-95y).
+pub(crate) static ALT_SCREEN_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Restore the terminal from a signal or panic handler. Always leaves raw mode (a
+/// no-op if it was never set; also recovers an interrupted `dialoguer` prompt), but
+/// leaves the alternate screen ONLY if the TUI entered it, so its escape never
+/// pollutes a command's stdout.
+pub(crate) fn restore_terminal() {
+    let _ = disable_raw_mode();
+    let active = ALT_SCREEN_ACTIVE.swap(false, Ordering::SeqCst);
+    let _ = write_leave_alt_screen(&mut stdout(), active);
+}
+
+/// Write LeaveAlternateScreen to `w` iff the alternate screen was active. Split out
+/// from `restore_terminal` so the stdout-hygiene contract is unit-testable without a
+/// real terminal, a signal, or the global flag.
+fn write_leave_alt_screen<W: io::Write>(w: &mut W, active: bool) -> io::Result<()> {
+    if active {
+        w.execute(LeaveAlternateScreen)?;
+    }
+    Ok(())
+}
 
 #[derive(Clone)]
 pub struct LogEntry {
@@ -92,6 +120,7 @@ impl Tui {
     pub fn run(&mut self) -> io::Result<()> {
         enable_raw_mode()?;
         stdout().execute(EnterAlternateScreen)?;
+        ALT_SCREEN_ACTIVE.store(true, Ordering::SeqCst);
         let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
 
         while !self.should_quit {
@@ -101,6 +130,7 @@ impl Tui {
 
         disable_raw_mode()?;
         stdout().execute(LeaveAlternateScreen)?;
+        ALT_SCREEN_ACTIVE.store(false, Ordering::SeqCst);
         Ok(())
     }
 
@@ -348,4 +378,35 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
             Constraint::Percentage((100 - percent_x) / 2),
         ])
         .split(popup_layout[1])[1]
+}
+
+#[cfg(test)]
+mod terminal_restore_tests {
+    use super::write_leave_alt_screen;
+
+    // A non-TUI command (e.g. `frost network oprf-unlock`) never entered the
+    // alternate screen, so a signal/panic exit must write NOTHING to the stream --
+    // stdout stays contractually the 32-byte LUKS key, with no control bytes
+    // (keep-node-95y).
+    #[test]
+    fn writes_nothing_when_alt_screen_inactive() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_leave_alt_screen(&mut buf, false).unwrap();
+        assert!(
+            buf.is_empty(),
+            "inactive alt-screen must emit no bytes, got {buf:?}"
+        );
+    }
+
+    // A real TUI session must still be restored on exit: the exact 8-byte
+    // LeaveAlternateScreen escape (ESC [ ? 1 0 4 9 l).
+    #[test]
+    fn emits_leave_alternate_screen_when_active() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_leave_alt_screen(&mut buf, true).unwrap();
+        assert_eq!(
+            buf, b"\x1b[?1049l",
+            "active alt-screen must emit LeaveAlternateScreen"
+        );
+    }
 }


### PR DESCRIPTION
## What

Only emit the terminal `LeaveAlternateScreen` escape (`\e[?1049l`) when the interactive TUI actually entered the alternate screen, so the signal and panic handlers never leak it onto a command's stdout.

## Why (root cause, verified)

`keep frost network oprf-unlock` contracts stdout to be **exactly the 32-byte LUKS key** (the frost gate reads it directly). But `ctrlc` is built with the `termination` feature (`Cargo.toml:53`), so the Ctrl-C handler also catches **SIGTERM** — which is precisely what the frost gate sends to the unlock process on the fail-closed path. The handler ran `execute!(stdout(), LeaveAlternateScreen)` unconditionally (`main.rs`), writing the 8-byte escape (`1b 5b 3f 31 30 34 39 6c`) onto the key-only stdout. The panic handler (`panic.rs`) had the same unconditional pattern.

(The tracking bead guessed the progress-spinner; it is not — `indicatif` doesn't use the alternate screen, and `enable_raw_mode`/alt-screen appear only in the TUI. Verified by tracing every terminal write.)

## Fix

- `tui.rs`: an `ALT_SCREEN_ACTIVE` flag set only while the TUI holds the alternate screen, and a shared `restore_terminal()` that always leaves raw mode (harmless; also recovers an interrupted `dialoguer` prompt) but emits `LeaveAlternateScreen` **only if** the flag is set.
- `main.rs` (SIGINT/SIGTERM handler) and `panic.rs` route through `restore_terminal()`.

A non-TUI command like `oprf-unlock` never sets the flag, so a SIGTERM/panic exit writes **nothing** to stdout — it stays strictly the key.

## Verification

Factored the write into `write_leave_alt_screen(w, active)` so the contract is unit-testable without a terminal/signal:
- `writes_nothing_when_alt_screen_inactive` → empty output.
- `emits_leave_alternate_screen_when_active` → exactly `\x1b[?1049l`.

Both pass; clippy clean; build clean. TUI restore-on-exit/Ctrl-C is unchanged (flag is set during a real TUI session).

Fixes keep-node-95y. (A follow-up keep-node change can then drop the ANSI-stripping workaround in the oprf-unlock fail-closed assertion.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal cleanup when exiting, interrupting, or encountering an error.
  * Prevented stray terminal control characters from appearing in output for commands that do not use the interactive interface.
  * Ensured alternate-screen mode is exited only when it was actually activated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->