### PR TITLE
keep-frost-net: derive threshold-secret seal keys from the OPRF quorum

### DIFF
--- a/keep-core/src/oprf.rs
+++ b/keep-core/src/oprf.rs
@@ -28,6 +28,17 @@ impl CipherSuite for Secp256k1Sha256 {
     type Hash = sha2_010::Sha256;
 }
 
+/// OPRF evaluation input for the threshold-sealed **secrets** store, distinct from
+/// the LUKS vault-unlock input. Feeding a different input to the SAME provisioned
+/// OPRF root yields a different OPRF output, so a secret's quorum-derived key can
+/// never collide with a LUKS volume key even though both reuse one root and the
+/// same `derive_luks_key` KDF. Per-secret separation is then layered on via the
+/// `volume_id` (the secret id) and `epoch`. Fixed like the LUKS input: the eval
+/// oracle authenticates callers (that is what protects it), so input entropy is
+/// not relied upon. MUST NOT change once it has sealed data (it would orphan every
+/// existing sealed value from its quorum).
+pub const SECRET_SEAL_INPUT: &[u8] = b"keep-secret-seal-v1";
+
 /// 2-of-3 (configurable t-of-n) threshold layer over the secp256k1 OPRF.
 ///
 /// The OPRF key is Shamir-shared across the share-holders (box / phone / replica). Each holder
@@ -699,6 +710,82 @@ mod tests {
                 "quorum {{{i},{j}}} must reproduce the provisioned LUKS key"
             );
         }
+    }
+
+    /// Derive a 32-byte key from `count` holder shares through the full quorum path
+    /// (blind -> per-holder evaluate -> combine -> derive), exactly as a networked
+    /// unlock does but in-process. `threshold` MUST be the `t` used at split.
+    fn quorum_derive(
+        shares: &[threshold::KeyShare],
+        count: usize,
+        input: &[u8],
+        volume_id: &str,
+        epoch: u32,
+        threshold: usize,
+    ) -> Result<zeroize::Zeroizing<[u8; 32]>, crate::error::CryptoError> {
+        let (client, blinded) = unlock::blind(input)?;
+        let mut partials = Vec::with_capacity(count);
+        for share in shares.iter().take(count) {
+            partials.push(unlock::evaluate(share, &blinded)?.to_vec());
+        }
+        client.finalize_luks_key(&partials, threshold, volume_id, epoch)
+    }
+
+    /// End-to-end proof for threshold-sealed secrets (increment 2): a secret sealed
+    /// under the OPRF-quorum-derived key is revealable ONLY by re-deriving that key
+    /// through a t-of-n quorum, and a below-threshold set (single device) fails. This
+    /// exercises the real OPRF math + the `secret::seal` layer, without the network.
+    #[test]
+    fn secret_sealed_under_quorum_key_unseals_only_with_a_quorum() {
+        use crate::crypto::SecretKey;
+        use crate::secret::{seal_value, unseal_value};
+
+        let (t, n) = (2usize, 3usize);
+        // The seal's `oprf_id` is the secret id (hex); it is the OPRF `volume_id`.
+        let secret_id = hex::encode([7u8; 32]);
+        let epoch = 0u32;
+
+        // One provisioned OPRF root (reused across secrets) with the SECRETS input;
+        // shares are held by the quorum.
+        let (provisioned, shares) =
+            unlock::provision(SECRET_SEAL_INPUT, &secret_id, epoch, t, n).expect("provision");
+
+        // Seal a secret's value under the provisioned quorum key.
+        let key = SecretKey::from_slice(&provisioned[..]).expect("key");
+        let (ciphertext, seal) =
+            seal_value(b"only-with-a-quorum", &key, secret_id.clone(), epoch).expect("seal");
+
+        // Reveal: a quorum of `t` shares re-derives the SAME key and unseals.
+        let via_quorum =
+            quorum_derive(&shares, t, SECRET_SEAL_INPUT, &secret_id, epoch, t).expect("quorum");
+        assert_eq!(
+            &provisioned[..],
+            &via_quorum[..],
+            "a t-of-n quorum unlock must reproduce the provisioned seal key"
+        );
+        let key2 = SecretKey::from_slice(&via_quorum[..]).expect("key2");
+        assert_eq!(
+            &unseal_value(&ciphertext, &seal, &key2).expect("unseal")[..],
+            b"only-with-a-quorum"
+        );
+
+        // Below threshold (t-1 shares = a single device short of quorum): the partials
+        // cannot combine, so no key is derived and the value stays sealed.
+        assert!(
+            quorum_derive(&shares, t - 1, SECRET_SEAL_INPUT, &secret_id, epoch, t).is_err(),
+            "t-1 shares must fail to derive the key (single-device access fails)"
+        );
+
+        // A DIFFERENT secret id derives a DIFFERENT key from the same root/quorum
+        // (per-secret domain separation), so it cannot unseal this secret.
+        let other_id = hex::encode([8u8; 32]);
+        let other_key = quorum_derive(&shares, t, SECRET_SEAL_INPUT, &other_id, epoch, t)
+            .expect("other quorum");
+        assert_ne!(
+            &via_quorum[..],
+            &other_key[..],
+            "each secret id must derive a distinct key from the shared root"
+        );
     }
 
     /// A key share that is serialized then deserialized must behave identically to the original:

--- a/keep-core/src/oprf.rs
+++ b/keep-core/src/oprf.rs
@@ -37,6 +37,12 @@ impl CipherSuite for Secp256k1Sha256 {
 /// oracle authenticates callers (that is what protects it), so input entropy is
 /// not relied upon. MUST NOT change once it has sealed data (it would orphan every
 /// existing sealed value from its quorum).
+///
+/// Cross-domain separation from LUKS rests on this input occupying HKDF's IKM
+/// position in [`derive_luks_key`] (a different OPRF output for the same root), NOT
+/// on the HKDF `info` label, which stays `keep-node/luks/v1` for both domains. That
+/// is cryptographically sufficient on its own; also varying the `info` label per
+/// domain would be belt-and-suspenders, not a fix.
 pub const SECRET_SEAL_INPUT: &[u8] = b"keep-secret-seal-v1";
 
 /// 2-of-3 (configurable t-of-n) threshold layer over the secp256k1 OPRF.

--- a/keep-frost-net/src/node/oprf.rs
+++ b/keep-frost-net/src/node/oprf.rs
@@ -358,6 +358,24 @@ impl KfpNode {
         ))
     }
 
+    /// Derive the quorum key that seals/unseals a threshold **secret**, by running
+    /// the OPRF unlock flow with the dedicated secrets input
+    /// ([`keep_core::oprf::SECRET_SEAL_INPUT`]) instead of the LUKS one. `oprf_id`
+    /// is the secret's id (its `ThresholdSeal.oprf_id`, used as the OPRF `volume_id`)
+    /// and `epoch` its rotation counter, so every secret derives a distinct key from
+    /// the SAME provisioned OPRF root the vault already uses for LUKS unlock, with no
+    /// per-secret provisioning. Requires a t-of-n quorum: a single device cannot
+    /// assemble the partials, so it cannot derive the key. The 32 bytes are the
+    /// `oprf_key` fed to `keep_core::secret::{seal_value, unseal_value}`.
+    pub async fn request_secret_seal_key(
+        &self,
+        oprf_id: &str,
+        epoch: u32,
+    ) -> Result<Zeroizing<[u8; 32]>> {
+        self.request_oprf_unlock(keep_core::oprf::SECRET_SEAL_INPUT, oprf_id, epoch)
+            .await
+    }
+
     /// One OPRF unlock round: sample (excluding `excluded`), blind, send, and
     /// wait one timeout. On timeout, the returned `non_responders` are the
     /// sampled holders that never deposited a partial, so the caller can exclude

--- a/keep-frost-net/src/node/oprf.rs
+++ b/keep-frost-net/src/node/oprf.rs
@@ -367,6 +367,14 @@ impl KfpNode {
     /// per-secret provisioning. Requires a t-of-n quorum: a single device cannot
     /// assemble the partials, so it cannot derive the key. The 32 bytes are the
     /// `oprf_key` fed to `keep_core::secret::{seal_value, unseal_value}`.
+    ///
+    /// DESIGN PROPERTY: the OPRF eval is oblivious, so a holder's `approve_oprf_eval`
+    /// hook sees only `(requester_share_index, session_id)` -- it cannot tell a
+    /// secret-seal eval from a LUKS-unlock eval, nor which secret. Any authorized
+    /// quorum eval therefore grants derivation across both domains; an operator
+    /// cannot approve "this one secret only". Acceptable because both domains already
+    /// demand the identical quorum + fresh attestation, so this crosses no new
+    /// authority boundary.
     pub async fn request_secret_seal_key(
         &self,
         oprf_id: &str,


### PR DESCRIPTION
## Threshold-sealed secrets: wire the OPRF quorum (increment 2)

Connects the threshold-sealed secrets store (increment 1, #760/#761) to the real t-of-n OPRF quorum, so a secret's seal key comes from a device quorum rather than a caller-supplied parameter.

### Approach

The client-side quorum driver already exists: `KfpNode::request_oprf_unlock(input, volume_id, epoch)` runs blind → sample t-1 holders → collect partials → combine → derive, with failover. Increment 1's `ThresholdSeal` already records `oprf_id = hex(secret_id)` and `epoch`, which map directly onto that driver's `(volume_id, epoch)` domain-separation parameters.

- **Reuse the existing OPRF root, dedicated input.** Secrets reuse the box's already-provisioned OPRF root and quorum (the same one LUKS vault-unlock uses), queried with a dedicated input `keep_core::oprf::SECRET_SEAL_INPUT = b"keep-secret-seal-v1"`. The OPRF root is input-agnostic, so a different input yields a different OPRF output: a secret's key can never collide with a LUKS volume key even though both reuse one root and the same `derive_luks_key` KDF. Per-secret separation is then layered on via `volume_id = secret id`. No per-secret provisioning.
- **Adapter.** `KfpNode::request_secret_seal_key(oprf_id, epoch)` wraps `request_oprf_unlock` with the secrets input; the returned 32 bytes are the `oprf_key` fed to `keep_core::secret::{seal_value, unseal_value}`.

### Verification

An automated end-to-end test (`secret_sealed_under_quorum_key_unseals_only_with_a_quorum`) exercises the real OPRF math + the seal layer, no live network:

- provision a t-of-n root with the secrets input → seal a value under the provisioned quorum key,
- re-derive the key from a **quorum of t shares** (blind → per-holder evaluate → combine → derive) → unseal succeeds and matches the provisioned key,
- a **below-threshold set (t-1 shares)** fails to derive the key (single-device access fails),
- a **different secret id** derives a distinct key from the same root (per-secret domain separation).

### Scope

This is the crypto/adapter layer with automated coverage. The networked CLI (`keep secret add --threshold` / `get` building a live `KfpNode`) is increment 3 (keep-97gj), which can only be integration-tested against a real multi-device quorum.

373 keep-core tests (with `oprf`) and 415+ keep-frost-net tests pass; default (no-`oprf`) build unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added threshold-based secret sealing and unsealing using quorum-derived keys.
  - Added support for deriving dedicated seal keys for specific secret identifiers and epochs.
  - Ensured sealed values can only be unsealed with the required quorum and matching identifier.
- **Tests**
  - Added coverage for successful quorum recovery, insufficient quorum failures, and mismatched-key rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->