### PR TITLE
nip46: gate remember-persistence on a user-decision flag, not client connect scope

### DIFF
--- a/keep-cli/src/commands/nip46.rs
+++ b/keep-cli/src/commands/nip46.rs
@@ -150,6 +150,8 @@ pub fn cmd_nip46_grant(
         duration: parsed_duration,
         connected_at: now,
         timed_kind_grants: Vec::new(),
+        // An operator running the grant command is an explicit remember decision.
+        explicitly_remembered: Some(true),
     };
     let replaced = match existing {
         Some(idx) => {

--- a/keep-core/src/backup.rs
+++ b/keep-core/src/backup.rs
@@ -1063,6 +1063,7 @@ mod tests {
             duration: StoredPermissionDuration::Forever,
             connected_at: 1_700_000_000,
             timed_kind_grants: Vec::new(),
+            explicitly_remembered: None,
         });
         relay_cfg.auto_approve_kinds = vec![22242];
         keep.store_relay_config(&relay_cfg).unwrap();

--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -1389,6 +1389,7 @@ mod tests {
             duration: StoredPermissionDuration::Forever,
             connected_at: 100,
             timed_kind_grants: Vec::new(),
+            explicitly_remembered: None,
         });
         cfg.auto_approve_kinds = vec![22242];
 

--- a/keep-core/src/relay.rs
+++ b/keep-core/src/relay.rs
@@ -75,6 +75,15 @@ pub struct StoredBunkerPermission {
     /// are pruned when the bunker restores this client.
     #[serde(default)]
     pub timed_kind_grants: Vec<StoredTimedKindGrant>,
+    /// Whether the user made an explicit remember-decision for this app (picking
+    /// a `Forever` or timed duration on the approval prompt), as opposed to a
+    /// bare connection or a client-requested connect-time kind scope. Only
+    /// remembered apps are persisted and restored, so a merely-connected client
+    /// must re-present the connect secret after a restart. `None` marks a legacy
+    /// row written before this field existed; the bunker falls back to inspecting
+    /// the row's grants on restore.
+    #[serde(default)]
+    pub explicitly_remembered: Option<bool>,
 }
 
 /// Per-peer send/receive policy entry, stored alongside relay configuration.
@@ -219,6 +228,7 @@ impl RelayConfig {
                 duration: bp.duration,
                 connected_at: bp.connected_at,
                 timed_kind_grants: bp.timed_kind_grants,
+                explicitly_remembered: bp.explicitly_remembered,
             });
         }
 

--- a/keep-core/src/relay.rs
+++ b/keep-core/src/relay.rs
@@ -896,4 +896,31 @@ mod tests {
         assert!(validate_relay_url("wss://LocalHost./").is_err());
         assert!(validate_relay_url("wss://LOCALHOST./").is_err());
     }
+
+    #[test]
+    fn stored_bunker_permission_legacy_json_defaults_remember_flag_to_none() {
+        // A row persisted before the flag existed omits `explicitly_remembered`;
+        // it must deserialize to None so the restore path treats it as legacy and
+        // falls back to inspecting the row's grants.
+        let legacy = r#"{
+            "pubkey_hex": "aa",
+            "name": "app",
+            "permissions": 3,
+            "auto_approve_kinds": [1],
+            "duration": "Forever",
+            "connected_at": 100
+        }"#;
+        let bp: StoredBunkerPermission = serde_json::from_str(legacy).unwrap();
+        assert_eq!(bp.explicitly_remembered, None);
+        assert!(bp.timed_kind_grants.is_empty());
+
+        // A current row round-trips the flag.
+        let current = StoredBunkerPermission {
+            explicitly_remembered: Some(true),
+            ..bp
+        };
+        let json = serde_json::to_string(&current).unwrap();
+        let back: StoredBunkerPermission = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.explicitly_remembered, Some(true));
+    }
 }

--- a/keep-desktop/src/bunker_service.rs
+++ b/keep-desktop/src/bunker_service.rs
@@ -709,6 +709,11 @@ impl App {
                     .iter()
                     .map(|&(kind, expires_at)| StoredTimedKindGrant { kind, expires_at })
                     .collect(),
+                // This desktop sync path does not carry the remember flag; leave
+                // it legacy (`None`) so the restore path falls back to inspecting
+                // the row's grants. Gating this write on an explicit remember is
+                // tracked separately.
+                explicitly_remembered: None,
             })
             .collect();
         self.update_relay_config(|config| config.bunker_permissions = stored);
@@ -735,6 +740,7 @@ impl App {
                     app.duration,
                     app.connected_at,
                     app.timed_kind_grants,
+                    app.explicitly_remembered,
                 )
                 .await;
         }

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -836,6 +836,7 @@ impl SignerHandler {
         duration: PermissionDuration,
         connected_at: Timestamp,
         timed_kind_grants: HashMap<Kind, u64>,
+        explicitly_remembered: Option<bool>,
     ) {
         let mut pm = self.permissions.lock().await;
         pm.restore_persisted(
@@ -846,6 +847,7 @@ impl SignerHandler {
             duration,
             connected_at,
             timed_kind_grants,
+            explicitly_remembered,
         );
     }
 

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -122,6 +122,14 @@ pub struct AppPermission {
     pub request_count: u64,
     #[serde(default = "default_duration")]
     pub duration: PermissionDuration,
+    /// Set true when the user makes an explicit remember-decision for this app
+    /// (`grant_kind_forever` / `grant_kind_for`), false for a bare connection or
+    /// a client-supplied connect-time kind scope. Distinguishes a real user
+    /// remember from a client's `sign_event:<kind>` connect request so only the
+    /// former is persisted/restored across a bunker restart. Rebuilt from the
+    /// persisted row on restore.
+    #[serde(default)]
+    pub explicitly_remembered: bool,
 }
 
 fn default_duration() -> PermissionDuration {
@@ -140,6 +148,7 @@ impl AppPermission {
             last_used: Timestamp::now(),
             request_count: 0,
             duration: PermissionDuration::Forever,
+            explicitly_remembered: false,
         }
     }
 
@@ -152,17 +161,19 @@ impl AppPermission {
             .is_some_and(|expiry| now_unix_secs() < *expiry)
     }
 
-    /// Whether the user has made an explicit remember-decision for this app: a
-    /// Forever per-kind grant beyond the seeded `Reaction` default, or a live
-    /// non-NIP-98 timed per-kind grant. A bare connection, or only the default
-    /// `Reaction` (which is auto-approved globally regardless), does not count.
+    /// Whether the app currently holds a live remember-grant: a Forever per-kind
+    /// grant beyond the seeded `Reaction` default, or an unexpired non-NIP-98
+    /// timed per-kind grant. A bare connection, or only the default `Reaction`
+    /// (auto-approved globally regardless), does not count.
     ///
-    /// Only such apps are persisted and restored, so a merely-connected client
+    /// This is the "still has something to remember" half of the persistence
+    /// gate; combined with [`AppPermission::explicitly_remembered`] (the "user
+    /// actually chose to remember, vs a client-supplied connect scope" half), it
+    /// decides whether the app is persisted/restored. A merely-connected client
     /// must re-present the connect secret via a fresh `connect` after a bunker
-    /// restart instead of being silently re-authorized. This matches NIP-46's
-    /// single-connection `secret` and the remember-only persistence model used
-    /// by NIP-55 and reference signers.
-    pub fn has_explicit_remember_grant(&self) -> bool {
+    /// restart instead of being silently re-authorized, matching NIP-46's
+    /// single-connection `secret` and the remember-only model of NIP-55.
+    pub fn has_live_remember_grant(&self) -> bool {
         let now = now_unix_secs();
         self.auto_approve_kinds
             .iter()
@@ -171,6 +182,12 @@ impl AppPermission {
                 .timed_kind_grants
                 .iter()
                 .any(|(k, expiry)| *k != NIP98_HTTP_AUTH && now < *expiry)
+    }
+
+    /// Whether this app should be persisted / restored: the user explicitly
+    /// remembered it AND it still holds a live remember-grant.
+    pub fn is_persistable_remember(&self) -> bool {
+        self.explicitly_remembered && self.has_live_remember_grant()
     }
 
     fn prune_expired_kind_grants(&mut self) {
@@ -369,6 +386,9 @@ impl PermissionManager {
             // A Forever grant supersedes any timed grant for the same kind.
             app.timed_kind_grants.remove(&kind);
             app.last_used = Timestamp::now();
+            // An explicit user remember-decision (vs a client-supplied connect
+            // kind scope); gates cross-restart persistence.
+            app.explicitly_remembered = true;
             return true;
         }
         false
@@ -419,6 +439,8 @@ impl PermissionManager {
             let expiry = now.saturating_add(secs);
             app.timed_kind_grants.insert(kind, expiry);
             app.last_used = Timestamp::now();
+            // An explicit user remember-decision; gates cross-restart persistence.
+            app.explicitly_remembered = true;
             return true;
         }
         false
@@ -453,7 +475,7 @@ impl PermissionManager {
             .values()
             .filter(|app| {
                 !matches!(app.duration, PermissionDuration::Session)
-                    && app.has_explicit_remember_grant()
+                    && app.is_persistable_remember()
             })
             .map(|app| StoredBunkerPermission {
                 pubkey_hex: app.pubkey.to_hex(),
@@ -475,6 +497,7 @@ impl PermissionManager {
                         expires_at: *expiry,
                     })
                     .collect(),
+                explicitly_remembered: Some(app.explicitly_remembered),
             })
             .collect()
     }
@@ -515,6 +538,7 @@ impl PermissionManager {
         duration: PermissionDuration,
         connected_at: Timestamp,
         timed_kind_grants: HashMap<Kind, u64>,
+        explicitly_remembered: Option<bool>,
     ) -> bool {
         match duration {
             PermissionDuration::Session => return false,
@@ -543,13 +567,18 @@ impl PermissionManager {
             .into_iter()
             .filter(|(kind, expiry)| *kind != NIP98_HTTP_AUTH && now < *expiry)
             .collect();
-        // Only restore apps the user explicitly chose to remember. A record with
-        // no remaining remember-grant (a bare connection, or a legacy row that
-        // over-captured every connected app) is dropped so the client must
-        // re-present the connect secret via a fresh `connect` rather than being
-        // silently re-authorized; this also migrates away pre-existing over-broad
-        // rows on the next load.
-        if !app.has_explicit_remember_grant() {
+        // Rebuild the remember flag. A legacy row (`None`) predates the flag, so
+        // fall back to whether it still carries a live grant, which preserves a
+        // genuine remembered app while dropping a legacy bare row. A current row
+        // is authoritative, so a client that only supplied a connect-time kind
+        // scope (persisted as `Some(false)`) is not resurrected.
+        app.explicitly_remembered =
+            explicitly_remembered.unwrap_or_else(|| app.has_live_remember_grant());
+        // Only restore apps the user explicitly chose to remember AND that still
+        // hold a live grant, so a merely-connected client must re-present the
+        // connect secret via a fresh `connect` rather than being silently
+        // re-authorized. Also migrates away pre-existing over-broad rows.
+        if !app.is_persistable_remember() {
             return false;
         }
         self.insert(app);
@@ -825,6 +854,7 @@ mod tests {
             PermissionDuration::Forever,
             Timestamp::now(),
             grants,
+            None,
         );
         assert!(restored);
 
@@ -979,6 +1009,7 @@ mod tests {
             PermissionDuration::Forever,
             Timestamp::now(),
             grants,
+            None,
         );
         assert!(restored);
 
@@ -1018,6 +1049,7 @@ mod tests {
             PermissionDuration::Forever,
             Timestamp::now(),
             persisted,
+            None,
         );
 
         assert!(
@@ -1078,6 +1110,7 @@ mod tests {
             duration,
             Timestamp::from_secs(stored.connected_at),
             timed,
+            stored.explicitly_remembered,
         );
 
         assert!(
@@ -1162,6 +1195,7 @@ mod tests {
             PermissionDuration::Forever,
             Timestamp::now(),
             HashMap::new(),
+            None,
         );
         assert!(!restored, "a bare legacy row is not restored");
         assert!(pm.get_app(&pubkey).is_none());
@@ -1183,6 +1217,7 @@ mod tests {
             PermissionDuration::Forever,
             Timestamp::now(),
             grants,
+            None,
         );
         assert!(
             !restored,
@@ -1207,8 +1242,57 @@ mod tests {
             PermissionDuration::Forever,
             Timestamp::now(),
             grants,
+            None,
         );
         assert!(!restored, "a NIP-98-only legacy row is dropped on restore");
+        assert!(pm.get_app(&pubkey).is_none());
+    }
+
+    #[test]
+    fn stored_snapshot_omits_client_scoped_connect() {
+        // A client that requests a kind-scoped signing permission at connect
+        // (`sign_event:1` -> auto-approve kind 1) is silently approved for that
+        // kind this session, but must NOT self-qualify for cross-restart
+        // persistence: only an explicit user remember does.
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect_with_permissions(
+            pubkey,
+            "App".into(),
+            Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT,
+            HashSet::from([Kind::Custom(1)]),
+        );
+        assert!(
+            !pm.needs_approval(&pubkey, Kind::Custom(1)),
+            "client scope is live"
+        );
+        assert!(
+            pm.stored_snapshot().is_empty(),
+            "a client-supplied connect kind scope is not persisted"
+        );
+        // Once the user explicitly remembers a kind, the app persists.
+        assert!(pm.grant_kind_forever(&pubkey, Kind::Custom(2)));
+        assert_eq!(pm.stored_snapshot().len(), 1);
+    }
+
+    #[test]
+    fn restore_persisted_drops_row_marked_not_remembered() {
+        // A row authoritatively flagged not-remembered (`Some(false)`, e.g. a
+        // client connect scope persisted under an older path) is not restored,
+        // even though it carries a non-Reaction auto kind.
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        let restored = pm.restore_persisted(
+            pubkey,
+            "Client".into(),
+            Permission::SIGN_EVENT,
+            HashSet::from([Kind::Custom(1)]),
+            PermissionDuration::Forever,
+            Timestamp::now(),
+            HashMap::new(),
+            Some(false),
+        );
+        assert!(!restored, "a row marked not-remembered is not restored");
         assert!(pm.get_app(&pubkey).is_none());
     }
 

--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -63,6 +63,9 @@ pub struct PreGrantedApp {
     pub duration: PermissionDuration,
     pub connected_at: Timestamp,
     pub timed_kind_grants: std::collections::HashMap<nostr_sdk::Kind, u64>,
+    /// `None` for a legacy row predating the flag; the restore path then falls
+    /// back to inspecting the row's grants.
+    pub explicitly_remembered: Option<bool>,
 }
 
 impl PreGrantedApp {
@@ -117,6 +120,7 @@ impl PreGrantedApp {
             duration,
             connected_at: Timestamp::from_secs(stored.connected_at),
             timed_kind_grants,
+            explicitly_remembered: stored.explicitly_remembered,
         })
     }
 }
@@ -191,6 +195,7 @@ async fn apply_pre_grants(
             app.duration,
             app.connected_at,
             app.timed_kind_grants.clone(),
+            app.explicitly_remembered,
         );
     }
 }
@@ -876,6 +881,7 @@ mod tests {
             duration,
             connected_at,
             timed_kind_grants: Vec::new(),
+            explicitly_remembered: None,
         }
     }
 


### PR DESCRIPTION
Follow-up to #809. That change persisted/restored only apps carrying a non-Reaction remember-grant, but the content predicate could not tell a user's explicit "Forever/timed" remember from a client-supplied connect-time kind scope: a NIP-46 client controls its connect `permissions` string, and `sign_event:<kind>` becomes an `auto_approve_kinds` entry. So a client requesting a kind-scoped signing permission still self-qualified for cross-restart persistence and kept signing that kind after a restart without re-presenting the connect secret (secret rotation did not revoke it).

## Change

Distinguish the two with an explicit user-decision flag rather than inferring from grant contents.

- `AppPermission::explicitly_remembered` is set **only** by the user-decision paths (`grant_kind_forever` / `grant_kind_for`), never by `connect_with_permissions`. Persistence now gates on `is_persistable_remember()` = the flag AND a live remember-grant.
- Persisted in `StoredBunkerPermission.explicitly_remembered: Option<bool>` (`#[serde(default)]`):
  - `None` = legacy row predating the flag: restore falls back to the grant-content check, preserving genuinely remembered apps while dropping bare/over-broad legacy rows.
  - `Some(false)` = a client connect scope: never restored, even though it carries a non-Reaction kind.
  - `Some(true)` = a real user remember: restored if it still holds a live grant.
- Threaded through `restore_persisted` / `restore_client` / `PreGrantedApp` and every `StoredBunkerPermission` construction site.

## Scope

This closes the residual on the **engine, mobile, and CLI** persistence paths: the mobile bunker persists via the gated `stored_snapshot()` callback, and the CLI grant marks its write `Some(true)`. A client can no longer opt itself into cross-restart persistence there; only an explicit user remember survives a restart.

It does **not** yet close it on **keep-desktop**: `sync_bunker_permissions_to_vault` is desktop's only durable writer and persists every non-Session client ungated with `explicitly_remembered: None`, so on restore the legacy content-fallback still resurrects a client-supplied `sign_event:<kind>` connect scope. Routing desktop persistence through the gated snapshot (and setting the flag in `set_auto_approve_kinds_for_app` so user-configured auto-kinds are not dropped) is tracked in a dedicated follow-up.

A separate residual (a client's connect-scope kinds riding along on an app the user *did* remember) needs per-kind origin tracking and is also tracked for follow-up.

## Testing

- New: a `sign_event:1` client connect scope is live for the session but not persisted; a user remember then persists it. A row flagged `Some(false)` is not restored. A legacy JSON blob without the field deserializes to `None`.
- Existing snapshot/restore round-trip, NIP-98, and migration tests updated to thread the flag and remain green. `cargo test` across keep-nip46 (173), keep-core, keep-cli, keep-desktop all pass; workspace build, fmt, clippy clean.
