### PR TITLE
docs: document the relay trust model

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -44,6 +44,17 @@ This means:
 - **Share number leaks operational structure.** A peer-discovered announce reveals which share index a device claims. Pair this with relay metadata and an attacker can map your topology even without breaking any crypto. Run announces on a dedicated FROST relay (`--frost-relay`) when that matters.
 - **Rotate shares with `keep frost refresh` after suspected compromise of any device, even if the group pubkey doesn't need to change.** Refresh invalidates the old share bundle without producing a new group identity.
 
+## Relay Trust
+
+Keep treats the Nostr relay as untrusted transport, not a trusted party. Coordination security does not depend on the relay behaving honestly:
+
+- **Payloads are end-to-end encrypted.** Every FROST/OPRF coordination message is NIP-44 (v2) encrypted to the recipient's key before it reaches a relay, so a relay (or anyone who intercepts its TLS connection) sees only ciphertext, never share material, nonces, or OPRF evaluations.
+- **Messages are authenticated.** Coordination events are Nostr-signed and re-verified by peers, so a relay cannot forge or tamper with a message; a substituted or replayed event is rejected on receipt.
+- **The client authenticates to the relay (NIP-42).** Keep responds to relay `AUTH` challenges automatically, so a relay that requires authentication (kind 22242) admits only your quorum members.
+- **What a relay (or a TLS man-in-the-middle) can still do** is limited to metadata analysis (which keys talk, and when) and availability attacks (dropping, delaying, or censoring messages). It cannot read or forge coordination.
+- **For high assurance, run your own relay.** Self-hosting a relay (privkey's [`wisp`](https://github.com/privkeyio/wisp) is designed for this) and pointing your quorum at it removes the third-party relay from the trust and metadata surface entirely; binding it to a private, authenticated network (e.g. a WireGuard mesh) also removes reliance on relay TLS. This is the model the keep-node appliance uses.
+- **Certificate pinning is available as opt-in defense-in-depth** for the metadata/availability surface when coordinating over an external `wss://` relay (`verify_relay_certificate`, `PinningServerCertVerifier`). It hardens against a relay-TLS man-in-the-middle observing metadata or impersonating the relay endpoint; it is not required for confidentiality or integrity, which the two properties above already provide.
+
 ## Reporting Vulnerabilities
 
 If you discover a security vulnerability, please report it privately via [GitHub Security Advisories](https://github.com/privkeyio/keep/security/advisories/new) rather than opening a public issue.


### PR DESCRIPTION
Documents Keep's relay trust model in `docs/SECURITY.md`: the Nostr relay is untrusted transport, with confidentiality from NIP-44 end-to-end encryption, authenticity from Nostr signatures, access control from NIP-42 relay auth (which keep's client performs automatically), and a recommendation to self-host a relay (wisp) bound to a private network for high assurance.

This records the conclusion from analyzing #784: because coordination payloads are already E2E encrypted and authenticated, a relay TLS man-in-the-middle is limited to metadata analysis and availability attacks, not confidentiality or integrity. Certificate pinning (`PinningServerCertVerifier`, added in #805) is documented as opt-in defense-in-depth for that residual metadata/availability surface rather than a required control.

Docs-only; no code change.