### PR TITLE
keep-core: fail closed on RNG health-check failure instead of panicking (keep-jrec)

### DIFF
--- a/keep-cli/src/commands/serve.rs
+++ b/keep-cli/src/commands/serve.rs
@@ -131,7 +131,7 @@ pub fn cmd_serve(
             let net_signer = NetworkFrostSigner::with_shared_node(group_pubkey, node);
             out.success("Connected to FROST network");
 
-            let transport_key: [u8; 32] = keep_core::crypto::random_bytes();
+            let transport_key: [u8; 32] = keep_core::crypto::try_random_bytes()?;
 
             let mut server = Server::new_network_frost_with_config(
                 net_signer,
@@ -244,7 +244,7 @@ pub fn cmd_serve(
             });
 
             let mut server = if let Some(frost) = frost_signer {
-                let transport_key: [u8; 32] = keep_core::crypto::random_bytes();
+                let transport_key: [u8; 32] = keep_core::crypto::try_random_bytes()?;
                 Server::new_with_config(
                     Arc::new(Mutex::new(Keyring::new())),
                     Some(frost),
@@ -277,7 +277,7 @@ pub fn cmd_serve(
 
     let (bunker_url, npub, keyring_for_tui, transport_key_for_tui) = rt.block_on(async {
         if let Some(ref frost) = frost_signer {
-            let transport_key: [u8; 32] = keep_core::crypto::random_bytes();
+            let transport_key: [u8; 32] = keep_core::crypto::try_random_bytes()?;
             let server =
                 Server::new_frost(frost.clone(), transport_key, &[relay.to_string()], None).await?;
             Ok::<_, KeepError>((

--- a/keep-core/src/entropy.rs
+++ b/keep-core/src/entropy.rs
@@ -212,7 +212,11 @@ pub fn try_random_bytes<const N: usize>() -> Result<[u8; N], EntropyHealthError>
 /// For larger requests, generates multiple 32-byte blocks with unique counters.
 ///
 /// # Panics
-/// Panics if the RNG health check fails (use `try_random_bytes` to handle errors).
+/// Panics if the RNG health check fails. **Production code MUST use
+/// [`try_random_bytes`] and propagate the error instead** — a CSPRNG failure is a
+/// fail-closed condition, not a crash. This panicking convenience is for tests,
+/// benchmarks, and non-fallible contexts only (#jrec: all production callers were
+/// migrated to `try_random_bytes`).
 pub fn random_bytes<const N: usize>() -> [u8; N] {
     try_random_bytes().expect("RNG health check failed: constant or zero output detected")
 }

--- a/keep-core/src/frost/coordinator.rs
+++ b/keep-core/src/frost/coordinator.rs
@@ -40,17 +40,18 @@ pub struct Coordinator {
 }
 
 impl Coordinator {
-    /// Create a new signing coordinator.
-    pub fn new(message: Vec<u8>, threshold: u16) -> Self {
-        Self {
-            session_id: crate::crypto::random_bytes(),
+    /// Create a new signing coordinator. Returns `Err` (rather than panicking) if
+    /// the CSPRNG health check fails.
+    pub fn new(message: Vec<u8>, threshold: u16) -> Result<Self> {
+        Ok(Self {
+            session_id: crate::crypto::try_random_bytes()?,
             message,
             threshold,
             commitments: BTreeMap::new(),
             signature_shares: BTreeMap::new(),
             our_identifier: None,
             our_nonces: None,
-        }
+        })
     }
 
     /// The session ID.
@@ -215,7 +216,7 @@ mod tests {
         let (shares, _) = dealer.generate("test").unwrap();
 
         let message = b"test message".to_vec();
-        let mut coord = Coordinator::new(message, 2);
+        let mut coord = Coordinator::new(message, 2).unwrap();
 
         let _msg1 = coord.add_local_share(&shares[0]).unwrap();
 

--- a/keep-core/src/frost/signing.rs
+++ b/keep-core/src/frost/signing.rs
@@ -57,11 +57,12 @@ pub struct SigningSession {
 }
 
 impl SigningSession {
-    /// Create a new signing session.
-    pub fn new(message: Vec<u8>, threshold: u16) -> Self {
-        let session_id = Self::compute_session_id(&message);
+    /// Create a new signing session. Returns `Err` (rather than panicking) if the
+    /// CSPRNG health check fails, so a broken RNG cannot crash the caller.
+    pub fn new(message: Vec<u8>, threshold: u16) -> Result<Self> {
+        let session_id = Self::compute_session_id(&message)?;
 
-        Self {
+        Ok(Self {
             session_id,
             message,
             threshold,
@@ -70,19 +71,19 @@ impl SigningSession {
             signature_shares: BTreeMap::new(),
             our_nonces: None,
             signature: None,
-        }
+        })
     }
 
-    fn compute_session_id(message: &[u8]) -> [u8; 32] {
+    fn compute_session_id(message: &[u8]) -> Result<[u8; 32]> {
         let timestamp = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
-        let random: [u8; 16] = crypto::random_bytes();
+        let random: [u8; 16] = crypto::try_random_bytes()?;
 
         let mut preimage = Vec::with_capacity(message.len() + 24);
         preimage.extend_from_slice(message);
         preimage.extend_from_slice(&timestamp.to_le_bytes());
         preimage.extend_from_slice(&random);
 
-        crypto::blake2b_256(&preimage)
+        Ok(crypto::blake2b_256(&preimage))
     }
 
     /// The session ID.
@@ -324,8 +325,8 @@ mod tests {
         let kp0 = shares[0].key_package().unwrap();
         let kp1 = shares[1].key_package().unwrap();
 
-        let mut session0 = SigningSession::new(message.clone(), 2);
-        let mut session1 = SigningSession::new(message.clone(), 2);
+        let mut session0 = SigningSession::new(message.clone(), 2).unwrap();
+        let mut session1 = SigningSession::new(message.clone(), 2).unwrap();
         session1.session_id = session0.session_id;
 
         let commit0 = session0.generate_commitment(&kp0).unwrap();
@@ -363,7 +364,7 @@ mod tests {
         let message = b"test message".to_vec();
         let kp = shares[0].key_package().unwrap();
 
-        let mut session = SigningSession::new(message, 2);
+        let mut session = SigningSession::new(message, 2).unwrap();
         let _ = session.generate_commitment(&kp).unwrap();
 
         let result = session.generate_commitment(&kp);

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -2177,7 +2177,7 @@ mod tests {
         let message = b"test".to_vec();
         let kp0 = shares[0].key_package().unwrap();
 
-        let mut session = SigningSession::new(message, 2);
+        let mut session = SigningSession::new(message, 2).unwrap();
         session.generate_commitment(&kp0).unwrap();
 
         assert_eq!(session.commitments_needed(), 1);


### PR DESCRIPTION
`entropy::random_bytes()` calls `.expect()` and panics if the CSPRNG health check fails. In safety-critical code a crypto RNG failure should return `Result`, not crash. The fallible `try_random_bytes()` already exists; this migrates the production callers to it.

- **serve.rs** (3 NIP-46 transport keys): now `try_random_bytes()?`, fail-closed in their `Result` contexts.
- **`SigningSession::new`** and **`Coordinator::new`** (public constructors, currently test-only-called but part of the public API): now return `Result`, so a downstream caller can't hit the panic either. Their `compute_session_id`/session-id randomness uses `try_random_bytes`. Test callers updated.
- The panicking `random_bytes()` remains for tests/benchmarks/non-fallible contexts, with a doc note directing production code to `try_random_bytes`.

359 keep-core tests pass; clippy + fmt clean. Closes keep-jrec.