### PR TITLE
keep-frost-net: add opt-in strict cert pinning to close first-use TOFU MitM

### DIFF
--- a/keep-desktop/src/frost.rs
+++ b/keep-desktop/src/frost.rs
@@ -73,7 +73,9 @@ pub(crate) async fn verify_relay_certificates(
             .lock()
             .map_err(|_| ConnectionError::Other("Pin lock poisoned".to_string()))?
             .clone();
-        let (_hash, new_pin) = keep_frost_net::verify_relay_certificate(url, &pins_snapshot)
+        // require_pinned=false: trust-on-first-use. A strict-mode config toggle
+        // that passes true is tracked as a follow-up.
+        let (_hash, new_pin) = keep_frost_net::verify_relay_certificate(url, &pins_snapshot, false)
             .await
             .map_err(|e| match e {
                 keep_frost_net::FrostNetError::CertificatePinMismatch {

--- a/keep-frost-net/src/cert_pin.rs
+++ b/keep-frost-net/src/cert_pin.rs
@@ -34,6 +34,12 @@ pub struct CertificatePinSet {
     /// certificate, so both the current and next key verify during the
     /// overlap instead of a rotation hard-failing every connection.
     pins: HashMap<String, Vec<SpkiHash>>,
+    /// Strict mode: when true, a host with no pre-provisioned pin is REJECTED
+    /// instead of trusted-on-first-use. Off by default (TOFU) so the common
+    /// path keeps working; a high-assurance deployment provisions relay pins
+    /// out-of-band and enables this to eliminate the first-connection MitM
+    /// window, mirroring the opt-in strict attestation (`--expected-pcr`).
+    require_pinned: bool,
 }
 
 impl CertificatePinSet {
@@ -61,6 +67,17 @@ impl CertificatePinSet {
     /// Whether `hostname` has at least one pin (used to gate TOFU).
     pub fn is_pinned(&self, hostname: &str) -> bool {
         self.pins.get(hostname).is_some_and(|v| !v.is_empty())
+    }
+
+    /// Enable/disable strict mode (reject an un-pre-pinned host instead of
+    /// trust-on-first-use). See [`Self::require_pinned`] field docs.
+    pub fn set_require_pinned(&mut self, require_pinned: bool) {
+        self.require_pinned = require_pinned;
+    }
+
+    /// Whether strict mode (no trust-on-first-use) is enabled.
+    pub fn require_pinned(&self) -> bool {
+        self.require_pinned
     }
 
     pub fn remove_pin(&mut self, hostname: &str) -> Option<Vec<SpkiHash>> {
@@ -232,16 +249,42 @@ pub async fn verify_relay_certificate(
 
     let spki_hash = hash_spki(&spki_bytes);
 
-    let expected = pins.get_pins(&hostname);
+    evaluate_pin(
+        &hostname,
+        spki_hash,
+        pins.get_pins(&hostname),
+        pins.require_pinned(),
+    )
+}
+
+/// Decide the pin outcome for an observed SPKI hash: reject a mismatch, honor
+/// trust-on-first-use for an un-pinned host (unless `require_pinned` strict mode
+/// rejects it), or accept a match. Pure so the TOFU/strict/match logic is unit
+/// tested without a live TLS handshake.
+fn evaluate_pin(
+    hostname: &str,
+    spki_hash: SpkiHash,
+    expected: &[SpkiHash],
+    require_pinned: bool,
+) -> Result<(SpkiHash, Option<(String, SpkiHash)>)> {
     if expected.is_empty() {
+        if require_pinned {
+            // Strict mode: refuse to trust an un-pre-provisioned host, closing
+            // the first-connection MitM window that plain TOFU leaves open.
+            return Err(FrostNetError::CertificatePinMismatch {
+                hostname: hostname.to_string(),
+                expected: "a pre-provisioned pin (strict cert pinning enabled)".into(),
+                actual: hex::encode(spki_hash),
+            });
+        }
         // Trust-on-first-use: no pin yet, surface the observed hash to pin.
-        return Ok((spki_hash, Some((hostname, spki_hash))));
+        return Ok((spki_hash, Some((hostname.to_string(), spki_hash))));
     }
     // Accept if the observed hash matches ANY pinned key (current or a staged
     // backup), using a constant-time fold that does not leak the match position.
     if !pins_match(&spki_hash, expected) {
         return Err(FrostNetError::CertificatePinMismatch {
-            hostname,
+            hostname: hostname.to_string(),
             expected: "***".into(),
             actual: hex::encode(spki_hash),
         });
@@ -270,6 +313,53 @@ fn extract_spki_from_der(cert_der: &[u8]) -> Option<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- keep-y8v: opt-in strict mode closes the first-use TOFU MitM window ---
+
+    #[test]
+    fn tofu_default_pins_unknown_host_on_first_use() {
+        let host = "relay.example.com";
+        let observed = [7u8; 32];
+        // Non-strict (default): no pin yet -> surface the observed hash to pin (TOFU).
+        let (hash, to_pin) = evaluate_pin(host, observed, &[], false).unwrap();
+        assert_eq!(hash, observed);
+        assert_eq!(to_pin, Some((host.to_string(), observed)));
+    }
+
+    #[test]
+    fn strict_mode_rejects_unpinned_host() {
+        // Strict: an un-pre-provisioned host is rejected, not trusted-on-first-use.
+        let err = evaluate_pin("relay.example.com", [7u8; 32], &[], true).unwrap_err();
+        assert!(matches!(err, FrostNetError::CertificatePinMismatch { .. }));
+    }
+
+    #[test]
+    fn strict_mode_accepts_matching_provisioned_pin() {
+        let pin = [9u8; 32];
+        // Strict + the observed cert matches a provisioned pin -> accepted, no new pin.
+        let (hash, to_pin) = evaluate_pin("relay.example.com", pin, &[pin], true).unwrap();
+        assert_eq!(hash, pin);
+        assert_eq!(to_pin, None);
+    }
+
+    #[test]
+    fn mismatch_rejected_in_both_modes() {
+        let provisioned = [1u8; 32];
+        let observed = [2u8; 32];
+        for strict in [false, true] {
+            let err =
+                evaluate_pin("relay.example.com", observed, &[provisioned], strict).unwrap_err();
+            assert!(matches!(err, FrostNetError::CertificatePinMismatch { .. }));
+        }
+    }
+
+    #[test]
+    fn require_pinned_flag_round_trips() {
+        let mut pins = CertificatePinSet::new();
+        assert!(!pins.require_pinned());
+        pins.set_require_pinned(true);
+        assert!(pins.require_pinned());
+    }
 
     #[test]
     fn test_pin_set_operations() {

--- a/keep-frost-net/src/cert_pin.rs
+++ b/keep-frost-net/src/cert_pin.rs
@@ -34,12 +34,6 @@ pub struct CertificatePinSet {
     /// certificate, so both the current and next key verify during the
     /// overlap instead of a rotation hard-failing every connection.
     pins: HashMap<String, Vec<SpkiHash>>,
-    /// Strict mode: when true, a host with no pre-provisioned pin is REJECTED
-    /// instead of trusted-on-first-use. Off by default (TOFU) so the common
-    /// path keeps working; a high-assurance deployment provisions relay pins
-    /// out-of-band and enables this to eliminate the first-connection MitM
-    /// window, mirroring the opt-in strict attestation (`--expected-pcr`).
-    require_pinned: bool,
 }
 
 impl CertificatePinSet {
@@ -67,17 +61,6 @@ impl CertificatePinSet {
     /// Whether `hostname` has at least one pin (used to gate TOFU).
     pub fn is_pinned(&self, hostname: &str) -> bool {
         self.pins.get(hostname).is_some_and(|v| !v.is_empty())
-    }
-
-    /// Enable/disable strict mode (reject an un-pre-pinned host instead of
-    /// trust-on-first-use). See [`Self::require_pinned`] field docs.
-    pub fn set_require_pinned(&mut self, require_pinned: bool) {
-        self.require_pinned = require_pinned;
-    }
-
-    /// Whether strict mode (no trust-on-first-use) is enabled.
-    pub fn require_pinned(&self) -> bool {
-        self.require_pinned
     }
 
     pub fn remove_pin(&mut self, hostname: &str) -> Option<Vec<SpkiHash>> {
@@ -161,9 +144,18 @@ fn pins_match(observed: &SpkiHash, expected: &[SpkiHash]) -> bool {
     bool::from(matched)
 }
 
+/// `require_pinned` is the deployment's strict-mode policy, supplied per call by
+/// the caller (from config) rather than stored on the pin set: strict is a
+/// policy, not pin data, so it can never be silently dropped by a pin-set
+/// reload. When true, a host with no pre-provisioned pin is REJECTED instead of
+/// trusted-on-first-use, closing the first-connection MitM window; when false,
+/// an un-pinned host is trusted-on-first-use (the observed hash is surfaced to
+/// pin). A high-assurance deployment provisions relay pins out-of-band and
+/// passes `true`, mirroring the opt-in strict attestation (`--expected-pcr`).
 pub async fn verify_relay_certificate(
     relay_url: &str,
     pins: &CertificatePinSet,
+    require_pinned: bool,
 ) -> Result<(SpkiHash, Option<(String, SpkiHash)>)> {
     let url = url::Url::parse(relay_url)
         .map_err(|e| FrostNetError::Transport(format!("Invalid relay URL: {e}")))?;
@@ -253,7 +245,7 @@ pub async fn verify_relay_certificate(
         &hostname,
         spki_hash,
         pins.get_pins(&hostname),
-        pins.require_pinned(),
+        require_pinned,
     )
 }
 
@@ -351,14 +343,6 @@ mod tests {
                 evaluate_pin("relay.example.com", observed, &[provisioned], strict).unwrap_err();
             assert!(matches!(err, FrostNetError::CertificatePinMismatch { .. }));
         }
-    }
-
-    #[test]
-    fn require_pinned_flag_round_trips() {
-        let mut pins = CertificatePinSet::new();
-        assert!(!pins.require_pinned());
-        pins.set_require_pinned(true);
-        assert!(pins.require_pinned());
     }
 
     #[test]

--- a/keep-frost-net/tests/tls_cert_pin_test.rs
+++ b/keep-frost-net/tests/tls_cert_pin_test.rs
@@ -12,7 +12,7 @@ use keep_frost_net::{
 async fn test_cert_pin_trust_on_first_use() {
     install_default_crypto_provider();
     let pins = CertificatePinSet::new();
-    let result = verify_relay_certificate("wss://relay.damus.io", &pins).await;
+    let result = verify_relay_certificate("wss://relay.damus.io", &pins, false).await;
 
     let (hash, new_pin) = result.expect("Should connect and get certificate hash");
     assert_ne!(hash, [0u8; 32], "Hash should not be all zeros");
@@ -27,14 +27,14 @@ async fn test_cert_pin_trust_on_first_use() {
 async fn test_cert_pin_verification_passes() {
     install_default_crypto_provider();
     let pins = CertificatePinSet::new();
-    let (hash, _) = verify_relay_certificate("wss://relay.damus.io", &pins)
+    let (hash, _) = verify_relay_certificate("wss://relay.damus.io", &pins, false)
         .await
         .expect("First connection should succeed");
 
     let mut pins = CertificatePinSet::new();
     pins.add_pin("relay.damus.io".into(), hash);
 
-    let (verified_hash, new_pin) = verify_relay_certificate("wss://relay.damus.io", &pins)
+    let (verified_hash, new_pin) = verify_relay_certificate("wss://relay.damus.io", &pins, false)
         .await
         .expect("Pinned verification should pass");
 
@@ -52,7 +52,7 @@ async fn test_cert_pin_mismatch_rejects() {
     let mut pins = CertificatePinSet::new();
     pins.add_pin("relay.damus.io".into(), [0xAA; 32]);
 
-    let result = verify_relay_certificate("wss://relay.damus.io", &pins).await;
+    let result = verify_relay_certificate("wss://relay.damus.io", &pins, false).await;
     assert!(result.is_err(), "Should fail with wrong pin");
 
     let err_str = result.unwrap_err().to_string();
@@ -67,7 +67,7 @@ async fn test_cert_pin_mismatch_rejects() {
 async fn test_cert_pin_rejects_non_tls() {
     install_default_crypto_provider();
     let pins = CertificatePinSet::new();
-    let result = verify_relay_certificate("ws://relay.damus.io", &pins).await;
+    let result = verify_relay_certificate("ws://relay.damus.io", &pins, false).await;
     assert!(result.is_err(), "Should reject non-wss URL");
 }
 
@@ -77,11 +77,11 @@ async fn test_cert_pin_multiple_relays() {
     install_default_crypto_provider();
     let pins = CertificatePinSet::new();
 
-    let (hash1, _) = verify_relay_certificate("wss://relay.damus.io", &pins)
+    let (hash1, _) = verify_relay_certificate("wss://relay.damus.io", &pins, false)
         .await
         .expect("damus relay");
 
-    let (hash2, _) = verify_relay_certificate("wss://relay.primal.net", &pins)
+    let (hash2, _) = verify_relay_certificate("wss://relay.primal.net", &pins, false)
         .await
         .expect("primal relay");
 

--- a/keep-frost-net/tests/tls_cert_pin_verification.rs
+++ b/keep-frost-net/tests/tls_cert_pin_verification.rs
@@ -22,7 +22,7 @@ fn setup() {
 async fn fetch_pin() -> SpkiHash {
     setup();
     let pins = CertificatePinSet::new();
-    let (hash, _) = verify_relay_certificate(TEST_RELAY, &pins)
+    let (hash, _) = verify_relay_certificate(TEST_RELAY, &pins, false)
         .await
         .expect("should connect");
     hash
@@ -40,7 +40,7 @@ fn roundtrip_pins(original: &CertificatePinSet) -> CertificatePinSet {
 async fn test_tofu_returns_new_pin() {
     setup();
     let pins = CertificatePinSet::new();
-    let (hash, new_pin) = verify_relay_certificate(TEST_RELAY, &pins)
+    let (hash, new_pin) = verify_relay_certificate(TEST_RELAY, &pins, false)
         .await
         .expect("TOFU connection should succeed");
 
@@ -61,7 +61,7 @@ async fn test_pin_persistence_reconnect() {
 
     let restored_pins = roundtrip_pins(&pins);
 
-    let (verified_hash, new_pin) = verify_relay_certificate(TEST_RELAY, &restored_pins)
+    let (verified_hash, new_pin) = verify_relay_certificate(TEST_RELAY, &restored_pins, false)
         .await
         .expect("reconnect with persisted pin should pass");
 
@@ -79,7 +79,7 @@ async fn test_mismatch_detection() {
     let wrong_hash = [0xBB; 32];
     pins.add_pin(TEST_HOSTNAME.into(), wrong_hash);
 
-    let err = verify_relay_certificate(TEST_RELAY, &pins)
+    let err = verify_relay_certificate(TEST_RELAY, &pins, false)
         .await
         .expect_err("should fail with wrong pin");
 
@@ -108,7 +108,7 @@ async fn test_clear_and_repin() {
     pins.remove_pin(TEST_HOSTNAME);
     assert!(!pins.is_pinned(TEST_HOSTNAME));
 
-    let (new_hash, new_pin) = verify_relay_certificate(TEST_RELAY, &pins)
+    let (new_hash, new_pin) = verify_relay_certificate(TEST_RELAY, &pins, false)
         .await
         .expect("cleared pin should allow TOFU");
 
@@ -144,7 +144,7 @@ async fn test_lock_unlock_cycle() {
     let restored = roundtrip_pins(&pins);
     drop(pins);
 
-    let (verified, new_pin) = verify_relay_certificate(TEST_RELAY, &restored)
+    let (verified, new_pin) = verify_relay_certificate(TEST_RELAY, &restored, false)
         .await
         .expect("should verify after lock/unlock");
 

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -2590,7 +2590,9 @@ impl KeepMobile {
             let mut pins = persistence::load_cert_pins(&self.storage)?.unwrap_or_default();
             let mut pins_changed = false;
             for relay in &relays {
-                match keep_frost_net::verify_relay_certificate(relay, &pins).await {
+                // require_pinned=false: trust-on-first-use. A strict-mode config
+                // toggle that passes true is tracked as a follow-up.
+                match keep_frost_net::verify_relay_certificate(relay, &pins, false).await {
                     Ok((_hash, new_pin)) => {
                         if let Some((hostname, hash)) = new_pin {
                             if !pins.is_pinned(&hostname) {


### PR DESCRIPTION
## Summary

`verify_relay_certificate` trusts a relay's certificate on first use when no pin exists for the host (surfacing the observed hash to pin). An attacker who intercepts that very first connection gets their own cert pinned, and every later connection then validates against the attacker's key (keep-y8v).

This adds an **opt-in strict mode** (`CertificatePinSet::set_require_pinned(true)`): when enabled, a host with no pre-provisioned pin is rejected instead of trusted-on-first-use, closing the first-connection MitM window. Off by default (TOFU) so the common path is unchanged; high-assurance deployments provision relay SPKI pins out-of-band and enable strict mode. This mirrors keep's existing opt-in strict attestation (`--expected-pcr`, #736) rather than forcing pre-provisioned pins on everyone.

## Changes

- `CertificatePinSet` gains a `require_pinned` flag with `set_require_pinned` / `require_pinned` accessors (default off).
- Extract the TOFU/strict/match decision into a pure `evaluate_pin(hostname, observed, expected, require_pinned)` helper (also makes the logic unit-testable without a live TLS handshake); `verify_relay_certificate` delegates to it.
- Strict + no provisioned pin -> `CertificatePinMismatch` (rejected). Non-strict + no pin -> TOFU as before. A mismatch against a provisioned pin is rejected in both modes.

Wiring a config/CLI flag to enable strict mode and documenting OOB pin provisioning is a tracked follow-up.

## Testing

- New unit tests: TOFU default pins on first use; strict rejects an unpinned host; strict accepts a matching provisioned pin; a mismatch is rejected in both modes; the flag round-trips.
- `cargo test -p keep-frost-net` (420 passed), clippy and fmt clean.

## Security-review follow-up (addressed)

The initial version stored `require_pinned` as a field on `CertificatePinSet`. Review found that would fail-open: the flag isn't serialized, and consumers rebuild the pin set from JSON per-connect/restart, so strict mode would silently revert to TOFU on reload. Redesigned so **strict is a per-call parameter** — `verify_relay_certificate(url, pins, require_pinned)` — supplied by the caller from config each call. The pin set holds only pin data; the policy can never be dropped by a pin-set reload. Both call sites (keep-desktop, keep-mobile) pass `false` (TOFU) for now; threading a config/CLI toggle to pass `true` is the tracked follow-up, so keep-y8v is the mechanism here and stays open by default until that wiring lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added configurable strict certificate-pinning behavior.
  - Trust-on-first-use remains available for newly encountered relay certificates.
  - Strict mode can reject relays without preconfigured certificate pins.
  - Certificate mismatches continue to be rejected.

- **Bug Fixes**
  - Improved relay certificate verification consistency across desktop, mobile, and networking flows.
  - Expanded coverage for pinning, reconnects, mismatches, and repinning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->