### PR TITLE
keep-cli: gate the inspect socket behind cfg(unix) so Windows builds

### DIFF
--- a/keep-cli/src/ipc.rs
+++ b/keep-cli/src/ipc.rs
@@ -33,10 +33,13 @@ use keep_core::keyring::Keyring;
 const SOCKET_NAME: &str = "keep.sock";
 /// Upper bound on a request/response line, a cheap guard against a runaway or
 /// hostile (same-user) peer streaming bytes without a newline.
+#[cfg(unix)]
 const MAX_REQUEST_BYTES: u64 = 8 * 1024;
 /// Drop a connection whose request does not arrive promptly (slowloris guard).
+#[cfg(unix)]
 const READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 /// Cap on concurrent in-flight connections, so a burst cannot pile up tasks/FDs.
+#[cfg(unix)]
 const MAX_CONNECTIONS: usize = 32;
 
 /// Path of the inspect socket for a vault.
@@ -44,6 +47,7 @@ pub(crate) fn inspect_socket_path(vault: &Path) -> PathBuf {
     vault.join(SOCKET_NAME)
 }
 
+#[cfg(unix)]
 #[derive(Serialize, Deserialize)]
 struct InspectRequest {
     cmd: String,
@@ -57,6 +61,7 @@ pub(crate) struct KeyInfo {
     pub npub: String,
 }
 
+#[cfg(unix)]
 #[derive(Serialize, Deserialize, Default)]
 struct InspectResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -67,6 +72,7 @@ struct InspectResponse {
 
 /// Snapshot the keyring's non-secret key metadata (name, kind, npub). Never
 /// touches secret material.
+#[cfg(unix)]
 fn list_keys(keyring: &Keyring) -> Vec<KeyInfo> {
     keyring
         .list()
@@ -81,6 +87,7 @@ fn list_keys(keyring: &Keyring) -> Vec<KeyInfo> {
 /// Serve the inspect socket for `vault`, answering read-only requests from the
 /// shared `keyring`, until the task is dropped/aborted. Binds `0600` and clears
 /// any stale socket first. Returns only on a bind error.
+#[cfg(unix)]
 pub(crate) async fn serve_inspect_socket(
     vault: &Path,
     keyring: Arc<Mutex<Keyring>>,
@@ -112,6 +119,7 @@ pub(crate) async fn serve_inspect_socket(
     Ok(())
 }
 
+#[cfg(unix)]
 async fn handle_conn(
     mut stream: tokio::net::UnixStream,
     keyring: Arc<Mutex<Keyring>>,
@@ -160,6 +168,7 @@ async fn handle_conn(
 
 /// Ask a running daemon for its key list over the inspect socket. Used by
 /// `keep list` when `Keep::open` reports the vault is already open.
+#[cfg(unix)]
 pub(crate) fn query_list(vault: &Path) -> Result<Vec<KeyInfo>> {
     use std::io::{BufRead, BufReader, Write};
     use std::time::Duration;
@@ -198,7 +207,28 @@ pub(crate) fn query_list(vault: &Path) -> Result<Vec<KeyInfo>> {
     Ok(response.keys.unwrap_or_default())
 }
 
-#[cfg(test)]
+/// Non-Unix stub: the inspect socket is a Unix domain socket, so there is
+/// nothing to serve. The daemon still runs; read-only commands fall back to
+/// opening the vault directly.
+#[cfg(not(unix))]
+pub(crate) async fn serve_inspect_socket(
+    _vault: &Path,
+    _keyring: Arc<Mutex<Keyring>>,
+) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// Non-Unix stub: no inspect socket exists (see [`serve_inspect_socket`]), so
+/// there is no daemon to query. `inspect_socket_path(..).exists()` is always
+/// false here, so this is never reached in practice.
+#[cfg(not(unix))]
+pub(crate) fn query_list(_vault: &Path) -> Result<Vec<KeyInfo>> {
+    Err(KeepError::Runtime(
+        "the inspect socket is only available on Unix".into(),
+    ))
+}
+
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use keep_core::keys::KeyType;


### PR DESCRIPTION
## Summary

The inspect socket added in #772 (#533) uses a Unix domain socket (`tokio::net::UnixListener`/`UnixStream`, `std::os::unix::net::UnixStream`, and `PermissionsExt::from_mode`) without a platform gate, so `cargo build` fails to compile on Windows. The `build-windows` job runs only on push to main (not on PRs), so this landed on main unnoticed and has been red since #772.

## Fix

Gate the Unix-socket implementation (`serve_inspect_socket`, `handle_conn`, `list_keys`, `query_list`, the request/response types, and their constants) behind `#[cfg(unix)]`, and provide `#[cfg(not(unix))]` stubs:

- `serve_inspect_socket` returns `Ok(())` (nothing to serve; the daemon still runs).
- `query_list` returns an error; `inspect_socket_path(..).exists()` is always false on non-Unix, so read-only commands fall back to opening the vault directly.

`inspect_socket_path` and `KeyInfo` stay cross-platform. Unix behavior is unchanged.

## Testing

- `cargo check -p keep-cli --target x86_64-pc-windows-gnu` now compiles (previously 5 errors).
- `cargo test -p keep-cli --bins ipc::` passes on Unix (2 tests); `cargo clippy -p keep-cli --all-targets` and `cargo fmt` clean.

Note: `build-windows` does not run on PRs, so it will only exercise this on the post-merge main run; the fix was verified locally against the `x86_64-pc-windows-gnu` target CI uses.
