### PR TITLE
keep-mobile: expose backup cert-pin staging and per-pin removal

### DIFF
--- a/keep-frost-net/src/cert_pin.rs
+++ b/keep-frost-net/src/cert_pin.rs
@@ -67,6 +67,24 @@ impl CertificatePinSet {
         self.pins.remove(hostname)
     }
 
+    /// Remove a single `hash` from `hostname`, leaving the host's other pins in
+    /// place (unlike [`remove_pin`], which drops the whole host). If it was the
+    /// last pin, the host entry is dropped so [`is_pinned`] reports it unpinned.
+    /// Returns whether a pin was removed. Used to retire a rotated-out key while
+    /// keeping the current one active.
+    pub fn remove_specific_pin(&mut self, hostname: &str, hash: &SpkiHash) -> bool {
+        let Some(entry) = self.pins.get_mut(hostname) else {
+            return false;
+        };
+        let before = entry.len();
+        entry.retain(|h| h != hash);
+        let removed = entry.len() != before;
+        if entry.is_empty() {
+            self.pins.remove(hostname);
+        }
+        removed
+    }
+
     pub fn pins(&self) -> &HashMap<String, Vec<SpkiHash>> {
         &self.pins
     }
@@ -374,6 +392,29 @@ mod tests {
         assert_eq!(pins.get_pins("relay.example.com"), &[current, backup]);
         assert!(pins.get_pins("other.example.com").is_empty());
         assert!(!pins.is_pinned("other.example.com"));
+    }
+
+    #[test]
+    fn test_remove_specific_pin_retires_one_key() {
+        let mut pins = CertificatePinSet::new();
+        let current = [1u8; 32];
+        let backup = [2u8; 32];
+        pins.add_pin("relay.example.com".into(), current);
+        pins.add_pin("relay.example.com".into(), backup);
+
+        // Retire the rotated-out key; the host stays pinned on the remaining one.
+        assert!(pins.remove_specific_pin("relay.example.com", &current));
+        assert_eq!(pins.get_pins("relay.example.com"), &[backup]);
+        assert!(pins.is_pinned("relay.example.com"));
+
+        // Removing an absent pin is a no-op returning false.
+        assert!(!pins.remove_specific_pin("relay.example.com", &current));
+        assert!(!pins.remove_specific_pin("nohost.example.com", &backup));
+
+        // Removing the last pin drops the host so it reads as unpinned.
+        assert!(pins.remove_specific_pin("relay.example.com", &backup));
+        assert!(!pins.is_pinned("relay.example.com"));
+        assert!(pins.get_pins("relay.example.com").is_empty());
     }
 
     #[test]

--- a/keep-frost-net/src/cert_pin.rs
+++ b/keep-frost-net/src/cert_pin.rs
@@ -162,6 +162,24 @@ pub(crate) fn pins_match(observed: &SpkiHash, expected: &[SpkiHash]) -> bool {
     bool::from(matched)
 }
 
+/// Canonicalize a host to the exact key [`verify_relay_certificate`] pins under:
+/// `url::Url::host_str` for a `wss` URL (ASCII/IDNA-lowercased host with the
+/// scheme, port, path, and any trailing dot stripped). Accepts a bare host
+/// (`relay.example.com`) or a full `wss://`/`ws://` URL. Returns `None` when it
+/// cannot be parsed to a host. Pin staging and removal MUST route the operator's
+/// input through this, or a pin stored under a non-canonical host (`Relay.EXAMPLE`,
+/// `host:443`, `wss://host/`) silently never applies at verification time.
+pub fn normalize_pin_hostname(input: &str) -> Option<String> {
+    let trimmed = input.trim();
+    let candidate = if trimmed.contains("://") {
+        trimmed.to_string()
+    } else {
+        format!("wss://{trimmed}")
+    };
+    let host = url::Url::parse(&candidate).ok()?.host_str()?.to_string();
+    (!host.is_empty()).then_some(host)
+}
+
 /// `require_pinned` is the deployment's strict-mode policy, supplied per call by
 /// the caller (from config) rather than stored on the pin set: strict is a
 /// policy, not pin data, so it can never be silently dropped by a pin-set
@@ -392,6 +410,33 @@ mod tests {
         assert_eq!(pins.get_pins("relay.example.com"), &[current, backup]);
         assert!(pins.get_pins("other.example.com").is_empty());
         assert!(!pins.is_pinned("other.example.com"));
+    }
+
+    #[test]
+    fn test_normalize_pin_hostname_matches_verify_key() {
+        // Bare host, case, port, scheme, path all canonicalize to url::Url::host_str.
+        assert_eq!(
+            normalize_pin_hostname("relay.example.com").as_deref(),
+            Some("relay.example.com")
+        );
+        assert_eq!(
+            normalize_pin_hostname("Relay.Example.COM").as_deref(),
+            Some("relay.example.com")
+        );
+        assert_eq!(
+            normalize_pin_hostname("relay.example.com:443").as_deref(),
+            Some("relay.example.com")
+        );
+        assert_eq!(
+            normalize_pin_hostname("wss://relay.example.com/").as_deref(),
+            Some("relay.example.com")
+        );
+        assert_eq!(
+            normalize_pin_hostname("  relay.example.com  ").as_deref(),
+            Some("relay.example.com")
+        );
+        assert_eq!(normalize_pin_hostname(""), None);
+        assert_eq!(normalize_pin_hostname("wss://"), None);
     }
 
     #[test]

--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -92,7 +92,7 @@ pub use attestation::{
     ExpectedPcrs,
 };
 pub use audit::{SigningAuditEntry, SigningAuditLog, SigningOperation};
-pub use cert_pin::{verify_relay_certificate, CertificatePinSet, SpkiHash};
+pub use cert_pin::{normalize_pin_hostname, verify_relay_certificate, CertificatePinSet, SpkiHash};
 pub use descriptor_session::{
     derive_descriptor_session_id, derive_policy_hash, find_local_external_xpub_in_tier,
     load_verified_wallet_policy, participant_indices, reconstruct_descriptor, DescriptorSession,

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1282,6 +1282,36 @@ impl KeepMobile {
         persistence::persist_cert_pins(&self.storage, &pins)
     }
 
+    /// Stage an additional accepted SPKI pin for `hostname` (RFC 7469 backup pin)
+    /// so the next relay key can be pre-pinned before rotation without a
+    /// hard-fail during the key overlap. Additive and de-duplicated, bounded per
+    /// host. Adding a trusted pin is a sensitive operator action; the caller MUST
+    /// gate it behind explicit user confirmation.
+    pub fn stage_certificate_pin(
+        &self,
+        hostname: String,
+        spki_hash: String,
+    ) -> Result<(), KeepMobileError> {
+        let hash = parse_spki_hash(&spki_hash)?;
+        let mut pins = persistence::load_cert_pins(&self.storage)?.unwrap_or_default();
+        pins.add_pin(hostname, hash);
+        persistence::persist_cert_pins(&self.storage, &pins)
+    }
+
+    /// Remove a single SPKI pin from `hostname`, retiring a rotated-out key while
+    /// keeping the host's remaining pins active (unlike `clear_certificate_pin`,
+    /// which unpins the whole host). A no-op if the pin is not present.
+    pub fn remove_certificate_pin(
+        &self,
+        hostname: String,
+        spki_hash: String,
+    ) -> Result<(), KeepMobileError> {
+        let hash = parse_spki_hash(&spki_hash)?;
+        let mut pins = persistence::load_cert_pins(&self.storage)?.unwrap_or_default();
+        pins.remove_specific_pin(&hostname, &hash);
+        persistence::persist_cert_pins(&self.storage, &pins)
+    }
+
     pub fn wallet_descriptor_list(&self) -> Vec<WalletDescriptorInfo> {
         persistence::load_descriptors(&self.storage)
     }
@@ -2385,6 +2415,11 @@ fn bytes_to_32(bytes: &[u8], label: &str) -> Result<[u8; 32], KeepMobileError> {
     <[u8; 32]>::try_from(bytes).map_err(|_| KeepMobileError::BackupError {
         msg: format!("invalid {label} length: {} (expected 32)", bytes.len()),
     })
+}
+
+/// Parse a hex-encoded SHA-256 SPKI pin (64 hex chars) into its 32 bytes.
+fn parse_spki_hash(spki_hash: &str) -> Result<[u8; 32], KeepMobileError> {
+    bytes_to_32(&decode_hex(spki_hash, "SPKI hash")?, "SPKI hash")
 }
 
 fn relay_config_key(group_pubkey: Option<&str>) -> String {

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -265,6 +265,16 @@ pub struct CertificatePin {
 }
 
 #[derive(uniffi::Record)]
+pub struct CertPinRemovalResult {
+    /// Whether a pin was actually removed (false when the hash was not present).
+    pub pin_removed: bool,
+    /// Whether the host now has no pins left. The next connection will
+    /// trust-on-first-use and re-pin whatever cert is presented, so the UI should
+    /// require explicit confirmation before leaving a host unpinned.
+    pub host_now_unpinned: bool,
+}
+
+#[derive(uniffi::Record)]
 pub struct RelayConfigInfo {
     pub frost_relays: Vec<String>,
     pub profile_relays: Vec<String>,
@@ -1292,6 +1302,7 @@ impl KeepMobile {
         hostname: String,
         spki_hash: String,
     ) -> Result<(), KeepMobileError> {
+        let hostname = normalize_pin_host(&hostname)?;
         let hash = parse_spki_hash(&spki_hash)?;
         let mut pins = persistence::load_cert_pins(&self.storage)?.unwrap_or_default();
         pins.add_pin(hostname, hash);
@@ -1300,16 +1311,24 @@ impl KeepMobile {
 
     /// Remove a single SPKI pin from `hostname`, retiring a rotated-out key while
     /// keeping the host's remaining pins active (unlike `clear_certificate_pin`,
-    /// which unpins the whole host). A no-op if the pin is not present.
+    /// which unpins the whole host). Returns whether a pin was actually removed and
+    /// whether the host is now fully unpinned, so the caller can confirm before
+    /// leaving a host with no pins (which re-opens trust-on-first-use).
     pub fn remove_certificate_pin(
         &self,
         hostname: String,
         spki_hash: String,
-    ) -> Result<(), KeepMobileError> {
+    ) -> Result<CertPinRemovalResult, KeepMobileError> {
+        let hostname = normalize_pin_host(&hostname)?;
         let hash = parse_spki_hash(&spki_hash)?;
         let mut pins = persistence::load_cert_pins(&self.storage)?.unwrap_or_default();
-        pins.remove_specific_pin(&hostname, &hash);
-        persistence::persist_cert_pins(&self.storage, &pins)
+        let pin_removed = pins.remove_specific_pin(&hostname, &hash);
+        let host_now_unpinned = !pins.is_pinned(&hostname);
+        persistence::persist_cert_pins(&self.storage, &pins)?;
+        Ok(CertPinRemovalResult {
+            pin_removed,
+            host_now_unpinned,
+        })
     }
 
     pub fn wallet_descriptor_list(&self) -> Vec<WalletDescriptorInfo> {
@@ -2420,6 +2439,18 @@ fn bytes_to_32(bytes: &[u8], label: &str) -> Result<[u8; 32], KeepMobileError> {
 /// Parse a hex-encoded SHA-256 SPKI pin (64 hex chars) into its 32 bytes.
 fn parse_spki_hash(spki_hash: &str) -> Result<[u8; 32], KeepMobileError> {
     bytes_to_32(&decode_hex(spki_hash, "SPKI hash")?, "SPKI hash")
+}
+
+/// Canonicalize an operator-supplied relay host to the exact key certificate pins
+/// are stored and verified under, rejecting input that cannot be parsed to a host
+/// (so a pin can never be stored under a scheme/port/case-variant that never
+/// matches at verification time).
+fn normalize_pin_host(hostname: &str) -> Result<String, KeepMobileError> {
+    keep_frost_net::normalize_pin_hostname(hostname).ok_or_else(|| {
+        KeepMobileError::InvalidRelayUrl {
+            msg: "invalid relay hostname for certificate pin".into(),
+        }
+    })
 }
 
 fn relay_config_key(group_pubkey: Option<&str>) -> String {


### PR DESCRIPTION
## Summary

`CertificatePinSet` supports multiple SPKI pins per host (RFC 7469 backup pins, #696) so a relay's certificate can rotate without a hard-fail during the key overlap. But the mobile automatic-pin flow only ever `add_pin`s when a host is currently unpinned (via `verify_relay_certificate` returning a new pin for unpinned hosts), so the multi-pin capability was dormant: an operator had no way to pre-stage the next relay key.

This adds the missing surface so an operator can stage a backup pin before rotation and retire the old one after.

## Changes

- keep-frost-net: `CertificatePinSet::remove_specific_pin(hostname, hash)` removes one pin while keeping the host's other pins active (existing `remove_pin` drops the whole host); dropping the last pin unpins the host. Returns whether a pin was removed.
- keep-mobile FFI:
  - `stage_certificate_pin(hostname, spki_hash)` — add a backup SPKI pin for an already-pinned host (additive, de-duplicated, bounded per host) and persist.
  - `remove_certificate_pin(hostname, spki_hash)` — retire a single pin, keeping the rest, and persist.
  - `parse_spki_hash` validates the hex (64 chars / 32 bytes) at the FFI boundary via the existing `decode_hex`/`bytes_to_32`.

Staging a pin adds a trusted key, so it is a sensitive operator action; the doc comment states the caller must gate it behind explicit user confirmation (the keep-android UI is a follow-up).

## Testing

- `test_remove_specific_pin_retires_one_key` covers retiring one of two pins (host stays pinned), the no-op cases (absent pin / absent host), and dropping the last pin (host becomes unpinned). `cargo build -p keep-mobile`, `cargo clippy`, `cargo fmt` clean.

keep GitHub issue #801.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added certificate pin management for mobile users, including staging additional pins and removing specific pins.
  * Removing one pin preserves other valid pins for the same hostname.
  * Hosts are automatically unpinned when their final certificate pin is removed.
  * Invalid pin values are rejected with consistent error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->