### PR TITLE
ci: run keep-cli end-to-end integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,10 @@ jobs:
       - run: cargo test -p keep-core --features testing --test integration_tests
       - run: cargo test -p keep-frost-net --features testing --test multinode_test
       - run: cargo test -p keep-enclave-host --test integration_tests
+      # End-to-end CLI tests drive the release `keep` binary built above as a
+      # subprocess (the tests locate `target/release/keep`), so run them in
+      # --release too. Previously only compile-checked, never executed in CI.
+      - run: cargo test -p keep-cli --release --test cli_integration
 
   build-windows:
     runs-on: windows-latest


### PR DESCRIPTION
The `keep-cli` `cli_integration` suite (init/generate/list/export, WDC validation, and the new #434 slices: backup/restore, rotate/refresh, audit, bitcoin, config/migrate — 39 tests) was only compile-checked in CI (`cargo check --all-targets`), never executed. So the CLI end-to-end coverage did not gate against regressions.

This adds a CI step that runs them. The tests drive the release `keep` binary already built at `cargo build --release` (ci.yml:75) as a subprocess, so they run in `--release` (the tests locate `target/release/keep`; optimized argon2 keeps them fast). Verified locally: 39 tests pass in ~24s in release mode.

Makes the CLI integration coverage a real regression gate. Refs #434.