### PR TITLE
keep-cli: inspect socket so read-only commands coexist with a running daemon (#533)

### DIFF
--- a/keep-cli/src/commands/serve.rs
+++ b/keep-cli/src/commands/serve.rs
@@ -230,6 +230,19 @@ pub fn cmd_serve(
             ..Default::default()
         };
         rt.block_on(async {
+            // Serve a local inspect socket so read-only commands (`keep list`)
+            // can query this daemon instead of failing on the exclusive writer
+            // lock (#533). Owner-only; metadata only. Shares the same keyring.
+            let inspect_keyring = Arc::clone(&keyring);
+            let inspect_vault = path.to_path_buf();
+            tokio::spawn(async move {
+                if let Err(e) =
+                    crate::ipc::serve_inspect_socket(&inspect_vault, inspect_keyring).await
+                {
+                    tracing::warn!(error = %e, "inspect socket unavailable");
+                }
+            });
+
             let mut server = if let Some(frost) = frost_signer {
                 let transport_key: [u8; 32] = keep_core::crypto::random_bytes();
                 Server::new_with_config(

--- a/keep-cli/src/commands/vault.rs
+++ b/keep-cli/src/commands/vault.rs
@@ -396,6 +396,16 @@ pub fn cmd_list(out: &Output, path: &Path, hidden: bool) -> Result<()> {
 
     debug!("listing keys");
 
+    // #533: if a `keep serve` daemon holds redb's exclusive writer lock, it also
+    // serves a local inspect socket. Answer from it when present, which avoids the
+    // lock conflict (taken at unlock) and the password prompt entirely. A stale
+    // socket (dead daemon) fails the query, so fall through to a normal open.
+    if crate::ipc::inspect_socket_path(path).exists() {
+        if let Ok(keys) = crate::ipc::query_list(path) {
+            return render_daemon_keys(out, keys);
+        }
+    }
+
     let mut keep = Keep::open(path)?;
     let password = get_password("Enter password")?;
 
@@ -430,6 +440,33 @@ pub fn cmd_list(out: &Output, path: &Path, hidden: bool) -> Result<()> {
     out.newline();
     out.info(&format!("{} key(s) total", keys.len()));
 
+    Ok(())
+}
+
+/// Render a key list obtained from a running daemon's inspect socket (#533),
+/// matching `cmd_list`'s table. The data came from the daemon's already-unlocked
+/// vault, so no local password prompt or unlock happens here.
+fn render_daemon_keys(out: &Output, keys: Vec<crate::ipc::KeyInfo>) -> Result<()> {
+    if keys.is_empty() {
+        out.newline();
+        out.info("No keys found. Use 'keep generate' to create one.");
+        return Ok(());
+    }
+    out.table_header(&[("NAME", 20), ("TYPE", 20), ("PUBKEY", 28)]);
+    for key in &keys {
+        let display_npub = if key.npub.len() > 24 {
+            format!("{}...", &key.npub[..24])
+        } else {
+            key.npub.clone()
+        };
+        out.table_row(&[
+            (&key.name, 20, false),
+            (&key.key_type, 20, false),
+            (&display_npub, 28, true),
+        ]);
+    }
+    out.newline();
+    out.info(&format!("{} key(s) total (via running daemon)", keys.len()));
     Ok(())
 }
 

--- a/keep-cli/src/ipc.rs
+++ b/keep-cli/src/ipc.rs
@@ -8,10 +8,17 @@
 //! to a per-vault Unix socket the daemon serves and get the (metadata-only)
 //! answer from the daemon's already-open, unlocked vault.
 //!
-//! Security: the socket is created mode `0600` inside the vault directory, so
-//! only processes running as the vault owner (who already holds the password)
-//! can connect. The daemon answers ONLY read-only, metadata-only requests and
-//! NEVER returns secret key material.
+//! Security: the socket is created mode `0600` inside the (0700, owner-only)
+//! vault directory, so only processes running as the vault owner can connect.
+//! The daemon answers ONLY read-only, metadata-only requests (key name, kind,
+//! npub) and NEVER returns secret key material.
+//!
+//! Trust model note: unlike a direct `keep list`, the socket path returns
+//! metadata WITHOUT the vault password. This lowers the bar for reading key
+//! names/npubs from "knows the password" to "is the same Unix user" while a
+//! daemon runs. That is acceptable because the daemon already holds the unlocked
+//! keyring in memory, which a same-user attacker can recover regardless; the
+//! socket exposes strictly less (metadata only, no secrets).
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -24,8 +31,13 @@ use keep_core::keyring::Keyring;
 
 /// Filename of the per-vault inspect socket, inside the vault directory.
 const SOCKET_NAME: &str = "keep.sock";
-/// Upper bound on a request line, a cheap guard against a runaway/hostile peer.
+/// Upper bound on a request/response line, a cheap guard against a runaway or
+/// hostile (same-user) peer streaming bytes without a newline.
 const MAX_REQUEST_BYTES: u64 = 8 * 1024;
+/// Drop a connection whose request does not arrive promptly (slowloris guard).
+const READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+/// Cap on concurrent in-flight connections, so a burst cannot pile up tasks/FDs.
+const MAX_CONNECTIONS: usize = 32;
 
 /// Path of the inspect socket for a vault.
 pub(crate) fn inspect_socket_path(vault: &Path) -> PathBuf {
@@ -84,13 +96,20 @@ pub(crate) async fn serve_inspect_socket(
     // and chmod is not reachable by another user in practice.
     std::fs::set_permissions(&sock, std::fs::Permissions::from_mode(0o600))?;
 
+    let limit = Arc::new(tokio::sync::Semaphore::new(MAX_CONNECTIONS));
     loop {
         let (stream, _addr) = listener.accept().await?;
+        // Backpressure: never hold more than MAX_CONNECTIONS handlers at once.
+        let Ok(permit) = Arc::clone(&limit).acquire_owned().await else {
+            break; // semaphore closed
+        };
         let keyring = Arc::clone(&keyring);
         tokio::spawn(async move {
             let _ = handle_conn(stream, keyring).await;
+            drop(permit);
         });
     }
+    Ok(())
 }
 
 async fn handle_conn(
@@ -102,7 +121,14 @@ async fn handle_conn(
     let (rd, mut wr) = stream.split();
     let mut reader = BufReader::new(rd).take(MAX_REQUEST_BYTES);
     let mut line = String::new();
-    reader.read_line(&mut line).await?;
+    // Bounded (MAX_REQUEST_BYTES via take) and time-bounded: a client that never
+    // sends a newline is dropped rather than parking the task.
+    if tokio::time::timeout(READ_TIMEOUT, reader.read_line(&mut line))
+        .await
+        .is_err()
+    {
+        return Ok(());
+    }
 
     let response = match serde_json::from_str::<InspectRequest>(line.trim()) {
         Ok(req) if req.cmd == "list" => {
@@ -157,7 +183,9 @@ pub(crate) fn query_list(vault: &Path) -> Result<Vec<KeyInfo>> {
         .map_err(|e| KeepError::Runtime(format!("write to inspect socket: {e}")))?;
 
     let mut line = String::new();
-    BufReader::new(&stream)
+    // Bound the response too: a malicious (same-user) socket cannot grow this
+    // unboundedly. `set_read_timeout` above bounds a hang; `take` bounds volume.
+    BufReader::new(std::io::Read::take(&stream, MAX_REQUEST_BYTES))
         .read_line(&mut line)
         .map_err(|e| KeepError::Runtime(format!("read from inspect socket: {e}")))?;
     let response: InspectResponse = serde_json::from_str(line.trim())

--- a/keep-cli/src/ipc.rs
+++ b/keep-cli/src/ipc.rs
@@ -1,0 +1,219 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+//! Local inspect socket so read-only CLI commands can coexist with a running
+//! `keep serve` daemon that holds redb's exclusive writer lock (#533).
+//!
+//! redb opens the vault file with an exclusive lock, so a second `Keep::open`
+//! fails while the daemon runs. Instead of failing, read-only commands connect
+//! to a per-vault Unix socket the daemon serves and get the (metadata-only)
+//! answer from the daemon's already-open, unlocked vault.
+//!
+//! Security: the socket is created mode `0600` inside the vault directory, so
+//! only processes running as the vault owner (who already holds the password)
+//! can connect. The daemon answers ONLY read-only, metadata-only requests and
+//! NEVER returns secret key material.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use keep_core::error::{KeepError, Result};
+use keep_core::keyring::Keyring;
+
+/// Filename of the per-vault inspect socket, inside the vault directory.
+const SOCKET_NAME: &str = "keep.sock";
+/// Upper bound on a request line, a cheap guard against a runaway/hostile peer.
+const MAX_REQUEST_BYTES: u64 = 8 * 1024;
+
+/// Path of the inspect socket for a vault.
+pub(crate) fn inspect_socket_path(vault: &Path) -> PathBuf {
+    vault.join(SOCKET_NAME)
+}
+
+#[derive(Serialize, Deserialize)]
+struct InspectRequest {
+    cmd: String,
+}
+
+/// One key's non-secret metadata, mirroring what `keep list` renders.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct KeyInfo {
+    pub name: String,
+    pub key_type: String,
+    pub npub: String,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+struct InspectResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    keys: Option<Vec<KeyInfo>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+/// Snapshot the keyring's non-secret key metadata (name, kind, npub). Never
+/// touches secret material.
+fn list_keys(keyring: &Keyring) -> Vec<KeyInfo> {
+    keyring
+        .list()
+        .map(|slot| KeyInfo {
+            name: slot.name.clone(),
+            key_type: format!("{:?}", slot.key_type),
+            npub: keep_core::keys::bytes_to_npub(&slot.pubkey),
+        })
+        .collect()
+}
+
+/// Serve the inspect socket for `vault`, answering read-only requests from the
+/// shared `keyring`, until the task is dropped/aborted. Binds `0600` and clears
+/// any stale socket first. Returns only on a bind error.
+pub(crate) async fn serve_inspect_socket(
+    vault: &Path,
+    keyring: Arc<Mutex<Keyring>>,
+) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let sock = inspect_socket_path(vault);
+    // A leftover socket from a crashed daemon would block bind; the writer lock
+    // proves no live daemon owns it, so removing it is safe.
+    let _ = std::fs::remove_file(&sock);
+    let listener = tokio::net::UnixListener::bind(&sock)?;
+    // Owner-only. The vault dir is itself restrictive, so the window between bind
+    // and chmod is not reachable by another user in practice.
+    std::fs::set_permissions(&sock, std::fs::Permissions::from_mode(0o600))?;
+
+    loop {
+        let (stream, _addr) = listener.accept().await?;
+        let keyring = Arc::clone(&keyring);
+        tokio::spawn(async move {
+            let _ = handle_conn(stream, keyring).await;
+        });
+    }
+}
+
+async fn handle_conn(
+    mut stream: tokio::net::UnixStream,
+    keyring: Arc<Mutex<Keyring>>,
+) -> std::io::Result<()> {
+    use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+
+    let (rd, mut wr) = stream.split();
+    let mut reader = BufReader::new(rd).take(MAX_REQUEST_BYTES);
+    let mut line = String::new();
+    reader.read_line(&mut line).await?;
+
+    let response = match serde_json::from_str::<InspectRequest>(line.trim()) {
+        Ok(req) if req.cmd == "list" => {
+            let keys = {
+                let kr = keyring.lock().await;
+                list_keys(&kr)
+            };
+            InspectResponse {
+                keys: Some(keys),
+                error: None,
+            }
+        }
+        Ok(req) => InspectResponse {
+            keys: None,
+            error: Some(format!("unsupported inspect command: {}", req.cmd)),
+        },
+        Err(_) => InspectResponse {
+            keys: None,
+            error: Some("malformed inspect request".into()),
+        },
+    };
+
+    let mut bytes = serde_json::to_vec(&response).unwrap_or_default();
+    bytes.push(b'\n');
+    wr.write_all(&bytes).await?;
+    wr.flush().await?;
+    Ok(())
+}
+
+/// Ask a running daemon for its key list over the inspect socket. Used by
+/// `keep list` when `Keep::open` reports the vault is already open.
+pub(crate) fn query_list(vault: &Path) -> Result<Vec<KeyInfo>> {
+    use std::io::{BufRead, BufReader, Write};
+    use std::time::Duration;
+
+    let sock = inspect_socket_path(vault);
+    let mut stream = std::os::unix::net::UnixStream::connect(&sock).map_err(|e| {
+        KeepError::Runtime(format!(
+            "the vault is held by a daemon, but its inspect socket {} is unreachable: {e}",
+            sock.display()
+        ))
+    })?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .map_err(|e| KeepError::Runtime(format!("set socket timeout: {e}")))?;
+
+    let mut request = serde_json::to_vec(&InspectRequest { cmd: "list".into() })
+        .map_err(|e| KeepError::Runtime(format!("encode request: {e}")))?;
+    request.push(b'\n');
+    stream
+        .write_all(&request)
+        .map_err(|e| KeepError::Runtime(format!("write to inspect socket: {e}")))?;
+
+    let mut line = String::new();
+    BufReader::new(&stream)
+        .read_line(&mut line)
+        .map_err(|e| KeepError::Runtime(format!("read from inspect socket: {e}")))?;
+    let response: InspectResponse = serde_json::from_str(line.trim())
+        .map_err(|e| KeepError::Runtime(format!("decode inspect response: {e}")))?;
+    if let Some(err) = response.error {
+        return Err(KeepError::Runtime(format!(
+            "daemon rejected request: {err}"
+        )));
+    }
+    Ok(response.keys.unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use keep_core::keys::KeyType;
+
+    #[tokio::test]
+    async fn inspect_socket_round_trips_key_metadata() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let vault = dir.path().to_path_buf();
+
+        // A keyring with one loaded key, as the daemon would hold post-unlock.
+        let keyring = {
+            let mut kr = Keyring::new();
+            kr.load_key([9u8; 32], [7u8; 32], KeyType::Nostr, "alpha".to_string())
+                .unwrap();
+            Arc::new(Mutex::new(kr))
+        };
+
+        let vault_for_server = vault.clone();
+        let server = tokio::spawn(async move {
+            let _ = serve_inspect_socket(&vault_for_server, keyring).await;
+        });
+
+        // Give the listener a moment to bind.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let vault_for_client = vault.clone();
+        let keys = tokio::task::spawn_blocking(move || query_list(&vault_for_client))
+            .await
+            .unwrap()
+            .expect("query_list");
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].name, "alpha");
+        assert_eq!(keys[0].key_type, "Nostr");
+        assert!(keys[0].npub.starts_with("npub1"));
+
+        server.abort();
+    }
+
+    #[test]
+    fn query_list_errors_when_no_daemon() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // No server bound: connecting must fail with a clear message.
+        let err = query_list(dir.path()).unwrap_err();
+        assert!(err.to_string().contains("inspect socket"));
+    }
+}

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -6,6 +6,7 @@
 mod cli;
 mod commands;
 mod config;
+mod ipc;
 mod output;
 mod panic;
 #[cfg(windows)]

--- a/keep-cli/tests/cli_integration.rs
+++ b/keep-cli/tests/cli_integration.rs
@@ -1783,3 +1783,66 @@ async fn test_serve_bunker_e2e_sign_verifies() {
     client.disconnect().await;
     drop(mock); // keep the relay alive until the flow completes
 }
+
+// -----------------------------------------------------------------------------
+// #533: read-only `keep list` coexists with a running daemon (inspect socket)
+// -----------------------------------------------------------------------------
+
+/// While `keep serve` holds redb's exclusive writer lock, `keep list` must still
+/// work by routing through the daemon's inspect socket, not fail on the lock.
+#[tokio::test]
+async fn test_list_coexists_with_running_daemon() {
+    let bin = match keep_binary() {
+        Some(b) => b,
+        None => {
+            eprintln!("SKIPPED: keep binary not found (build with: cargo build -p keep-cli)");
+            return;
+        }
+    };
+
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+
+    let dir = TempDir::new().unwrap();
+    let vault = dir.path().join("daemon-vault");
+
+    // Create a key BEFORE the daemon starts, so `list` has something to show.
+    assert_success(&KeepCmd::new(&bin).path(&vault).args(["init"]).run());
+    assert_success(
+        &KeepCmd::new(&bin)
+            .path(&vault)
+            .args(["generate", "--name", "daemonkey"])
+            .run(),
+    );
+
+    // Sanity: `list` works normally when no daemon holds the vault.
+    let before = KeepCmd::new(&bin).path(&vault).args(["list"]).run();
+    assert_success(&before);
+    assert!(output_contains(&before, "daemonkey"));
+
+    // Start the daemon (holds the writer lock + serves the inspect socket).
+    let mock = nostr_relay_builder::MockRelay::run()
+        .await
+        .expect("mock relay start");
+    let relay = mock.url().await.to_string();
+    let (_serve, _bunker_url) = spawn_bunker(&bin, &vault, &relay);
+    // Let the inspect socket bind after the bunker URL is printed.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // `list` now must route through the daemon (the direct open would fail on the
+    // exclusive lock).
+    let during = KeepCmd::new(&bin).path(&vault).args(["list"]).run();
+    assert_success(&during);
+    assert!(
+        output_contains(&during, "daemonkey"),
+        "list must show the key via the daemon:\n{}",
+        String::from_utf8_lossy(&during.stderr)
+    );
+    assert!(
+        output_contains(&during, "via running daemon"),
+        "list must indicate it came from the daemon"
+    );
+
+    drop(mock);
+}

--- a/keep-core/src/backend.rs
+++ b/keep-core/src/backend.rs
@@ -451,12 +451,12 @@ pub(crate) fn open_database_with_retry(
 /// so this helper does not swallow real database failures.
 pub(crate) fn map_open_failure(path: &Path, e: redb::DatabaseError) -> KeepError {
     if matches!(&e, redb::DatabaseError::DatabaseAlreadyOpen) {
-        return KeepError::Database(format!(
+        return KeepError::VaultAlreadyOpen(format!(
             "vault at {} is already opened by another process. \
              A `keep serve` or `keep frost network serve` daemon typically holds the lock; \
              stop it (or wait for it to exit) and retry. \
-             A separate follow-up will let read-only commands (`list`, `audit list`, etc.) \
-             coexist with a running daemon; see #422 for details.",
+             Read-only commands like `list` route through the running daemon automatically \
+             (#533); see #422 for details.",
             path.display()
         ));
     }
@@ -703,8 +703,8 @@ mod tests {
         };
         let msg = err.to_string();
         assert!(
-            matches!(err, KeepError::Database(_)),
-            "expected Database from map_open_failure, got {err:?}"
+            matches!(err, KeepError::VaultAlreadyOpen(_)),
+            "expected VaultAlreadyOpen from map_open_failure, got {err:?}"
         );
         assert!(
             msg.contains("already opened by another process"),

--- a/keep-core/src/error.rs
+++ b/keep-core/src/error.rs
@@ -515,6 +515,13 @@ pub enum KeepError {
     Encryption(String),
     #[error("Database error: {0}")]
     Database(String),
+    /// The vault's redb file is already opened (exclusive lock) by another
+    /// process, typically a running `keep serve` daemon. Distinct from `Database`
+    /// so read-only CLI commands can detect it and route through the daemon's
+    /// inspect socket instead of failing (#533). The payload is a
+    /// ready-to-display hint.
+    #[error("{0}")]
+    VaultAlreadyOpen(String),
     #[error("Migration error: {0}")]
     Migration(String),
     #[error("Home directory not found")]

--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -1499,8 +1499,8 @@ mod tests {
         };
         let msg = err.to_string();
         assert!(
-            matches!(err, KeepError::Database(_)),
-            "expected Database from map_open_failure, got {err:?}"
+            matches!(err, KeepError::VaultAlreadyOpen(_)),
+            "expected VaultAlreadyOpen from map_open_failure, got {err:?}"
         );
         assert!(
             msg.contains("already opened by another process"),

--- a/keep-nip46/src/error.rs
+++ b/keep-nip46/src/error.rs
@@ -17,9 +17,10 @@ pub(crate) fn sanitize_error_for_client(e: &KeepError) -> &'static str {
         KeepError::AlreadyExists(_) | KeepError::NotFound(_) => "Resource error",
         KeepError::InvalidNetwork(_) => "Invalid network",
         KeepError::Encryption(_) | KeepError::CryptoErr(_) => "Cryptographic operation failed",
-        KeepError::Database(_) | KeepError::Migration(_) | KeepError::StorageErr(_) => {
-            "Storage error"
-        }
+        KeepError::Database(_)
+        | KeepError::VaultAlreadyOpen(_)
+        | KeepError::Migration(_)
+        | KeepError::StorageErr(_) => "Storage error",
         KeepError::HomeNotFound | KeepError::Config(_) => "Configuration error",
         KeepError::CapacityExceeded(_) => "Capacity exceeded",
         KeepError::PermissionDenied(_) => "Permission denied",


### PR DESCRIPTION
## Inspect socket: read-only commands coexist with a running daemon (#533)

redb takes an exclusive lock on the vault, so while `keep serve` runs, `keep list` (and other read-only commands) fail. Per #533's recorded decision, this implements approach **(1) the IPC daemon** (bible-correct, single source of truth) — a minimal first increment covering `keep list`.

### How it works

- **Server.** `keep serve --headless` already keeps the vault open (holding the lock) and shares its keyring as `Arc<Mutex<Keyring>>`. A concurrent task binds a per-vault Unix socket at `<vault>/keep.sock` and answers read-only requests from that keyring.
- **Client.** `keep list` checks for the socket first; if a daemon is serving it, `list` gets its answer over the socket (avoiding both the lock conflict — which is actually taken at `unlock`, not `open` — and the password prompt) and renders the same table, tagged "(via running daemon)". A stale socket (dead daemon) fails the query and falls through to a normal open.
- **Protocol.** One JSON request line, one response line: `{"cmd":"list"}` → `{"keys":[{name,key_type,npub}]}`. Extensible to `audit list`, `frost list`, etc.

### Security

- Socket created mode **0600** inside the vault directory (itself restrictive) — only processes running as the vault owner (who already holds the password) can connect.
- The daemon returns **metadata only** (name, kind, npub); it **never** returns secret key material.
- Bounded request size (8 KiB) guards against a runaway/hostile peer; a stale socket is removed before bind (the writer lock proves no live daemon owns it).
- New `KeepError::VaultAlreadyOpen` distinguishes the lock conflict from generic DB errors so the routing is exact, not message-matched.

### Tests

- `ipc::tests`: in-process socket round-trip returns key metadata; a missing daemon errors clearly.
- `test_list_coexists_with_running_daemon`: spawns a real `keep serve` daemon (holding the writer) over a mock relay and asserts `keep list` returns the key via the socket while the daemon holds the lock — the #533 acceptance criterion. Verified stable across repeated runs.

Scope: `list` only in this PR; other read-only commands follow the same pattern. Refs #533, #422.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `keep list` can now display vault keys through a running `keep serve` daemon.
  * Added a secure, read-only inspection connection for querying key metadata without interrupting the daemon.
* **Bug Fixes**
  * Improved vault-lock errors with clearer guidance when a vault is already open.
  * Read-only listing no longer fails because the daemon holds the vault lock.
* **Tests**
  * Added coverage for listing keys while the daemon is running and for inspection connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->