### PR TITLE
keep-state: publish an initial snapshot so a fresh standby gets pre-replication records

### DIFF
--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -144,6 +144,13 @@ impl Keep {
         self.storage.state_version(table, record_id)
     }
 
+    /// Snapshot all replicable records for the keep-state publisher to replay at startup, so records
+    /// written before the replication hook was installed still reach a fresh standby. See
+    /// [`Storage::snapshot_replicable_records`].
+    pub fn snapshot_replicable_records(&self) -> Result<Vec<(&'static str, String, Vec<u8>)>> {
+        self.storage.snapshot_replicable_records()
+    }
+
     /// Create a new Keep with the given password.
     ///
     /// # Example

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -471,6 +471,26 @@ impl Storage {
             other => Err(KeepError::Other(format!("table {other} is not replicable"))),
         }
     }
+
+    /// Snapshot every replicable record currently in storage as `(logical table, hex record id, at-rest
+    /// encrypted bytes)` -- the same shape the [`StatePublisher`] hook emits for a live write. The
+    /// keep-state publisher replays this once at startup so records written BEFORE replication was wired
+    /// (which the write-time hook never observed) reach a fresh standby instead of being stranded.
+    ///
+    /// Reads the raw stored ciphertext (`hex(backend key)` is the record id, the stored value is the
+    /// encrypted blob), so it matches the hook byte-for-byte and needs neither decryption nor the data
+    /// key. The three logical tables mirror [`replicated_table`].
+    pub fn snapshot_replicable_records(&self) -> Result<Vec<(&'static str, String, Vec<u8>)>> {
+        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
+        let mut out = Vec::new();
+        for table in ["keys", "descriptors", "relay_configs"] {
+            let backend_table = Self::replicated_table(table)?;
+            for (key, encrypted) in backend.list(backend_table)? {
+                out.push((table, hex::encode(key), encrypted));
+            }
+        }
+        Ok(out)
+    }
     /// Create new storage with the given password.
     pub fn create(path: &Path, password: &str, params: Argon2Params) -> Result<Self> {
         create_storage_dir(path)?;
@@ -1955,6 +1975,41 @@ mod tests {
                 .unwrap(),
             ReplicatedApply::Applied
         );
+    }
+
+    #[test]
+    fn snapshot_replicable_records_matches_publisher_hook() {
+        let dir = tempdir().unwrap();
+        let storage =
+            Storage::create(&dir.path().join("v"), "password", Argon2Params::TESTING).unwrap();
+        let publisher = std::sync::Arc::new(RecordingPublisher::default());
+        storage.set_state_publisher(publisher.clone());
+
+        let rec = KeyRecord::new(
+            [7u8; 32],
+            crate::keys::KeyType::Nostr,
+            "snap".into(),
+            vec![9, 8, 7],
+        );
+        storage.store_key(&rec).unwrap();
+
+        // The write-time hook and the startup snapshot must agree on (table, id, bytes) exactly, or a
+        // snapshot-published record would land under a different d-tag than the hook's and fail to
+        // supersede it on the standby.
+        let hook_id = hex::encode(rec.id);
+        let hook_bytes = publisher.last_bytes.lock().unwrap().clone();
+
+        let snap = storage.snapshot_replicable_records().unwrap();
+        let entry = snap
+            .iter()
+            .find(|(t, id, _)| *t == "keys" && *id == hook_id)
+            .expect("snapshot must include the stored key");
+        assert_eq!(
+            entry.2, hook_bytes,
+            "snapshot bytes must equal the hook's on_record bytes"
+        );
+        // Exactly one record was stored, so empty tables contribute no phantom rows.
+        assert_eq!(snap.len(), 1);
     }
 
     #[test]

--- a/keep-web/src/state_replication.rs
+++ b/keep-web/src/state_replication.rs
@@ -208,6 +208,33 @@ async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys)
         }));
 
     tokio::spawn(async move {
+        // Seed the pending set with every record already in storage. The hook above only observes
+        // FUTURE writes, so records written before replication was wired would otherwise never be
+        // published, and a fresh standby would never receive them. `or_insert` never clobbers a write
+        // the hook captured between installing it and this snapshot (both read the same storage), and
+        // the per-d-tag coalescing keeps the map bounded by record count. Each seeded record is then
+        // published with a created_at seeded from its own persisted mark by the loop below.
+        match keep.lock().await.snapshot_replicable_records() {
+            Ok(records) => {
+                {
+                    let mut guard = pending.lock().unwrap();
+                    for (table, id, encrypted) in records {
+                        guard
+                            .entry(format!("{table}:{id}"))
+                            .or_insert(Change::Record {
+                                table: table.to_string(),
+                                id,
+                                encrypted,
+                            });
+                    }
+                }
+                notify.notify_one();
+            }
+            Err(e) => tracing::error!(
+                "keep-state: initial snapshot failed; a fresh standby may miss records written before replication started: {e}"
+            ),
+        }
+
         // `last_ts` is an in-memory per-d-tag high-water-mark guaranteeing strict per-d-tag monotonicity
         // of created_at within a run: a record and its immediate delete (or two rapid writes) must not
         // collide on the same second, or the relay's created_at dedup could keep the wrong one and the


### PR DESCRIPTION
## Problem

keep-state's publisher (`spawn_publisher`) installs a `StatePublisher` hook that ships each vault-state write to the state relay. The hook only observes writes that happen *after* it is installed. Records written before replication was wired (keys, descriptors, relay_configs already in the vault) are therefore never published, so a fresh standby subscribing to the cluster identity never receives them, even though the active holds them.

## Fix

Publish an initial snapshot of every existing replicable record when the publisher starts.

- **keep-core**: `Storage::snapshot_replicable_records()` (and a `Keep` delegate) reads the raw at-rest entries of the three replicable tables via `backend.list`, returning `(logical table, hex record id, encrypted bytes)`. This is the same shape and the same bytes the write-time `on_record` hook emits: the backend key hex-encodes to the record id, and the stored value is the encrypted blob, so it neither decrypts nor needs the data key. A unit test asserts the snapshot bytes equal the hook's `on_record` bytes for a stored record (so a snapshot-published record lands under the same d-tag as a hook-published one).
- **keep-web**: `spawn_publisher` seeds the pending set from the snapshot at startup, using `or_insert` so it never clobbers a write the hook captured between install and snapshot (both read the same storage). Each seeded record is then published by the existing loop with a `created_at` seeded from its own persisted mark, so per-d-tag monotonicity and the standby rollback guard are unaffected.

## Correctness

- Snapshot tuples are byte-for-byte identical to the hook's, verified by test, so a standby dedups/replaces correctly whether a record arrives via snapshot or hook.
- Coalescing by d-tag keeps the pending map bounded by record count.
- Records already applied by a standby carry a persisted mark; re-publishing them is idempotent under the rollback guard (not strictly newer -> ignored).
