### PR TITLE
fuzz: add a TPM-quote parser target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,9 @@ jobs:
       - name: Fuzz FROST messages
         run: cargo +nightly fuzz run fuzz_frost_messages -- -max_total_time=30
         working-directory: fuzz
+      - name: Fuzz TPM quote parsing
+        run: cargo +nightly fuzz run fuzz_tpm_quote -- -max_total_time=30
+        working-directory: fuzz
       - name: Fuzz encrypted data
         run: cargo +nightly fuzz run fuzz_encrypted_data -- -max_total_time=30
         working-directory: fuzz

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,6 +13,13 @@ keep-frost-net = { path = "../keep-frost-net", default-features = false, feature
 libfuzzer-sys = "0.4"
 
 [[bin]]
+name = "fuzz_tpm_quote"
+path = "fuzz_targets/fuzz_tpm_quote.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "fuzz_nsec"
 path = "fuzz_targets/fuzz_nsec.rs"
 test = false

--- a/fuzz/fuzz_targets/fuzz_tpm_quote.rs
+++ b/fuzz/fuzz_targets/fuzz_tpm_quote.rs
@@ -1,0 +1,15 @@
+#![no_main]
+
+// Fuzz the TPM-quote byte parser with arbitrary input. `pcr_selection_from_attest` reaches the
+// low-level `parse_quote`, which byte-slices a marshaled `TPMS_ATTEST` blob taken verbatim from a
+// peer's announce -- fully attacker-controlled, untrusted input on the boot/discovery gate. The
+// parser must NEVER panic (slice out-of-bounds, length overflow) on malformed/truncated/oversized
+// input; a panic here is a remote DoS on the gate. Any `Err` is a correct outcome; only a crash is
+// a bug. Complements `fuzz_frost_messages`, which stops at `KfpMessage::validate()` and never
+// reaches the quote parser.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = keep_frost_net::tpm_quote::pcr_selection_from_attest(data);
+});


### PR DESCRIPTION
## What

Add a `cargo-fuzz` target (`fuzz_tpm_quote`) + CI step that fuzzes the TPM-quote byte parser with arbitrary input.

## Why

`parse_quote` (reached via the public `pcr_selection_from_attest`) byte-slices a marshaled `TPMS_ATTEST` blob taken **verbatim from a peer's announce** — fully attacker-controlled, untrusted input on the boot/discovery gate. A panic there (slice OOB, length overflow) would be a remote DoS on the gate. It was **not** fuzzed: `fuzz_frost_messages` stops at `KfpMessage::validate()` and never reaches the quote parser.

Surfaced by a proactive security audit of the untrusted-input surface: the audit found the parser's `Cursor` is correctly bounds-checked (`checked_add` + `.get()`), so this is a **regression guard** — it proves panic-safety empirically today and catches any future unchecked read added to the parser.

## Verification

Ran locally: **35.9M executions in 61s, zero crashes** (the fuzzer discovered the `TPM_GENERATED` magic and explored the deeper parse paths, so coverage reaches past the early rejects). CI runs it for 30s alongside the existing targets.