### PR TITLE
keep-desktop: fail closed when the certificate-pin store is corrupt

### DIFF
--- a/keep-desktop/src/app/mod.rs
+++ b/keep-desktop/src/app/mod.rs
@@ -17,9 +17,9 @@ pub use config::Settings;
 pub(crate) use config::{load_settings, save_settings};
 pub use util::set_pending_nostrconnect;
 pub(crate) use util::{
-    collect_shares, default_bunker_relays, friendly_err, load_cert_pins, lock_keep, parse_hex_key,
-    save_cert_pins, take_pending_nostrconnect, to_display_entry, with_keep_blocking,
-    write_private_bytes,
+    cert_pin_store_corruption, cert_pins_path, collect_shares, default_bunker_relays, friendly_err,
+    load_cert_pins, lock_keep, parse_hex_key, save_cert_pins, take_pending_nostrconnect,
+    to_display_entry, with_keep_blocking, write_private_bytes,
 };
 
 use std::collections::{HashMap, VecDeque};

--- a/keep-desktop/src/app/settings.rs
+++ b/keep-desktop/src/app/settings.rs
@@ -8,6 +8,13 @@ use crate::screen::Screen;
 
 use super::{friendly_err, lock_keep, save_cert_pins, save_settings, App, ToastKind};
 
+/// Shown when an in-app pin edit cannot be persisted. The usual cause is a
+/// corrupt on-disk store, which `save_cert_pins` refuses to overwrite so a
+/// silently-dropped host is not downgraded to trust-on-first-use.
+const CERT_PIN_WRITE_BLOCKED: &str =
+    "Could not update pins. The certificate pin store may be corrupt; resolve or delete \
+     cert-pins.json, then retry.";
+
 impl App {
     pub(crate) fn handle_settings_message_new(
         &mut self,
@@ -124,18 +131,17 @@ impl App {
                 return self.handle_kill_switch_deactivate(password);
             }
             Event::CertPinClear(hostname) => {
-                let ok = if let Ok(mut pins) = self.certificate_pins.lock() {
+                let saved = if let Ok(mut pins) = self.certificate_pins.lock() {
                     pins.remove_pin(&hostname);
-                    save_cert_pins(&self.keep_path, &pins);
-                    true
+                    save_cert_pins(&self.keep_path, &pins)
                 } else {
                     false
                 };
-                if ok {
+                if saved {
                     self.sync_cert_pins_to_screen();
                     self.set_toast(format!("Cleared pin for {hostname}"), ToastKind::Success);
                 } else {
-                    self.set_toast("Failed to clear pin".into(), ToastKind::Error);
+                    self.set_toast(CERT_PIN_WRITE_BLOCKED.into(), ToastKind::Error);
                 }
                 return Task::none();
             }
@@ -155,21 +161,20 @@ impl App {
                 return self.handle_restore_submit(passphrase, vault_password);
             }
             Event::CertPinClearAll => {
-                let ok = if let Ok(mut pins) = self.certificate_pins.lock() {
+                let saved = if let Ok(mut pins) = self.certificate_pins.lock() {
                     *pins = keep_frost_net::CertificatePinSet::new();
-                    save_cert_pins(&self.keep_path, &pins);
-                    true
+                    save_cert_pins(&self.keep_path, &pins)
                 } else {
                     false
                 };
-                if ok {
+                if saved {
                     self.sync_cert_pins_to_screen();
                     if let Screen::Settings(s) = &mut self.screen {
                         s.clear_all_pins_done();
                     }
                     self.set_toast("Cleared all certificate pins".into(), ToastKind::Success);
                 } else {
-                    self.set_toast("Failed to clear pins".into(), ToastKind::Error);
+                    self.set_toast(CERT_PIN_WRITE_BLOCKED.into(), ToastKind::Error);
                 }
                 return Task::none();
             }
@@ -199,15 +204,15 @@ impl App {
                 let Some(mismatch) = self.pin_mismatch.as_ref() else {
                     return Task::none();
                 };
-                let ok = if let Ok(mut pins) = self.certificate_pins.lock() {
-                    pins.remove_pin(&mismatch.hostname);
-                    save_cert_pins(&self.keep_path, &pins);
-                    true
+                let hostname = mismatch.hostname.clone();
+                let saved = if let Ok(mut pins) = self.certificate_pins.lock() {
+                    pins.remove_pin(&hostname);
+                    save_cert_pins(&self.keep_path, &pins)
                 } else {
                     false
                 };
-                if !ok {
-                    self.set_toast("Failed to clear pin".into(), ToastKind::Error);
+                if !saved {
+                    self.set_toast(CERT_PIN_WRITE_BLOCKED.into(), ToastKind::Error);
                     return Task::none();
                 }
                 self.pin_mismatch = None;

--- a/keep-desktop/src/app/util.rs
+++ b/keep-desktop/src/app/util.rs
@@ -185,23 +185,58 @@ pub(crate) fn load_cert_pins(keep_path: &std::path::Path) -> keep_frost_net::Cer
 /// `Err` on any malformed entry.
 pub(crate) fn cert_pin_store_corruption(keep_path: &std::path::Path) -> Option<Vec<String>> {
     let path = cert_pins_path(keep_path);
-    // Absent file is a legitimate first-run state, not corruption.
-    let contents = std::fs::read_to_string(&path).ok()?;
-    match keep_frost_net::CertificatePinSet::from_json_bytes(contents.as_bytes()) {
+    // Read raw bytes (like keep-mobile) so non-UTF-8 content surfaces as a
+    // parse error below rather than a read failure, and so from_json_bytes
+    // sees exactly what was stored.
+    let contents = match std::fs::read(&path) {
+        Ok(contents) => contents,
+        // Absent file is a legitimate first-run state, not corruption.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        // Any other read error (permissions, I/O) must fail closed rather than
+        // read as "no pins" and wave the connect through under TOFU. Mirrors
+        // keep-mobile, which only maps StorageNotFound to Ok(None).
+        Err(e) => return Some(vec![format!("unreadable: {e}")]),
+    };
+    match keep_frost_net::CertificatePinSet::from_json_bytes(&contents) {
         Ok((_, malformed)) if malformed.is_empty() => None,
         Ok((_, malformed)) => Some(malformed),
         Err(e) => Some(vec![format!("parse error: {e}")]),
     }
 }
 
+/// Persist `pins` to `cert-pins.json`. Returns `true` when the file was written.
+///
+/// Refuses (returns `false`) when the on-disk store is currently corrupt. The
+/// in-memory `pins` was built by [`load_cert_pins`], which silently drops
+/// malformed entries, so overwriting a corrupt file with it would erase the
+/// invisible corrupt entry and downgrade that host to trust-on-first-use on the
+/// next connect, reopening the very window the connect-time gate closes. While
+/// the store is corrupt the only safe resolutions are fixing or deleting the
+/// file by hand.
 pub(crate) fn save_cert_pins(
     keep_path: &std::path::Path,
     pins: &keep_frost_net::CertificatePinSet,
-) {
+) -> bool {
+    if let Some(reasons) = cert_pin_store_corruption(keep_path) {
+        tracing::warn!(
+            "Refusing to overwrite corrupt certificate pin store ({}); \
+             resolve or delete the file to reset",
+            reasons.join(", ")
+        );
+        return false;
+    }
     let path = cert_pins_path(keep_path);
-    if let Ok(json) = serde_json::to_string_pretty(&pins.to_hex_map()) {
-        if let Err(e) = write_private(&path, &json) {
-            tracing::error!("Failed to save certificate pins: {e}");
+    match serde_json::to_string_pretty(&pins.to_hex_map()) {
+        Ok(json) => match write_private(&path, &json) {
+            Ok(()) => true,
+            Err(e) => {
+                tracing::error!("Failed to save certificate pins: {e}");
+                false
+            }
+        },
+        Err(e) => {
+            tracing::error!("Failed to serialize certificate pins: {e}");
+            false
         }
     }
 }
@@ -256,7 +291,10 @@ mod tests {
     fn corruption_none_for_valid_store() {
         let dir = tempfile::tempdir().unwrap();
         let hash = "aa".repeat(32);
-        write_store(dir.path(), &format!(r#"{{"relay.example.com":["{hash}"]}}"#));
+        write_store(
+            dir.path(),
+            &format!(r#"{{"relay.example.com":["{hash}"]}}"#),
+        );
         assert!(cert_pin_store_corruption(dir.path()).is_none());
         // And the valid pin still loads (parity: healthy files unaffected).
         assert!(load_cert_pins(dir.path()).is_pinned("relay.example.com"));
@@ -279,5 +317,53 @@ mod tests {
         write_store(dir.path(), "{ this is not json");
         let reasons = cert_pin_store_corruption(dir.path()).expect("bad json => corrupt");
         assert!(reasons.iter().any(|r| r.contains("parse error")));
+    }
+
+    #[test]
+    fn corruption_some_when_store_unreadable() {
+        let dir = tempfile::tempdir().unwrap();
+        // A directory at the store path yields a non-NotFound read error, which
+        // must fail closed rather than read as "no pins" (open TOFU fallback).
+        std::fs::create_dir(cert_pins_path(dir.path())).unwrap();
+        let reasons = cert_pin_store_corruption(dir.path()).expect("unreadable => corrupt");
+        assert!(reasons.iter().any(|r| r.contains("unreadable")));
+    }
+
+    #[test]
+    fn save_refused_when_store_corrupt() {
+        let dir = tempfile::tempdir().unwrap();
+        let corrupt = r#"{"relay.example.com":"nothex"}"#;
+        write_store(dir.path(), corrupt);
+
+        // A degraded in-memory set (the corrupt host dropped at load) must not
+        // be persisted over the corrupt file, which would erase the corrupt
+        // entry and silently re-enable TOFU for that host.
+        let mut pins = keep_frost_net::CertificatePinSet::new();
+        pins.add_pin("other.example.com".into(), [1u8; 32]);
+        assert!(
+            !save_cert_pins(dir.path(), &pins),
+            "must refuse to overwrite"
+        );
+
+        // The on-disk file is left untouched, so the connect-time gate still fires.
+        let on_disk = std::fs::read_to_string(cert_pins_path(dir.path())).unwrap();
+        assert_eq!(on_disk, corrupt);
+        assert!(cert_pin_store_corruption(dir.path()).is_some());
+    }
+
+    #[test]
+    fn save_succeeds_when_store_absent_or_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pins = keep_frost_net::CertificatePinSet::new();
+        pins.add_pin("relay.example.com".into(), [2u8; 32]);
+
+        // Absent file: first pin persists.
+        assert!(save_cert_pins(dir.path(), &pins));
+        assert!(load_cert_pins(dir.path()).is_pinned("relay.example.com"));
+
+        // Healthy file: a further save still succeeds.
+        pins.add_pin("relay2.example.com".into(), [3u8; 32]);
+        assert!(save_cert_pins(dir.path(), &pins));
+        assert!(load_cert_pins(dir.path()).is_pinned("relay2.example.com"));
     }
 }

--- a/keep-desktop/src/app/util.rs
+++ b/keep-desktop/src/app/util.rs
@@ -170,6 +170,30 @@ pub(crate) fn load_cert_pins(keep_path: &std::path::Path) -> keep_frost_net::Cer
     }
 }
 
+/// Corruption status of the on-disk certificate-pin store.
+///
+/// Returns `None` when the file is absent (first run: no pins yet) or parses
+/// cleanly with no malformed entries. Returns `Some(reasons)` when the file
+/// exists but fails to parse, or parses with one or more malformed entries.
+///
+/// This is the fail-closed counterpart to [`load_cert_pins`], which drops
+/// malformed entries so valid pins still load. A corrupt store must not
+/// silently downgrade a previously-pinned host to trust-on-first-use: dropping
+/// a host's only (corrupted) entry would let `verify_relay_certificate` re-pin
+/// whatever certificate an on-path attacker presents. The connect path checks
+/// this and refuses, mirroring keep-mobile, whose `load_cert_pins` returns
+/// `Err` on any malformed entry.
+pub(crate) fn cert_pin_store_corruption(keep_path: &std::path::Path) -> Option<Vec<String>> {
+    let path = cert_pins_path(keep_path);
+    // Absent file is a legitimate first-run state, not corruption.
+    let contents = std::fs::read_to_string(&path).ok()?;
+    match keep_frost_net::CertificatePinSet::from_json_bytes(contents.as_bytes()) {
+        Ok((_, malformed)) if malformed.is_empty() => None,
+        Ok((_, malformed)) => Some(malformed),
+        Err(e) => Some(vec![format!("parse error: {e}")]),
+    }
+}
+
 pub(crate) fn save_cert_pins(
     keep_path: &std::path::Path,
     pins: &keep_frost_net::CertificatePinSet,
@@ -211,4 +235,49 @@ pub(crate) fn default_bunker_relays() -> Vec<String> {
         .iter()
         .map(|s| s.to_string())
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_store(dir: &std::path::Path, json: &str) {
+        std::fs::write(cert_pins_path(dir), json).unwrap();
+    }
+
+    #[test]
+    fn corruption_none_when_file_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        // First run: no cert-pins.json yet is not corruption.
+        assert!(cert_pin_store_corruption(dir.path()).is_none());
+    }
+
+    #[test]
+    fn corruption_none_for_valid_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let hash = "aa".repeat(32);
+        write_store(dir.path(), &format!(r#"{{"relay.example.com":["{hash}"]}}"#));
+        assert!(cert_pin_store_corruption(dir.path()).is_none());
+        // And the valid pin still loads (parity: healthy files unaffected).
+        assert!(load_cert_pins(dir.path()).is_pinned("relay.example.com"));
+    }
+
+    #[test]
+    fn corruption_some_for_malformed_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        // A previously-pinned host whose only entry no longer decodes to a hash.
+        write_store(dir.path(), r#"{"relay.example.com":"nothex"}"#);
+        let reasons = cert_pin_store_corruption(dir.path()).expect("malformed => corrupt");
+        assert!(reasons.iter().any(|r| r.contains("relay.example.com")));
+        // The host must not silently survive as an unpinned (TOFU) host.
+        assert!(!load_cert_pins(dir.path()).is_pinned("relay.example.com"));
+    }
+
+    #[test]
+    fn corruption_some_for_unparseable_json() {
+        let dir = tempfile::tempdir().unwrap();
+        write_store(dir.path(), "{ this is not json");
+        let reasons = cert_pin_store_corruption(dir.path()).expect("bad json => corrupt");
+        assert!(reasons.iter().any(|r| r.contains("parse error")));
+    }
 }

--- a/keep-desktop/src/frost.rs
+++ b/keep-desktop/src/frost.rs
@@ -53,6 +53,21 @@ pub(crate) async fn verify_relay_certificates(
     keep_path: &std::path::Path,
 ) -> Result<(), crate::message::ConnectionError> {
     use crate::message::ConnectionError;
+    // Fail closed: refuse to connect when the on-disk pin store exists but is
+    // corrupt. Otherwise a corrupted entry for a previously-pinned host would
+    // have been silently dropped at load, and the loop below would re-pin
+    // (TOFU) whatever certificate is presented, which an on-path attacker can
+    // exploit to install their own pin. Re-checked from disk on every connect
+    // so fixing the file and reconnecting recovers without a restart. Mirrors
+    // keep-mobile, which returns Err from load_cert_pins on any malformed entry.
+    if let Some(reasons) = crate::app::cert_pin_store_corruption(keep_path) {
+        return Err(ConnectionError::Other(format!(
+            "Certificate pin store {} is corrupt ({}). Refusing to connect under \
+             weakened pinning; resolve or clear the file, then reconnect.",
+            crate::app::cert_pins_path(keep_path).display(),
+            reasons.join("; "),
+        )));
+    }
     for url in relay_urls.iter().filter(|u| u.starts_with("wss://")) {
         let pins_snapshot = certificate_pins
             .lock()


### PR DESCRIPTION
Closes #697.

## Problem

`keep-desktop`'s cert-pin loader (`load_cert_pins`) parses `cert-pins.json` leniently: it keeps valid pins, drops entries that fail to decode, logs a warning, and returns the rest. If a previously-pinned host's only entry is corrupted so it no longer decodes to a hash, that host silently vanishes from the pin set. On the next connection `verify_relay_certificate` sees no pin for it and falls back to trust-on-first-use, re-pinning whatever certificate is presented, so an on-path attacker who can corrupt the file can install their own pin.

`keep-mobile` already fails closed here: `load_cert_pins` returns `Err` when the malformed list is non-empty, aborting the connect. Desktop lacked equivalent protection.

## Fix

Two chokepoints, mirroring keep-mobile:

**Connect chokepoint.** Both connect paths (FROST node and bunker) funnel through `verify_relay_certificates`, so a single check there cannot be bypassed. New `cert_pin_store_corruption(keep_path)` returns `Some(reasons)` when `cert-pins.json` exists but fails to read/parse or contains malformed entries, and `None` when it is absent (legitimate first run) or fully valid. Raw bytes are read with `std::fs::read` and passed to `from_json_bytes`, so `NotFound` is the only non-corrupt read outcome (permission/I/O errors and non-UTF-8 content fail closed), matching keep-mobile exactly. `verify_relay_certificates` returns a `ConnectionError` (surfaced through the existing connection-error UI) instead of proceeding under weakened pinning, re-read from disk on every connect so fixing or clearing the file and reconnecting recovers without a restart.

**Persistence chokepoint.** `save_cert_pins` now refuses to overwrite a corrupt on-disk store (returns `bool`). Without this, the degraded in-memory set built by `load_cert_pins` could be written back by an unrelated settings action (e.g. clearing one pin), silently erasing the corrupt host's entry and re-enabling TOFU for it. While the store is corrupt, in-app pin edits surface a clear "resolve or delete cert-pins.json" message; the connect gate remains authoritative.

Trust boundary is local-filesystem write access to the keep data dir, so severity is Low; this brings desktop to parity with mobile as defense-in-depth.

## Tests

Unit tests cover: absent file (not corrupt), valid store (not corrupt, valid pins still load), malformed entry (corrupt, host does not survive as TOFU), unparseable JSON (corrupt), unreadable store (corrupt), save refused over a corrupt store (file left untouched), and save succeeds on an absent/valid store.

## Not in scope

The nostrconnect bunker-start path performs no relay certificate pinning at all (even with a healthy store); it is a distinct pre-existing gap, tracked as a follow-up rather than expanded into here.

Acceptance criteria from #697:
- A corrupted previously-pinned host no longer silently downgrades to TOFU.
- Desktop refuses to connect (surfaced as a connection error) instead of re-pinning an attacker-presented certificate.
- Valid pins in an otherwise-healthy file continue to load unaffected.
