### PR TITLE
keep-cli: fail closed when the duress state directory is group/world-writable

### DIFF
--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -424,38 +424,45 @@ pub(crate) fn parse_beacon_pins(pins: &[String]) -> Result<Vec<PublicKey>> {
 /// to trust its contents (an absent file could be a deleted freeze) rather than
 /// read it as "never frozen". Non-Unix targets rely on the platform ACLs; the
 /// duress serve boundary is documented for Unix.
+/// The offending directory and its permission bits if the directory holding
+/// `path` is writable by a non-owner: group- or world-writable WITHOUT the
+/// sticky bit, which lets someone other than the file's owner unlink it. `None`
+/// when the directory is owner-safe, sticky (the sticky bit restricts unlink to
+/// the owner), or cannot be stat'd (a truly inaccessible dir surfaces on the
+/// read instead). Unix-only; other targets rely on the platform's ACLs.
+///
+/// Single source of truth for "insecure duress state directory", shared by this
+/// read-side fail-closed check and `probe_duress_state`'s boot-time warning so
+/// the two cannot drift (e.g. on the sticky-bit exemption).
 #[cfg(unix)]
-fn validate_state_dir_perms(path: &Path) -> Result<()> {
+pub(crate) fn state_dir_writable_by_non_owner(path: &Path) -> Option<(PathBuf, u32)> {
     use std::os::unix::fs::MetadataExt;
     let dir = path
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
-    let meta = match std::fs::metadata(dir) {
-        Ok(m) => m,
-        // No directory yet means no persisted freeze can exist: nothing to guard.
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(e) => {
-            return Err(KeepError::runtime(format!(
-                "stat duress state directory {}: {e}",
-                dir.display()
-            )))
-        }
-    };
-    if meta.mode() & 0o022 != 0 {
-        return Err(KeepError::runtime(format!(
-            "duress state directory {} is group/world-writable (mode {:o}); a non-owner could \
-             delete a persisted freeze and silently resume serving. Restrict it (chmod go-w) and \
-             keep it root-owned.",
-            dir.display(),
-            meta.mode() & 0o7777
-        )));
-    }
-    Ok(())
+    let mode = std::fs::metadata(dir).ok()?.mode();
+    (mode & 0o022 != 0 && mode & 0o1000 == 0).then(|| (dir.to_path_buf(), mode & 0o7777))
 }
 
 #[cfg(not(unix))]
-fn validate_state_dir_perms(_path: &Path) -> Result<()> {
+pub(crate) fn state_dir_writable_by_non_owner(_path: &Path) -> Option<(PathBuf, u32)> {
+    None
+}
+
+/// Fail closed if the duress state directory is writable by a non-owner, so a
+/// coercer cannot delete a persisted freeze and silently resume serving. The
+/// missing-directory and non-Unix cases pass through (no freeze can exist / rely
+/// on platform ACLs).
+fn validate_state_dir_perms(path: &Path) -> Result<()> {
+    if let Some((dir, mode)) = state_dir_writable_by_non_owner(path) {
+        return Err(KeepError::runtime(format!(
+            "duress state directory {} is group/world-writable without the sticky bit (mode \
+             {mode:o}); a non-owner could delete a persisted freeze and silently resume serving. \
+             Restrict it (chmod go-w) and keep it root-owned.",
+            dir.display()
+        )));
+    }
     Ok(())
 }
 
@@ -840,8 +847,23 @@ mod tests {
         // A group-writable dir (not just world) is also rejected.
         std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o770)).unwrap();
         assert!(read_persisted_freeze(&path).is_err());
+
+        // The sticky bit restricts unlink to the file's owner, so a sticky
+        // world-writable dir is accepted (and matches probe_duress_state).
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o1777)).unwrap();
+        assert!(read_persisted_freeze(&path).unwrap().is_none());
+
         // Restore before tempdir cleanup.
         std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+    }
+
+    #[test]
+    fn read_persisted_freeze_allows_nonexistent_state_dir() {
+        // A missing directory means no freeze can exist yet: absent -> None, not
+        // a permission error.
+        let dir = secure_state_tempdir();
+        let path = dir.path().join("no-such-subdir").join("duress.state");
+        assert!(read_persisted_freeze(&path).unwrap().is_none());
     }
 
     #[test]

--- a/keep-cli/src/commands/frost_network/duress.rs
+++ b/keep-cli/src/commands/frost_network/duress.rs
@@ -416,11 +416,59 @@ pub(crate) fn parse_beacon_pins(pins: &[String]) -> Result<Vec<PublicKey>> {
         .collect()
 }
 
+/// Fail closed if the directory holding the duress state file is writable by
+/// group or others. The sticky-freeze guarantee ("no file means not frozen")
+/// only holds when a non-owner cannot delete the file, which reduces to the
+/// directory's write permission. A group/world-writable state directory lets any
+/// local user delete a persisted freeze and silently resume serving, so refuse
+/// to trust its contents (an absent file could be a deleted freeze) rather than
+/// read it as "never frozen". Non-Unix targets rely on the platform ACLs; the
+/// duress serve boundary is documented for Unix.
+#[cfg(unix)]
+fn validate_state_dir_perms(path: &Path) -> Result<()> {
+    use std::os::unix::fs::MetadataExt;
+    let dir = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let meta = match std::fs::metadata(dir) {
+        Ok(m) => m,
+        // No directory yet means no persisted freeze can exist: nothing to guard.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(KeepError::runtime(format!(
+                "stat duress state directory {}: {e}",
+                dir.display()
+            )))
+        }
+    };
+    if meta.mode() & 0o022 != 0 {
+        return Err(KeepError::runtime(format!(
+            "duress state directory {} is group/world-writable (mode {:o}); a non-owner could \
+             delete a persisted freeze and silently resume serving. Restrict it (chmod go-w) and \
+             keep it root-owned.",
+            dir.display(),
+            meta.mode() & 0o7777
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn validate_state_dir_perms(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
 /// Read a persisted duress freeze at boot. `None` if the file is absent (normal:
 /// not frozen). An existing but unparseable file is FATAL, not silently ignored:
 /// a corrupt freeze marker must fail the node closed rather than let it resume
 /// answering, which is the whole point of the sticky freeze.
+///
+/// First validates the state directory's permissions ([`validate_state_dir_perms`]):
+/// a group/world-writable directory makes "absent" untrustworthy (a freeze could
+/// have been deleted by a non-owner), so it fails closed.
 pub(crate) fn read_persisted_freeze(path: &Path) -> Result<Option<DuressFreeze>> {
+    validate_state_dir_perms(path)?;
     match std::fs::read(path) {
         Ok(bytes) => {
             let freeze = serde_json::from_slice(&bytes).map_err(|e| {
@@ -600,6 +648,20 @@ mod tests {
         parallelism: 1,
     };
 
+    /// A tempdir with owner-only (0o700) permissions, as a real duress state
+    /// directory must be. `tempfile::tempdir()` honors the umask (often
+    /// group-writable), which `read_persisted_freeze`'s permission check rejects.
+    fn secure_state_tempdir() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        #[cfg(unix)]
+        std::fs::set_permissions(
+            dir.path(),
+            std::os::unix::fs::PermissionsExt::from_mode(0o700),
+        )
+        .unwrap();
+        dir
+    }
+
     #[test]
     fn derive_beacon_key_is_deterministic() {
         let salt = [7u8; SALT_SIZE];
@@ -661,7 +723,7 @@ mod tests {
 
     #[test]
     fn clear_initiate_requires_an_active_freeze() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = secure_state_tempdir();
         let path = dir.path().join("d.state");
         // No freeze -> initiate refuses.
         assert!(clear_initiate(&path, TEST_DELAY, 1000).is_err());
@@ -672,7 +734,7 @@ mod tests {
 
     #[test]
     fn clear_initiate_rejects_delay_below_the_floor() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = secure_state_tempdir();
         let path = dir.path().join("d.state");
         write_freeze(&path);
         // 0 (or anything below the floor) is refused: the window cannot be nulled.
@@ -683,7 +745,7 @@ mod tests {
 
     #[test]
     fn clear_execute_gated_by_delay_then_lifts_freeze() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = secure_state_tempdir();
         let path = dir.path().join("d.state");
         write_freeze(&path);
         // Execute with no pending clear -> error.
@@ -702,7 +764,7 @@ mod tests {
 
     #[test]
     fn clear_execute_refuses_when_the_freeze_changed() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = secure_state_tempdir();
         let path = dir.path().join("d.state");
         write_freeze_nonce(&path, [1u8; 32]);
         clear_initiate(&path, TEST_DELAY, 1000).unwrap();
@@ -719,7 +781,7 @@ mod tests {
 
     #[test]
     fn clear_cancel_aborts_a_pending_clear() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = secure_state_tempdir();
         let path = dir.path().join("d.state");
         write_freeze(&path);
         assert!(!clear_cancel(&path).unwrap(), "no marker yet");
@@ -740,7 +802,7 @@ mod tests {
 
     #[test]
     fn read_persisted_freeze_roundtrips_and_fails_closed_on_corrupt() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = secure_state_tempdir();
         let path = dir.path().join("duress.state");
         // Absent -> None (not frozen).
         assert!(read_persisted_freeze(&path).unwrap().is_none());
@@ -757,6 +819,29 @@ mod tests {
         // A present-but-corrupt file fails closed (Err), never silently un-frozen.
         std::fs::write(&path, b"garbage").unwrap();
         assert!(read_persisted_freeze(&path).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_persisted_freeze_rejects_group_or_world_writable_state_dir() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("duress.state");
+
+        // A group/world-writable state dir cannot be trusted: a non-owner could
+        // have deleted a freeze, so an absent file must not read as "not frozen".
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o777)).unwrap();
+        assert!(read_persisted_freeze(&path).is_err());
+
+        // Restricting it restores the normal absent -> None behavior.
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(read_persisted_freeze(&path).unwrap().is_none());
+
+        // A group-writable dir (not just world) is also rejected.
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o770)).unwrap();
+        assert!(read_persisted_freeze(&path).is_err());
+        // Restore before tempdir cleanup.
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
     }
 
     #[test]

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -1801,6 +1801,13 @@ mod tests {
     #[test]
     fn persist_freeze_roundtrips_through_the_state_file() {
         let dir = tempfile::tempdir().unwrap();
+        // A real duress state dir is owner-only; tempdir honors the umask, which
+        // the read-side permission check now rejects if group/world-writable.
+        std::fs::set_permissions(
+            dir.path(),
+            std::os::unix::fs::PermissionsExt::from_mode(0o700),
+        )
+        .unwrap();
         let path = dir.path().join("duress.state");
         let f = sample_freeze();
         persist_freeze(&path, &f).unwrap();

--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -1322,25 +1322,16 @@ fn probe_duress_state(out: &Output, path: &Path) -> Result<()> {
     })?;
     let _ = std::fs::remove_file(&probe);
 
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-        let dir = match path.parent() {
-            Some(p) if !p.as_os_str().is_empty() => p,
-            _ => Path::new("."),
-        };
-        if let Ok(md) = std::fs::metadata(dir) {
-            let mode = md.mode();
-            // group/world write with no sticky bit lets a non-owner unlink the file.
-            if mode & 0o022 != 0 && mode & 0o1000 == 0 {
-                out.warn(&format!(
-                    "duress state directory {} is group/world-writable without the sticky bit: a \
-                     non-owner could delete the freeze marker and silently unfreeze on reboot. \
-                     Place --duress-state-file in a root-owned, non-writable directory.",
-                    dir.display()
-                ));
-            }
-        }
+    // Shares its definition of "insecure directory" with the read-side
+    // fail-closed check (`duress::validate_state_dir_perms`) so the boot-time
+    // warning and the hard failure cannot disagree (e.g. on the sticky bit).
+    if let Some((dir, _mode)) = duress::state_dir_writable_by_non_owner(path) {
+        out.warn(&format!(
+            "duress state directory {} is group/world-writable without the sticky bit: a \
+             non-owner could delete the freeze marker and silently unfreeze on reboot. \
+             Place --duress-state-file in a root-owned, non-writable directory.",
+            dir.display()
+        ));
     }
     Ok(())
 }


### PR DESCRIPTION
The duress sticky-freeze guarantee ("no state file means not frozen") rests entirely on the state directory being writable only by a trusted owner, so that a coercer cannot delete a persisted freeze and silently resume serving. The code documented that requirement ("the state directory MUST be root-owned and not operator-writable") but never enforced or checked it: `read_persisted_freeze` treated an absent file as "not frozen" unconditionally, so on a group/world-writable directory any local user could delete the freeze and the node would resume serving with no error.

## Change

- `read_persisted_freeze` now validates the state directory's permissions first (`validate_state_dir_perms`, Unix): if the directory is group- or world-writable, it fails closed with an actionable error instead of trusting a possibly-deleted freeze. A missing directory (no freeze can exist yet) and non-Unix targets pass through.
- This makes the absence of a freeze file trustworthy only when a non-owner could not have removed it.

## Scope

This is part (a) of the hardening: enforcing the directory-permission boundary the whole mechanism relies on. Part (b), a tamper-evident anchor so that even a write-capable party's deletion is *detectable* (absence != never-frozen), needs a design decision on where the anchor lives and is tracked as a follow-up.

## Testing

- New unit test: a group- or world-writable state dir makes `read_persisted_freeze` fail closed; restricting it (`0o700`) restores the normal absent -> None behavior.
- Existing duress tests updated to use an owner-only (`0o700`) tempdir (a real duress state dir must be), via a shared `secure_state_tempdir` helper. `tempfile::tempdir()` honors the umask and is often group-writable.
- `cargo test -p keep-cli` (166) passes; fmt, clippy, and the Windows target check are clean.

Part (a) of the duress hardening item #788.
