### PR TITLE
keep-mobile: add export activity types to SigningRequestType

### DIFF
--- a/keep-mobile/src/audit.rs
+++ b/keep-mobile/src/audit.rs
@@ -357,6 +357,8 @@ pub enum SigningRequestType {
     Nip44Decrypt = 6,
     Disconnect = 7,
     KillSwitch = 8,
+    ExportNcryptsec = 9,
+    ExportShare = 10,
 }
 
 impl std::fmt::Display for SigningRequestType {
@@ -371,6 +373,8 @@ impl std::fmt::Display for SigningRequestType {
             Self::Nip44Decrypt => write!(f, "nip44_decrypt"),
             Self::Disconnect => write!(f, "disconnect"),
             Self::KillSwitch => write!(f, "kill_switch"),
+            Self::ExportNcryptsec => write!(f, "export_ncryptsec"),
+            Self::ExportShare => write!(f, "export_share"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds `ExportNcryptsec` and `ExportShare` variants to `SigningRequestType` so self-initiated key-management events can be recorded and rendered as distinct activity types in the tamper-evident activity log, instead of being mislabeled as a signing request.

`SigningRequestType` already models non-signing activities (`Connect`, `Disconnect`, `KillSwitch`), so it is the activity-type enum for the audit/history surface; these two variants extend it for key export.

This is the keep-mobile half of auditing private-key exports; the keep-android side (recording the events and rendering the new types) consumes these variants.

## Changes

- Two enum variants (discriminants 9, 10) plus their `Display` snake-case strings (`export_ncryptsec`, `export_share`). Serde (de)serialization is name-based and picks them up automatically.

## Testing

- `cargo test -p keep-mobile` (audit/signing-audit suites pass), `cargo clippy` and `cargo fmt` clean.
