### PR TITLE
docs: document the encrypted secrets store and threshold-sealed secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Keep runs as a CLI, a desktop app (Linux/macOS/Windows), a mobile library (Andro
 - **Threshold signatures**: FROST t-of-n key splitting with distributed key generation (DKG)
 - **Network signing**: Coordinate FROST signing across devices over Nostr relays
 - **Threshold vault unlock**: Reconstruct a disk-encryption key at boot from a t-of-n OPRF quorum across TPM-attested holders (powers [keep-node](https://github.com/privkeyio/keep-node))
+- **Encrypted secrets store**: Keep key-adjacent secrets (BIP39 passphrases, exchange API keys, recovery codes) in the same vault; optionally **threshold-seal** a secret so its value can only be revealed by a t-of-n OPRF quorum, never from a single device
 - **Bitcoin**: BIP-86 Taproot addresses, PSBT signing, wallet descriptor coordination
 - **Enclaves**: AWS Nitro Enclave signing with attestation-based KMS
 - **Agent SDK**: Constrained signing sessions for AI agents (Python, TypeScript, MCP)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -6,6 +6,7 @@
 - [Quick Start](#quick-start)
 - [CLI Reference](#cli-reference)
 - [Backup & Restore](#backup--restore)
+- [Secrets Store](#secrets-store)
 - [Remote Signing (NIP-46)](#remote-signing-nip-46)
 - [Bitcoin](#bitcoin)
 - [Threshold Signatures (FROST)](#threshold-signatures-frost)
@@ -90,6 +91,16 @@ Run `keep <command> --help` for the full flag list of any command.
 | `keep backup [--output <file>]` | Write a passphrase-encrypted vault backup |
 | `keep restore <file> --target <dir>` | Restore a backup into a **new** vault |
 
+**Secrets store** (see [Secrets Store](#secrets-store)):
+
+| Command | Description |
+|---------|-------------|
+| `keep secret add --name <n> [--kind <k>]` | Store a secret (value read from a hidden prompt or piped stdin, never argv) |
+| `keep secret add --name <n> --threshold --group <npub> --share-file <f>` | Store a secret sealed behind a t-of-n OPRF quorum |
+| `keep secret get <name>` | Reveal a secret (interactive TTY only); unseals via the quorum if threshold-sealed |
+| `keep secret list` | List secrets (name, kind, id) — never values |
+| `keep secret rm <name>` | Remove a secret |
+
 **Signing & coordination:**
 
 | Command | Description |
@@ -133,6 +144,60 @@ a restore can never clobber your live keys.
 For FROST shares specifically, use `keep frost export` / `keep frost import` (per-share,
 passphrase-encrypted) so shares can be moved or backed up independently. See
 [Threshold Signatures](#threshold-signatures-frost).
+
+---
+
+## Secrets Store
+
+An encrypted store for high-value, **key-adjacent** secrets that belong next to your
+keys: BIP39 passphrases, exchange API keys, hardware-wallet PINs, recovery codes. It
+is not a password manager — there is no clipboard, autofill, TOTP, or URL matching —
+just an encrypted place for the handful of secrets you already guard as carefully as
+your keys. Each record's name, kind, and value are encrypted under the vault data key
+at rest; values are never passed on the command line (read from a hidden prompt or
+piped stdin) and are scrubbed from memory on drop.
+
+```bash
+# Store a secret; the value is read from a hidden prompt (or piped stdin)
+keep secret add --name exchange-api --kind api-token
+
+# Pipe a value non-interactively (a single trailing newline is stripped)
+printf '%s' "$MY_SECRET" | keep secret add --name seed-passphrase --kind password
+
+# List (names/kinds/ids only, never values), reveal (interactive TTY only), remove
+keep secret list
+keep secret get exchange-api
+keep secret rm exchange-api
+```
+
+Kinds are labels only (`password`, `api-token`, `note`, `generic`). Secrets are
+included in `keep backup` and re-encrypted by `keep rotate-data-key` like every other
+record, and they never sync to relays.
+
+### Threshold-sealed secrets
+
+Seal a secret's **value** behind a *t-of-n* OPRF quorum so it can be revealed only by
+assembling the quorum, never from a single device — even one with the vault unlocked.
+The name and kind stay readable locally; only the value is quorum-gated. This reuses
+the same OPRF root and holders as
+[Threshold-OPRF Vault Unlock](#threshold-oprf-vault-unlock-advanced): provision the
+quorum once (`keep frost network oprf-provision`, with holders serving), then:
+
+```bash
+# Seal a new secret under the quorum (holders must be online and serving).
+# --group and --share-file are required.
+keep secret add --name cold-storage-passphrase --kind password --threshold \
+  --group npub1... --share-file box.share --tpm-tcti device:/dev/tpmrm0
+
+# Reveal it — runs the t-of-n quorum to unseal the value:
+keep secret get cold-storage-passphrase \
+  --group npub1... --share-file box.share --tpm-tcti device:/dev/tpmrm0
+```
+
+If you pass the OPRF options to `secret add` without `--threshold`, the command
+refuses rather than silently storing a plaintext secret you meant to seal. A threshold
+reveal fails closed if the quorum is unreachable: the value stays sealed and no reveal
+is recorded.
 
 ---
 


### PR DESCRIPTION
Documents the encrypted secrets store now that a user-facing CLI surface has shipped (secret add/get/list/rm, and `--threshold` sealing).

- **README.md**: a Features bullet framing it as a key-adjacent secrets store, leading with the threshold-seal differentiator.
- **docs/USAGE.md**: a CLI Reference table group, a TOC entry, and a Secrets Store section covering plain `secret add/get/list/rm` plus a Threshold-sealed secrets subsection that reuses the documented OPRF provisioning.

Framed as an encrypted store for high-value, key-adjacent secrets (BIP39 passphrases, exchange API keys, recovery codes), NOT a password manager. Documents only capabilities that actually ship: no clipboard, autofill, TOTP, or URL matching. Notes the fail-closed behavior (OPRF options without `--threshold` are refused; a threshold reveal fails closed if the quorum is unreachable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the encrypted Secrets Store feature.
  * Documented commands for adding, retrieving, listing, and removing secrets.
  * Explained hidden or piped secret input, while keeping secret values out of command arguments and listings.
  * Documented threshold-sealed secrets, quorum-based access, and fail-closed behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->