### PR TITLE
keep-core: threshold-sealed secrets (OPRF quorum-gated values)

### DIFF
--- a/keep-cli/src/commands/audit.rs
+++ b/keep-cli/src/commands/audit.rs
@@ -313,6 +313,7 @@ struct AuditStats {
     data_key_rotate_fail: u32,
     secret_create: u32,
     secret_delete: u32,
+    secret_reveal: u32,
 }
 
 impl AuditStats {
@@ -346,6 +347,7 @@ impl AuditStats {
             AuditEventType::DataKeyRotateFailed => self.data_key_rotate_fail += 1,
             AuditEventType::SecretCreate => self.secret_create += 1,
             AuditEventType::SecretDelete => self.secret_delete += 1,
+            AuditEventType::SecretReveal => self.secret_reveal += 1,
         }
     }
 }
@@ -419,8 +421,8 @@ pub fn cmd_audit_stats(out: &Output, path: &Path, hidden: bool) -> Result<()> {
         stats.data_key_rotate_ok, stats.data_key_rotate_fail
     ));
     out.info(&format!(
-        "  Secrets: {} created / {} deleted",
-        stats.secret_create, stats.secret_delete
+        "  Secrets: {} created / {} deleted / {} revealed",
+        stats.secret_create, stats.secret_delete, stats.secret_reveal
     ));
 
     Ok(())
@@ -467,6 +469,7 @@ mod stats_tests {
         stats.record(AuditEventType::DataKeyRotateFailed);
         stats.record(AuditEventType::SecretCreate);
         stats.record(AuditEventType::SecretDelete);
+        stats.record(AuditEventType::SecretReveal);
 
         assert_eq!(stats.key_gen, 1);
         assert_eq!(stats.key_import, 2);
@@ -492,6 +495,7 @@ mod stats_tests {
         assert_eq!(stats.data_key_rotate_fail, 1);
         assert_eq!(stats.secret_create, 1);
         assert_eq!(stats.secret_delete, 1);
+        assert_eq!(stats.secret_reveal, 1);
     }
 
     /// Closes the #526 gap surfaced by #441's testing pass: each of the

--- a/keep-core/src/audit.rs
+++ b/keep-core/src/audit.rs
@@ -91,6 +91,10 @@ pub enum AuditEventType {
     SecretCreate = 25,
     /// Arbitrary secret deleted.
     SecretDelete = 26,
+    /// Threshold-sealed secret value revealed via an OPRF quorum unseal. The most
+    /// sensitive read in the store (it hands out the plaintext), audited like
+    /// `KeyExport`.
+    SecretReveal = 27,
 }
 
 impl std::fmt::Display for AuditEventType {
@@ -123,6 +127,7 @@ impl std::fmt::Display for AuditEventType {
             Self::DataKeyRotateFailed => write!(f, "data_key_rotate_failed"),
             Self::SecretCreate => write!(f, "secret_create"),
             Self::SecretDelete => write!(f, "secret_delete"),
+            Self::SecretReveal => write!(f, "secret_reveal"),
         }
     }
 }

--- a/keep-core/src/backend.rs
+++ b/keep-core/src/backend.rs
@@ -29,6 +29,10 @@ pub const HEALTH_STATUS_TABLE: &str = "key_health_status";
 /// Deliberately NOT a replicable table (see `Storage::replicated_table`): a
 /// password vault's metadata surface must not sync to public Nostr relays.
 pub const SECRETS_TABLE: &str = "secrets";
+/// Table name for threshold seals: maps a secret id to its `ThresholdSeal`
+/// (wrapped DEK + OPRF params), present only for secrets whose value is gated
+/// behind a t-of-n OPRF quorum. Like `SECRETS_TABLE`, NOT a replicable table.
+pub const SECRET_SEALS_TABLE: &str = "secret_seals";
 /// Table name for the keep-state replication high-water-mark: maps a `<table>:<record-id>` d-tag to
 /// the highest `created_at` (8-byte big-endian) applied for it, so the consumer rejects any replicated
 /// event that is not strictly newer (replay/rollback protection).
@@ -144,6 +148,7 @@ const CONFIG_TABLE_DEF: TableDefinition<&[u8], &[u8]> = TableDefinition::new("co
 const HEALTH_STATUS_TABLE_DEF: TableDefinition<&[u8], &[u8]> =
     TableDefinition::new("key_health_status");
 const SECRETS_TABLE_DEF: TableDefinition<&[u8], &[u8]> = TableDefinition::new("secrets");
+const SECRET_SEALS_TABLE_DEF: TableDefinition<&[u8], &[u8]> = TableDefinition::new("secret_seals");
 const STATE_VERSIONS_TABLE_DEF: TableDefinition<&[u8], &[u8]> =
     TableDefinition::new("state_versions");
 
@@ -200,6 +205,11 @@ impl RedbBackend {
             RELAY_CONFIGS_TABLE,
             CONFIG_TABLE,
             HEALTH_STATUS_TABLE,
+            // Arbitrary-secret rows and their threshold seals must survive a file-format upgrade too;
+            // omitting them would silently drop the password/secret store (and leave any sealed value
+            // undecryptable if only one of the pair carried through). Missing tables are skipped below.
+            SECRETS_TABLE,
+            SECRET_SEALS_TABLE,
             // Carried through a file-format upgrade so the keep-state rollback-guard high-water-marks
             // survive; otherwise they reset and the guard reverts to first-sync (TOFU) for every d-tag.
             STATE_VERSIONS_TABLE,
@@ -374,6 +384,7 @@ impl RedbBackend {
             CONFIG_TABLE => Ok(CONFIG_TABLE_DEF),
             HEALTH_STATUS_TABLE => Ok(HEALTH_STATUS_TABLE_DEF),
             SECRETS_TABLE => Ok(SECRETS_TABLE_DEF),
+            SECRET_SEALS_TABLE => Ok(SECRET_SEALS_TABLE_DEF),
             STATE_VERSIONS_TABLE => Ok(STATE_VERSIONS_TABLE_DEF),
             _ => Err(StorageError::database(format!("unknown table: {name}")).into()),
         }

--- a/keep-core/src/backup.rs
+++ b/keep-core/src/backup.rs
@@ -169,6 +169,27 @@ pub struct BackupSecret {
     /// Unix timestamp of the last update.
     #[zeroize(skip)]
     pub updated_at: i64,
+    /// Present only for a threshold-sealed secret: the wrapped DEK + OPRF params.
+    /// When present, `value` is the DEK-CIPHERTEXT (hex), not plaintext, and the
+    /// value stays gated behind the OPRF quorum after restore (the OPRF root is
+    /// never in a backup). `#[serde(default)]` so older backups decode as `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seal: Option<BackupSeal>,
+}
+
+/// Threshold seal carried in a backup: the wrapped DEK plus the OPRF params
+/// needed to re-derive the unwrapping key. Only ciphertext/params, never
+/// plaintext, so a backup never contains a threshold secret's value in the clear.
+#[derive(Serialize, Deserialize, Clone, Zeroize, ZeroizeOnDrop)]
+pub struct BackupSeal {
+    /// Hex-encoded wrapped DEK (the per-secret key encrypted under the OPRF key).
+    pub wrapped_dek: String,
+    /// OPRF domain-separation label (hex secret id).
+    #[zeroize(skip)]
+    pub oprf_id: String,
+    /// OPRF epoch (rotation counter for the derived key).
+    #[zeroize(skip)]
+    pub epoch: u32,
 }
 
 impl std::fmt::Debug for BackupSecret {
@@ -178,6 +199,7 @@ impl std::fmt::Debug for BackupSecret {
             .field("kind", &self.kind)
             .field("name", &"[REDACTED]")
             .field("value", &"[REDACTED]")
+            .field("sealed", &self.seal.is_some())
             .finish()
     }
 }
@@ -381,6 +403,14 @@ pub fn create_backup(keep: &Keep, passphrase: &str) -> Result<Vec<u8>> {
     let secret_records = keep.list_secrets()?;
     let mut backup_secrets = Vec::with_capacity(secret_records.len());
     for record in &secret_records {
+        // For a threshold-sealed secret `record.value` is the DEK-ciphertext (not
+        // plaintext); the seal carries the wrapped DEK + OPRF params. Backing both
+        // up preserves the quorum gate without ever holding the plaintext.
+        let seal = keep.load_secret_seal(&record.id)?.map(|s| BackupSeal {
+            wrapped_dek: hex::encode(&s.wrapped_dek),
+            oprf_id: s.oprf_id.clone(),
+            epoch: s.epoch,
+        });
         backup_secrets.push(BackupSecret {
             id: hex::encode(record.id),
             name: record.name.clone(),
@@ -388,6 +418,7 @@ pub fn create_backup(keep: &Keep, passphrase: &str) -> Result<Vec<u8>> {
             value: hex::encode(&record.value),
             created_at: record.created_at,
             updated_at: record.updated_at,
+            seal,
         });
     }
 
@@ -617,7 +648,20 @@ fn restore_to_path(backup: &DecryptedBackup, path: &Path, vault_password: &str) 
             created_at: bs.created_at,
             updated_at: bs.updated_at,
         };
-        keep.restore_secret(&record)?;
+        match &bs.seal {
+            // Threshold-sealed: `value` is the DEK-ciphertext; restore it with the
+            // seal so the value stays gated behind the OPRF quorum.
+            Some(bseal) => {
+                let seal = crate::secret::ThresholdSeal {
+                    wrapped_dek: hex::decode(&bseal.wrapped_dek)
+                        .map_err(|e| KeepError::Other(format!("hex decode wrapped dek: {e}")))?,
+                    oprf_id: bseal.oprf_id.clone(),
+                    epoch: bseal.epoch,
+                };
+                keep.restore_sealed_secret(&record, &seal)?;
+            }
+            None => keep.restore_secret(&record)?,
+        }
     }
 
     keep.set_kill_switch(backup.config.kill_switch)?;
@@ -845,6 +889,66 @@ mod tests {
         assert_eq!(loaded.value, b"s3cr3t");
         // Restore preserves the original id and timestamps, not fresh ones.
         assert_eq!(loaded.created_at, created);
+    }
+
+    /// A threshold-sealed secret MUST survive backup + restore with its value
+    /// still gated behind the OPRF quorum: the backup carries the DEK-ciphertext
+    /// and the wrapped DEK (never plaintext), so after restore the value only
+    /// unseals under the SAME OPRF key -- exactly as before the backup.
+    #[test]
+    fn backup_roundtrip_preserves_sealed_secrets() {
+        let dir = tempdir().unwrap();
+        let src_path = dir.path().join("src");
+        let mut keep = create_test_keep(&src_path);
+        keep.unlock("test-password-123").unwrap();
+
+        let oprf_key = crypto::SecretKey::generate().unwrap();
+        let record = keep
+            .store_sealed_secret(
+                "quorum note".into(),
+                crate::secret::SecretKind::Note,
+                b"only-with-a-quorum",
+                &oprf_key,
+                0,
+            )
+            .unwrap();
+        let id = record.id;
+
+        let backup_data = create_backup(&keep, "backup-passphrase-ok").unwrap();
+
+        // The plaintext must NOT appear anywhere in the encrypted-then-decoded
+        // backup path; but more strongly, the value in the backup is DEK-ciphertext.
+        let dst_path = dir.path().join("dst");
+        restore_backup(
+            &backup_data,
+            "backup-passphrase-ok",
+            &dst_path,
+            "new-password-456",
+        )
+        .unwrap();
+
+        let mut restored = Keep::open(&dst_path).unwrap();
+        restored.unlock("new-password-456").unwrap();
+
+        // Metadata survives and is readable without a quorum.
+        let loaded = restored.load_secret(&id).expect("sealed record survives");
+        assert_eq!(loaded.name, "quorum note");
+        assert_eq!(loaded.kind, crate::secret::SecretKind::Note);
+        assert_ne!(
+            loaded.value, b"only-with-a-quorum",
+            "value must stay sealed"
+        );
+
+        // The value only comes back with the OPRF key; a wrong key stays sealed.
+        let revealed = restored
+            .reveal_sealed_secret(&id, &oprf_key)
+            .expect("value unseals with the OPRF key after restore");
+        assert_eq!(&revealed[..], b"only-with-a-quorum");
+        let wrong = crypto::SecretKey::generate().unwrap();
+        assert!(
+            restored.reveal_sealed_secret(&id, &wrong).is_err(),
+            "single-device (wrong OPRF key) must fail after restore too"
+        );
     }
 
     #[test]

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -516,6 +516,66 @@ impl Keep {
         self.storage.store_secret(record)
     }
 
+    /// Store a secret whose value can only be revealed with a t-of-n OPRF quorum.
+    ///
+    /// `oprf_key` is the quorum-derived key ([`crate::oprf::derive_luks_key`]
+    /// output, obtained via the threshold-OPRF flow); `epoch` is its OPRF rotation
+    /// counter. The value is sealed under a fresh per-secret DEK wrapped by
+    /// `oprf_key`, so a single device that never assembles the quorum cannot
+    /// decrypt it even with the vault unlocked. The secret's name/kind stay
+    /// readable with the vault data key. Returns the minted record, whose random
+    /// id is the OPRF domain-separation label recorded in the seal. Records a
+    /// `SecretCreate` audit event tagged with the id.
+    pub fn store_sealed_secret(
+        &mut self,
+        name: String,
+        kind: crate::secret::SecretKind,
+        value: &[u8],
+        oprf_key: &crate::crypto::SecretKey,
+        epoch: u32,
+    ) -> Result<crate::secret::SecretRecord> {
+        let mut record = crate::secret::SecretRecord::new(name, kind, Vec::new())?;
+        let oprf_id = hex::encode(record.id);
+        let (value_ciphertext, seal) = crate::secret::seal_value(value, oprf_key, oprf_id, epoch)?;
+        record.value = value_ciphertext;
+        self.storage.store_sealed_secret(&record, &seal)?;
+        self.audit_event(AuditEventType::SecretCreate, |e| e.with_pubkey(&record.id));
+        Ok(record)
+    }
+
+    /// Load the threshold seal for a secret id, or `None` if the secret is an
+    /// ordinary plaintext-value secret. The seal carries the OPRF params
+    /// (`oprf_id`, `epoch`) the quorum needs to re-derive the unwrapping key.
+    pub fn load_secret_seal(&self, id: &[u8; 32]) -> Result<Option<crate::secret::ThresholdSeal>> {
+        self.storage.load_secret_seal(id)
+    }
+
+    /// Reveal a threshold-sealed secret's plaintext value given the OPRF-quorum
+    /// -derived key. Errors if the secret is not sealed, or if `oprf_key` is wrong
+    /// (a single-device caller that never assembled the quorum cannot derive it).
+    pub fn reveal_sealed_secret(
+        &self,
+        id: &[u8; 32],
+        oprf_key: &crate::crypto::SecretKey,
+    ) -> Result<zeroize::Zeroizing<Vec<u8>>> {
+        let record = self.storage.load_secret(id)?;
+        let seal = self
+            .storage
+            .load_secret_seal(id)?
+            .ok_or_else(|| KeepError::invalid_input("secret is not threshold-sealed"))?;
+        crate::secret::unseal_value(&record.value, &seal, oprf_key)
+    }
+
+    /// Restore a threshold-sealed secret (record + seal) WITHOUT emitting an audit
+    /// event, for the backup-restore path only. Mirrors [`Self::restore_secret`].
+    pub fn restore_sealed_secret(
+        &self,
+        record: &crate::secret::SecretRecord,
+        seal: &crate::secret::ThresholdSeal,
+    ) -> Result<()> {
+        self.storage.store_sealed_secret(record, seal)
+    }
+
     /// Export a stored nsec key as NIP-49 ncryptsec.
     pub fn export_ncryptsec(&mut self, pubkey: &[u8; 32], password: &str) -> Result<String> {
         if !self.is_unlocked() {

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -553,8 +553,13 @@ impl Keep {
     /// Reveal a threshold-sealed secret's plaintext value given the OPRF-quorum
     /// -derived key. Errors if the secret is not sealed, or if `oprf_key` is wrong
     /// (a single-device caller that never assembled the quorum cannot derive it).
+    ///
+    /// Records a `SecretReveal` audit event (tagged with the id) only on a
+    /// successful unseal: revealing a quorum-gated plaintext is the most sensitive
+    /// read in the store, audited like `KeyExport`. A wrong-key attempt leaves no
+    /// entry (it never yields the value).
     pub fn reveal_sealed_secret(
-        &self,
+        &mut self,
         id: &[u8; 32],
         oprf_key: &crate::crypto::SecretKey,
     ) -> Result<zeroize::Zeroizing<Vec<u8>>> {
@@ -563,7 +568,9 @@ impl Keep {
             .storage
             .load_secret_seal(id)?
             .ok_or_else(|| KeepError::invalid_input("secret is not threshold-sealed"))?;
-        crate::secret::unseal_value(&record.value, &seal, oprf_key)
+        let plaintext = crate::secret::unseal_value(&record.value, &seal, oprf_key)?;
+        self.audit_event(AuditEventType::SecretReveal, |e| e.with_pubkey(id));
+        Ok(plaintext)
     }
 
     /// Restore a threshold-sealed secret (record + seal) WITHOUT emitting an audit

--- a/keep-core/src/migration.rs
+++ b/keep-core/src/migration.rs
@@ -9,7 +9,7 @@ const METADATA_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("metad
 const SCHEMA_VERSION_KEY: &str = "schema_version";
 
 /// The current schema version supported by this build.
-pub const CURRENT_SCHEMA_VERSION: u32 = 6;
+pub const CURRENT_SCHEMA_VERSION: u32 = 7;
 
 /// A migration function that transforms the database schema.
 pub type MigrationFn = fn(&Database) -> Result<()>;
@@ -120,6 +120,7 @@ fn migrate_v4_to_v5(db: &Database) -> Result<()> {
 }
 
 const SECRETS_TABLE_DEF: TableDefinition<&[u8], &[u8]> = TableDefinition::new("secrets");
+const SECRET_SEALS_TABLE_DEF: TableDefinition<&[u8], &[u8]> = TableDefinition::new("secret_seals");
 
 /// v5 → v6: introduce the `secrets` table for arbitrary-secret records
 /// (passwords, API tokens, notes). Creating the empty table is the whole
@@ -128,6 +129,16 @@ const SECRETS_TABLE_DEF: TableDefinition<&[u8], &[u8]> = TableDefinition::new("s
 fn migrate_v5_to_v6(db: &Database) -> Result<()> {
     let wtxn = db.begin_write()?;
     wtxn.open_table(SECRETS_TABLE_DEF)?;
+    wtxn.commit()?;
+    Ok(())
+}
+
+/// v6 → v7: introduce the `secret_seals` table for threshold seals (the wrapped
+/// DEK plus OPRF params) of secrets whose value is gated behind a t-of-n OPRF
+/// quorum. Creating the empty table is the whole migration; rows are untouched.
+fn migrate_v6_to_v7(db: &Database) -> Result<()> {
+    let wtxn = db.begin_write()?;
+    wtxn.open_table(SECRET_SEALS_TABLE_DEF)?;
     wtxn.commit()?;
     Ok(())
 }
@@ -158,6 +169,11 @@ fn get_migrations() -> Vec<Migration> {
             from_version: 5,
             to_version: 6,
             migrate: migrate_v5_to_v6,
+        },
+        Migration {
+            from_version: 6,
+            to_version: 7,
+            migrate: migrate_v6_to_v7,
         },
     ]
 }

--- a/keep-core/src/rotation.rs
+++ b/keep-core/src/rotation.rs
@@ -13,7 +13,7 @@ use zeroize::Zeroizing;
 
 use crate::backend::{
     RedbBackend, StorageBackend, CONFIG_TABLE, DESCRIPTORS_TABLE, HEALTH_STATUS_TABLE, KEYS_TABLE,
-    RELAY_CONFIGS_TABLE, SECRETS_TABLE, SHARES_TABLE,
+    RELAY_CONFIGS_TABLE, SECRETS_TABLE, SECRET_SEALS_TABLE, SHARES_TABLE,
 };
 use crate::crypto::{self, EncryptedData, SecretKey};
 use crate::error::{KeepError, Result};
@@ -34,7 +34,16 @@ use crate::wallet::WalletDescriptor;
 /// `SECRETS_TABLE` qualifies: each row is `crypto::encrypt(bincode(SecretRecord))`, a single
 /// blob under the data key with no inner per-field encryption (unlike `KeyRecord`, whose
 /// separately-encrypted secret is why keys are rotated on their own typed path, not here).
-const OPAQUE_TABLES: [&str; 3] = [CONFIG_TABLE, HEALTH_STATUS_TABLE, SECRETS_TABLE];
+///
+/// `SECRET_SEALS_TABLE` likewise: each row is `crypto::encrypt(bincode(ThresholdSeal))`. Rotation
+/// re-wraps only this outer data-key layer; the inner DEK-ciphertext value and the OPRF-wrapped DEK
+/// are opaque bytes carried through untouched, so no OPRF quorum is needed to rotate the data key.
+const OPAQUE_TABLES: [&str; 4] = [
+    CONFIG_TABLE,
+    HEALTH_STATUS_TABLE,
+    SECRETS_TABLE,
+    SECRET_SEALS_TABLE,
+];
 
 /// One row of an [`OPAQUE_TABLES`] table, held decrypted across a rotation.
 struct OpaqueRow {
@@ -1186,6 +1195,50 @@ mod tests {
         assert_eq!(loaded.value, b"tok-secret");
         assert_eq!(loaded.name, "api");
         assert_eq!(loaded.kind, SecretKind::ApiToken);
+    }
+
+    /// A threshold-sealed secret MUST survive a `rotate_data_key`: both the
+    /// record (`SECRETS_TABLE`) and its seal (`SECRET_SEALS_TABLE`) are registered
+    /// in `OPAQUE_TABLES`, so rotation re-wraps only the outer data-key layer and
+    /// the value still unseals under the SAME OPRF key afterward (no quorum needed
+    /// to rotate).
+    #[test]
+    fn rotate_data_key_preserves_sealed_secrets() {
+        use crate::secret::{seal_value, unseal_value, SecretKind, SecretRecord};
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sealed-secrets-survive-rotation");
+        let oprf_key = crypto::SecretKey::generate().unwrap();
+        let id;
+        {
+            let storage = Storage::create(&path, "pass1234", Argon2Params::TESTING).unwrap();
+            let mut rec =
+                SecretRecord::new("vault-key".into(), SecretKind::Generic, Vec::new()).unwrap();
+            id = rec.id;
+            let (value_ct, seal) =
+                seal_value(b"threshold-secret", &oprf_key, hex::encode(rec.id), 0).unwrap();
+            rec.value = value_ct;
+            storage.store_sealed_secret(&rec, &seal).unwrap();
+        }
+        {
+            let mut storage = Storage::open(&path).unwrap();
+            storage.rotate_data_key("pass1234").unwrap();
+        }
+        let mut storage = Storage::open(&path).unwrap();
+        storage.unlock("pass1234").unwrap();
+        let loaded = storage
+            .load_secret(&id)
+            .expect("sealed record MUST survive a data-key rotation");
+        let seal = storage
+            .load_secret_seal(&id)
+            .expect("seal load ok")
+            .expect("seal MUST survive a data-key rotation");
+        let plaintext =
+            unseal_value(&loaded.value, &seal, &oprf_key).expect("unseal after rotation");
+        assert_eq!(
+            &plaintext[..],
+            b"threshold-secret",
+            "value must still unseal under the same OPRF key post-rotation"
+        );
     }
 
     /// `rotate_data_key` MUST reject a wrong password. Without the gate,

--- a/keep-core/src/secret.rs
+++ b/keep-core/src/secret.rs
@@ -13,8 +13,9 @@
 //! only in memory and is scrubbed on drop.
 
 use serde::{Deserialize, Serialize};
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
+use crate::crypto::{self, EncryptedData, SecretKey};
 use crate::entropy;
 use crate::error::Result;
 
@@ -84,6 +85,86 @@ impl SecretRecord {
     }
 }
 
+/// The threshold seal that gates a secret's VALUE behind a t-of-n OPRF quorum.
+///
+/// The value is encrypted under a fresh random per-secret data-encryption key
+/// (DEK); the DEK is itself encrypted ("wrapped") under the OPRF-quorum-derived
+/// key ([`crate::oprf::derive_luks_key`]). Recovering the plaintext therefore
+/// requires re-deriving the OPRF key, which needs a t-of-n quorum of devices --
+/// a single device that never assembles the quorum cannot decrypt the value even
+/// with the vault unlocked. Only the value is gated; a secret's name and kind
+/// stay readable with the vault data key so the store remains browsable.
+///
+/// `wrapped_dek` is ciphertext, so the seal is not itself secret, but it is
+/// stored encrypted under the vault data key at rest like every other record.
+#[derive(Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
+pub struct ThresholdSeal {
+    /// The per-secret DEK, encrypted under the OPRF-quorum-derived key
+    /// ([`EncryptedData::to_bytes`] output).
+    pub wrapped_dek: Vec<u8>,
+    /// OPRF domain-separation label fed to `derive_luks_key` (the secret id, hex),
+    /// so the quorum re-derives the same key for this secret.
+    #[zeroize(skip)]
+    pub oprf_id: String,
+    /// OPRF epoch: the rotation counter for the derived key, bumped to re-seal a
+    /// secret under a fresh key without changing the OPRF root.
+    #[zeroize(skip)]
+    pub epoch: u32,
+}
+
+impl std::fmt::Debug for ThresholdSeal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ThresholdSeal")
+            .field("oprf_id", &self.oprf_id)
+            .field("epoch", &self.epoch)
+            .field("wrapped_dek", &"[wrapped]")
+            .finish()
+    }
+}
+
+/// Seal `plaintext` under a fresh per-secret DEK and wrap that DEK under
+/// `oprf_key` (the t-of-n OPRF-quorum-derived key). Returns the value ciphertext
+/// (to store as the record's `value`) and the matching [`ThresholdSeal`] (to
+/// store alongside). `oprf_id`/`epoch` are recorded in the seal so the quorum can
+/// later re-derive the same key.
+pub fn seal_value(
+    plaintext: &[u8],
+    oprf_key: &SecretKey,
+    oprf_id: String,
+    epoch: u32,
+) -> Result<(Vec<u8>, ThresholdSeal)> {
+    let dek = SecretKey::generate()?;
+    let value_ciphertext = crypto::encrypt(plaintext, &dek)?.to_bytes();
+    // Wrap the raw DEK bytes under the OPRF key. `decrypt` returns an mlocked,
+    // zeroize-on-drop copy of the 32 DEK bytes.
+    let dek_raw = dek.decrypt()?;
+    let wrapped_dek = crypto::encrypt(&dek_raw[..], oprf_key)?.to_bytes();
+    Ok((
+        value_ciphertext,
+        ThresholdSeal {
+            wrapped_dek,
+            oprf_id,
+            epoch,
+        },
+    ))
+}
+
+/// Recover a sealed secret's plaintext from `value_ciphertext` given its
+/// [`ThresholdSeal`] and the OPRF-quorum-derived key. Fails if `oprf_key` is
+/// wrong: a single-device caller that never assembled the quorum cannot derive
+/// it, so the wrapped-DEK decryption fails and the value stays sealed.
+pub fn unseal_value(
+    value_ciphertext: &[u8],
+    seal: &ThresholdSeal,
+    oprf_key: &SecretKey,
+) -> Result<Zeroizing<Vec<u8>>> {
+    let wrapped = EncryptedData::from_bytes(&seal.wrapped_dek)?;
+    let dek_bytes = crypto::decrypt(&wrapped, oprf_key)?.as_slice()?;
+    let dek = SecretKey::from_slice(&dek_bytes)?;
+    let value = EncryptedData::from_bytes(value_ciphertext)?;
+    crypto::decrypt(&value, &dek)?.as_slice()
+}
+
 impl std::fmt::Debug for SecretRecord {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Never print `name` or `value`: both are secret. `name` leaks what the
@@ -109,6 +190,51 @@ mod tests {
         let b = SecretRecord::new("x".into(), SecretKind::Password, b"v".to_vec()).unwrap();
         assert_ne!(a.id, b.id, "each secret gets a fresh random id");
         assert_eq!(a.created_at, a.updated_at);
+    }
+
+    #[test]
+    fn seal_then_unseal_roundtrips_with_the_same_key() {
+        let oprf_key = SecretKey::generate().unwrap();
+        let (ct, seal) = seal_value(b"top-secret", &oprf_key, "abcd".into(), 0).unwrap();
+        assert_ne!(ct, b"top-secret", "value must be encrypted, not stored raw");
+        let plaintext = unseal_value(&ct, &seal, &oprf_key).unwrap();
+        assert_eq!(&plaintext[..], b"top-secret");
+        assert_eq!(seal.oprf_id, "abcd");
+        assert_eq!(seal.epoch, 0);
+    }
+
+    /// The core threshold property: without the quorum-derived key (a single
+    /// device that never assembled t-of-n), the wrapped DEK cannot be recovered,
+    /// so the value stays sealed.
+    #[test]
+    fn unseal_fails_with_a_different_oprf_key() {
+        let oprf_key = SecretKey::generate().unwrap();
+        let wrong_key = SecretKey::generate().unwrap();
+        let (ct, seal) = seal_value(b"top-secret", &oprf_key, "abcd".into(), 0).unwrap();
+        assert!(
+            unseal_value(&ct, &seal, &wrong_key).is_err(),
+            "unsealing with the wrong OPRF key must fail"
+        );
+    }
+
+    #[test]
+    fn each_seal_uses_a_distinct_dek() {
+        let oprf_key = SecretKey::generate().unwrap();
+        let (_, seal_a) = seal_value(b"v", &oprf_key, "a".into(), 0).unwrap();
+        let (_, seal_b) = seal_value(b"v", &oprf_key, "b".into(), 0).unwrap();
+        assert_ne!(
+            seal_a.wrapped_dek, seal_b.wrapped_dek,
+            "each secret must get a fresh random DEK"
+        );
+    }
+
+    #[test]
+    fn threshold_seal_debug_never_leaks_wrapped_dek() {
+        let oprf_key = SecretKey::generate().unwrap();
+        let (_, seal) = seal_value(b"v", &oprf_key, "abcd".into(), 3).unwrap();
+        let s = format!("{seal:?}");
+        assert!(s.contains("abcd") && s.contains('3'));
+        assert!(!s.contains(&hex::encode(&seal.wrapped_dek)));
     }
 
     #[test]

--- a/keep-core/src/secret.rs
+++ b/keep-core/src/secret.rs
@@ -122,11 +122,34 @@ impl std::fmt::Debug for ThresholdSeal {
     }
 }
 
+/// AAD binding the wrapped DEK to its secret id and OPRF epoch, so a wrapped DEK
+/// cannot be lifted onto a different secret or a tampered epoch: altering the
+/// stored `oprf_id`/`epoch` (which an attacker holding the vault data key could
+/// otherwise do to redirect the quorum query) makes the unwrap fail rather than
+/// silently succeed. Length-prefixed for injectivity, matching `derive_luks_key`.
+fn wrap_aad(oprf_id: &str, epoch: u32) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(23 + 8 + oprf_id.len() + 4);
+    aad.extend_from_slice(b"keep/secret-seal/dek/v1");
+    aad.extend_from_slice(&(oprf_id.len() as u64).to_be_bytes());
+    aad.extend_from_slice(oprf_id.as_bytes());
+    aad.extend_from_slice(&epoch.to_be_bytes());
+    aad
+}
+
+/// AAD binding the value ciphertext to its secret id, so a value blob cannot be
+/// swapped between secrets.
+fn value_aad(oprf_id: &str) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(25 + oprf_id.len());
+    aad.extend_from_slice(b"keep/secret-seal/value/v1");
+    aad.extend_from_slice(oprf_id.as_bytes());
+    aad
+}
+
 /// Seal `plaintext` under a fresh per-secret DEK and wrap that DEK under
 /// `oprf_key` (the t-of-n OPRF-quorum-derived key). Returns the value ciphertext
 /// (to store as the record's `value`) and the matching [`ThresholdSeal`] (to
 /// store alongside). `oprf_id`/`epoch` are recorded in the seal so the quorum can
-/// later re-derive the same key.
+/// later re-derive the same key, and are bound into both ciphertexts as AAD.
 pub fn seal_value(
     plaintext: &[u8],
     oprf_key: &SecretKey,
@@ -134,11 +157,13 @@ pub fn seal_value(
     epoch: u32,
 ) -> Result<(Vec<u8>, ThresholdSeal)> {
     let dek = SecretKey::generate()?;
-    let value_ciphertext = crypto::encrypt(plaintext, &dek)?.to_bytes();
+    let value_ciphertext =
+        crypto::encrypt_with_aad(plaintext, &value_aad(&oprf_id), &dek)?.to_bytes();
     // Wrap the raw DEK bytes under the OPRF key. `decrypt` returns an mlocked,
     // zeroize-on-drop copy of the 32 DEK bytes.
     let dek_raw = dek.decrypt()?;
-    let wrapped_dek = crypto::encrypt(&dek_raw[..], oprf_key)?.to_bytes();
+    let wrapped_dek =
+        crypto::encrypt_with_aad(&dek_raw[..], &wrap_aad(&oprf_id, epoch), oprf_key)?.to_bytes();
     Ok((
         value_ciphertext,
         ThresholdSeal {
@@ -151,18 +176,21 @@ pub fn seal_value(
 
 /// Recover a sealed secret's plaintext from `value_ciphertext` given its
 /// [`ThresholdSeal`] and the OPRF-quorum-derived key. Fails if `oprf_key` is
-/// wrong: a single-device caller that never assembled the quorum cannot derive
-/// it, so the wrapped-DEK decryption fails and the value stays sealed.
+/// wrong (a single-device caller that never assembled the quorum cannot derive
+/// it) or if the seal's bound `oprf_id`/`epoch` were tampered with: either way
+/// the AEAD tag check fails and the value stays sealed.
 pub fn unseal_value(
     value_ciphertext: &[u8],
     seal: &ThresholdSeal,
     oprf_key: &SecretKey,
 ) -> Result<Zeroizing<Vec<u8>>> {
     let wrapped = EncryptedData::from_bytes(&seal.wrapped_dek)?;
-    let dek_bytes = crypto::decrypt(&wrapped, oprf_key)?.as_slice()?;
+    let dek_bytes =
+        crypto::decrypt_with_aad(&wrapped, &wrap_aad(&seal.oprf_id, seal.epoch), oprf_key)?
+            .as_slice()?;
     let dek = SecretKey::from_slice(&dek_bytes)?;
     let value = EncryptedData::from_bytes(value_ciphertext)?;
-    crypto::decrypt(&value, &dek)?.as_slice()
+    crypto::decrypt_with_aad(&value, &value_aad(&seal.oprf_id), &dek)?.as_slice()
 }
 
 impl std::fmt::Debug for SecretRecord {
@@ -214,6 +242,29 @@ mod tests {
         assert!(
             unseal_value(&ct, &seal, &wrong_key).is_err(),
             "unsealing with the wrong OPRF key must fail"
+        );
+    }
+
+    /// The seal's `oprf_id`/`epoch` are bound as AAD, so tampering with either
+    /// (an attacker with the vault data key redirecting the quorum query) makes
+    /// the unseal fail rather than silently proceed.
+    #[test]
+    fn unseal_fails_when_bound_oprf_params_are_tampered() {
+        let oprf_key = SecretKey::generate().unwrap();
+        let (ct, seal) = seal_value(b"v", &oprf_key, "abcd".into(), 0).unwrap();
+
+        let mut bad_epoch = seal.clone();
+        bad_epoch.epoch = 1;
+        assert!(
+            unseal_value(&ct, &bad_epoch, &oprf_key).is_err(),
+            "a tampered epoch must break the wrapped-DEK AAD"
+        );
+
+        let mut bad_id = seal.clone();
+        bad_id.oprf_id = "ffff".into();
+        assert!(
+            unseal_value(&ct, &bad_id, &oprf_key).is_err(),
+            "a tampered oprf_id must break the AAD"
         );
     }
 

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -9,7 +9,8 @@ use tracing::{debug, trace, warn};
 
 use crate::backend::{
     AtomicOp, RedbBackend, StorageBackend, CONFIG_TABLE, DESCRIPTORS_TABLE, HEALTH_STATUS_TABLE,
-    KEYS_TABLE, RELAY_CONFIGS_TABLE, SECRETS_TABLE, SHARES_TABLE, STATE_VERSIONS_TABLE,
+    KEYS_TABLE, RELAY_CONFIGS_TABLE, SECRETS_TABLE, SECRET_SEALS_TABLE, SHARES_TABLE,
+    STATE_VERSIONS_TABLE,
 };
 use crate::crypto::{self, Argon2Params, EncryptedData, SecretKey, SALT_SIZE};
 use crate::error::{KeepError, Result, StorageError};
@@ -17,7 +18,7 @@ use crate::frost::StoredShare;
 use crate::keys::KeyRecord;
 use crate::rate_limit;
 use crate::relay::{self, RelayConfig};
-use crate::secret::SecretRecord;
+use crate::secret::{SecretRecord, ThresholdSeal};
 use crate::wallet::{KeyHealthStatus, WalletDescriptor};
 
 use bincode::Options;
@@ -567,6 +568,7 @@ impl Storage {
         backend.create_table(CONFIG_TABLE)?;
         backend.create_table(HEALTH_STATUS_TABLE)?;
         backend.create_table(SECRETS_TABLE)?;
+        backend.create_table(SECRET_SEALS_TABLE)?;
         backend.create_table(STATE_VERSIONS_TABLE)?;
 
         Ok(Self {
@@ -891,15 +893,79 @@ impl Storage {
         Ok(records)
     }
 
-    /// Delete a secret record by `id`. Errors if no such secret exists.
+    /// Store a secret whose VALUE is sealed behind a t-of-n OPRF quorum. The
+    /// record's `value` must already be the DEK-ciphertext produced by
+    /// [`crate::secret::seal_value`]; `seal` is its matching wrapped DEK + OPRF
+    /// params. The record (name/kind/DEK-ciphertext) and the seal are each
+    /// encrypted under the vault data key and written in ONE atomic transaction,
+    /// so a crash can never leave a sealed value without its wrapped DEK (which
+    /// would make the value permanently undecryptable). Like `store_secret`, it
+    /// never notifies the replication sink: secrets are not replicable.
+    pub fn store_sealed_secret(&self, record: &SecretRecord, seal: &ThresholdSeal) -> Result<()> {
+        debug!(id = %hex::encode(record.id), "storing sealed secret");
+        let data_key = self.data_key.as_ref().ok_or(KeepError::Locked)?;
+        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
+
+        let rec_serialized = Zeroizing::new(bincode::serialize(record)?);
+        let rec_encrypted = crypto::encrypt(&rec_serialized, data_key)?.to_bytes();
+        let seal_serialized = Zeroizing::new(bincode::serialize(seal)?);
+        let seal_encrypted = crypto::encrypt(&seal_serialized, data_key)?.to_bytes();
+
+        backend.write_atomic(&[
+            AtomicOp {
+                table: SECRETS_TABLE,
+                key: &record.id,
+                value: Some(&rec_encrypted),
+            },
+            AtomicOp {
+                table: SECRET_SEALS_TABLE,
+                key: &record.id,
+                value: Some(&seal_encrypted),
+            },
+        ])?;
+        Ok(())
+    }
+
+    /// Load the [`ThresholdSeal`] for a secret `id`, or `None` when the secret is
+    /// not threshold-sealed (an ordinary plaintext-value secret). The presence of
+    /// a seal is what marks a secret as threshold-gated; its `value` is then the
+    /// DEK-ciphertext rather than plaintext.
+    pub fn load_secret_seal(&self, id: &[u8; 32]) -> Result<Option<ThresholdSeal>> {
+        trace!(id = %hex::encode(id), "loading secret seal");
+        let data_key = self.data_key.as_ref().ok_or(KeepError::Locked)?;
+        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
+
+        let Some(encrypted_bytes) = backend.get(SECRET_SEALS_TABLE, id)? else {
+            return Ok(None);
+        };
+        let encrypted = EncryptedData::from_bytes(&encrypted_bytes)?;
+        let decrypted = crypto::decrypt(&encrypted, data_key)?;
+        let decrypted_bytes = decrypted.as_slice()?;
+        Ok(Some(bincode_options().deserialize(&decrypted_bytes)?))
+    }
+
+    /// Delete a secret record by `id`, along with its threshold seal if it has
+    /// one, in a single atomic transaction. Errors if no such secret exists.
     pub fn delete_secret(&self, id: &[u8; 32]) -> Result<()> {
         debug!(id = %hex::encode(id), "deleting secret");
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
-        if backend.delete(SECRETS_TABLE, id)? {
-            Ok(())
-        } else {
-            Err(KeepError::NotFound(hex::encode(id)))
+        // The secret row must exist; the seal is optional, so gate on the record.
+        if backend.get(SECRETS_TABLE, id)?.is_none() {
+            return Err(KeepError::NotFound(hex::encode(id)));
         }
+        backend.write_atomic(&[
+            AtomicOp {
+                table: SECRETS_TABLE,
+                key: id,
+                value: None,
+            },
+            AtomicOp {
+                table: SECRET_SEALS_TABLE,
+                key: id,
+                value: None,
+            },
+        ])?;
+        Ok(())
     }
 
     /// The storage directory path.
@@ -1747,6 +1813,43 @@ mod tests {
         assert!(storage.list_secrets().unwrap().is_empty());
         // Deleting a missing secret errors rather than silently succeeding.
         assert!(storage.delete_secret(&id).is_err());
+    }
+
+    #[test]
+    fn sealed_secret_store_load_seal_and_delete_removes_both() {
+        use crate::secret::{seal_value, unseal_value, SecretKind, SecretRecord};
+        let dir = tempdir().unwrap();
+        let storage =
+            Storage::create(&dir.path().join("v"), "password", Argon2Params::TESTING).unwrap();
+        let oprf_key = crypto::SecretKey::generate().unwrap();
+
+        let mut rec = SecretRecord::new("api".into(), SecretKind::ApiToken, Vec::new()).unwrap();
+        let id = rec.id;
+        let (value_ct, seal) = seal_value(b"tok", &oprf_key, hex::encode(id), 2).unwrap();
+        rec.value = value_ct;
+        storage.store_sealed_secret(&rec, &seal).unwrap();
+
+        // A normal load returns the DEK-ciphertext (still gated); the seal loads
+        // and the value unseals under the OPRF key.
+        let loaded = storage.load_secret(&id).unwrap();
+        assert_ne!(loaded.value, b"tok", "stored value must be DEK-ciphertext");
+        let loaded_seal = storage
+            .load_secret_seal(&id)
+            .unwrap()
+            .expect("seal present");
+        assert_eq!(loaded_seal.epoch, 2);
+        let plaintext = unseal_value(&loaded.value, &loaded_seal, &oprf_key).unwrap();
+        assert_eq!(&plaintext[..], b"tok");
+
+        // A plain (unsealed) secret reports no seal.
+        let plain = SecretRecord::new("p".into(), SecretKind::Generic, b"v".to_vec()).unwrap();
+        storage.store_secret(&plain).unwrap();
+        assert!(storage.load_secret_seal(&plain.id).unwrap().is_none());
+
+        // Deleting a sealed secret drops its seal row atomically too.
+        storage.delete_secret(&id).unwrap();
+        assert!(storage.load_secret(&id).is_err());
+        assert!(storage.load_secret_seal(&id).unwrap().is_none());
     }
 
     #[test]

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -856,7 +856,24 @@ impl Storage {
 
         let serialized = Zeroizing::new(bincode::serialize(record)?);
         let encrypted = crypto::encrypt(&serialized, data_key)?;
-        backend.put(SECRETS_TABLE, &record.id, &encrypted.to_bytes())?;
+        let encrypted_bytes = encrypted.to_bytes();
+        // A seal row is what marks a secret's `value` as DEK-ciphertext. Overwriting
+        // an id that was previously threshold-sealed via this plain path must clear
+        // that stale seal atomically, else the new plaintext `value` would be misread
+        // as ciphertext and `reveal_sealed_secret` would fail. Deleting an absent
+        // seal row (the common case) is a no-op.
+        backend.write_atomic(&[
+            AtomicOp {
+                table: SECRETS_TABLE,
+                key: &record.id,
+                value: Some(&encrypted_bytes),
+            },
+            AtomicOp {
+                table: SECRET_SEALS_TABLE,
+                key: &record.id,
+                value: None,
+            },
+        ])?;
         Ok(())
     }
 
@@ -903,6 +920,15 @@ impl Storage {
     /// never notifies the replication sink: secrets are not replicable.
     pub fn store_sealed_secret(&self, record: &SecretRecord, seal: &ThresholdSeal) -> Result<()> {
         debug!(id = %hex::encode(record.id), "storing sealed secret");
+        // The seal's OPRF label MUST be the record's own id: it is the quorum's
+        // domain-separation input and is bound as AAD. Rejecting a mismatch at this
+        // boundary (which also guards backup restore) prevents an identity-confused
+        // or unrecoverable sealed record from ever being persisted.
+        if seal.oprf_id != hex::encode(record.id) {
+            return Err(KeepError::invalid_input(
+                "threshold seal OPRF id does not match secret id",
+            ));
+        }
         let data_key = self.data_key.as_ref().ok_or(KeepError::Locked)?;
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
 
@@ -1850,6 +1876,54 @@ mod tests {
         storage.delete_secret(&id).unwrap();
         assert!(storage.load_secret(&id).is_err());
         assert!(storage.load_secret_seal(&id).unwrap().is_none());
+    }
+
+    #[test]
+    fn overwriting_a_sealed_id_via_plain_store_clears_the_stale_seal() {
+        use crate::secret::{seal_value, SecretKind, SecretRecord};
+        let dir = tempdir().unwrap();
+        let storage =
+            Storage::create(&dir.path().join("v"), "password", Argon2Params::TESTING).unwrap();
+        let oprf_key = crypto::SecretKey::generate().unwrap();
+
+        let mut rec = SecretRecord::new("s".into(), SecretKind::Generic, Vec::new()).unwrap();
+        let id = rec.id;
+        let (value_ct, seal) = seal_value(b"sealed", &oprf_key, hex::encode(id), 0).unwrap();
+        rec.value = value_ct;
+        storage.store_sealed_secret(&rec, &seal).unwrap();
+        assert!(storage.load_secret_seal(&id).unwrap().is_some());
+
+        // Overwrite the SAME id with a plain (unsealed) record: the stale seal must
+        // be gone so `value` is read as plaintext, not ciphertext.
+        let plain = SecretRecord {
+            id,
+            name: "s".into(),
+            kind: SecretKind::Generic,
+            value: b"now-plain".to_vec(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        storage.store_secret(&plain).unwrap();
+        assert!(storage.load_secret_seal(&id).unwrap().is_none());
+        assert_eq!(storage.load_secret(&id).unwrap().value, b"now-plain");
+    }
+
+    #[test]
+    fn store_sealed_secret_rejects_mismatched_oprf_id() {
+        use crate::secret::{seal_value, SecretKind, SecretRecord};
+        let dir = tempdir().unwrap();
+        let storage =
+            Storage::create(&dir.path().join("v"), "password", Argon2Params::TESTING).unwrap();
+        let oprf_key = crypto::SecretKey::generate().unwrap();
+
+        let mut rec = SecretRecord::new("s".into(), SecretKind::Generic, Vec::new()).unwrap();
+        // Seal built for a DIFFERENT id than the record it is stored against.
+        let (value_ct, seal) = seal_value(b"v", &oprf_key, hex::encode([9u8; 32]), 0).unwrap();
+        rec.value = value_ct;
+        assert!(
+            storage.store_sealed_secret(&rec, &seal).is_err(),
+            "a seal whose oprf_id != record id must be rejected"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Threshold-sealed secrets

Adds the keep-core cryptographic core for secrets whose **value** can only be revealed with a t-of-n OPRF quorum, resolving #434's threshold-unlock track (first of three increments; network wiring and the CLI surface follow).

### Model

A threshold secret's value is encrypted under a fresh random per-secret DEK; that DEK is itself encrypted ("wrapped") under the OPRF-quorum-derived key (`oprf::derive_luks_key`). Recovering the plaintext requires re-deriving the OPRF key, which needs a quorum of devices, so a single device cannot decrypt the value even with the vault unlocked. Only the value is gated: name and kind stay readable with the vault data key so the store remains browsable.

`ThresholdSeal { wrapped_dek, oprf_id, epoch }` lives in a parallel `secret_seals` table keyed by secret id. A secret is threshold-gated iff it has a seal row (its `value` is then the DEK-ciphertext). Record and seal are written and deleted in one atomic transaction, so a crash can never leave a sealed value without its wrapped DEK.

### Interaction with rotation and backup

- **`rotate_data_key`**: `secret_seals` is registered in `OPAQUE_TABLES`, so rotation re-wraps only the outer data-key layer; the inner DEK-ciphertext and OPRF-wrapped DEK are opaque bytes carried through untouched. No quorum needed to rotate.
- **Backup/restore**: the backup carries the DEK-ciphertext and the wrapped DEK (never plaintext), so a threshold secret's value is never in the clear in a backup and stays quorum-gated after restore. No quorum needed at backup time; the OPRF root is never in a backup.

### Scope

The `oprf_key` is a caller-provided parameter here. Obtaining it via the threshold-OPRF network flow, and the `keep secret add --threshold` / `get` CLI surface that triggers the unlock, are follow-up increments.

Also carries `secrets` and `secret_seals` through the redb file-format-upgrade path (the existing `secrets` omission would have dropped the store on a major-format upgrade).

### Tests

- Seal/unseal round-trip; unseal fails with a different OPRF key (the single-device property); distinct DEK per secret; redacted `Debug`.
- Storage: store/load-seal/unseal; a plain secret reports no seal; delete drops the seal row atomically.
- Rotation preserves a sealed secret and it still unseals under the same key.
- Backup round-trip preserves a sealed secret, value stays sealed, unseals only with the OPRF key, wrong key fails.
- Schema migration v6 → v7 creates the `secret_seals` table.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added threshold-sealed secrets, which can only be revealed with the correct quorum-derived key.
  * Backups and restores now preserve sealed secrets without exposing their plaintext.
  * Data-key rotation preserves sealed secrets and their ability to be revealed.

* **Bug Fixes**
  * Database migrations now retain sealed-secret data.
  * Deleting a sealed secret also removes its associated sealing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->