### PR TITLE
keep-frost-net: reject placeholder policy_hash at the PSBT-spend boundary

### DIFF
--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -119,14 +119,16 @@ pub trait PersistedDescriptorLookup: Send + Sync {
     }
 
     /// Return the `policy_hash` of the persisted descriptor whose group +
-    /// canonical hash match, if any. Used at the PSBT-spend boundary to refuse
-    /// proposing a spend bound to a placeholder (all-zero) policy_hash, matching
-    /// the CLI spend guard. A descriptor imported before its policy is
-    /// coordinated carries `policy_hash == [0; 32]`, yet its canonical hash is
-    /// non-zero, so the plain all-zero-hash check cannot catch it. `None` (no
-    /// match, or no lookup configured) means "cannot confirm" and is not a
-    /// rejection; an unresolved hash is rejected downstream by responders'
-    /// descriptor_hash verification.
+    /// canonical hash match, if any. Used at both PSBT trust boundaries (the
+    /// proposer's `request_psbt_spend` and the responder's descriptor_hash
+    /// verification) to refuse a spend bound to a placeholder (all-zero)
+    /// policy_hash, matching the CLI spend guard. A descriptor imported before
+    /// its policy is coordinated carries `policy_hash == [0; 32]`, yet its
+    /// canonical hash is non-zero, so the plain all-zero-hash check cannot catch
+    /// it. `None` (no match, no lookup configured, or the vault temporarily
+    /// unreadable) means "cannot confirm" and is not a rejection: the per-caller
+    /// CLI/desktop spend paths keep their own fail-closed guard on the loaded
+    /// descriptor. This projection is defense-in-depth.
     fn policy_hash_for(&self, group: &[u8; 32], hash: &[u8; 32]) -> Option<[u8; 32]> {
         let _ = (group, hash);
         None

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -118,6 +118,20 @@ pub trait PersistedDescriptorLookup: Send + Sync {
         None
     }
 
+    /// Return the `policy_hash` of the persisted descriptor whose group +
+    /// canonical hash match, if any. Used at the PSBT-spend boundary to refuse
+    /// proposing a spend bound to a placeholder (all-zero) policy_hash, matching
+    /// the CLI spend guard. A descriptor imported before its policy is
+    /// coordinated carries `policy_hash == [0; 32]`, yet its canonical hash is
+    /// non-zero, so the plain all-zero-hash check cannot catch it. `None` (no
+    /// match, or no lookup configured) means "cannot confirm" and is not a
+    /// rejection; an unresolved hash is rejected downstream by responders'
+    /// descriptor_hash verification.
+    fn policy_hash_for(&self, group: &[u8; 32], hash: &[u8; 32]) -> Option<[u8; 32]> {
+        let _ = (group, hash);
+        None
+    }
+
     /// Return the largest persisted descriptor version for the given group,
     /// `Ok(None)` if no descriptor exists, or `Err(DescriptorLookupUnavailable)`
     /// if the underlying store could not be queried (e.g. vault locked). Used
@@ -208,6 +222,10 @@ where
 
     fn external_for(&self, group: &[u8; 32], hash: &[u8; 32]) -> Option<String> {
         self.lookup(|d| Some(d.external_descriptor.clone()), group, hash)
+    }
+
+    fn policy_hash_for(&self, group: &[u8; 32], hash: &[u8; 32]) -> Option<[u8; 32]> {
+        self.lookup(|d| Some(d.policy_hash), group, hash)
     }
 
     fn latest_version_for(

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -816,6 +816,17 @@ impl KfpNode {
     }
 
     fn verify_descriptor_hash_against_stored(&self, descriptor_hash: &[u8; 32]) -> Result<()> {
+        // Responder-side half of the placeholder-policy invariant: refuse to sign
+        // a spend keyed on a persisted descriptor whose policy_hash is the
+        // placeholder, so the guard enforced when proposing also holds at the
+        // boundary where this node actually signs. Fails open only when this
+        // node's own lookup cannot resolve the hash (see the guard's docs).
+        reject_placeholder_policy_spend(
+            &self.group_pubkey,
+            descriptor_hash,
+            self.descriptor_lookup.as_deref(),
+        )?;
+
         let (in_memory_match, saw_any_finalized) = {
             let sessions = self.descriptor_sessions.read();
             let mut saw_any_finalized = false;
@@ -827,6 +838,12 @@ impl KfpNode {
                 let Some(finalized) = session.descriptor() else {
                     continue;
                 };
+                // A finalized descriptor from a completed coordination carries a
+                // real policy_hash; treat a placeholder as no match so an
+                // uncoordinated policy can never validate a spend.
+                if finalized.policy_hash == [0u8; 32] {
+                    continue;
+                }
                 saw_any_finalized = true;
                 let expected = keep_core::wallet::canonical_descriptor_hash(
                     &finalized.external,
@@ -1714,18 +1731,25 @@ fn decide_descriptor_hash_verification(
     }
 }
 
-/// Proposer-side guard: refuse to propose a spend bound to a descriptor whose
-/// `policy_hash` is the placeholder all-zero value.
+/// Refuse a spend bound to a descriptor whose `policy_hash` is the placeholder
+/// all-zero value. Enforced at both trust boundaries: the proposer side
+/// (`request_psbt_spend`) and the responder side
+/// (`verify_descriptor_hash_against_stored`), so the invariant holds regardless
+/// of who initiates the coordination.
 ///
 /// A descriptor imported before its wallet policy is coordinated carries
 /// `policy_hash == [0; 32]`, yet its canonical `descriptor_hash` is non-zero, so
-/// the plain all-zero-hash check does not catch it. Binding a spend to such a
-/// descriptor would leave the coordination cryptographically tied to no policy.
-/// The CLI spend path rejects this; enforcing it here closes the same gap for
-/// desktop/mobile/third-party callers that reach `KfpNode::request_psbt_spend`
-/// directly. Only enforced when the descriptor resolves via the lookup; an
-/// unresolved hash is rejected downstream by responders' descriptor_hash
-/// verification, so a missing lookup is not treated as a rejection here.
+/// the plain all-zero-hash check does not catch it, and a responder recomputes
+/// the identical hash (policy_hash is committed into it) and would otherwise
+/// accept. Binding a spend to such a descriptor would leave the coordination
+/// cryptographically tied to no policy.
+///
+/// Only fires when the descriptor positively resolves via *this node's* lookup
+/// to an all-zero policy_hash. A hash that does not resolve (no lookup, no
+/// match, or the vault temporarily unreadable) is not a rejection here; the
+/// per-caller CLI/desktop spend guards fail closed on their own loaded
+/// descriptor, and the opposite boundary applies the same check. Defense in
+/// depth, not the sole guard.
 fn reject_placeholder_policy_spend(
     group: &[u8; 32],
     descriptor_hash: &[u8; 32],
@@ -1734,7 +1758,7 @@ fn reject_placeholder_policy_spend(
     if let Some(lookup) = lookup {
         if lookup.policy_hash_for(group, descriptor_hash) == Some([0u8; 32]) {
             return Err(FrostNetError::Session(
-                "descriptor has placeholder (all-zero) policy_hash; coordinate the wallet policy before proposing a spend".into(),
+                "descriptor has placeholder (all-zero) policy_hash; coordinate the wallet policy before spending".into(),
             ));
         }
     }

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -388,6 +388,12 @@ impl KfpNode {
             ));
         }
 
+        reject_placeholder_policy_spend(
+            &self.group_pubkey,
+            &descriptor_hash,
+            self.descriptor_lookup.as_deref(),
+        )?;
+
         let our_index = self.share.metadata.identifier;
         self.check_psbt_proposer_authorized(our_index)?;
         self.check_psbt_proposer_session_budget(&self.keys.public_key())?;
@@ -1708,6 +1714,33 @@ fn decide_descriptor_hash_verification(
     }
 }
 
+/// Proposer-side guard: refuse to propose a spend bound to a descriptor whose
+/// `policy_hash` is the placeholder all-zero value.
+///
+/// A descriptor imported before its wallet policy is coordinated carries
+/// `policy_hash == [0; 32]`, yet its canonical `descriptor_hash` is non-zero, so
+/// the plain all-zero-hash check does not catch it. Binding a spend to such a
+/// descriptor would leave the coordination cryptographically tied to no policy.
+/// The CLI spend path rejects this; enforcing it here closes the same gap for
+/// desktop/mobile/third-party callers that reach `KfpNode::request_psbt_spend`
+/// directly. Only enforced when the descriptor resolves via the lookup; an
+/// unresolved hash is rejected downstream by responders' descriptor_hash
+/// verification, so a missing lookup is not treated as a rejection here.
+fn reject_placeholder_policy_spend(
+    group: &[u8; 32],
+    descriptor_hash: &[u8; 32],
+    lookup: Option<&dyn super::PersistedDescriptorLookup>,
+) -> Result<()> {
+    if let Some(lookup) = lookup {
+        if lookup.policy_hash_for(group, descriptor_hash) == Some([0u8; 32]) {
+            return Err(FrostNetError::Session(
+                "descriptor has placeholder (all-zero) policy_hash; coordinate the wallet policy before proposing a spend".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod descriptor_lookup_tests {
     use super::*;
@@ -1779,6 +1812,53 @@ mod descriptor_lookup_tests {
         let result_no_lookup =
             decide_descriptor_hash_verification(false, true, &group, &hash, None);
         assert!(result_no_lookup.is_err());
+    }
+
+    struct PolicyMock {
+        policy_hash: Option<[u8; 32]>,
+    }
+
+    impl PersistedDescriptorLookup for PolicyMock {
+        fn find_by_hash(&self, _group: &[u8; 32], _hash: &[u8; 32]) -> bool {
+            self.policy_hash.is_some()
+        }
+        fn policy_hash_for(&self, _group: &[u8; 32], _hash: &[u8; 32]) -> Option<[u8; 32]> {
+            self.policy_hash
+        }
+        fn latest_version_for(
+            &self,
+            _group: &[u8; 32],
+        ) -> std::result::Result<Option<u32>, crate::node::DescriptorLookupUnavailable> {
+            Ok(None)
+        }
+    }
+
+    #[test]
+    fn placeholder_policy_hash_spend_is_rejected() {
+        let (group, hash) = fixture();
+        let lookup = PolicyMock {
+            policy_hash: Some([0u8; 32]),
+        };
+        assert!(reject_placeholder_policy_spend(&group, &hash, Some(&lookup)).is_err());
+    }
+
+    #[test]
+    fn coordinated_policy_hash_spend_is_allowed() {
+        let (group, hash) = fixture();
+        let lookup = PolicyMock {
+            policy_hash: Some([0xABu8; 32]),
+        };
+        assert!(reject_placeholder_policy_spend(&group, &hash, Some(&lookup)).is_ok());
+    }
+
+    #[test]
+    fn unresolved_or_absent_lookup_does_not_reject() {
+        let (group, hash) = fixture();
+        // No lookup configured: not our boundary to reject (responders verify).
+        assert!(reject_placeholder_policy_spend(&group, &hash, None).is_ok());
+        // Lookup present but the hash resolves to no descriptor.
+        let lookup = PolicyMock { policy_hash: None };
+        assert!(reject_placeholder_policy_spend(&group, &hash, Some(&lookup)).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`KfpNode::request_psbt_spend` did not enforce that the proposed spend is bound to a coordinated wallet policy. A descriptor imported before its policy is coordinated is persisted with a placeholder all-zero `policy_hash` (its canonical `descriptor_hash` is still non-zero, so the existing all-zero-hash guard does not catch it). The CLI spend path already rejects this, but desktop, mobile, and third-party callers reaching the library entry point directly could initiate a PSBT coordination cryptographically bound only to the placeholder policy, weakening the binding between the spend and the wallet policy.

## Change

- Add `PersistedDescriptorLookup::policy_hash_for(group, hash)` (default `None`; implemented on `KeepDescriptorLookup`), mirroring the existing `external_for` / `network_for` field projections.
- In `request_psbt_spend`, refuse to propose when the descriptor resolves via the lookup to an all-zero `policy_hash`, matching the CLI spend guard at the library boundary.
- The check is fail-safe: a hash that does not resolve (or no lookup configured) is not treated as a rejection here, since responders independently verify `descriptor_hash` against their stored finalized descriptors.

## Tests

Added unit tests covering the placeholder rejection, a coordinated (non-zero) policy_hash acceptance, and the absent/unresolved-lookup pass-through. Full `keep-frost-net` lib suite green (422 tests).

Closes #787.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for checking a persisted descriptor’s policy information during spend coordination.
  - Spend requests can now verify that the selected descriptor has a coordinated wallet policy.

- **Bug Fixes**
  - Prevented spend proposals from proceeding when the descriptor uses an uninitialized placeholder policy.
  - Requests continue to work when policy information is unavailable or no matching descriptor is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->