### PR TITLE
keep-mobile: wire opt-in strict certificate pinning to close first-use TOFU MitM

### DIFF
--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -254,6 +254,7 @@ const HEALTH_STATUS_KEY_PREFIX: &str = "__keep_health_";
 const RELAY_CONFIG_KEY_PREFIX: &str = "__keep_relay_config_";
 const RELAY_CONFIG_GLOBAL_KEY: &str = "__keep_relay_config_global";
 const PROXY_CONFIG_STORAGE_KEY: &str = "__keep_proxy_config_v1";
+const STRICT_PIN_CONFIG_STORAGE_KEY: &str = "__keep_strict_pin_config_v1";
 const BUNKER_CONFIG_STORAGE_KEY: &str = "__keep_bunker_config_v1";
 const KILL_SWITCH_STORAGE_KEY: &str = "__keep_kill_switch_v1";
 const DESCRIPTOR_SESSION_TIMEOUT: Duration = Duration::from_secs(600);
@@ -1900,6 +1901,31 @@ impl KeepMobile {
         persistence::persist_proxy_config(&self.storage, PROXY_CONFIG_STORAGE_KEY, &stored)
     }
 
+    /// Whether strict certificate pinning is enabled. When true, connecting to a
+    /// relay that has no pre-provisioned pin is rejected (fail-closed) instead of
+    /// trusted-on-first-use, closing the first-connection MitM window that plain
+    /// TOFU leaves open. Opt-in and disabled by default: enable it only after
+    /// staging each relay's pin via `stage_certificate_pin`, or new connections
+    /// to un-pinned relays will fail until their pins are provisioned.
+    pub fn get_strict_cert_pinning(&self) -> Result<bool, KeepMobileError> {
+        Ok(
+            persistence::load_strict_pin_config(&self.storage, STRICT_PIN_CONFIG_STORAGE_KEY)?
+                .unwrap_or_default()
+                .enabled,
+        )
+    }
+
+    /// Enable or disable strict certificate pinning (see `get_strict_cert_pinning`).
+    /// Takes effect on the next connection.
+    pub fn set_strict_cert_pinning(&self, enabled: bool) -> Result<(), KeepMobileError> {
+        let config = persistence::StoredStrictPinConfig { enabled };
+        persistence::persist_strict_pin_config(
+            &self.storage,
+            STRICT_PIN_CONFIG_STORAGE_KEY,
+            &config,
+        )
+    }
+
     pub fn get_bunker_config(&self) -> Result<BunkerConfigInfo, KeepMobileError> {
         let stored = persistence::load_bunker_config(&self.storage, BUNKER_CONFIG_STORAGE_KEY)?;
         let config = stored.unwrap_or_default();
@@ -2683,12 +2709,16 @@ impl KeepMobile {
         let share = self.load_share_package()?;
 
         self.runtime.block_on(async {
+            // Opt-in strict pinning: when enabled, an un-pinned relay is rejected
+            // (fail-closed) rather than trusted-on-first-use. Disabled by default.
+            let require_pinned =
+                persistence::load_strict_pin_config(&self.storage, STRICT_PIN_CONFIG_STORAGE_KEY)?
+                    .unwrap_or_default()
+                    .enabled;
             let mut pins = persistence::load_cert_pins(&self.storage)?.unwrap_or_default();
             let mut pins_changed = false;
             for relay in &relays {
-                // require_pinned=false: trust-on-first-use. A strict-mode config
-                // toggle that passes true is tracked as a follow-up.
-                match keep_frost_net::verify_relay_certificate(relay, &pins, false).await {
+                match keep_frost_net::verify_relay_certificate(relay, &pins, require_pinned).await {
                     Ok((_hash, new_pin)) => {
                         if let Some((hostname, hash)) = new_pin {
                             if !pins.is_pinned(&hostname) {
@@ -3947,5 +3977,18 @@ mod cert_pin_ffi_tests {
         assert!(keep
             .stage_certificate_pin("relay.example.com".into(), "not-a-hash".into())
             .is_err());
+    }
+
+    #[test]
+    fn strict_cert_pinning_defaults_off_and_persists() {
+        let keep = keep();
+        assert!(
+            !keep.get_strict_cert_pinning().unwrap(),
+            "strict pinning is opt-in, off by default"
+        );
+        keep.set_strict_cert_pinning(true).unwrap();
+        assert!(keep.get_strict_cert_pinning().unwrap());
+        keep.set_strict_cert_pinning(false).unwrap();
+        assert!(!keep.get_strict_cert_pinning().unwrap());
     }
 }

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -2500,6 +2500,17 @@ fn normalize_pin_host(hostname: &str) -> Result<String, KeepMobileError> {
     })
 }
 
+/// Whether `relay` is a `wss` URL whose host has no provisioned certificate pin.
+/// Uses the same host key as the verified-relay filter so strict mode skips
+/// exactly the relays that filter would exclude. Non-`wss` or unparseable relays
+/// are left to the normal verification path.
+fn wss_relay_lacks_pin(relay: &str, pins: &keep_frost_net::CertificatePinSet) -> bool {
+    match url::Url::parse(relay) {
+        Ok(u) if u.scheme() == "wss" => u.host_str().map(|h| !pins.is_pinned(h)).unwrap_or(true),
+        _ => false,
+    }
+}
+
 fn relay_config_key(group_pubkey: Option<&str>) -> String {
     match group_pubkey {
         Some(pk) => {
@@ -2709,8 +2720,9 @@ impl KeepMobile {
         let share = self.load_share_package()?;
 
         self.runtime.block_on(async {
-            // Opt-in strict pinning: when enabled, an un-pinned relay is rejected
-            // (fail-closed) rather than trusted-on-first-use. Disabled by default.
+            // Opt-in strict pinning: when enabled, an un-pinned relay is not
+            // trusted-on-first-use; it is skipped (see the per-relay handling
+            // below) rather than pinned. Disabled by default.
             let require_pinned =
                 persistence::load_strict_pin_config(&self.storage, STRICT_PIN_CONFIG_STORAGE_KEY)?
                     .unwrap_or_default()
@@ -2718,6 +2730,17 @@ impl KeepMobile {
             let mut pins = persistence::load_cert_pins(&self.storage)?.unwrap_or_default();
             let mut pins_changed = false;
             for relay in &relays {
+                // Strict mode: skip an un-pinned relay rather than aborting init
+                // for the whole set. It is excluded from `verified_relays` below,
+                // and the empty-set check there fails closed if none are pinned.
+                // A pinned relay presenting a mismatched cert stays a fatal MitM.
+                if require_pinned && wss_relay_lacks_pin(relay, &pins) {
+                    tracing::warn!(
+                        relay = %relay,
+                        "strict pinning: skipping relay with no provisioned pin"
+                    );
+                    continue;
+                }
                 match keep_frost_net::verify_relay_certificate(relay, &pins, require_pinned).await {
                     Ok((_hash, new_pin)) => {
                         if let Some((hostname, hash)) = new_pin {
@@ -3990,5 +4013,21 @@ mod cert_pin_ffi_tests {
         assert!(keep.get_strict_cert_pinning().unwrap());
         keep.set_strict_cert_pinning(false).unwrap();
         assert!(!keep.get_strict_cert_pinning().unwrap());
+    }
+
+    #[test]
+    fn wss_relay_lacks_pin_tracks_pin_state() {
+        let mut pins = keep_frost_net::CertificatePinSet::new();
+        // An un-pinned wss relay lacks a pin (skipped in strict mode).
+        assert!(super::wss_relay_lacks_pin("wss://relay.example.com", &pins));
+        // After staging its pin (same host key), it no longer lacks one.
+        pins.add_pin("relay.example.com".into(), [0xaa; 32]);
+        assert!(!super::wss_relay_lacks_pin(
+            "wss://relay.example.com",
+            &pins
+        ));
+        // Non-wss and unparseable relays are not treated as pin-skips.
+        assert!(!super::wss_relay_lacks_pin("ws://relay.example.com", &pins));
+        assert!(!super::wss_relay_lacks_pin("not a url", &pins));
     }
 }

--- a/keep-mobile/src/persistence.rs
+++ b/keep-mobile/src/persistence.rs
@@ -632,6 +632,47 @@ pub(crate) fn persist_proxy_config(
     storage.store_share_by_key(key.into(), data, storage_metadata("proxy_config"))
 }
 
+/// Opt-in strict certificate pinning. When enabled, a relay with no
+/// pre-provisioned pin is rejected at connect (fail-closed) instead of
+/// trusted-on-first-use, closing the first-connection MitM window. Defaults to
+/// disabled so existing deployments are not broken until the operator has staged
+/// each relay's pin.
+#[derive(Serialize, Deserialize, Default)]
+pub(crate) struct StoredStrictPinConfig {
+    pub(crate) enabled: bool,
+}
+
+pub(crate) fn load_strict_pin_config(
+    storage: &Arc<dyn SecureStorage>,
+    key: &str,
+) -> Result<Option<StoredStrictPinConfig>, KeepMobileError> {
+    match storage.load_share_by_key(key.into()) {
+        Ok(data) => {
+            let config: StoredStrictPinConfig =
+                serde_json::from_slice(&data).map_err(|e| KeepMobileError::StorageError {
+                    msg: format!("failed to deserialize strict pin config: {e}"),
+                })?;
+            Ok(Some(config))
+        }
+        Err(KeepMobileError::StorageNotFound) => Ok(None),
+        Err(e) => {
+            tracing::warn!("failed to load strict pin config: {e}");
+            Err(e)
+        }
+    }
+}
+
+pub(crate) fn persist_strict_pin_config(
+    storage: &Arc<dyn SecureStorage>,
+    key: &str,
+    config: &StoredStrictPinConfig,
+) -> Result<(), KeepMobileError> {
+    let data = serde_json::to_vec(config).map_err(|e| KeepMobileError::StorageError {
+        msg: format!("failed to serialize strict pin config: {e}"),
+    })?;
+    storage.store_share_by_key(key.into(), data, storage_metadata("strict_pin_config"))
+}
+
 #[derive(Serialize, Deserialize, Default)]
 pub(crate) struct StoredBunkerConfig {
     pub(crate) enabled: bool,


### PR DESCRIPTION
keep-frost-net has the strict-pinning mechanism (per-call `require_pinned`, #783), but keep-mobile never exposed a way to turn it on: `do_initialize` always passed `require_pinned = false`, so an un-pinned relay's certificate was trusted-on-first-use. This wires an opt-in toggle.

## Change

- `get_strict_cert_pinning()` / `set_strict_cert_pinning(bool)` FFI, backed by a persisted `StoredStrictPinConfig` (mirrors the proxy-config pattern), disabled by default.
- `do_initialize` loads the flag and passes it as `require_pinned`. In strict mode an un-pinned relay is **skipped** (excluded from `verified_relays`; the existing empty-set check fails closed if none are pinned) rather than trusted-on-first-use, so adding one un-pinned relay does not abort init for the whole set. A pinned relay presenting a mismatched certificate stays a fatal mismatch (genuine MitM).
- Composes with pin staging (#807): stage each relay's pin out-of-band, then enable strict mode.

## Scope (important)

This enforces the pin on `verify_relay_certificate`'s pre-flight probe connection. As a security review noted, the certificate pin is currently enforced only on that probe, not on the live `nostr_sdk` data connection (which does standard WebPKI CA validation), `PinningServerCertVerifier` exists but is not wired into the data client. So strict mode is a real improvement against a persistent on-path attacker (it rejects an unpinned/mismatched cert and aborts, vs TOFU which trusts it), but a selective/late MitM presenting a CA-valid cert on only the data socket is not yet caught. Enforcing the pin on the actual data connection is a separate, higher-priority follow-up and is required before the first-connection MitM window is fully closed; this PR does not claim that.

## Testing

- New FFI test: strict pinning off by default, round-trips through persistence. New unit test for the un-pinned-relay skip predicate.
- The strict/TOFU/match decision is unit-tested in keep-frost-net (`evaluate_pin`).
- `cargo test -p keep-mobile` (231) passes; fmt, clippy clean.

Partial wiring for the TOFU/MitM hardening item #786. A keep-android settings toggle is a follow-up.
