### PR TITLE
keep-mobile: document the non-blocking store_entry contract on audit storage traits

### DIFF
--- a/keep-mobile/src/audit.rs
+++ b/keep-mobile/src/audit.rs
@@ -162,6 +162,20 @@ impl TryFrom<AuditEntry> for AuditEntryExport {
     }
 }
 
+/// Persistence backend for the append-only audit chain, implemented by foreign
+/// (mobile platform) code.
+///
+/// # Contract: `store_entry` must be non-blocking
+///
+/// [`AuditLog::log_event`] holds the chain's `last_hash` mutex across the call to
+/// [`store_entry`](Self::store_entry): the lock must span
+/// compute-previous-hash → store → advance-hash so two concurrent writers cannot
+/// chain onto the same previous hash and fork the log. Releasing the lock earlier
+/// is therefore not an option. As a result `store_entry` implementations MUST be
+/// non-blocking and fast: a single synchronous local write, with no unbounded
+/// I/O, no network, no user prompts/biometrics, and no re-entrancy back into this
+/// `AuditLog` (which would deadlock). A slow or hung `store_entry` stalls every
+/// concurrent audit write (a DoS). The read methods are not called under the lock.
 #[uniffi::export(with_foreign)]
 pub trait AuditStorage: Send + Sync {
     fn store_entry(&self, entry_json: String) -> Result<(), KeepMobileError>;
@@ -508,6 +522,12 @@ impl TryFrom<SigningAuditEntry> for SigningAuditEntryExport {
     }
 }
 
+/// Persistence backend for the signing audit chain (foreign-implemented). Like
+/// [`AuditStorage`], [`store_entry`](Self::store_entry) is called while
+/// [`SigningAuditLog::log_event`] holds the chain lock, so it MUST be non-blocking
+/// and fast (single synchronous local write; no unbounded I/O, network, prompts,
+/// or re-entrancy). A hung `store_entry` stalls every concurrent signing-audit
+/// write.
 #[uniffi::export(with_foreign)]
 pub trait SigningAuditStorage: Send + Sync {
     fn store_entry(&self, entry_json: String) -> Result<(), KeepMobileError>;


### PR DESCRIPTION
## Summary

`AuditLog::log_event` (and `SigningAuditLog::log_event`) holds the chain's `last_hash` mutex across the foreign `store_entry` call. That serialization is inherent to an append-only hash chain: the lock must span compute-previous-hash → store → advance so two concurrent writers cannot chain onto the same previous hash and fork the log. Releasing the lock before the store would reintroduce the fork.

The real requirement is therefore a contract on the foreign implementation: `store_entry` must be non-blocking. This documents that contract on the `AuditStorage` and `SigningAuditStorage` traits so implementers know a slow or hung `store_entry` stalls every concurrent audit write (a DoS) and must avoid unbounded I/O, network, prompts, or re-entrancy.

No behavior change (documentation only).

## Testing

- `cargo build -p keep-mobile`, `cargo clippy`, and `cargo fmt` clean (doc links resolve).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing persistence requirements for audit storage.
  * Clarified that audit entry writes must be fast, non-blocking, local, and free from operations that could stall concurrent audit activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->