### PR TITLE
keep-frost-net: security-audit hardening

### DIFF
--- a/keep-core/src/oprf.rs
+++ b/keep-core/src/oprf.rs
@@ -294,8 +294,9 @@ pub mod unlock {
     use voprf::{BlindedElement, OprfClient};
 
     /// Client state for one unlock attempt: the voprf blinding secret plus the unlock input,
-    /// both needed at [`Client::finalize_luks_key`]. The input is a fixed, low-entropy label, so
-    /// the eval oracle MUST be authenticated and rate-limited (see [`evaluate`]).
+    /// both needed at [`Client::finalize_luks_key`]. The input is a fixed label, so the eval oracle
+    /// MUST AUTHENTICATE its callers (that is what protects the key); rate-limiting it is DoS hygiene
+    /// only (see [`evaluate`]).
     pub struct Client {
         state: OprfClient<Secp256k1Sha256>,
         input: Vec<u8>,

--- a/keep-core/src/oprf.rs
+++ b/keep-core/src/oprf.rs
@@ -97,10 +97,13 @@ pub mod threshold {
     /// A share-holder's partial evaluation: `P_i = s_i * B`, carrying the same identifier so the
     /// combination knows its Lagrange index. The share `s_i` never leaves the holder.
     ///
-    /// SECURITY: the transport layer that exposes this evaluation oracle to clients MUST enforce
-    /// per-identity authentication and strict rate limiting. The OPRF-unlock's resistance to
-    /// low-entropy-input guessing depends on bounding the number of evaluations an attacker can
-    /// obtain; an unbounded or unauthenticated oracle reduces it to an offline brute force.
+    /// SECURITY: the transport exposing this oracle MUST AUTHENTICATE the caller before returning a
+    /// partial -- for keep, only a genuinely-booted (fresh measured-boot attestation) and non-duressed
+    /// box. That authentication is what protects the fixed unlock input: an unauthenticated oracle
+    /// hands the key to a stolen/reflashed box. Rate-limiting the authenticated caller is DoS hygiene,
+    /// not anti-grinding: the unlock input is FIXED, so a caller that passes authentication needs only
+    /// one evaluation per holder, and bounding evaluations adds no offline-guessing resistance for a
+    /// fixed input.
     pub fn partial_eval(
         share: &KeyShare,
         blinded: &BlindedElement<Secp256k1Sha256>,
@@ -340,9 +343,10 @@ pub mod unlock {
     /// holder's key share, returning the partial evaluation as wire bytes. The share never leaves
     /// the holder.
     ///
-    /// SECURITY: the transport exposing this oracle MUST authenticate the caller and strictly
-    /// rate-limit it. Bounding evaluations is what keeps the fixed, low-entropy unlock input from
-    /// being brute-forced offline (see [`super::threshold::partial_eval`]).
+    /// SECURITY: the transport exposing this oracle MUST AUTHENTICATE the caller before returning a
+    /// partial -- that authentication (an attested, non-duressed requester), not a rate cap, is what
+    /// protects the fixed unlock input. Rate-limit the authenticated caller for DoS hygiene only (see
+    /// [`super::threshold::partial_eval`]).
     pub fn evaluate(
         share: &KeyShare,
         blinded: &[u8],

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1906,6 +1906,15 @@ impl KfpNode {
         threshold: usize,
         exclude: &[u16],
     ) -> Result<(Vec<u16>, Vec<(u16, PublicKey)>)> {
+        // Defensive: every real group has threshold >= 2 (split_key rejects t < 2), but guard against
+        // a 0 threshold so the `threshold - 1` sample count below cannot underflow into a huge value
+        // and panic. Fail closed.
+        if threshold == 0 {
+            return Err(FrostNetError::InsufficientPeers {
+                needed: 0,
+                available: 0,
+            });
+        }
         let selected_peers: Vec<Peer> = {
             let peers = self.peers.read();
             let eligible_peers: Vec<_> = peers
@@ -2509,7 +2518,11 @@ impl KfpNode {
         }
 
         let now = Timestamp::now().as_secs();
-        if payload.timestamp + ANNOUNCE_MAX_AGE_SECS < now {
+        // `payload.timestamp` is attacker-controlled and this runs BEFORE verify_proof, so use
+        // saturating arithmetic (matching within_replay_window): an unchecked add would wrap on a
+        // near-u64::MAX timestamp today and, under an `overflow-checks = true` release build, panic
+        // -- a remote pre-auth DoS on the discovery/boot gate.
+        if payload.timestamp.saturating_add(ANNOUNCE_MAX_AGE_SECS) < now {
             debug!(
                 timestamp = payload.timestamp,
                 now, "Rejecting stale announcement"
@@ -2518,7 +2531,7 @@ impl KfpNode {
                 "Announcement timestamp too old".into(),
             ));
         }
-        if payload.timestamp > now + ANNOUNCE_MAX_FUTURE_SECS {
+        if payload.timestamp > now.saturating_add(ANNOUNCE_MAX_FUTURE_SECS) {
             debug!(
                 timestamp = payload.timestamp,
                 now, "Rejecting future-dated announcement"

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -2519,9 +2519,9 @@ impl KfpNode {
 
         let now = Timestamp::now().as_secs();
         // `payload.timestamp` is attacker-controlled and this runs BEFORE verify_proof, so use
-        // saturating arithmetic (matching within_replay_window): an unchecked add would wrap on a
-        // near-u64::MAX timestamp today and, under an `overflow-checks = true` release build, panic
-        // -- a remote pre-auth DoS on the discovery/boot gate.
+        // saturating arithmetic (as within_replay_window does for the same reason): an unchecked add
+        // would wrap on a near-u64::MAX timestamp today and, under an `overflow-checks = true` release
+        // build, panic -- a remote pre-auth DoS on the discovery/boot gate.
         if payload.timestamp.saturating_add(ANNOUNCE_MAX_AGE_SECS) < now {
             debug!(
                 timestamp = payload.timestamp,

--- a/keep-frost-net/src/node/oprf.rs
+++ b/keep-frost-net/src/node/oprf.rs
@@ -135,8 +135,9 @@ impl KfpNode {
             }
         }
 
-        // Rate-limit the oracle per requester. Bounding evaluations is what keeps
-        // the fixed, low-entropy unlock input from being brute-forced offline.
+        // DoS-hygiene rate limit on the oracle. This is NOT the anti-grinding control (the fresh
+        // attestation gate just above is): the unlock input is fixed, so one eval per holder yields
+        // the key and a rate cap adds no offline-guessing resistance. See OprfEvalRateLimiter's doc.
         if !self.oprf_rate_limiter.write().check_and_record(from) {
             warn!(from = %from, "Rejecting OPRF eval request: rate limit exceeded");
             return Err(FrostNetError::RateLimited(format!(

--- a/keep-frost-net/src/oprf_session.rs
+++ b/keep-frost-net/src/oprf_session.rs
@@ -287,17 +287,25 @@ impl Default for OprfUnlockSessionManager {
 /// Per-requester sliding-window rate limiter for the holder-side OPRF evaluation
 /// oracle.
 ///
-/// SECURITY: the OPRF-unlock input is a fixed, low-entropy label, so the
-/// unlock's resistance to offline guessing depends on bounding how many
-/// evaluations any one identity can obtain (see
-/// `keep_core::oprf::threshold::partial_eval`). This caps each requester at
-/// [`MAX_OPRF_EVALS_PER_WINDOW`] evaluations per [`OPRF_EVAL_WINDOW`]; beyond
-/// that the holder refuses with [`FrostNetError::RateLimited`].
+/// SECURITY: this is DoS hygiene for the oracle, NOT the anti-grinding control. The
+/// OPRF-unlock input is FIXED, so obtaining the key needs exactly one evaluation per
+/// holder, not many -- a rate cap therefore cannot be what resists offline guessing.
+/// What actually gates the oracle is per-requester AUTHENTICATION: the fresh
+/// measured-boot attestation check and the duress freeze in the #621 gate chain,
+/// which only let a genuinely-booted, non-duressed box obtain any evaluation at all.
+/// This limiter bounds how much an already-authenticated requester can load the
+/// oracle, capping each at [`MAX_OPRF_EVALS_PER_WINDOW`] evaluations per
+/// [`OPRF_EVAL_WINDOW`]; beyond that the holder refuses with
+/// [`FrostNetError::RateLimited`].
 ///
-/// Memory ceiling: tracked identities are pruned lazily once their window
-/// empties, and the table is capped at [`MAX_TRACKED_REQUESTERS`]. If a
-/// finer-grained guarantee is ever needed (e.g. global eval budget), upgrade
-/// this to a token-bucket keyed by both identity and group.
+/// It is keyed on the requester's transport pubkey, i.e. a per-connection DoS bound,
+/// not a per-share budget: a genuine box that rotates its transport identity gets a
+/// fresh bucket. That is acceptable precisely because the anti-grinding guarantee does
+/// not rest on it; if a per-share budget is ever wanted, key on
+/// (group_pubkey, share_index) instead.
+///
+/// Memory ceiling: tracked identities are pruned lazily once their window empties, and
+/// the table is capped at [`MAX_TRACKED_REQUESTERS`].
 pub const MAX_OPRF_EVALS_PER_WINDOW: u32 = 8;
 pub const OPRF_EVAL_WINDOW: Duration = Duration::from_secs(60);
 const MAX_TRACKED_REQUESTERS: usize = 1024;

--- a/keep-frost-net/src/oprf_session.rs
+++ b/keep-frost-net/src/oprf_session.rs
@@ -290,11 +290,12 @@ impl Default for OprfUnlockSessionManager {
 /// SECURITY: this is DoS hygiene for the oracle, NOT the anti-grinding control. The
 /// OPRF-unlock input is FIXED, so obtaining the key needs exactly one evaluation per
 /// holder, not many -- a rate cap therefore cannot be what resists offline guessing.
-/// What actually gates the oracle is per-requester AUTHENTICATION: the fresh
-/// measured-boot attestation check and the duress freeze in the #621 gate chain,
-/// which only let a genuinely-booted, non-duressed box obtain any evaluation at all.
-/// This limiter bounds how much an already-authenticated requester can load the
-/// oracle, capping each at [`MAX_OPRF_EVALS_PER_WINDOW`] evaluations per
+/// What actually protects the key is the #621 gate chain: the per-requester
+/// fresh-measured-boot attestation check (the anti-theft control -- only a
+/// genuinely-booted box is admitted) plus the holder's own duress self-freeze (the
+/// anti-coercion control -- a duressed holder refuses ALL evaluations). This limiter
+/// bounds how much an already-authenticated requester can load the oracle, capping
+/// each at [`MAX_OPRF_EVALS_PER_WINDOW`] evaluations per
 /// [`OPRF_EVAL_WINDOW`]; beyond that the holder refuses with
 /// [`FrostNetError::RateLimited`].
 ///


### PR DESCRIPTION
Follow-ups from a proactive adversarial audit of the OPRF-unlock + attestation path and the untrusted-input surface. The audit found **no Critical/High/Medium exploitable vulnerabilities** (the crypto core, the #621 gate chain, the 7-check TPM-quote verification, and the wire parsing are all sound); these are the concrete hardening/accuracy items it surfaced.

## 1. Overflow-safe announce timestamps (real defensive fix)

`handle_announce` did `payload.timestamp + ANNOUNCE_MAX_AGE_SECS` on an **attacker-controlled `u64`**, **before** `verify_proof` (pre-auth, reachable by any relay client). It wraps harmlessly in the default release profile, but under an `overflow-checks = true` build it is a **remote pre-auth panic — a DoS on the discovery/boot gate**, and it's inconsistent with the `saturating_*` math the sibling `within_replay_window` already uses. Fixed with `saturating_add` (both the age and the future-bound comparison), so it is safe regardless of build profile.

## 2. Accurate OPRF-oracle security docs (corrects a false claim)

The rate-limiter and `partial_eval`/`evaluate` doc-comments claimed rate-limiting is what gives the fixed-input unlock its "resistance to offline guessing." That is misleading and could mislead a future change into weakening the real control: the unlock input is **fixed**, so the key needs exactly **one** evaluation per holder — a rate cap cannot be the anti-grinding bound. The load-bearing control is **per-requester authentication** (fresh measured-boot attestation + duress freeze in the #621 gate chain); the limiter is **DoS hygiene**. Comments corrected across `oprf_session.rs` and `keep-core/oprf.rs`, and the limiter's transport-pubkey keying (a per-connection DoS bound, not a per-share budget) is now documented as such.

## 3. Defensive `threshold == 0` guard

`select_eligible_peers` computed `threshold - 1` as a sample count; a `0` threshold would underflow into a huge value and panic. Unreachable today (`split_key` rejects `t < 2`), so this is a fail-closed robustness guard, not a live bug.

## Verification

Build + clippy clean; `oprf_session` unit tests pass (14/14); comment-only changes in keep-core carry no functional risk. No behavioral change for any valid input (saturating math == plain add below overflow; `threshold == 0` is unreachable).