### PR TITLE
ci: add least-privilege read-only permissions block to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege: no job in this workflow writes to the repo, but every job runs
+# third-party actions (cargo-deny, setup-android, taiki-e/install-action, rust-cache).
+# Pin GITHUB_TOKEN to read-only so a compromised action cannot use whatever scope the
+# repository's ambient default grants (which can be write on push / same-repo PRs).
+permissions:
+  contents: read
+
 jobs:
   deny:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml` has no `permissions:` block at any level, so `GITHUB_TOKEN` inherits the repository's ambient default scope. On push to main and same-repo pull requests that default can be write-scoped. Every job in the workflow runs third-party actions (cargo-deny-action, setup-android, taiki-e/install-action, Swatinem/rust-cache), and a compromise of any of them could use whatever scope is ambient. `release.yml` already sets an explicit permissions block; `ci.yml` did not.

## Fix

Add a top-level `permissions: contents: read` so `GITHUB_TOKEN` is read-only for every job. No job in this workflow writes to the repository (all are checkout + build/test/lint/deny/fuzz/reproducible; none use `GITHUB_TOKEN`, `gh`, secrets, artifact upload, or any write step), so read is sufficient. This PR's own CI run exercises the new scope and confirms it.

Raised by security review of PR #730; pre-existing repo-wide gap, not introduced by that PR.
