### PR TITLE
nip46: persist and restore only apps with an explicit remember-grant

### DIFF
--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -152,6 +152,27 @@ impl AppPermission {
             .is_some_and(|expiry| now_unix_secs() < *expiry)
     }
 
+    /// Whether the user has made an explicit remember-decision for this app: a
+    /// Forever per-kind grant beyond the seeded `Reaction` default, or a live
+    /// non-NIP-98 timed per-kind grant. A bare connection, or only the default
+    /// `Reaction` (which is auto-approved globally regardless), does not count.
+    ///
+    /// Only such apps are persisted and restored, so a merely-connected client
+    /// must re-present the connect secret via a fresh `connect` after a bunker
+    /// restart instead of being silently re-authorized. This matches NIP-46's
+    /// single-connection `secret` and the remember-only persistence model used
+    /// by NIP-55 and reference signers.
+    pub fn has_explicit_remember_grant(&self) -> bool {
+        let now = now_unix_secs();
+        self.auto_approve_kinds
+            .iter()
+            .any(|k| *k != Kind::Reaction && *k != NIP98_HTTP_AUTH)
+            || self
+                .timed_kind_grants
+                .iter()
+                .any(|(k, expiry)| *k != NIP98_HTTP_AUTH && now < *expiry)
+    }
+
     fn prune_expired_kind_grants(&mut self) {
         let now = now_unix_secs();
         self.timed_kind_grants.retain(|_, expiry| now < *expiry);
@@ -430,7 +451,10 @@ impl PermissionManager {
         let now = now_unix_secs();
         self.apps
             .values()
-            .filter(|app| !matches!(app.duration, PermissionDuration::Session))
+            .filter(|app| {
+                !matches!(app.duration, PermissionDuration::Session)
+                    && app.has_explicit_remember_grant()
+            })
             .map(|app| StoredBunkerPermission {
                 pubkey_hex: app.pubkey.to_hex(),
                 name: app.name.clone(),
@@ -519,6 +543,15 @@ impl PermissionManager {
             .into_iter()
             .filter(|(kind, expiry)| *kind != NIP98_HTTP_AUTH && now < *expiry)
             .collect();
+        // Only restore apps the user explicitly chose to remember. A record with
+        // no remaining remember-grant (a bare connection, or a legacy row that
+        // over-captured every connected app) is dropped so the client must
+        // re-present the connect secret via a fresh `connect` rather than being
+        // silently re-authorized; this also migrates away pre-existing over-broad
+        // rows on the next load.
+        if !app.has_explicit_remember_grant() {
+            return false;
+        }
         self.insert(app);
         true
     }
@@ -1059,6 +1092,79 @@ mod tests {
             restored.needs_approval(&pubkey, Kind::Metadata),
             "an ungranted kind still prompts after restore"
         );
+    }
+
+    #[test]
+    fn stored_snapshot_omits_bare_connected_app() {
+        // A merely-connected app (secret accepted, SIGN_EVENT capability, but no
+        // remember-decision) must NOT be persisted, or it would be silently
+        // re-authorized on the next start without re-presenting the secret.
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect_with_permissions(
+            pubkey,
+            "App".into(),
+            Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT,
+            HashSet::new(),
+        );
+        assert!(
+            pm.stored_snapshot().is_empty(),
+            "a connected app with no remember-grant is not persisted"
+        );
+    }
+
+    #[test]
+    fn stored_snapshot_reaction_only_is_treated_as_bare() {
+        // Reaction (kind 7) is the seeded default and is auto-approved globally,
+        // so an app carrying only Reaction is indistinguishable from a bare
+        // connection and must not be persisted.
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+        assert!(pm.grant_kind_forever(&pubkey, Kind::Reaction));
+        assert!(
+            pm.stored_snapshot().is_empty(),
+            "a Reaction-only app is not persisted"
+        );
+    }
+
+    #[test]
+    fn stored_snapshot_keeps_forever_and_timed_remembers() {
+        let mut pm = PermissionManager::new();
+        let forever = Keys::generate().public_key();
+        let timed = Keys::generate().public_key();
+        let bare = Keys::generate().public_key();
+        pm.connect(forever, "Forever".into());
+        pm.connect(timed, "Timed".into());
+        pm.connect(bare, "Bare".into());
+        assert!(pm.grant_kind_forever(&forever, Kind::TextNote));
+        assert!(pm.grant_kind_for(&timed, Kind::TextNote, 3600));
+
+        let snapshot = pm.stored_snapshot();
+        assert_eq!(snapshot.len(), 2, "only the two remembered apps persist");
+        let hexes: HashSet<String> = snapshot.iter().map(|s| s.pubkey_hex.clone()).collect();
+        assert!(hexes.contains(&forever.to_hex()));
+        assert!(hexes.contains(&timed.to_hex()));
+        assert!(!hexes.contains(&bare.to_hex()));
+    }
+
+    #[test]
+    fn restore_persisted_drops_legacy_bare_row() {
+        // A legacy over-captured row (SIGN_EVENT, only the Reaction seed, no timed
+        // grant) is dropped on restore, migrating away the old broad persistence.
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        let restored = pm.restore_persisted(
+            pubkey,
+            "Bare".into(),
+            Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT,
+            HashSet::from([Kind::Reaction]),
+            PermissionDuration::Forever,
+            Timestamp::now(),
+            HashMap::new(),
+        );
+        assert!(!restored, "a bare legacy row is not restored");
+        assert!(pm.get_app(&pubkey).is_none());
     }
 
     #[test]

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -1168,6 +1168,51 @@ mod tests {
     }
 
     #[test]
+    fn restore_persisted_drops_expired_timed_only_row() {
+        // A row whose only grant is a timed grant that expired while the bunker
+        // was down prunes to empty, leaving no remember, so it is dropped.
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        let mut grants = HashMap::new();
+        grants.insert(Kind::TextNote, 1); // expiry at epoch+1s: always in the past
+        let restored = pm.restore_persisted(
+            pubkey,
+            "Expired".into(),
+            Permission::SIGN_EVENT,
+            HashSet::new(),
+            PermissionDuration::Forever,
+            Timestamp::now(),
+            grants,
+        );
+        assert!(
+            !restored,
+            "an app whose only grant expired while down is dropped"
+        );
+        assert!(pm.get_app(&pubkey).is_none());
+    }
+
+    #[test]
+    fn restore_persisted_drops_nip98_only_row() {
+        // A legacy row whose only grants are NIP-98 (stripped on restore) leaves
+        // no remember and is dropped rather than silently re-authorized.
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        let mut grants = HashMap::new();
+        grants.insert(NIP98_HTTP_AUTH, now_unix_secs() + 3600);
+        let restored = pm.restore_persisted(
+            pubkey,
+            "Nip98".into(),
+            Permission::SIGN_EVENT,
+            HashSet::from([NIP98_HTTP_AUTH]),
+            PermissionDuration::Forever,
+            Timestamp::now(),
+            grants,
+        );
+        assert!(!restored, "a NIP-98-only legacy row is dropped on restore");
+        assert!(pm.get_app(&pubkey).is_none());
+    }
+
+    #[test]
     fn grant_kind_forever_enforces_max_auto_kinds_cap() {
         let mut pm = PermissionManager::new();
         let pubkey = Keys::generate().public_key();


### PR DESCRIPTION
On a bunker restart, keep-nip46 restored **every** previously-connected app, not just apps the user chose to remember. On mobile, apps default to `Forever` with `SIGN_EVENT`, so `stored_snapshot` captured a full sign capability for any client that ever connected, and `apply_pre_grants` restored it. A previously-connected client then passed `require_permission` and signed remembered kinds with zero interaction, never re-presenting the connect secret, and rotating the secret no longer revoked it.

This diverges from the NIP-46 spec (the connect `secret` is a single-connection token; there is no requirement to persist authorization across a signer restart) and from how reference signers behave (persist only explicit remember-decisions; a merely-connected app re-prompts / must reconnect after restart). NIP-55's background path is likewise gated on a prior explicit remember.

## Change

- Add `AppPermission::has_explicit_remember_grant()`: true only when the user made a real remember-decision, a Forever per-kind grant beyond the seeded `Reaction` default, or a live non-NIP-98 timed grant. A bare connection, or only `Reaction` (which is auto-approved globally regardless), does not count.
- Gate **both** sides on it:
  - `stored_snapshot` persists only remembered apps.
  - `restore_persisted` skips rows with no remember-grant, so a bare row is never re-authorized and pre-existing over-broad rows are migrated away on the next load.
- Net effect: a merely-connected client must send a fresh `connect` (re-presenting the reusable secret) after a restart before it can sign; explicitly remembered apps and kinds are unaffected. This also makes secret rotation authoritative for un-remembered clients.

## Testing

- New tests: bare connected app is not persisted; `Reaction`-only is treated as bare; forever + timed remembers persist while a bare peer does not; a legacy bare row is dropped on restore.
- Existing snapshot/restore round-trip and NIP-98 tests unchanged and green. `cargo test -p keep-nip46` (170 tests) passes; workspace build, keep-mobile nip46 tests, fmt, and clippy all green.

Fixes the NIP-46 hardening item tracking restart re-auth.
