### PR TITLE
keep-core: scrub the tweaked FROST signing-share SecretKey in BIP-32 tweak_key_package

### DIFF
--- a/keep-core/src/frost/bip32_signing.rs
+++ b/keep-core/src/frost/bip32_signing.rs
@@ -101,12 +101,16 @@ fn tweak_key_package(kp: &KeyPackage, tweak: &[u8; 32]) -> Result<KeyPackage> {
     let ss_bytes = Zeroizing::new(kp.signing_share().serialize());
     let ss_sk = bitcoin::secp256k1::SecretKey::from_slice(ss_bytes.as_slice())
         .map_err(|e| KeepError::Frost(format!("signing share is not a valid scalar: {e}")))?;
-    let tweaked_ss_bytes = Zeroizing::new(
-        ss_sk
-            .add_tweak(&scalar)
-            .map_err(|e| KeepError::Frost(format!("signing share + tweak invalid: {e}")))?
-            .secret_bytes(),
-    );
+    // `add_tweak` consumes `ss_sk` (transforming the raw share scalar in place),
+    // so the tweaked `SecretKey` is the only remaining live copy. secp256k1's
+    // `SecretKey` does NOT scrub on drop, and the raw share is recoverable from
+    // the tweaked scalar because the tweak is public, so scrub it explicitly once
+    // its bytes are captured in a Zeroizing buffer.
+    let mut tweaked_ss_sk = ss_sk
+        .add_tweak(&scalar)
+        .map_err(|e| KeepError::Frost(format!("signing share + tweak invalid: {e}")))?;
+    let tweaked_ss_bytes = Zeroizing::new(tweaked_ss_sk.secret_bytes());
+    tweaked_ss_sk.non_secure_erase();
     let tweaked_signing_share = SigningShare::deserialize(&*tweaked_ss_bytes)
         .map_err(|e| KeepError::Frost(format!("tweaked signing share deserialize: {e}")))?;
 


### PR DESCRIPTION
## Problem

In `tweak_key_package` (keep-core/src/frost/bip32_signing.rs), the raw and tweaked FROST signing-share byte arrays were already wrapped in `Zeroizing`, but the intermediate `secp256k1::SecretKey` values were not. `secp256k1::SecretKey` does not scrub its scalar on drop, so the tweaked share scalar lingered in freed stack memory. Because the BIP-32 tweak is public, the raw signing share is recoverable from the tweaked scalar, so this is effectively a secret-share leak into freed memory.

## Fix

Bind the tweaked `SecretKey`, capture its bytes into the existing `Zeroizing` buffer, then call `SecretKey::non_secure_erase()` on it before it drops. `add_tweak` consumes the raw `ss_sk` (transforming its scalar in place), so the tweaked key is the only remaining live `SecretKey` copy; the raw share's other representation (`ss_bytes`) is already `Zeroizing`.

## Verification

All 21 BIP-32 tests pass, including the signing round-trips that exercise `tweak_key_package` (`signs_and_verifies_under_derived_child_pubkey_at_leaf`, `three_of_five_signs_and_verifies_at_two_level_path`, odd-Y cases). The bytes are extracted into the `Zeroizing` buffer before the erase, so the derived `SigningShare` is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved protection of sensitive signing-share data by reducing the time plaintext key material remains in memory.
  * Preserved existing validation and error handling for invalid key tweaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->