### PR TITLE
nip46: gate keep-desktop bunker persistence on the explicit-remember flag

### DIFF
--- a/keep-desktop/src/bunker_service.rs
+++ b/keep-desktop/src/bunker_service.rs
@@ -690,7 +690,10 @@ impl App {
         let stored: Vec<StoredBunkerPermission> = bunker
             .clients
             .iter()
-            .filter(|c| c.duration != "Session")
+            // Persist only clients the user explicitly remembered; a bare
+            // connection or a client-supplied connect-time kind scope is not
+            // durable, so it must re-present the connect secret after a restart.
+            .filter(|c| c.duration != "Session" && c.explicitly_remembered)
             .map(|c| StoredBunkerPermission {
                 pubkey_hex: c.pubkey.clone(),
                 name: c.name.clone(),
@@ -709,11 +712,7 @@ impl App {
                     .iter()
                     .map(|&(kind, expires_at)| StoredTimedKindGrant { kind, expires_at })
                     .collect(),
-                // This desktop sync path does not carry the remember flag; leave
-                // it legacy (`None`) so the restore path falls back to inspecting
-                // the row's grants. Gating this write on an explicit remember is
-                // tracked separately.
-                explicitly_remembered: None,
+                explicitly_remembered: Some(c.explicitly_remembered),
             })
             .collect();
         self.update_relay_config(|config| config.bunker_permissions = stored);
@@ -793,6 +792,7 @@ impl App {
                                 .iter()
                                 .map(|(k, &expiry)| (k.as_u16(), expiry))
                                 .collect(),
+                            explicitly_remembered: app.explicitly_remembered,
                         }
                     })
                     .collect()

--- a/keep-desktop/src/bunker_service.rs
+++ b/keep-desktop/src/bunker_service.rs
@@ -687,34 +687,7 @@ impl App {
         let Some(ref bunker) = self.bunker else {
             return;
         };
-        let stored: Vec<StoredBunkerPermission> = bunker
-            .clients
-            .iter()
-            // Persist only clients the user explicitly remembered; a bare
-            // connection or a client-supplied connect-time kind scope is not
-            // durable, so it must re-present the connect secret after a restart.
-            .filter(|c| c.duration != "Session" && c.explicitly_remembered)
-            .map(|c| StoredBunkerPermission {
-                pubkey_hex: c.pubkey.clone(),
-                name: c.name.clone(),
-                permissions: c.permissions,
-                auto_approve_kinds: c.auto_approve_kinds.clone(),
-                duration: match c.duration.as_str() {
-                    "Forever" => StoredPermissionDuration::Forever,
-                    _ => c
-                        .duration_seconds
-                        .map(StoredPermissionDuration::Seconds)
-                        .unwrap_or(StoredPermissionDuration::Session),
-                },
-                connected_at: c.connected_at,
-                timed_kind_grants: c
-                    .timed_kind_grants
-                    .iter()
-                    .map(|&(kind, expires_at)| StoredTimedKindGrant { kind, expires_at })
-                    .collect(),
-                explicitly_remembered: Some(c.explicitly_remembered),
-            })
-            .collect();
+        let stored = remembered_clients_to_stored(&bunker.clients);
         self.update_relay_config(|config| config.bunker_permissions = stored);
     }
 
@@ -799,5 +772,75 @@ impl App {
             },
             Message::BunkerClientsLoaded,
         )
+    }
+}
+
+/// Map the connected-client list to the vault's persisted bunker permissions,
+/// keeping only clients the user explicitly remembered. A bare connection or a
+/// client-supplied connect-time kind scope is not durable, so it must re-present
+/// the connect secret via a fresh `connect` after a restart. Pure so the persist
+/// gate can be tested independently of `App`.
+pub(crate) fn remembered_clients_to_stored(
+    clients: &[ConnectedClient],
+) -> Vec<StoredBunkerPermission> {
+    clients
+        .iter()
+        .filter(|c| c.duration != "Session" && c.explicitly_remembered)
+        .map(|c| StoredBunkerPermission {
+            pubkey_hex: c.pubkey.clone(),
+            name: c.name.clone(),
+            permissions: c.permissions,
+            auto_approve_kinds: c.auto_approve_kinds.clone(),
+            duration: match c.duration.as_str() {
+                "Forever" => StoredPermissionDuration::Forever,
+                _ => c
+                    .duration_seconds
+                    .map(StoredPermissionDuration::Seconds)
+                    .unwrap_or(StoredPermissionDuration::Session),
+            },
+            connected_at: c.connected_at,
+            timed_kind_grants: c
+                .timed_kind_grants
+                .iter()
+                .map(|&(kind, expires_at)| StoredTimedKindGrant { kind, expires_at })
+                .collect(),
+            explicitly_remembered: Some(c.explicitly_remembered),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn client(pubkey: &str, remembered: bool) -> ConnectedClient {
+        ConnectedClient {
+            pubkey: pubkey.to_string(),
+            name: "app".into(),
+            permissions: 3,
+            auto_approve_kinds: vec![1],
+            request_count: 0,
+            duration: "Forever".into(),
+            duration_seconds: None,
+            connected_at: 100,
+            timed_kind_grants: Vec::new(),
+            explicitly_remembered: remembered,
+        }
+    }
+
+    #[test]
+    fn only_remembered_clients_are_persisted() {
+        let clients = vec![client("aa", true), client("bb", false)];
+        let stored = remembered_clients_to_stored(&clients);
+        assert_eq!(stored.len(), 1, "the un-remembered client is dropped");
+        assert_eq!(stored[0].pubkey_hex, "aa");
+        assert_eq!(stored[0].explicitly_remembered, Some(true));
+    }
+
+    #[test]
+    fn session_clients_are_skipped_even_if_remembered() {
+        let mut c = client("aa", true);
+        c.duration = "Session".into();
+        assert!(remembered_clients_to_stored(&[c]).is_empty());
     }
 }

--- a/keep-desktop/src/screen/bunker.rs
+++ b/keep-desktop/src/screen/bunker.rs
@@ -20,6 +20,10 @@ pub struct ConnectedClient {
     pub duration_seconds: Option<u64>,
     pub connected_at: u64,
     pub timed_kind_grants: Vec<(u16, u64)>,
+    /// Whether the user made an explicit remember-decision for this client, as
+    /// opposed to a bare connection or a client-supplied connect-time kind scope.
+    /// Only remembered clients are persisted to the vault.
+    pub explicitly_remembered: bool,
 }
 
 const PERM_FLAGS: &[(&str, u32)] = &[

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -595,6 +595,13 @@ impl PermissionManager {
         // #575: NIP-98 (kind 27235) is never auto-approved.
         kinds.remove(&NIP98_HTTP_AUTH);
         if let Some(app) = self.apps.get_mut(pubkey) {
+            // A user configuring auto-approve kinds is an explicit remember
+            // decision, so gate persistence keeps it (and does not false-drop it
+            // on restart). Clearing to empty leaves the flag untouched so a
+            // separate live timed grant still counts as remembered.
+            if !kinds.is_empty() {
+                app.explicitly_remembered = true;
+            }
             app.auto_approve_kinds = kinds;
             app.last_used = Timestamp::now();
         }
@@ -1294,6 +1301,21 @@ mod tests {
         );
         assert!(!restored, "a row marked not-remembered is not restored");
         assert!(pm.get_app(&pubkey).is_none());
+    }
+
+    #[test]
+    fn set_auto_approve_kinds_marks_app_remembered() {
+        // A user configuring auto-approve kinds is an explicit remember, so the
+        // app persists (and is not false-dropped by the gated persist path).
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+        assert!(!pm.get_app(&pubkey).unwrap().explicitly_remembered);
+        assert!(pm.stored_snapshot().is_empty());
+
+        pm.set_auto_approve_kinds_for_app(&pubkey, HashSet::from([Kind::TextNote]));
+        assert!(pm.get_app(&pubkey).unwrap().explicitly_remembered);
+        assert_eq!(pm.stored_snapshot().len(), 1);
     }
 
     #[test]

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -1319,6 +1319,24 @@ mod tests {
     }
 
     #[test]
+    fn set_auto_approve_kinds_empty_preserves_timed_remember() {
+        // Clearing auto-approve kinds must not un-remember an app that still holds
+        // a live timed grant (a separate explicit remember decision).
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+        assert!(pm.grant_kind_for(&pubkey, Kind::TextNote, 3600));
+        assert!(pm.get_app(&pubkey).unwrap().explicitly_remembered);
+
+        pm.set_auto_approve_kinds_for_app(&pubkey, HashSet::new());
+        assert!(
+            pm.get_app(&pubkey).unwrap().explicitly_remembered,
+            "clearing auto-kinds must not drop a live timed remember"
+        );
+        assert_eq!(pm.stored_snapshot().len(), 1);
+    }
+
+    #[test]
     fn grant_kind_forever_enforces_max_auto_kinds_cap() {
         let mut pm = PermissionManager::new();
         let pubkey = Keys::generate().public_key();


### PR DESCRIPTION
Closes the keep-desktop half of the NIP-46 remember-persistence gap left open by #810. On desktop, `sync_bunker_permissions_to_vault` is the only durable writer of `bunker_permissions` (the `DesktopCallbacks` server callback does not override `persist_permissions`, so the gated `stored_snapshot()` path is a no-op there). It persisted every non-Session client with `explicitly_remembered: None`, so on restart the legacy content-fallback resurrected a client-supplied `sign_event:<kind>` connect scope, keeping the residual bypass exploitable on desktop.

## Change

- Thread `AppPermission::explicitly_remembered` (from `SignerHandler::list_clients()`) onto the desktop `bunker::ConnectedClient`.
- `sync_bunker_permissions_to_vault` now persists only clients the user explicitly remembered and writes `Some(explicitly_remembered)` instead of `None`. A bare connection or a client connect-time kind scope is no longer written, so it is not restored and must re-present the connect secret after a restart.
- `PermissionManager::set_auto_approve_kinds_for_app` now sets the remember flag when the user configures auto-approve kinds, so a user's desktop auto-kind edits are not false-dropped by the now-gated persistence (clearing to empty leaves the flag untouched so a separate live timed grant still counts).

With this, the flag gates persistence on every surface (engine, mobile, CLI, desktop); a client can no longer opt itself into cross-restart persistence by requesting a kind scope at connect.

## Testing

- New engine test: configuring auto-approve kinds marks the app remembered and makes it persist.
- keep-nip46 (165) and keep-desktop (63) tests pass; build, fmt, clippy clean.

The separate per-kind ride-along residual (connect-scope kinds persisting alongside a genuine user remember) still needs per-kind origin tracking and is tracked separately.
