### PR TITLE
keep-core: add a generic encrypted secrets store (passwords, API tokens, notes)

### DIFF
--- a/keep-cli/src/commands/audit.rs
+++ b/keep-cli/src/commands/audit.rs
@@ -311,6 +311,8 @@ struct AuditStats {
     password_rotate_fail: u32,
     data_key_rotate_ok: u32,
     data_key_rotate_fail: u32,
+    secret_create: u32,
+    secret_delete: u32,
 }
 
 impl AuditStats {
@@ -342,6 +344,8 @@ impl AuditStats {
             AuditEventType::PasswordRotateFailed => self.password_rotate_fail += 1,
             AuditEventType::DataKeyRotate => self.data_key_rotate_ok += 1,
             AuditEventType::DataKeyRotateFailed => self.data_key_rotate_fail += 1,
+            AuditEventType::SecretCreate => self.secret_create += 1,
+            AuditEventType::SecretDelete => self.secret_delete += 1,
         }
     }
 }
@@ -414,6 +418,10 @@ pub fn cmd_audit_stats(out: &Output, path: &Path, hidden: bool) -> Result<()> {
         "  Data-key rotations: {} ok / {} failed",
         stats.data_key_rotate_ok, stats.data_key_rotate_fail
     ));
+    out.info(&format!(
+        "  Secrets: {} created / {} deleted",
+        stats.secret_create, stats.secret_delete
+    ));
 
     Ok(())
 }
@@ -457,6 +465,8 @@ mod stats_tests {
         stats.record(AuditEventType::PasswordRotateFailed);
         stats.record(AuditEventType::DataKeyRotate);
         stats.record(AuditEventType::DataKeyRotateFailed);
+        stats.record(AuditEventType::SecretCreate);
+        stats.record(AuditEventType::SecretDelete);
 
         assert_eq!(stats.key_gen, 1);
         assert_eq!(stats.key_import, 2);
@@ -480,6 +490,8 @@ mod stats_tests {
         assert_eq!(stats.password_rotate_fail, 1);
         assert_eq!(stats.data_key_rotate_ok, 1);
         assert_eq!(stats.data_key_rotate_fail, 1);
+        assert_eq!(stats.secret_create, 1);
+        assert_eq!(stats.secret_delete, 1);
     }
 
     /// Closes the #526 gap surfaced by #441's testing pass: each of the

--- a/keep-core/src/audit.rs
+++ b/keep-core/src/audit.rs
@@ -87,6 +87,10 @@ pub enum AuditEventType {
     /// Data-key rotation attempted but rejected (wrong password or mid-
     /// rotation failure). Same locked-vault caveat as `PasswordRotateFailed`.
     DataKeyRotateFailed = 24,
+    /// Arbitrary secret (password, API token, note) created or overwritten.
+    SecretCreate = 25,
+    /// Arbitrary secret deleted.
+    SecretDelete = 26,
 }
 
 impl std::fmt::Display for AuditEventType {
@@ -117,6 +121,8 @@ impl std::fmt::Display for AuditEventType {
             Self::PasswordRotateFailed => write!(f, "password_rotate_failed"),
             Self::DataKeyRotate => write!(f, "data_key_rotate"),
             Self::DataKeyRotateFailed => write!(f, "data_key_rotate_failed"),
+            Self::SecretCreate => write!(f, "secret_create"),
+            Self::SecretDelete => write!(f, "secret_delete"),
         }
     }
 }

--- a/keep-core/src/backend.rs
+++ b/keep-core/src/backend.rs
@@ -25,6 +25,10 @@ pub const RELAY_CONFIGS_TABLE: &str = "relay_configs";
 pub const CONFIG_TABLE: &str = "config";
 /// Table name for key health status records.
 pub const HEALTH_STATUS_TABLE: &str = "key_health_status";
+/// Table name for arbitrary-secret records (passwords, API tokens, notes).
+/// Deliberately NOT a replicable table (see `Storage::replicated_table`): a
+/// password vault's metadata surface must not sync to public Nostr relays.
+pub const SECRETS_TABLE: &str = "secrets";
 /// Table name for the keep-state replication high-water-mark: maps a `<table>:<record-id>` d-tag to
 /// the highest `created_at` (8-byte big-endian) applied for it, so the consumer rejects any replicated
 /// event that is not strictly newer (replay/rollback protection).
@@ -139,6 +143,7 @@ const RELAY_CONFIGS_TABLE_DEF: TableDefinition<&[u8], &[u8]> =
 const CONFIG_TABLE_DEF: TableDefinition<&[u8], &[u8]> = TableDefinition::new("config");
 const HEALTH_STATUS_TABLE_DEF: TableDefinition<&[u8], &[u8]> =
     TableDefinition::new("key_health_status");
+const SECRETS_TABLE_DEF: TableDefinition<&[u8], &[u8]> = TableDefinition::new("secrets");
 const STATE_VERSIONS_TABLE_DEF: TableDefinition<&[u8], &[u8]> =
     TableDefinition::new("state_versions");
 
@@ -368,6 +373,7 @@ impl RedbBackend {
             RELAY_CONFIGS_TABLE => Ok(RELAY_CONFIGS_TABLE_DEF),
             CONFIG_TABLE => Ok(CONFIG_TABLE_DEF),
             HEALTH_STATUS_TABLE => Ok(HEALTH_STATUS_TABLE_DEF),
+            SECRETS_TABLE => Ok(SECRETS_TABLE_DEF),
             STATE_VERSIONS_TABLE => Ok(STATE_VERSIONS_TABLE_DEF),
             _ => Err(StorageError::database(format!("unknown table: {name}")).into()),
         }

--- a/keep-core/src/backup.rs
+++ b/keep-core/src/backup.rs
@@ -617,7 +617,7 @@ fn restore_to_path(backup: &DecryptedBackup, path: &Path, vault_password: &str) 
             created_at: bs.created_at,
             updated_at: bs.updated_at,
         };
-        keep.store_secret(&record)?;
+        keep.restore_secret(&record)?;
     }
 
     keep.set_kill_switch(backup.config.kill_switch)?;
@@ -818,7 +818,8 @@ mod tests {
             "db password".into(),
             SecretKind::Password,
             b"s3cr3t".to_vec(),
-        );
+        )
+        .unwrap();
         let id = rec.id;
         let created = rec.created_at;
         keep.store_secret(&rec).unwrap();
@@ -844,6 +845,34 @@ mod tests {
         assert_eq!(loaded.value, b"s3cr3t");
         // Restore preserves the original id and timestamps, not fresh ones.
         assert_eq!(loaded.created_at, created);
+    }
+
+    #[test]
+    fn secret_create_and_delete_are_audited() {
+        use crate::audit::AuditEventType;
+        use crate::secret::{SecretKind, SecretRecord};
+        let dir = tempdir().unwrap();
+        let mut keep = create_test_keep(&dir.path().join("v"));
+        keep.unlock("test-password-123").unwrap();
+
+        let rec = SecretRecord::new("t".into(), SecretKind::Note, b"v".to_vec()).unwrap();
+        let id = rec.id;
+        keep.store_secret(&rec).unwrap();
+        keep.delete_secret(&id).unwrap();
+
+        let entries = keep.audit_read_all().unwrap();
+        assert!(
+            entries
+                .iter()
+                .any(|e| matches!(e.event_type, AuditEventType::SecretCreate)),
+            "store_secret must emit a SecretCreate audit event"
+        );
+        assert!(
+            entries
+                .iter()
+                .any(|e| matches!(e.event_type, AuditEventType::SecretDelete)),
+            "delete_secret must emit a SecretDelete audit event"
+        );
     }
 
     /// Pin that backup + restore preserves every stored row type — not just

--- a/keep-core/src/backup.rs
+++ b/keep-core/src/backup.rs
@@ -6,7 +6,7 @@
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::audit::{AuditEntry, AuditLog};
 use crate::crypto::{self, Argon2Params, EncryptedData, NONCE_SIZE, SALT_SIZE};
@@ -15,6 +15,7 @@ use crate::error::{KeepError, Result};
 use crate::frost::StoredShare;
 use crate::keys::{KeyRecord, KeyType};
 use crate::relay::RelayConfig;
+use crate::secret::{SecretKind, SecretRecord};
 use crate::storage::ProxyConfig;
 use crate::wallet::{KeyHealthStatus, WalletDescriptor};
 use crate::Keep;
@@ -55,6 +56,10 @@ struct VaultBackup {
     /// differ from the source but the timeline of events is preserved.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     audit_entries: Vec<AuditEntry>,
+    /// Arbitrary secrets (passwords, API tokens, notes). `#[serde(default)]` so
+    /// a backup written before this field existed restores with none.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    secrets: Vec<BackupSecret>,
 }
 
 /// A key entry in a backup file.
@@ -142,6 +147,41 @@ impl std::fmt::Debug for BackupShare {
     }
 }
 
+/// A secret entry (password, API token, note) in a backup file. Omitting these
+/// from backups would be silent data loss, so a full-vault backup includes them.
+/// The backup file is itself passphrase-encrypted; `name` and `value` are also
+/// scrubbed from memory on drop and never printed.
+#[derive(Serialize, Deserialize, Clone, Zeroize, ZeroizeOnDrop)]
+pub struct BackupSecret {
+    /// Hex-encoded 32-byte secret id (preserved so the restored row keeps its identity).
+    #[zeroize(skip)]
+    pub id: String,
+    /// Human-readable title.
+    pub name: String,
+    /// Secret kind string (e.g. "Password", "ApiToken").
+    #[zeroize(skip)]
+    pub kind: String,
+    /// Hex-encoded plaintext secret value.
+    pub value: String,
+    /// Unix timestamp when the secret was created.
+    #[zeroize(skip)]
+    pub created_at: i64,
+    /// Unix timestamp of the last update.
+    #[zeroize(skip)]
+    pub updated_at: i64,
+}
+
+impl std::fmt::Debug for BackupSecret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BackupSecret")
+            .field("id", &self.id)
+            .field("kind", &self.kind)
+            .field("name", &"[REDACTED]")
+            .field("value", &"[REDACTED]")
+            .finish()
+    }
+}
+
 /// Summary information about a backup file.
 #[derive(Debug, Clone)]
 pub struct BackupInfo {
@@ -173,6 +213,8 @@ pub struct DecryptedBackup {
     pub config: BackupConfig,
     /// Decrypted audit entries from the source vault.
     pub audit_entries: Vec<AuditEntry>,
+    /// Arbitrary secrets (passwords, API tokens, notes).
+    pub secrets: Vec<BackupSecret>,
     /// ISO-8601 timestamp when the backup was created.
     pub created_at: String,
 }
@@ -181,6 +223,7 @@ impl Drop for DecryptedBackup {
     fn drop(&mut self) {
         self.keys.zeroize();
         self.shares.zeroize();
+        self.secrets.zeroize();
     }
 }
 
@@ -203,6 +246,27 @@ fn string_to_key_type(s: &str) -> Result<KeyType> {
     }
 }
 
+fn secret_kind_to_string(k: SecretKind) -> String {
+    match k {
+        SecretKind::Password => "Password".into(),
+        SecretKind::ApiToken => "ApiToken".into(),
+        SecretKind::Note => "Note".into(),
+        SecretKind::Generic => "Generic".into(),
+    }
+}
+
+fn string_to_secret_kind(s: &str) -> Result<SecretKind> {
+    match s {
+        "Password" => Ok(SecretKind::Password),
+        "ApiToken" => Ok(SecretKind::ApiToken),
+        "Note" => Ok(SecretKind::Note),
+        "Generic" => Ok(SecretKind::Generic),
+        other => Err(KeepError::InvalidInput(format!(
+            "unknown secret kind: {other}"
+        ))),
+    }
+}
+
 /// Create an encrypted backup from pre-gathered data.
 #[allow(clippy::too_many_arguments)]
 pub fn create_backup_from_data(
@@ -215,12 +279,8 @@ pub fn create_backup_from_data(
     audit_entries: Vec<AuditEntry>,
     passphrase: &str,
 ) -> Result<Vec<u8>> {
-    if passphrase.chars().count() < MIN_PASSPHRASE_LEN {
-        return Err(KeepError::InvalidInput(format!(
-            "passphrase must be at least {MIN_PASSPHRASE_LEN} characters"
-        )));
-    }
-
+    // External callers (e.g. keep-mobile) that do not hold a secret store back up
+    // no secrets. The full-vault `create_backup` path threads them in explicitly.
     let backup = VaultBackup {
         version: VERSION,
         created_at: chrono::Utc::now().to_rfc3339(),
@@ -231,9 +291,22 @@ pub fn create_backup_from_data(
         health_statuses,
         config,
         audit_entries,
+        secrets: Vec::new(),
     };
+    encode_backup(&backup, passphrase)
+}
 
-    let mut json_bytes = serde_json::to_vec(&backup)
+/// Passphrase-check, serialize, Argon2-derive, and encrypt a [`VaultBackup`] into
+/// the on-disk backup format. Shared by [`create_backup_from_data`] and
+/// [`create_backup`] so the header/encryption layout stays in one place.
+fn encode_backup(backup: &VaultBackup, passphrase: &str) -> Result<Vec<u8>> {
+    if passphrase.chars().count() < MIN_PASSPHRASE_LEN {
+        return Err(KeepError::InvalidInput(format!(
+            "passphrase must be at least {MIN_PASSPHRASE_LEN} characters"
+        )));
+    }
+
+    let mut json_bytes = serde_json::to_vec(backup)
         .map_err(|e| KeepError::Other(format!("backup serialization failed: {e}")))?;
 
     let salt: [u8; SALT_SIZE] = entropy::try_random_bytes()?;
@@ -305,6 +378,19 @@ pub fn create_backup(keep: &Keep, passphrase: &str) -> Result<Vec<u8>> {
         });
     }
 
+    let secret_records = keep.list_secrets()?;
+    let mut backup_secrets = Vec::with_capacity(secret_records.len());
+    for record in &secret_records {
+        backup_secrets.push(BackupSecret {
+            id: hex::encode(record.id),
+            name: record.name.clone(),
+            kind: secret_kind_to_string(record.kind),
+            value: hex::encode(&record.value),
+            created_at: record.created_at,
+            updated_at: record.updated_at,
+        });
+    }
+
     let descriptors = keep.list_all_wallet_descriptor_versions()?;
     let relay_configs = keep.list_relay_configs()?;
     let health_statuses = keep.list_health_statuses()?;
@@ -312,19 +398,22 @@ pub fn create_backup(keep: &Keep, passphrase: &str) -> Result<Vec<u8>> {
     let proxy = keep.get_proxy_config()?;
     let audit_entries = keep.read_audit_entries()?;
 
-    create_backup_from_data(
-        backup_keys,
-        backup_shares,
-        descriptors,
+    let backup = VaultBackup {
+        version: VERSION,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        keys: backup_keys,
+        shares: backup_shares,
+        wallet_descriptors: descriptors,
         relay_configs,
         health_statuses,
-        BackupConfig {
+        config: BackupConfig {
             kill_switch,
             proxy: if proxy.enabled { Some(proxy) } else { None },
         },
         audit_entries,
-        passphrase,
-    )
+        secrets: backup_secrets,
+    };
+    encode_backup(&backup, passphrase)
 }
 
 struct ParsedHeader {
@@ -434,6 +523,7 @@ pub fn decrypt_backup(data: &[u8], passphrase: &str) -> Result<DecryptedBackup> 
         health_statuses: vault.health_statuses,
         config: vault.config,
         audit_entries: vault.audit_entries,
+        secrets: vault.secrets,
         created_at: vault.created_at,
     })
 }
@@ -509,6 +599,25 @@ fn restore_to_path(backup: &DecryptedBackup, path: &Path, vault_password: &str) 
 
     for h in &backup.health_statuses {
         keep.store_health_status(h)?;
+    }
+
+    for bs in &backup.secrets {
+        let id: [u8; 32] = decode_hex_32(&bs.id, "secret id")?;
+        let value = Zeroizing::new(
+            hex::decode(&bs.value)
+                .map_err(|e| KeepError::Other(format!("hex decode secret value: {e}")))?,
+        );
+        // Preserve the original id/timestamps so a restored secret keeps its
+        // identity; only `SecretRecord::new` mints a fresh id, which we bypass.
+        let record = SecretRecord {
+            id,
+            name: bs.name.clone(),
+            kind: string_to_secret_kind(&bs.kind)?,
+            value: value.to_vec(),
+            created_at: bs.created_at,
+            updated_at: bs.updated_at,
+        };
+        keep.store_secret(&record)?;
     }
 
     keep.set_kill_switch(backup.config.kill_switch)?;
@@ -695,6 +804,46 @@ mod tests {
             assert_eq!(dst.pubkey, src.pubkey, "entry {i} pubkey");
             assert_eq!(dst.timestamp, src.timestamp, "entry {i} timestamp");
         }
+    }
+
+    #[test]
+    fn backup_roundtrip_preserves_secrets() {
+        use crate::secret::{SecretKind, SecretRecord};
+        let dir = tempdir().unwrap();
+        let src_path = dir.path().join("src");
+        let mut keep = create_test_keep(&src_path);
+        keep.unlock("test-password-123").unwrap();
+
+        let rec = SecretRecord::new(
+            "db password".into(),
+            SecretKind::Password,
+            b"s3cr3t".to_vec(),
+        );
+        let id = rec.id;
+        let created = rec.created_at;
+        keep.store_secret(&rec).unwrap();
+
+        let backup_data = create_backup(&keep, "backup-passphrase-ok").unwrap();
+
+        let dst_path = dir.path().join("dst");
+        restore_backup(
+            &backup_data,
+            "backup-passphrase-ok",
+            &dst_path,
+            "new-password-456",
+        )
+        .unwrap();
+
+        let mut restored = Keep::open(&dst_path).unwrap();
+        restored.unlock("new-password-456").unwrap();
+        let loaded = restored
+            .load_secret(&id)
+            .expect("secret MUST survive backup + restore");
+        assert_eq!(loaded.name, "db password");
+        assert_eq!(loaded.kind, SecretKind::Password);
+        assert_eq!(loaded.value, b"s3cr3t");
+        // Restore preserves the original id and timestamps, not fresh ones.
+        assert_eq!(loaded.created_at, created);
     }
 
     /// Pin that backup + restore preserves every stored row type — not just

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -59,6 +59,7 @@ pub mod keyring;
 /// Key types and Nostr keypair operations.
 pub mod keys;
 pub mod migration;
+
 /// BIP-39 mnemonic generation and validation.
 pub mod mnemonic;
 /// NIP-06 key derivation from mnemonic seed phrase.
@@ -70,6 +71,8 @@ pub(crate) mod rate_limit;
 /// Relay configuration for FROST shares.
 pub mod relay;
 mod rotation;
+/// Arbitrary-secret records (passwords, API tokens, notes) stored in the vault.
+pub mod secret;
 /// Persistent encrypted storage backend.
 pub mod storage;
 /// Ephemeral time-limited secret vault.
@@ -473,6 +476,29 @@ impl Keep {
     /// List all stored key records.
     pub fn list_keys(&self) -> Result<Vec<KeyRecord>> {
         self.storage.list_keys()
+    }
+
+    /// Store (insert or overwrite by id) an arbitrary-secret record (password,
+    /// API token, note). The whole record, including its plaintext value and
+    /// title, is encrypted under the vault data key at rest. See
+    /// [`storage::Storage::store_secret`].
+    pub fn store_secret(&self, record: &crate::secret::SecretRecord) -> Result<()> {
+        self.storage.store_secret(record)
+    }
+
+    /// Load a secret record by its 32-byte id.
+    pub fn load_secret(&self, id: &[u8; 32]) -> Result<crate::secret::SecretRecord> {
+        self.storage.load_secret(id)
+    }
+
+    /// List all stored secret records.
+    pub fn list_secrets(&self) -> Result<Vec<crate::secret::SecretRecord>> {
+        self.storage.list_secrets()
+    }
+
+    /// Delete a secret record by its 32-byte id.
+    pub fn delete_secret(&self, id: &[u8; 32]) -> Result<()> {
+        self.storage.delete_secret(id)
     }
 
     /// Export a stored nsec key as NIP-49 ncryptsec.

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -481,9 +481,13 @@ impl Keep {
     /// Store (insert or overwrite by id) an arbitrary-secret record (password,
     /// API token, note). The whole record, including its plaintext value and
     /// title, is encrypted under the vault data key at rest. See
-    /// [`storage::Storage::store_secret`].
-    pub fn store_secret(&self, record: &crate::secret::SecretRecord) -> Result<()> {
-        self.storage.store_secret(record)
+    /// [`storage::Storage::store_secret`]. Records a `SecretCreate` audit event
+    /// (tagged with the non-sensitive random id, never the name or value) so
+    /// secret mutations leave a forensic trail like every other sensitive op.
+    pub fn store_secret(&mut self, record: &crate::secret::SecretRecord) -> Result<()> {
+        self.storage.store_secret(record)?;
+        self.audit_event(AuditEventType::SecretCreate, |e| e.with_pubkey(&record.id));
+        Ok(())
     }
 
     /// Load a secret record by its 32-byte id.
@@ -496,9 +500,20 @@ impl Keep {
         self.storage.list_secrets()
     }
 
-    /// Delete a secret record by its 32-byte id.
-    pub fn delete_secret(&self, id: &[u8; 32]) -> Result<()> {
-        self.storage.delete_secret(id)
+    /// Delete a secret record by its 32-byte id. Records a `SecretDelete` audit
+    /// event tagged with the id.
+    pub fn delete_secret(&mut self, id: &[u8; 32]) -> Result<()> {
+        self.storage.delete_secret(id)?;
+        self.audit_event(AuditEventType::SecretDelete, |e| e.with_pubkey(id));
+        Ok(())
+    }
+
+    /// Restore a secret WITHOUT emitting an audit event, for the backup-restore
+    /// path only. Restore re-establishes the source vault's audit log verbatim
+    /// (see `VaultBackup::audit_entries`), so re-auditing each restored row would
+    /// double-count. Mirrors `restore_key_record`.
+    pub fn restore_secret(&self, record: &crate::secret::SecretRecord) -> Result<()> {
+        self.storage.store_secret(record)
     }
 
     /// Export a stored nsec key as NIP-49 ncryptsec.

--- a/keep-core/src/migration.rs
+++ b/keep-core/src/migration.rs
@@ -9,7 +9,7 @@ const METADATA_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("metad
 const SCHEMA_VERSION_KEY: &str = "schema_version";
 
 /// The current schema version supported by this build.
-pub const CURRENT_SCHEMA_VERSION: u32 = 5;
+pub const CURRENT_SCHEMA_VERSION: u32 = 6;
 
 /// A migration function that transforms the database schema.
 pub type MigrationFn = fn(&Database) -> Result<()>;
@@ -119,6 +119,19 @@ fn migrate_v4_to_v5(db: &Database) -> Result<()> {
     Ok(())
 }
 
+const SECRETS_TABLE_DEF: TableDefinition<&[u8], &[u8]> = TableDefinition::new("secrets");
+
+/// v5 → v6: introduce the `secrets` table for arbitrary-secret records
+/// (passwords, API tokens, notes). Creating the empty table is the whole
+/// migration; existing rows are untouched. Idempotent: opening a table that
+/// already exists is a no-op.
+fn migrate_v5_to_v6(db: &Database) -> Result<()> {
+    let wtxn = db.begin_write()?;
+    wtxn.open_table(SECRETS_TABLE_DEF)?;
+    wtxn.commit()?;
+    Ok(())
+}
+
 fn get_migrations() -> Vec<Migration> {
     vec![
         Migration {
@@ -140,6 +153,11 @@ fn get_migrations() -> Vec<Migration> {
             from_version: 4,
             to_version: 5,
             migrate: migrate_v4_to_v5,
+        },
+        Migration {
+            from_version: 5,
+            to_version: 6,
+            migrate: migrate_v5_to_v6,
         },
     ]
 }

--- a/keep-core/src/rotation.rs
+++ b/keep-core/src/rotation.rs
@@ -1169,7 +1169,8 @@ mod tests {
         let id;
         {
             let storage = Storage::create(&path, "pass1234", Argon2Params::TESTING).unwrap();
-            let rec = SecretRecord::new("api".into(), SecretKind::ApiToken, b"tok-secret".to_vec());
+            let rec = SecretRecord::new("api".into(), SecretKind::ApiToken, b"tok-secret".to_vec())
+                .unwrap();
             id = rec.id;
             storage.store_secret(&rec).unwrap();
         }

--- a/keep-core/src/rotation.rs
+++ b/keep-core/src/rotation.rs
@@ -13,7 +13,7 @@ use zeroize::Zeroizing;
 
 use crate::backend::{
     RedbBackend, StorageBackend, CONFIG_TABLE, DESCRIPTORS_TABLE, HEALTH_STATUS_TABLE, KEYS_TABLE,
-    RELAY_CONFIGS_TABLE, SHARES_TABLE,
+    RELAY_CONFIGS_TABLE, SECRETS_TABLE, SHARES_TABLE,
 };
 use crate::crypto::{self, EncryptedData, SecretKey};
 use crate::error::{KeepError, Result};
@@ -30,7 +30,11 @@ use crate::wallet::WalletDescriptor;
 /// with no typed collection path of their own. Rotation moves them verbatim: decrypt each row
 /// under the old key, re-encrypt under the new one. `STATE_VERSIONS_TABLE` is deliberately
 /// absent because it stores plaintext big-endian counters, not ciphertext.
-const OPAQUE_TABLES: [&str; 2] = [CONFIG_TABLE, HEALTH_STATUS_TABLE];
+///
+/// `SECRETS_TABLE` qualifies: each row is `crypto::encrypt(bincode(SecretRecord))`, a single
+/// blob under the data key with no inner per-field encryption (unlike `KeyRecord`, whose
+/// separately-encrypted secret is why keys are rotated on their own typed path, not here).
+const OPAQUE_TABLES: [&str; 3] = [CONFIG_TABLE, HEALTH_STATUS_TABLE, SECRETS_TABLE];
 
 /// One row of an [`OPAQUE_TABLES`] table, held decrypted across a rotation.
 struct OpaqueRow {
@@ -1151,6 +1155,36 @@ mod tests {
             original_secret.as_slice(),
             "decrypted secret bytes MUST match the pre-rotation value"
         );
+    }
+
+    /// A `rotate_data_key` (new random data key, every row re-encrypted) MUST
+    /// carry `secrets` rows through: they are registered in `OPAQUE_TABLES`, so a
+    /// missed registration would leave them under the OLD key and fail to decrypt
+    /// here.
+    #[test]
+    fn rotate_data_key_preserves_secrets() {
+        use crate::secret::{SecretKind, SecretRecord};
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("secrets-survive-rotation");
+        let id;
+        {
+            let storage = Storage::create(&path, "pass1234", Argon2Params::TESTING).unwrap();
+            let rec = SecretRecord::new("api".into(), SecretKind::ApiToken, b"tok-secret".to_vec());
+            id = rec.id;
+            storage.store_secret(&rec).unwrap();
+        }
+        {
+            let mut storage = Storage::open(&path).unwrap();
+            storage.rotate_data_key("pass1234").unwrap();
+        }
+        let mut storage = Storage::open(&path).unwrap();
+        storage.unlock("pass1234").unwrap();
+        let loaded = storage
+            .load_secret(&id)
+            .expect("secret MUST survive a data-key rotation");
+        assert_eq!(loaded.value, b"tok-secret");
+        assert_eq!(loaded.name, "api");
+        assert_eq!(loaded.kind, SecretKind::ApiToken);
     }
 
     /// `rotate_data_key` MUST reject a wrong password. Without the gate,

--- a/keep-core/src/secret.rs
+++ b/keep-core/src/secret.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::entropy;
+use crate::error::Result;
 
 /// Category of a stored secret. Additive: only APPEND new variants, so a record
 /// written by an older build keeps decoding under bincode's integer tag.
@@ -67,18 +68,19 @@ pub struct SecretRecord {
 
 impl SecretRecord {
     /// Create a new secret record with a fresh random id and `created_at ==
-    /// updated_at == now`.
-    pub fn new(name: String, kind: SecretKind, value: Vec<u8>) -> Self {
-        let id: [u8; 32] = entropy::random_bytes();
+    /// updated_at == now`. Returns `Err` (rather than panicking) if the CSPRNG
+    /// health check fails, so a broken RNG cannot crash the process here.
+    pub fn new(name: String, kind: SecretKind, value: Vec<u8>) -> Result<Self> {
+        let id: [u8; 32] = entropy::try_random_bytes()?;
         let now = chrono::Utc::now().timestamp();
-        Self {
+        Ok(Self {
             id,
             name,
             kind,
             value,
             created_at: now,
             updated_at: now,
-        }
+        })
     }
 }
 
@@ -103,8 +105,8 @@ mod tests {
 
     #[test]
     fn new_mints_a_random_id_and_equal_timestamps() {
-        let a = SecretRecord::new("x".into(), SecretKind::Password, b"v".to_vec());
-        let b = SecretRecord::new("x".into(), SecretKind::Password, b"v".to_vec());
+        let a = SecretRecord::new("x".into(), SecretKind::Password, b"v".to_vec()).unwrap();
+        let b = SecretRecord::new("x".into(), SecretKind::Password, b"v".to_vec()).unwrap();
         assert_ne!(a.id, b.id, "each secret gets a fresh random id");
         assert_eq!(a.created_at, a.updated_at);
     }
@@ -115,7 +117,8 @@ mod tests {
             "GitHub login".into(),
             SecretKind::Password,
             b"hunter2".to_vec(),
-        );
+        )
+        .unwrap();
         let s = format!("{rec:?}");
         assert!(!s.contains("GitHub login"), "name must be redacted: {s}");
         assert!(!s.contains("hunter2"), "value must be redacted: {s}");

--- a/keep-core/src/secret.rs
+++ b/keep-core/src/secret.rs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+//! Arbitrary-secret records (passwords, API tokens, notes) stored in the vault
+//! alongside curve-key records.
+//!
+//! The vault below the record model is already secret-agnostic: the storage
+//! backend is a plain encrypted key-value store and [`crate::crypto`] encrypts
+//! arbitrary bytes, so storing generic secrets is an additive extension rather
+//! than a new subsystem. A [`SecretRecord`] is bincode-serialized as a whole --
+//! name, kind, AND the plaintext value -- then encrypted under the vault data
+//! key at rest (see [`crate::storage::Storage::store_secret`]), so entry titles
+//! are encrypted, not just the value. The plaintext `value` exists decrypted
+//! only in memory and is scrubbed on drop.
+
+use serde::{Deserialize, Serialize};
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use crate::entropy;
+
+/// Category of a stored secret. Additive: only APPEND new variants, so a record
+/// written by an older build keeps decoding under bincode's integer tag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SecretKind {
+    /// A login password.
+    Password,
+    /// An API token or other bearer credential.
+    ApiToken,
+    /// A free-form secret note.
+    Note,
+    /// Any other secret material that does not fit the categories above.
+    Generic,
+}
+
+/// A stored arbitrary secret sitting alongside curve-key records in the vault.
+///
+/// Unlike [`crate::keys::KeyRecord`], whose `id` is derived from a public key
+/// (stable identity and dedup for free), a secret has no public key, so `id` is
+/// random. Importing the same secret twice therefore creates two distinct rows.
+/// This is intended for a password store, where two logins can legitimately
+/// share one value; callers that need dedup must do it themselves.
+///
+/// Every field except the identity/metadata is zeroized on drop. `id`, `kind`,
+/// and the timestamps are not secret and are skipped; `name` and `value` are
+/// scrubbed because an entry title reveals what the secret is for.
+#[derive(Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
+pub struct SecretRecord {
+    /// Random 32-byte identifier (a secret has no pubkey to derive one from),
+    /// used as the storage key.
+    #[zeroize(skip)]
+    pub id: [u8; 32],
+    /// Human-readable title (e.g. "GitHub login"). Sensitive: encrypted at rest
+    /// with the value, and scrubbed from memory on drop.
+    pub name: String,
+    /// Category of secret.
+    #[zeroize(skip)]
+    pub kind: SecretKind,
+    /// The plaintext secret bytes. Encrypted at rest via the record's outer
+    /// encryption; held decrypted only in memory and scrubbed on drop.
+    pub value: Vec<u8>,
+    /// Unix timestamp when the secret was created.
+    #[zeroize(skip)]
+    pub created_at: i64,
+    /// Unix timestamp of the last update.
+    #[zeroize(skip)]
+    pub updated_at: i64,
+}
+
+impl SecretRecord {
+    /// Create a new secret record with a fresh random id and `created_at ==
+    /// updated_at == now`.
+    pub fn new(name: String, kind: SecretKind, value: Vec<u8>) -> Self {
+        let id: [u8; 32] = entropy::random_bytes();
+        let now = chrono::Utc::now().timestamp();
+        Self {
+            id,
+            name,
+            kind,
+            value,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}
+
+impl std::fmt::Debug for SecretRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never print `name` or `value`: both are secret. `name` leaks what the
+        // secret is for; `value` is the secret itself.
+        f.debug_struct("SecretRecord")
+            .field("id", &hex::encode(self.id))
+            .field("kind", &self.kind)
+            .field("name", &"[REDACTED]")
+            .field("value", &"[REDACTED]")
+            .field("created_at", &self.created_at)
+            .field("updated_at", &self.updated_at)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_mints_a_random_id_and_equal_timestamps() {
+        let a = SecretRecord::new("x".into(), SecretKind::Password, b"v".to_vec());
+        let b = SecretRecord::new("x".into(), SecretKind::Password, b"v".to_vec());
+        assert_ne!(a.id, b.id, "each secret gets a fresh random id");
+        assert_eq!(a.created_at, a.updated_at);
+    }
+
+    #[test]
+    fn debug_never_leaks_name_or_value() {
+        let rec = SecretRecord::new(
+            "GitHub login".into(),
+            SecretKind::Password,
+            b"hunter2".to_vec(),
+        );
+        let s = format!("{rec:?}");
+        assert!(!s.contains("GitHub login"), "name must be redacted: {s}");
+        assert!(!s.contains("hunter2"), "value must be redacted: {s}");
+        assert!(s.contains("[REDACTED]"));
+    }
+}

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -1729,7 +1729,8 @@ mod tests {
             "GitHub login".into(),
             SecretKind::Password,
             b"hunter2".to_vec(),
-        );
+        )
+        .unwrap();
         let id = rec.id;
         storage.store_secret(&rec).unwrap();
 
@@ -1757,8 +1758,8 @@ mod tests {
 
         // The same title + value stored twice yields two rows: a secret has no
         // pubkey to derive a stable id from, so ids are random (see SecretRecord).
-        let a = SecretRecord::new("dup".into(), SecretKind::Generic, b"same".to_vec());
-        let b = SecretRecord::new("dup".into(), SecretKind::Generic, b"same".to_vec());
+        let a = SecretRecord::new("dup".into(), SecretKind::Generic, b"same".to_vec()).unwrap();
+        let b = SecretRecord::new("dup".into(), SecretKind::Generic, b"same".to_vec()).unwrap();
         assert_ne!(a.id, b.id);
         storage.store_secret(&a).unwrap();
         storage.store_secret(&b).unwrap();

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -9,7 +9,7 @@ use tracing::{debug, trace, warn};
 
 use crate::backend::{
     AtomicOp, RedbBackend, StorageBackend, CONFIG_TABLE, DESCRIPTORS_TABLE, HEALTH_STATUS_TABLE,
-    KEYS_TABLE, RELAY_CONFIGS_TABLE, SHARES_TABLE, STATE_VERSIONS_TABLE,
+    KEYS_TABLE, RELAY_CONFIGS_TABLE, SECRETS_TABLE, SHARES_TABLE, STATE_VERSIONS_TABLE,
 };
 use crate::crypto::{self, Argon2Params, EncryptedData, SecretKey, SALT_SIZE};
 use crate::error::{KeepError, Result, StorageError};
@@ -17,6 +17,7 @@ use crate::frost::StoredShare;
 use crate::keys::KeyRecord;
 use crate::rate_limit;
 use crate::relay::{self, RelayConfig};
+use crate::secret::SecretRecord;
 use crate::wallet::{KeyHealthStatus, WalletDescriptor};
 
 use bincode::Options;
@@ -565,6 +566,7 @@ impl Storage {
         backend.create_table(RELAY_CONFIGS_TABLE)?;
         backend.create_table(CONFIG_TABLE)?;
         backend.create_table(HEALTH_STATUS_TABLE)?;
+        backend.create_table(SECRETS_TABLE)?;
         backend.create_table(STATE_VERSIONS_TABLE)?;
 
         Ok(Self {
@@ -836,6 +838,67 @@ impl Storage {
             Ok(())
         } else {
             Err(KeepError::KeyNotFound(hex::encode(id)))
+        }
+    }
+
+    /// Store (insert or overwrite) an arbitrary-secret record, keyed by its
+    /// random `id`. The whole record -- name, kind, AND plaintext value -- is
+    /// bincode-serialized then encrypted under the vault data key, so nothing is
+    /// on disk in the clear and the entry title is protected too. Unlike
+    /// `store_key` this never notifies the replication sink: secrets are not
+    /// replicable (see [`Self::replicated_table`]).
+    pub fn store_secret(&self, record: &SecretRecord) -> Result<()> {
+        debug!(id = %hex::encode(record.id), "storing secret");
+        let data_key = self.data_key.as_ref().ok_or(KeepError::Locked)?;
+        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
+
+        let serialized = Zeroizing::new(bincode::serialize(record)?);
+        let encrypted = crypto::encrypt(&serialized, data_key)?;
+        backend.put(SECRETS_TABLE, &record.id, &encrypted.to_bytes())?;
+        Ok(())
+    }
+
+    /// Load a secret record by its 32-byte `id`.
+    pub fn load_secret(&self, id: &[u8; 32]) -> Result<SecretRecord> {
+        trace!(id = %hex::encode(id), "loading secret");
+        let data_key = self.data_key.as_ref().ok_or(KeepError::Locked)?;
+        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
+
+        let encrypted_bytes = backend
+            .get(SECRETS_TABLE, id)?
+            .ok_or_else(|| KeepError::NotFound(hex::encode(id)))?;
+        let encrypted = EncryptedData::from_bytes(&encrypted_bytes)?;
+        let decrypted = crypto::decrypt(&encrypted, data_key)?;
+        let decrypted_bytes = decrypted.as_slice()?;
+        Ok(bincode_options().deserialize(&decrypted_bytes)?)
+    }
+
+    /// List all stored secret records. O(n) full decrypt, matching `list_keys`;
+    /// fine for the modest counts a first-pass secret store holds.
+    pub fn list_secrets(&self) -> Result<Vec<SecretRecord>> {
+        trace!("listing secrets");
+        let data_key = self.data_key.as_ref().ok_or(KeepError::Locked)?;
+        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
+
+        let entries = backend.list(SECRETS_TABLE)?;
+        let mut records = Vec::with_capacity(entries.len());
+        for (_, encrypted_bytes) in entries {
+            let encrypted = EncryptedData::from_bytes(&encrypted_bytes)?;
+            let decrypted = crypto::decrypt(&encrypted, data_key)?;
+            let decrypted_bytes = decrypted.as_slice()?;
+            records.push(bincode_options().deserialize(&decrypted_bytes)?);
+        }
+        Ok(records)
+    }
+
+    /// Delete a secret record by `id`. Errors if no such secret exists.
+    pub fn delete_secret(&self, id: &[u8; 32]) -> Result<()> {
+        debug!(id = %hex::encode(id), "deleting secret");
+        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
+        if backend.delete(SECRETS_TABLE, id)? {
+            Ok(())
+        } else {
+            Err(KeepError::NotFound(hex::encode(id)))
         }
     }
 
@@ -1653,6 +1716,60 @@ mod tests {
         let mut storage = Storage::open(&path).unwrap();
         let result = storage.unlock("wrongpass");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn secret_store_load_list_delete_round_trips() {
+        use crate::secret::{SecretKind, SecretRecord};
+        let dir = tempdir().unwrap();
+        let storage =
+            Storage::create(&dir.path().join("v"), "password", Argon2Params::TESTING).unwrap();
+
+        let rec = SecretRecord::new(
+            "GitHub login".into(),
+            SecretKind::Password,
+            b"hunter2".to_vec(),
+        );
+        let id = rec.id;
+        storage.store_secret(&rec).unwrap();
+
+        let loaded = storage.load_secret(&id).unwrap();
+        assert_eq!(loaded.id, id);
+        assert_eq!(loaded.name, "GitHub login");
+        assert_eq!(loaded.kind, SecretKind::Password);
+        assert_eq!(loaded.value, b"hunter2");
+
+        assert_eq!(storage.list_secrets().unwrap().len(), 1);
+
+        storage.delete_secret(&id).unwrap();
+        assert!(storage.load_secret(&id).is_err());
+        assert!(storage.list_secrets().unwrap().is_empty());
+        // Deleting a missing secret errors rather than silently succeeding.
+        assert!(storage.delete_secret(&id).is_err());
+    }
+
+    #[test]
+    fn secrets_get_distinct_random_ids() {
+        use crate::secret::{SecretKind, SecretRecord};
+        let dir = tempdir().unwrap();
+        let storage =
+            Storage::create(&dir.path().join("v"), "password", Argon2Params::TESTING).unwrap();
+
+        // The same title + value stored twice yields two rows: a secret has no
+        // pubkey to derive a stable id from, so ids are random (see SecretRecord).
+        let a = SecretRecord::new("dup".into(), SecretKind::Generic, b"same".to_vec());
+        let b = SecretRecord::new("dup".into(), SecretKind::Generic, b"same".to_vec());
+        assert_ne!(a.id, b.id);
+        storage.store_secret(&a).unwrap();
+        storage.store_secret(&b).unwrap();
+        assert_eq!(storage.list_secrets().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn secrets_table_is_not_replicable() {
+        // A password vault must never sync to public relays. `replicated_table`
+        // fails loudly for "secrets" rather than silently allowing it.
+        assert!(Storage::replicated_table("secrets").is_err());
     }
 
     #[test]


### PR DESCRIPTION
Implements the keep-core storage model for keep-3m9f: store arbitrary secrets (passwords, API tokens, notes) alongside curve-key records. Scope is **keep-core only** by design, so the model can be reviewed in isolation before any CLI/desktop/mobile surface.

## Model

- `secret::SecretRecord { id, name, kind, value, created_at, updated_at }` + `SecretKind` (Password/ApiToken/Note/Generic). The whole record — name, kind, AND the plaintext value — is bincode-serialized then `crypto::encrypt`ed under the vault data key (`Storage::store_secret`), so entry titles are encrypted at rest too, not just the value. `name`/`value` are zeroized on drop and redacted from `Debug`.
- `id` is **random** (a secret has no pubkey to derive a stable id from), so storing the same secret twice yields two rows — intended for a password store where two logins can legitimately share a value. This was the one flagged open design decision; documented on the type.
- `Storage`/`Keep` gain `store_secret`/`load_secret`/`list_secrets`/`delete_secret`.

## The four registration sites (the landmines the issue called out)

1. **Rotation** (`rotation.rs` `OPAQUE_TABLES`): a `SecretRecord` row is a single `crypto::encrypt(bincode(record))` blob with no inner per-field encryption (unlike `KeyRecord`, whose separately-encrypted secret is why keys rotate on their own typed path). That makes it a valid opaque-blob table, so it joins `OPAQUE_TABLES` as a one-line change and #713's generic decrypt/re-encrypt/verify path covers it. **Tested**: `rotate_data_key_preserves_secrets` re-keys the whole vault and asserts the secret still decrypts — a missed registration would leave it under the old key and fail.
2. **Backup** (`backup.rs`): `BackupSecret` added to the backup envelope and threaded through `create_backup` + restore, so secrets are not silent data loss on backup. `create_backup_from_data`'s public signature is unchanged (an `encode_backup` helper is shared), so the keep-mobile caller is unaffected and backs up no secrets. **Tested**: `backup_roundtrip_preserves_secrets` (value, kind, id, timestamps survive).
3. **Table creation** (`backend.rs` + `storage.rs` `create_inner`) and a `v5 → v6` migration (`CURRENT_SCHEMA_VERSION` bumped) that creates the empty `secrets` table; idempotent.
4. **Replication** (`storage.rs` `replicated_table`): deliberately NOT added — a password vault's metadata surface must not sync to public relays. **Tested**: `secrets_table_is_not_replicable` asserts it fails loudly.

## Tests

CRUD round-trip, distinct-random-ids, not-replicable, Debug redaction, migration-to-v6, rotation preservation, and backup/restore round-trip. Full keep-core suite (347+ tests) green; clippy/fmt clean; whole workspace builds.

## Not in scope

No CLI/desktop/mobile wiring; no searchable index (list decrypts every row, fine at these counts). The motivating end state — pointing the OPRF quorum key at this store for threshold-unlocked secrets — is a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for securely storing, viewing, listing, and deleting vault secrets such as passwords, API tokens, notes, and other sensitive values.
  * Secret entries include names, types, timestamps, and randomly generated identifiers.
  * Sensitive values are protected from accidental exposure in diagnostic output.

* **Backup & Restore**
  * Backups now include stored secrets and restore them with their original details and timestamps.

* **Security**
  * Secrets remain protected during data-key rotation and are excluded from replication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->