### PR TITLE
keep-cli: threshold-sealed secrets via secret add --threshold / get

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -294,12 +294,25 @@ pub(crate) enum SecretCommands {
         /// Category of secret.
         #[arg(short, long, value_enum, default_value = "generic")]
         kind: SecretKindArg,
+        /// Seal the value behind a t-of-n OPRF quorum: it can then be revealed
+        /// ONLY by assembling the quorum, not from this device alone. Requires
+        /// the OPRF connection options (at least --group and --share-file).
+        #[arg(long)]
+        threshold: bool,
+        /// OPRF key epoch for a `--threshold` secret (its rotation counter).
+        #[arg(long, default_value = "1")]
+        epoch: u32,
+        #[command(flatten)]
+        oprf: OprfSecretArgs,
     },
     /// Reveal a stored secret's value. Interactive-only (TTY-gated), like
-    /// `keep export`.
+    /// `keep export`. For a threshold-sealed secret, pass the OPRF connection
+    /// options so the value can be unsealed via the quorum.
     Get {
         /// Secret name, or its hex id (from `list`) to disambiguate duplicates.
         name: String,
+        #[command(flatten)]
+        oprf: OprfSecretArgs,
     },
     /// List stored secrets (name, kind, id) — never the values.
     List,
@@ -308,6 +321,29 @@ pub(crate) enum SecretCommands {
         /// Secret name, or its hex id (from `list`) to disambiguate duplicates.
         name: String,
     },
+}
+
+/// OPRF quorum connection options for threshold-sealed secrets, shared by
+/// `secret add --threshold` and `secret get`. All optional at the parser level;
+/// the handler enforces what a threshold operation actually needs (group +
+/// share-file) and leaves plain secrets untouched when none are given.
+#[derive(clap::Args)]
+pub(crate) struct OprfSecretArgs {
+    /// FROST group npub whose quorum gates the secret.
+    #[arg(long)]
+    pub group: Option<String>,
+    /// Coordination relay URL (defaults to the configured relay).
+    #[arg(long)]
+    pub relay: Option<String>,
+    /// Local FROST share index to use.
+    #[arg(long)]
+    pub share: Option<u16>,
+    /// Path to this box's 64-byte OPRF key share (TPM-unsealed at boot).
+    #[arg(long)]
+    pub share_file: Option<PathBuf>,
+    /// Attest to holders via the TPM at this TCTI (e.g. device:/dev/tpmrm0).
+    #[arg(long)]
+    pub tpm_tcti: Option<String>,
 }
 
 /// CLI mirror of [`keep_core::secret::SecretKind`].
@@ -1093,6 +1129,67 @@ mod tests {
             panic!("expected bitcoin sign command");
         };
         assert_eq!(psbt, "/tmp/unsigned.psbt");
+    }
+
+    #[test]
+    fn secret_add_threshold_parses_oprf_options() {
+        let cli = Cli::try_parse_from([
+            "keep",
+            "secret",
+            "add",
+            "--name",
+            "vault-key",
+            "--threshold",
+            "--group",
+            "npub1group",
+            "--share-file",
+            "/run/oprf.share",
+            "--epoch",
+            "2",
+        ])
+        .expect("parse secret add --threshold");
+        let Commands::Secret { command } = cli.command else {
+            panic!("expected secret command");
+        };
+        let SecretCommands::Add {
+            name,
+            threshold,
+            epoch,
+            oprf,
+            ..
+        } = command
+        else {
+            panic!("expected secret add");
+        };
+        assert_eq!(name, "vault-key");
+        assert!(threshold);
+        assert_eq!(epoch, 2);
+        assert_eq!(oprf.group.as_deref(), Some("npub1group"));
+        assert_eq!(oprf.share_file, Some(PathBuf::from("/run/oprf.share")));
+    }
+
+    #[test]
+    fn secret_get_parses_oprf_options() {
+        let cli = Cli::try_parse_from([
+            "keep",
+            "secret",
+            "get",
+            "vault-key",
+            "--group",
+            "npub1group",
+            "--share",
+            "2",
+        ])
+        .expect("parse secret get with oprf options");
+        let Commands::Secret { command } = cli.command else {
+            panic!("expected secret command");
+        };
+        let SecretCommands::Get { name, oprf } = command else {
+            panic!("expected secret get");
+        };
+        assert_eq!(name, "vault-key");
+        assert_eq!(oprf.group.as_deref(), Some("npub1group"));
+        assert_eq!(oprf.share, Some(2));
     }
 
     #[test]

--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -346,6 +346,20 @@ pub(crate) struct OprfSecretArgs {
     pub tpm_tcti: Option<String>,
 }
 
+impl OprfSecretArgs {
+    /// Whether any OPRF connection option was supplied. Used to fail closed when
+    /// these are given to `secret add` WITHOUT `--threshold`, so a forgotten
+    /// `--threshold` cannot silently store a plaintext secret the operator
+    /// believes is quorum-gated.
+    pub fn any_present(&self) -> bool {
+        self.group.is_some()
+            || self.relay.is_some()
+            || self.share.is_some()
+            || self.share_file.is_some()
+            || self.tpm_tcti.is_some()
+    }
+}
+
 /// CLI mirror of [`keep_core::secret::SecretKind`].
 #[derive(Copy, Clone, Debug, ValueEnum)]
 pub(crate) enum SecretKindArg {
@@ -1190,6 +1204,35 @@ mod tests {
         assert_eq!(name, "vault-key");
         assert_eq!(oprf.group.as_deref(), Some("npub1group"));
         assert_eq!(oprf.share, Some(2));
+    }
+
+    #[test]
+    fn secret_add_oprf_args_without_threshold_are_detectable() {
+        // The handler fails closed on this combination; here we pin that the parse
+        // surfaces it (OPRF args present, threshold flag absent) so the guard fires.
+        let cli = Cli::try_parse_from([
+            "keep",
+            "secret",
+            "add",
+            "--name",
+            "x",
+            "--group",
+            "npub1group",
+        ])
+        .expect("parse secret add with oprf arg but no --threshold");
+        let Commands::Secret {
+            command: SecretCommands::Add {
+                threshold, oprf, ..
+            },
+        } = cli.command
+        else {
+            panic!("expected secret add");
+        };
+        assert!(!threshold, "no --threshold flag");
+        assert!(
+            oprf.any_present(),
+            "OPRF args present -> handler must reject without --threshold"
+        );
     }
 
     #[test]

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -1349,6 +1349,131 @@ fn probe_duress_state(out: &Output, path: &Path) -> Result<()> {
 /// bytes to STDOUT (and nothing else), so a boot gate can pipe it to
 /// `cryptsetup open --key-file -`. All human/progress output goes to STDERR via
 /// `Output` (which is backed by `Term::stderr()`); the key is never logged.
+/// Read and deserialize this box's 64-byte OPRF key share (the TPM-unsealed
+/// secret). The raw file bytes live in a `Zeroizing` buffer wiped before return;
+/// the returned `KeyShare` is live key material the caller must zeroize.
+pub(crate) fn load_oprf_key_share(
+    share_file: &Path,
+) -> Result<keep_core::oprf::threshold::KeyShare> {
+    let mut share_bytes = zeroize::Zeroizing::new(
+        std::fs::read(share_file)
+            .map_err(|e| KeepError::Runtime(format!("read OPRF share file: {e}")))?,
+    );
+    let share = keep_core::oprf::threshold::deserialize_key_share(&share_bytes)
+        .map_err(|e| KeepError::Frost(format!("invalid OPRF key share: {e}")))?;
+    share_bytes.zeroize();
+    Ok(share)
+}
+
+/// Run the threshold-OPRF quorum flow and return the derived 32-byte key: build a
+/// coordination node from `share`, install `oprf_share` so this box answers its own
+/// quorum, attach the optional TPM attestor, start the node, wait for peers, and
+/// request an evaluation for `(input, volume_id, epoch)`. Shared by LUKS unlock and
+/// the threshold-secrets store, which differ ONLY in `input`. `oprf_share` is copied
+/// into the node (`KeyShare` is `Copy`); the caller MUST wipe its own copy afterward
+/// on both paths (it is not `ZeroizeOnDrop`).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_oprf_request(
+    out: &Output,
+    share: keep_core::frost::SharePackage,
+    relay: &str,
+    oprf_share: keep_core::oprf::threshold::KeyShare,
+    attestor: Option<Arc<dyn keep_frost_net::AnnounceAttestor>>,
+    input: &[u8],
+    volume_id: &str,
+    epoch: u32,
+) -> Result<zeroize::Zeroizing<[u8; 32]>> {
+    let mut node = keep_frost_net::KfpNode::new(share, vec![relay.to_string()])
+        .await
+        .map_err(|e| KeepError::Frost(e.to_string()))?;
+    // Install the OPRF key share BEFORE running so this box can answer its own
+    // quorum's evaluate requests.
+    node.set_oprf_key_share(oprf_share);
+    // If a TPM is configured, attach the fresh measured-boot quote source to every
+    // announce so holders can verify this box before answering evals.
+    attestation::set_optional_announce_attestor(out, &mut node, attestor);
+
+    out.info("Starting FROST coordination node...");
+    let shutdown_tx = node.take_shutdown_handle();
+    let node = Arc::new(node);
+    let node_clone = node.clone();
+    let _run_guard = NodeRunGuard {
+        handle: tokio::spawn(async move {
+            let _ = node_clone.run().await;
+        }),
+        shutdown: shutdown_tx,
+    };
+
+    out.info("Discovering peers...");
+    for i in 0..12 {
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        if node.online_peers() > 0 {
+            break;
+        }
+        if i < 11 {
+            out.info(&format!("  Waiting for peers... ({}/12)", i + 1));
+        }
+    }
+    if node.online_peers() == 0 {
+        return Err(KeepError::Frost("No peers online after 24s.".into()));
+    }
+    out.success(&format!("Found {} online peer(s)", node.online_peers()));
+    out.info("Waiting for peers to discover us...");
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+    node.request_oprf_unlock(input, volume_id, epoch)
+        .await
+        .map_err(|e| KeepError::Frost(e.to_string()))
+}
+
+/// Derive the OPRF-quorum key that seals/unseals a threshold **secret**, from an
+/// already-unlocked `keep` and the CLI's OPRF connection options. Resolves the
+/// FROST group/share, loads this box's OPRF share, runs the quorum for
+/// `(SECRET_SEAL_INPUT, oprf_id, epoch)`, and returns the key as a `SecretKey` for
+/// `keep.store_sealed_secret` / `reveal_sealed_secret`. Requires `--group` and
+/// `--share-file`; errors clearly if either is missing.
+pub(crate) fn derive_secret_seal_key(
+    out: &Output,
+    keep: &Keep,
+    oprf: &crate::cli::OprfSecretArgs,
+    default_relay: &str,
+    oprf_id: &str,
+    epoch: u32,
+) -> Result<keep_core::crypto::SecretKey> {
+    let group = oprf.group.as_deref().ok_or_else(|| {
+        KeepError::invalid_input("a threshold secret requires --group (the FROST group npub)")
+    })?;
+    let share_file = oprf.share_file.as_deref().ok_or_else(|| {
+        KeepError::invalid_input(
+            "a threshold secret requires --share-file (this box's 64-byte OPRF key share)",
+        )
+    })?;
+    let relay = oprf.relay.as_deref().unwrap_or(default_relay);
+    let group_pubkey = keep_core::keys::npub_to_bytes(group)?;
+    let share = match oprf.share {
+        Some(idx) => keep.frost_get_share_by_index(&group_pubkey, idx)?,
+        None => keep.frost_get_share(&group_pubkey)?,
+    };
+    let attestor = attestation::optional_announce_attestor(out, oprf.tpm_tcti.as_deref())?;
+    let rt =
+        tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
+    let mut oprf_share = load_oprf_key_share(share_file)?;
+    let result = rt.block_on(run_oprf_request(
+        out,
+        share,
+        relay,
+        oprf_share,
+        attestor,
+        keep_core::oprf::SECRET_SEAL_INPUT,
+        oprf_id,
+        epoch,
+    ));
+    // `KeyShare` is `Copy`, not `ZeroizeOnDrop`: wipe our local copy on both paths.
+    oprf_share.zeroize();
+    let key = result?;
+    keep_core::crypto::SecretKey::from_slice(&key[..])
+}
+
 #[tracing::instrument(skip(out), fields(path = %path.display()))]
 #[allow(clippy::too_many_arguments)]
 pub fn cmd_frost_network_oprf_unlock(
@@ -1397,16 +1522,8 @@ pub fn cmd_frost_network_oprf_unlock(
         tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
 
     // Read this box's OPRF key share credential (64 raw bytes; the TPM-unsealed
-    // secret at boot). Held in a Zeroizing buffer so the raw bytes are wiped on
-    // drop; deserialize it, then explicitly wipe and drop the buffer.
-    let mut share_bytes = zeroize::Zeroizing::new(
-        std::fs::read(share_file)
-            .map_err(|e| KeepError::Runtime(format!("read OPRF share file: {e}")))?,
-    );
-    let mut oprf_share = keep_core::oprf::threshold::deserialize_key_share(&share_bytes)
-        .map_err(|e| KeepError::Frost(format!("invalid OPRF key share: {e}")))?;
-    share_bytes.zeroize();
-    drop(share_bytes);
+    // secret at boot). `KeyShare` is live key material wiped by hand below.
+    let mut oprf_share = load_oprf_key_share(share_file)?;
 
     out.newline();
     out.header("OPRF Unlock");
@@ -1427,53 +1544,19 @@ pub fn cmd_frost_network_oprf_unlock(
     out.field("Epoch", &epoch.to_string());
     out.newline();
 
-    let result = rt.block_on(async move {
-        let mut node = keep_frost_net::KfpNode::new(share, vec![relay.to_string()])
-            .await
-            .map_err(|e| KeepError::Frost(e.to_string()))?;
-        // Install the OPRF key share BEFORE running so this box can answer its
-        // own quorum's evaluate requests.
-        node.set_oprf_key_share(oprf_share);
-
-        // If a TPM is configured, attach the fresh measured-boot quote source to
-        // every announce so holders can verify this box before answering evals.
-        attestation::set_optional_announce_attestor(out, &mut node, attestor);
-
-        out.info("Starting FROST coordination node...");
-        let shutdown_tx = node.take_shutdown_handle();
-        let node = std::sync::Arc::new(node);
-        let node_clone = node.clone();
-        let _run_guard = NodeRunGuard {
-            handle: tokio::spawn(async move {
-                let _ = node_clone.run().await;
-            }),
-            shutdown: shutdown_tx,
-        };
-
-        out.info("Discovering peers...");
-        for i in 0..12 {
-            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-            if node.online_peers() > 0 {
-                break;
-            }
-            if i < 11 {
-                out.info(&format!("  Waiting for peers... ({}/12)", i + 1));
-            }
-        }
-        if node.online_peers() == 0 {
-            return Err(KeepError::Frost("No peers online after 24s.".into()));
-        }
-        out.success(&format!("Found {} online peer(s)", node.online_peers()));
-        out.info("Waiting for peers to discover us...");
-        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-
-        node.request_oprf_unlock(OPRF_UNLOCK_INPUT, volume_id, epoch)
-            .await
-            .map_err(|e| KeepError::Frost(e.to_string()))
-    });
+    let result = rt.block_on(run_oprf_request(
+        out,
+        share,
+        relay,
+        oprf_share,
+        attestor,
+        OPRF_UNLOCK_INPUT,
+        volume_id,
+        epoch,
+    ));
     // `KeyShare` is `Copy` + `Zeroize` but NOT `ZeroizeOnDrop`: the copy moved
-    // into the async block is gone with the node, but our local copy must be
-    // wiped by hand on both the Ok and Err paths.
+    // into the node is gone with it, but our local copy must be wiped by hand on
+    // both the Ok and Err paths.
     oprf_share.zeroize();
     let key = result?;
 

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -1377,7 +1377,7 @@ pub(crate) async fn run_oprf_request(
     out: &Output,
     share: keep_core::frost::SharePackage,
     relay: &str,
-    oprf_share: keep_core::oprf::threshold::KeyShare,
+    mut oprf_share: keep_core::oprf::threshold::KeyShare,
     attestor: Option<Arc<dyn keep_frost_net::AnnounceAttestor>>,
     input: &[u8],
     volume_id: &str,
@@ -1387,8 +1387,10 @@ pub(crate) async fn run_oprf_request(
         .await
         .map_err(|e| KeepError::Frost(e.to_string()))?;
     // Install the OPRF key share BEFORE running so this box can answer its own
-    // quorum's evaluate requests.
+    // quorum's evaluate requests. `set_oprf_key_share` takes a `Copy`, so wipe our
+    // transient parameter copy immediately after; the caller wipes its own.
     node.set_oprf_key_share(oprf_share);
+    oprf_share.zeroize();
     // If a TPM is configured, attach the fresh measured-boot quote source to every
     // announce so holders can verify this box before answering evals.
     attestation::set_optional_announce_attestor(out, &mut node, attestor);

--- a/keep-cli/src/commands/secret.rs
+++ b/keep-cli/src/commands/secret.rs
@@ -125,6 +125,17 @@ pub fn cmd_secret_add(
     refuse_hidden(path, hidden)?;
     validate_name(name)?;
 
+    // Fail closed: OPRF options without `--threshold` almost certainly means the
+    // operator intended a quorum-gated secret but forgot the flag. Storing it as
+    // plaintext silently would betray that intent, so refuse rather than guess.
+    if !threshold && oprf.any_present() {
+        return Err(KeepError::invalid_input(
+            "OPRF options (--group/--relay/--share/--share-file/--tpm-tcti) were given without \
+             --threshold. Add --threshold to seal this secret behind the quorum, or drop those \
+             options to store it as a plaintext secret.",
+        ));
+    }
+
     // Read the value off a hidden prompt or piped stdin, never argv.
     let value = read_secret_value("Secret value")?;
     if value.is_empty() {

--- a/keep-cli/src/commands/secret.rs
+++ b/keep-cli/src/commands/secret.rs
@@ -9,12 +9,14 @@ use std::path::Path;
 
 use secrecy::ExposeSecret;
 use tracing::{debug, warn};
+use zeroize::Zeroizing;
 
 use keep_core::error::{KeepError, Result};
 use keep_core::secret::SecretRecord;
 use keep_core::Keep;
 
-use crate::cli::SecretKindArg;
+use crate::cli::{OprfSecretArgs, SecretKindArg};
+use crate::commands::frost_network::derive_secret_seal_key;
 use crate::output::Output;
 
 use super::{
@@ -108,12 +110,17 @@ fn resolve_in<'a>(secrets: &'a [SecretRecord], handle: &str) -> Result<&'a Secre
     )))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn cmd_secret_add(
     out: &Output,
     path: &Path,
     name: &str,
     kind: SecretKindArg,
     hidden: bool,
+    threshold: bool,
+    epoch: u32,
+    oprf: &OprfSecretArgs,
+    default_relay: &str,
 ) -> Result<()> {
     refuse_hidden(path, hidden)?;
     validate_name(name)?;
@@ -126,6 +133,22 @@ pub fn cmd_secret_add(
 
     let mut keep = open_unlock(out, path)?;
     let kind_core: keep_core::secret::SecretKind = kind.into();
+
+    if threshold {
+        // Mint the record FIRST so the id (its OPRF label) is known, derive the
+        // quorum key for that exact id, then seal + store under it. Deriving for
+        // any other id would seal a value no quorum could reopen.
+        let record = SecretRecord::new(name.to_string(), kind_core, value.to_vec())?;
+        let oprf_id = hex::encode(record.id);
+        let oprf_key = derive_secret_seal_key(out, &keep, oprf, default_relay, &oprf_id, epoch)?;
+        keep.store_sealed_secret(record, &oprf_key, epoch)?;
+        out.success(&format!(
+            "Stored threshold-sealed secret '{name}' ({kind_core:?}); id {oprf_id}. \
+             Revealing it requires a t-of-n quorum."
+        ));
+        return Ok(());
+    }
+
     let record = SecretRecord::new(name.to_string(), kind_core, value.to_vec())?;
     keep.store_secret(&record)?;
 
@@ -138,24 +161,49 @@ pub fn cmd_secret_add(
     Ok(())
 }
 
-pub fn cmd_secret_get(out: &Output, path: &Path, handle: &str, hidden: bool) -> Result<()> {
+pub fn cmd_secret_get(
+    out: &Output,
+    path: &Path,
+    handle: &str,
+    hidden: bool,
+    oprf: &OprfSecretArgs,
+    default_relay: &str,
+) -> Result<()> {
     // Revealing a secret value is interactive-only by design, matching `export`:
     // fail fast before any password prompt or vault unlock.
     require_interactive_tty("keep secret get")?;
     refuse_hidden(path, hidden)?;
 
-    let keep = open_unlock(out, path)?;
+    let mut keep = open_unlock(out, path)?;
     let record = resolve_secret(&keep, handle)?;
+    let id = record.id;
+    // A threshold-sealed secret has a seal row; its value needs the quorum. A plain
+    // secret has none and its `value` is the plaintext.
+    let seal = keep.load_secret_seal(&id)?;
 
     out.secret_warning();
     out.newline();
-    if get_confirm("Display secret value?")? {
-        warn!(id = %hex::encode(record.id), "secret value revealed");
-        out.newline();
-        match std::str::from_utf8(&record.value) {
-            Ok(s) => out.info(s),
-            Err(_) => out.info(&format!("(binary; hex) {}", hex::encode(&record.value))),
+    if !get_confirm("Display secret value?")? {
+        return Ok(());
+    }
+
+    // Unseal via the quorum before logging the reveal, so a failed quorum does not
+    // leave a misleading "revealed" audit/log entry. `reveal_sealed_secret` emits
+    // the `SecretReveal` audit event only on success.
+    let revealed: Zeroizing<Vec<u8>> = match seal {
+        Some(seal) => {
+            let oprf_key =
+                derive_secret_seal_key(out, &keep, oprf, default_relay, &seal.oprf_id, seal.epoch)?;
+            keep.reveal_sealed_secret(&id, &oprf_key)?
         }
+        None => Zeroizing::new(record.value.clone()),
+    };
+
+    warn!(id = %hex::encode(id), "secret value revealed");
+    out.newline();
+    match std::str::from_utf8(&revealed) {
+        Ok(s) => out.info(s),
+        Err(_) => out.info(&format!("(binary; hex) {}", hex::encode(&revealed))),
     }
     Ok(())
 }

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -126,12 +126,31 @@ fn run(out: &Output) -> Result<()> {
         Commands::RotatePassword => commands::vault::cmd_rotate_password(out, &path),
         Commands::RotateDataKey => commands::vault::cmd_rotate_data_key(out, &path),
         Commands::Secret { command } => match command {
-            SecretCommands::Add { name, kind } => {
-                commands::secret::cmd_secret_add(out, &path, &name, kind, hidden)
-            }
-            SecretCommands::Get { name } => {
-                commands::secret::cmd_secret_get(out, &path, &name, hidden)
-            }
+            SecretCommands::Add {
+                name,
+                kind,
+                threshold,
+                epoch,
+                oprf,
+            } => commands::secret::cmd_secret_add(
+                out,
+                &path,
+                &name,
+                kind,
+                hidden,
+                threshold,
+                epoch,
+                &oprf,
+                cfg.default_relay(),
+            ),
+            SecretCommands::Get { name, oprf } => commands::secret::cmd_secret_get(
+                out,
+                &path,
+                &name,
+                hidden,
+                &oprf,
+                cfg.default_relay(),
+            ),
             SecretCommands::List => commands::secret::cmd_secret_list(out, &path, hidden),
             SecretCommands::Rm { name } => {
                 commands::secret::cmd_secret_rm(out, &path, &name, hidden)

--- a/keep-core/src/backup.rs
+++ b/keep-core/src/backup.rs
@@ -903,15 +903,13 @@ mod tests {
         keep.unlock("test-password-123").unwrap();
 
         let oprf_key = crypto::SecretKey::generate().unwrap();
-        let record = keep
-            .store_sealed_secret(
-                "quorum note".into(),
-                crate::secret::SecretKind::Note,
-                b"only-with-a-quorum",
-                &oprf_key,
-                0,
-            )
-            .unwrap();
+        let to_seal = crate::secret::SecretRecord::new(
+            "quorum note".into(),
+            crate::secret::SecretKind::Note,
+            b"only-with-a-quorum".to_vec(),
+        )
+        .unwrap();
+        let record = keep.store_sealed_secret(to_seal, &oprf_key, 0).unwrap();
         let id = record.id;
 
         let backup_data = create_backup(&keep, "backup-passphrase-ok").unwrap();
@@ -987,15 +985,13 @@ mod tests {
         keep.unlock("test-password-123").unwrap();
 
         let oprf_key = crypto::SecretKey::generate().unwrap();
-        let rec = keep
-            .store_sealed_secret(
-                "t".into(),
-                crate::secret::SecretKind::Note,
-                b"quorum-only",
-                &oprf_key,
-                0,
-            )
-            .unwrap();
+        let record = crate::secret::SecretRecord::new(
+            "t".into(),
+            crate::secret::SecretKind::Note,
+            b"quorum-only".to_vec(),
+        )
+        .unwrap();
+        let rec = keep.store_sealed_secret(record, &oprf_key, 0).unwrap();
 
         // A wrong-key reveal must NOT audit (it never yields the value).
         let wrong = crypto::SecretKey::generate().unwrap();

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -518,25 +518,31 @@ impl Keep {
 
     /// Store a secret whose value can only be revealed with a t-of-n OPRF quorum.
     ///
+    /// Takes a caller-minted `record` (via [`crate::secret::SecretRecord::new`])
+    /// carrying the plaintext in `record.value`. The caller must mint the record
+    /// FIRST so it knows the id, then derive `oprf_key` from the quorum for that id
+    /// (`oprf_id = hex(record.id)`, `epoch`) BEFORE calling this: the seal records
+    /// `oprf_id`, and a reveal re-derives the key for the same id, so a key derived
+    /// for any other id would seal a value no quorum could ever reopen.
+    ///
     /// `oprf_key` is the quorum-derived key ([`crate::oprf::derive_luks_key`]
-    /// output, obtained via the threshold-OPRF flow); `epoch` is its OPRF rotation
-    /// counter. The value is sealed under a fresh per-secret DEK wrapped by
-    /// `oprf_key`, so a single device that never assembles the quorum cannot
-    /// decrypt it even with the vault unlocked. The secret's name/kind stay
-    /// readable with the vault data key. Returns the minted record, whose random
-    /// id is the OPRF domain-separation label recorded in the seal. Records a
-    /// `SecretCreate` audit event tagged with the id.
+    /// output); `epoch` its OPRF rotation counter. The value is sealed under a fresh
+    /// per-secret DEK wrapped by `oprf_key`, so a single device that never assembles
+    /// the quorum cannot decrypt it even with the vault unlocked. The record's
+    /// name/kind stay readable with the vault data key. Returns the stored record
+    /// (its `value` now the DEK-ciphertext). Records a `SecretCreate` audit event.
     pub fn store_sealed_secret(
         &mut self,
-        name: String,
-        kind: crate::secret::SecretKind,
-        value: &[u8],
+        mut record: crate::secret::SecretRecord,
         oprf_key: &crate::crypto::SecretKey,
         epoch: u32,
     ) -> Result<crate::secret::SecretRecord> {
-        let mut record = crate::secret::SecretRecord::new(name, kind, Vec::new())?;
         let oprf_id = hex::encode(record.id);
-        let (value_ciphertext, seal) = crate::secret::seal_value(value, oprf_key, oprf_id, epoch)?;
+        // Take the plaintext out of the record and seal it; `record.value` becomes
+        // the DEK-ciphertext. The lifted plaintext is zeroized when this scope ends.
+        let plaintext = zeroize::Zeroizing::new(std::mem::take(&mut record.value));
+        let (value_ciphertext, seal) =
+            crate::secret::seal_value(&plaintext, oprf_key, oprf_id, epoch)?;
         record.value = value_ciphertext;
         self.storage.store_sealed_secret(&record, &seal)?;
         self.audit_event(AuditEventType::SecretCreate, |e| e.with_pubkey(&record.id));


### PR DESCRIPTION
## Threshold-sealed secrets: CLI surface (increment 3)

Completes the OPRF threshold-unlock feature end to end: `keep secret add --threshold` seals a value behind a t-of-n OPRF quorum, and `keep secret get` unseals a threshold secret via the quorum. Builds on the sealing core (#760/#761) and the OPRF wiring (#762).

### keep-core

`Keep::store_sealed_secret` now takes a **pre-minted `SecretRecord`** instead of `(name, kind, value)`. This resolves an ordering constraint the networked flow exposes: the quorum derives the seal key from `(oprf_id = hex(secret_id), epoch)`, so the caller must know the id *before* contacting the quorum. The CLI mints the record, derives the key for its id, then seals+stores. A key derived for any other id would seal a value no quorum could reopen. (Two increment-1 tests updated to mint first.)

### keep-cli

- **`secret add --threshold`** — mints the record, derives the quorum key for `hex(id)`, seals and stores. Requires `--group` and `--share-file` (clear errors otherwise); `--relay`/`--share`/`--tpm-tcti`/`--epoch` mirror `frost network oprf-unlock`.
- **`secret get`** — auto-detects a seal (via `load_secret_seal`); if sealed, runs the quorum to unseal, else reveals the plaintext as before. The reveal is logged/audited (`SecretReveal`) only after a successful unseal, so a failed quorum leaves no misleading trail.
- **Shared node plumbing extracted.** The `KfpNode` lifecycle (construct → install share → attest → run → peer-discovery wait → OPRF request) is now `run_oprf_request`, and OPRF-share loading is `load_oprf_key_share`. `cmd_frost_network_oprf_unlock` (LUKS unlock) is refactored to use them — no behavior change — and the new `derive_secret_seal_key` orchestrator reuses them for secrets. No duplicated node code.
- OPRF connection options are a shared `#[command(flatten)]` `OprfSecretArgs` struct on both `add` and `get`.

### Testing

- keep-core: the `store_sealed_secret` refactor is covered by the existing seal/rotation/backup tests (373 pass with `oprf`).
- keep-cli: new clap parse tests for `add --threshold` and `get` OPRF options; full suite green.
- The live t-of-n quorum path over Nostr relays is integration-tested manually (it needs a real multi-device setup); the crypto it drives is proven end-to-end by the automated OPRF test from #762.
