### PR TITLE
keep-mobile: export nip55_signable_event_kind for single-sourced decision keys

### DIFF
--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -1036,6 +1036,17 @@ pub(crate) fn signable_event_kind_from_json(event_json: &str) -> Option<u16> {
     signable_event_kind(&event)
 }
 
+/// The signable event kind for a `sign_event` request body, exposed to the
+/// platform layer so it can key its decision inputs (velocity bucket, stored
+/// permission lookup, relay scope) by the SAME kind the signing decision derives
+/// internally. Using this instead of a platform-native JSON parser removes any
+/// parser-differential drift between the lookup key and the decision. `None` for
+/// a missing, non-numeric, or out-of-range (`> u16::MAX`) kind.
+#[uniffi::export]
+pub fn nip55_signable_event_kind(event_json: String) -> Option<u32> {
+    signable_event_kind_from_json(&event_json).map(u32::from)
+}
+
 /// Build the `keep_frost_net::NostrEventPayload` structured wire format from
 /// the sign-event request's JSON body so the co-signers can recompute the
 /// event id (#529). Same canonical field extraction as
@@ -1110,6 +1121,20 @@ mod tests {
         assert_eq!(signable_event_kind_from_json(r#"{"kind":-1}"#), None);
         assert_eq!(signable_event_kind_from_json(r#"{"kind":65536}"#), None); // > u16::MAX
         assert_eq!(signable_event_kind_from_json("not json"), None);
+    }
+
+    #[test]
+    fn exported_signable_kind_matches_internal() {
+        assert_eq!(
+            nip55_signable_event_kind(r#"{"kind":22242}"#.into()),
+            Some(22242)
+        );
+        assert_eq!(
+            nip55_signable_event_kind(r#"{"kind":1,"kind":4}"#.into()),
+            Some(4)
+        );
+        assert_eq!(nip55_signable_event_kind(r#"{"kind":65536}"#.into()), None);
+        assert_eq!(nip55_signable_event_kind("not json".into()), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Exports `nip55_signable_event_kind(event_json) -> Option<u32>` from keep-mobile so the platform layer can key its NIP-55 decision inputs (velocity bucket, stored-permission lookup, relay scope) by the same serde-derived kind that `evaluate_nip55_request` derives internally from the signed bytes.

## Why

A security review of the keep-android NIP-55 collapse noted a latent defense-in-depth gap: the Android layer keyed the candidate lookup and relay scope by its own JSON parser while the decision derived the kind via serde. It is not exploitable today (serde is the stricter parser, so any divergence fails closed to `invalid_event_kind`), but the lookup key and the decision key could drift in future. Exposing the one canonical kind function lets the caller single-source it, so they cannot diverge.

The function wraps the existing internal `signable_event_kind_from_json` (a numeric `kind` bounded to `u16`); it is the same logic the signer uses for the event id, so duplicate-key and coercion handling match.

## Testing

- `cargo test -p keep-mobile` (new `exported_signable_kind_matches_internal` plus the existing signable-kind tests pass), `cargo clippy` and `cargo fmt` clean.
