### PR TITLE
keep-mobile: add bunker credential rotation to revoke a leaked bunker URL

### DIFF
--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -282,6 +282,51 @@ impl BunkerHandler {
         }
     }
 
+    /// Rotate the bunker credentials: generate a fresh transport secret (new
+    /// bunker pubkey) and connect secret (new URL) and persist them, so any
+    /// previously distributed `bunker://` URL can no longer pair or sign — the
+    /// remedy for a leaked URL. The running bunker is stopped first (the old URL
+    /// stops serving immediately and in-memory grants drop); the caller restarts
+    /// it to obtain and publish the new URL, and existing clients must re-pair.
+    pub fn rotate_bunker_credentials(&self) -> Result<(), KeepMobileError> {
+        // Stop first so the old keys/URL stop serving before we replace them.
+        self.stop_bunker();
+
+        let _guard =
+            self.mobile
+                .bunker_config_lock
+                .lock()
+                .map_err(|_| KeepMobileError::StorageError {
+                    msg: "bunker config lock poisoned".into(),
+                })?;
+
+        let mut stored = crate::persistence::load_bunker_config(
+            &self.mobile.storage,
+            crate::BUNKER_CONFIG_STORAGE_KEY,
+        )?
+        .unwrap_or_default();
+
+        let transport = keep_core::crypto::try_random_bytes::<32>()?;
+        let connect = keep_core::crypto::try_random_bytes::<16>()?;
+        stored.transport_secret = Some(hex::encode(transport));
+        stored.connect_secret = Some(hex::encode(connect));
+
+        crate::persistence::persist_bunker_config(
+            &self.mobile.storage,
+            crate::BUNKER_CONFIG_STORAGE_KEY,
+            &stored,
+        )?;
+
+        // Clear the plaintext hex copies before drop.
+        if let Some(s) = stored.transport_secret.as_mut() {
+            s.zeroize();
+        }
+        if let Some(s) = stored.connect_secret.as_mut() {
+            s.zeroize();
+        }
+        Ok(())
+    }
+
     pub fn get_bunker_url(&self) -> Option<String> {
         self.bunker_url
             .lock()
@@ -752,6 +797,28 @@ mod tests {
         let (transport2, secret2) = load_or_create_bunker_keys(&mobile).unwrap();
         assert_eq!(*transport, *transport2);
         assert_eq!(*secret, *secret2);
+    }
+
+    // Rotating replaces both persisted secrets, so the derived bunker:// URL
+    // changes and any previously leaked URL can no longer pair.
+    #[test]
+    fn rotate_credentials_changes_transport_and_connect_secret() {
+        let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
+        let mobile = Arc::new(KeepMobile::new(Arc::clone(&storage)).unwrap());
+
+        let (transport1, secret1) = load_or_create_bunker_keys(&mobile).unwrap();
+
+        let handler = BunkerHandler::new(Arc::clone(&mobile));
+        handler.rotate_bunker_credentials().unwrap();
+
+        let (transport2, secret2) = load_or_create_bunker_keys(&mobile).unwrap();
+        assert_ne!(*transport1, *transport2, "transport secret must rotate");
+        assert_ne!(
+            secret1.as_str(),
+            secret2.as_str(),
+            "connect secret must rotate"
+        );
+        assert_eq!(transport2.len(), 32);
     }
 
     // A persisted transport secret that is valid 32-byte hex but not a valid

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -188,6 +188,10 @@ pub struct BunkerHandler {
     bunker_url: std::sync::Mutex<Option<String>>,
     shutdown_tx: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
     handler: std::sync::Mutex<Option<Arc<SignerHandler>>>,
+    /// Serializes `do_start_bunker` against `rotate_bunker_credentials` so a
+    /// credential rotation cannot interleave with an in-flight start (which
+    /// would otherwise finish serving the pre-rotation keys).
+    start_rotate_lock: std::sync::Mutex<()>,
 }
 
 impl BunkerHandler {
@@ -210,6 +214,7 @@ impl BunkerHandler {
             bunker_url: std::sync::Mutex::new(None),
             shutdown_tx: std::sync::Mutex::new(None),
             handler: std::sync::Mutex::new(None),
+            start_rotate_lock: std::sync::Mutex::new(()),
         }
     }
 
@@ -285,11 +290,29 @@ impl BunkerHandler {
     /// Rotate the bunker credentials: generate a fresh transport secret (new
     /// bunker pubkey) and connect secret (new URL) and persist them, so any
     /// previously distributed `bunker://` URL can no longer pair or sign — the
-    /// remedy for a leaked URL. The running bunker is stopped first (the old URL
-    /// stops serving immediately and in-memory grants drop); the caller restarts
-    /// it to obtain and publish the new URL, and existing clients must re-pair.
+    /// remedy for a leaked URL. Signals any running bunker to stop (dropping its
+    /// in-memory grants); the caller restarts it to obtain and publish the new
+    /// URL, and existing clients must re-pair.
+    ///
+    /// On `Err`, rotation did NOT happen and the previous (possibly leaked)
+    /// credential is still valid — callers must not report success.
     pub fn rotate_bunker_credentials(&self) -> Result<(), KeepMobileError> {
-        // Stop first so the old keys/URL stop serving before we replace them.
+        // Serialize against `do_start_bunker`: without this a start already past
+        // its status CAS (but not yet holding `shutdown_tx`) would escape the
+        // `stop_bunker` below and finish serving the old keys, silently defeating
+        // the rotation. Holding this for the whole rotate guarantees no start is
+        // mid-flight: any concurrent start either completed (so `shutdown_tx` is
+        // set and `stop_bunker` signals it) or is blocked here and will read the
+        // freshly-persisted secrets when it proceeds.
+        let _start_guard =
+            self.start_rotate_lock
+                .lock()
+                .map_err(|_| KeepMobileError::StorageError {
+                    msg: "bunker start/rotate lock poisoned".into(),
+                })?;
+
+        // Signal the running bunker to stop so its old keys/URL and grants tear
+        // down; server shutdown completes asynchronously in its own task.
         self.stop_bunker();
 
         let _guard =
@@ -306,25 +329,28 @@ impl BunkerHandler {
         )?
         .unwrap_or_default();
 
-        let transport = keep_core::crypto::try_random_bytes::<32>()?;
-        let connect = keep_core::crypto::try_random_bytes::<16>()?;
-        stored.transport_secret = Some(hex::encode(transport));
-        stored.connect_secret = Some(hex::encode(connect));
+        // Zeroize the decrypted plaintext secrets in `stored` on every exit path
+        // (the new secrets on success, the loaded old secrets on any error),
+        // since `StoredBunkerConfig` is not `ZeroizeOnDrop`.
+        let result = (|| {
+            let transport = Zeroizing::new(keep_core::crypto::try_random_bytes::<32>()?);
+            let connect = Zeroizing::new(keep_core::crypto::try_random_bytes::<16>()?);
+            stored.transport_secret = Some(hex::encode(&transport[..]));
+            stored.connect_secret = Some(hex::encode(&connect[..]));
+            crate::persistence::persist_bunker_config(
+                &self.mobile.storage,
+                crate::BUNKER_CONFIG_STORAGE_KEY,
+                &stored,
+            )
+        })();
 
-        crate::persistence::persist_bunker_config(
-            &self.mobile.storage,
-            crate::BUNKER_CONFIG_STORAGE_KEY,
-            &stored,
-        )?;
-
-        // Clear the plaintext hex copies before drop.
         if let Some(s) = stored.transport_secret.as_mut() {
             s.zeroize();
         }
         if let Some(s) = stored.connect_secret.as_mut() {
             s.zeroize();
         }
-        Ok(())
+        result
     }
 
     pub fn get_bunker_url(&self) -> Option<String> {
@@ -475,6 +501,16 @@ impl BunkerHandler {
         for relay in &relays {
             validate_relay_url(relay)?;
         }
+
+        // Held for the whole start so a concurrent `rotate_bunker_credentials`
+        // cannot slip between the status CAS and `shutdown_tx` being set and
+        // leave this start serving keys that rotation meant to revoke.
+        let _start_guard =
+            self.start_rotate_lock
+                .lock()
+                .map_err(|_| KeepMobileError::StorageError {
+                    msg: "bunker start/rotate lock poisoned".into(),
+                })?;
 
         if self
             .status


### PR DESCRIPTION
## Summary

The bunker transport secret (32B, derives the `bunker://` pubkey) and connect secret (16B, embedded in the URL) are persisted and reused across restarts so the URL stays stable for paired clients. The side effect: the `bunker://` URL is a long-lived `SIGN_EVENT` bearer credential with no way to invalidate it, so a single leak (QR photo, clipboard, malicious client) grants indefinite signing.

There was already `revoke_client` / `revoke_all_clients` (drop in-memory grants), but those do not invalidate the URL itself — a leaked URL can still re-pair. This adds the missing remedy.

## Changes

- `BunkerHandler::rotate_bunker_credentials()`: stops the running bunker (old URL/keys stop serving, in-memory grants drop), then generates a fresh transport secret and connect secret (via the fail-closed `try_random_bytes`) and persists them under the bunker-config lock. The next `start_bunker` derives and publishes a new URL; existing clients must re-pair, and any previously leaked URL can no longer pair or sign.

Matches the rotation pattern in reference signers (Amber lets a user generate a new bunker secret). Per-client secrets and the keep-android "Rotate URL" UI are tracked follow-ups.

## Testing

- New test `rotate_credentials_changes_transport_and_connect_secret`: after rotation both persisted secrets differ from the originals (so the derived URL changes).
- `cargo test -p keep-mobile` (nip46 suite green), clippy and fmt clean.

## Security-review follow-ups (addressed)

- **TOCTOU (High) fixed:** a `start_rotate_lock` now serializes `do_start_bunker` against `rotate_bunker_credentials`. Previously a start already past its status CAS but not yet holding `shutdown_tx` could escape rotate's `stop_bunker` and finish serving the pre-rotation keys, silently defeating the revocation. Rotation now holds the lock for its whole duration, so no start can be mid-flight.
- **Zeroization (Low) fixed:** the freshly generated transport/connect byte buffers are wrapped in `Zeroizing`, and the decrypted plaintext hex secrets in the loaded config are zeroized on every exit path (including the error/early-return paths), not just on success.
- Doc corrected: rotation *signals* the running bunker to stop (teardown completes asynchronously); on `Err` rotation did not occur and the old credential is still valid.
