### PR TITLE
keep-mobile: verify a loaded share's cryptographic group key matches its storage key

### DIFF
--- a/keep-core/src/frost/share.rs
+++ b/keep-core/src/frost/share.rs
@@ -187,6 +187,16 @@ impl SharePackage {
     pub fn group_pubkey(&self) -> &[u8; 32] {
         &self.metadata.group_pubkey
     }
+
+    /// The group public key derived cryptographically from the public-key
+    /// package, as opposed to the `metadata.group_pubkey` field (which is plain
+    /// data and could be forged by whatever produced the package). Use this to
+    /// verify that a share loaded from an untrusted store actually belongs to the
+    /// expected group: a store that returns a different or corrupted share cannot
+    /// produce a public-key package whose verifying key matches the expected key.
+    pub fn verified_group_pubkey(&self) -> Result<[u8; 32]> {
+        super::dealer::extract_group_pubkey(&self.pubkey_package()?)
+    }
 }
 
 /// An encrypted share for persistent storage.
@@ -332,6 +342,28 @@ mod tests {
     const GOLDEN_PUBKEY_PACKAGE_LEGACY: &str = "00230f8ab3030000000000000000000000000000000000000000000000000000000000000001036800734597e8251af183d2ebe63d4e40e13aadb1fbc6a42b9355bf0e8687b9b9000000000000000000000000000000000000000000000000000000000000000203528367b7e2165da412e85b4dd5dc59f289ecbb2051d2e9f76ff3524b7ce10eab000000000000000000000000000000000000000000000000000000000000000303d408b25a61c86d4cd2c5d56a0e8d697ed81149852971469975dd36d64c5c215b03e29d92d6ce9b54080afc8e1b720092590a4a759224ef2dc8f99bbbdb13347a88";
     const GOLDEN_KEY_PACKAGE_1: &str = "00230f8ab30000000000000000000000000000000000000000000000000000000000000001fb905abafb56780848f1404d19e7389ca53f838a52cd3d959ba015cbf1f30952036800734597e8251af183d2ebe63d4e40e13aadb1fbc6a42b9355bf0e8687b9b903e29d92d6ce9b54080afc8e1b720092590a4a759224ef2dc8f99bbbdb13347a8802";
     const GOLDEN_KEY_PACKAGE_2: &str = "00230f8ab300000000000000000000000000000000000000000000000000000000000000020b9bd02ae54309f2459d2399a429b6675874a8a822566ec198cb218c2ddc8c2603528367b7e2165da412e85b4dd5dc59f289ecbb2051d2e9f76ff3524b7ce10eab03e29d92d6ce9b54080afc8e1b720092590a4a759224ef2dc8f99bbbdb13347a8802";
+
+    #[test]
+    fn verified_group_pubkey_derives_from_package_not_metadata() {
+        let real: [u8; 32] = hex::decode(GOLDEN_GROUP_PUBKEY)
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let pubkey_bytes = hex::decode(GOLDEN_PUBKEY_PACKAGE_LEGACY).unwrap();
+        // Forge the metadata to claim a different group than the package really is.
+        let forged = [0xAAu8; 32];
+        let metadata = ShareMetadata::new(1, 2, 3, forged, "forged".into());
+        let share = SharePackage::from_bytes(
+            metadata,
+            hex::decode(GOLDEN_KEY_PACKAGE_1).unwrap(),
+            pubkey_bytes,
+        );
+        // The plain metadata field reflects the forgery...
+        assert_eq!(share.group_pubkey(), &forged);
+        // ...but the cryptographic identity is the real group key, so an untrusted
+        // store cannot pass off one share as another by rewriting the metadata.
+        assert_eq!(share.verified_group_pubkey().unwrap(), real);
+    }
 
     #[test]
     fn test_legacy_format_share_deserializes_and_signs() {

--- a/keep-core/src/frost/share.rs
+++ b/keep-core/src/frost/share.rs
@@ -188,12 +188,16 @@ impl SharePackage {
         &self.metadata.group_pubkey
     }
 
-    /// The group public key derived cryptographically from the public-key
-    /// package, as opposed to the `metadata.group_pubkey` field (which is plain
-    /// data and could be forged by whatever produced the package). Use this to
-    /// verify that a share loaded from an untrusted store actually belongs to the
-    /// expected group: a store that returns a different or corrupted share cannot
-    /// produce a public-key package whose verifying key matches the expected key.
+    /// The group public key read from the public-key package's verifying key,
+    /// as opposed to the separate `metadata.group_pubkey` field. Use this to
+    /// detect a share loaded from an untrusted store that belongs to a
+    /// *different* group (or is corrupted) than the key it was requested under.
+    ///
+    /// This compares the package's advertised verifying key, which is public
+    /// data and an independently-settable field, so it is NOT proof that the
+    /// share carries a valid secret for that group: a store could pair the
+    /// expected verifying key with junk key material. That case is caught later
+    /// at signing time (the partial signatures will not aggregate), not here.
     pub fn verified_group_pubkey(&self) -> Result<[u8; 32]> {
         super::dealer::extract_group_pubkey(&self.pubkey_package()?)
     }

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -3595,12 +3595,13 @@ impl KeepMobile {
             .map_err(|e| KeepMobileError::FrostError { msg: e.to_string() })?;
 
         // Defense-in-depth against a compromised or buggy foreign SecureStorage:
-        // the share's cryptographic group key (derived from the public-key
-        // package, not the forgeable metadata field) MUST match the key it was
-        // requested under. A store that returns a different or corrupted share is
-        // rejected here instead of being loaded as the requested identity. The
-        // store cannot forge a package whose verifying key matches `key` without
-        // an actual share for that group.
+        // the share's group key read from its public-key package (not the
+        // separate, forgeable metadata field) MUST match the key it was requested
+        // under. This detects a store that returns a share for a *different*
+        // group, or a corrupted one, rather than loading it as the requested
+        // identity. A store that pairs the expected verifying key with junk key
+        // material still passes here but fails at signing; confidentiality and
+        // same-identity tamper-resistance rest on the platform secure storage.
         let derived = share
             .verified_group_pubkey()
             .map_err(|e| KeepMobileError::InvalidShare { msg: e.to_string() })?;
@@ -3907,7 +3908,11 @@ mod import_teardown_tests {
             .unwrap();
         storage.set_active_share_key(Some(wrong_key)).unwrap();
 
-        assert!(mobile.load_share_package().is_err());
+        let result = mobile.load_share_package();
+        assert!(
+            matches!(&result, Err(KeepMobileError::InvalidShare { msg }) if msg.contains("does not match its group key")),
+            "expected a group-key mismatch rejection"
+        );
     }
 }
 

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -3551,7 +3551,7 @@ impl KeepMobile {
             Some(k) => k,
             None => self.resolve_active_share()?,
         };
-        let data = self.storage.load_share_by_key(key)?;
+        let data = self.storage.load_share_by_key(key.clone())?;
         let stored: StoredShareData = serde_json::from_slice(&data)
             .map_err(|e| KeepMobileError::InvalidShare { msg: e.to_string() })?;
 
@@ -3591,8 +3591,27 @@ impl KeepMobile {
                 msg: format!("Invalid pubkey package: {e}"),
             })?;
 
-        SharePackage::new(metadata, &key_package, &pubkey_package)
-            .map_err(|e| KeepMobileError::FrostError { msg: e.to_string() })
+        let share = SharePackage::new(metadata, &key_package, &pubkey_package)
+            .map_err(|e| KeepMobileError::FrostError { msg: e.to_string() })?;
+
+        // Defense-in-depth against a compromised or buggy foreign SecureStorage:
+        // the share's cryptographic group key (derived from the public-key
+        // package, not the forgeable metadata field) MUST match the key it was
+        // requested under. A store that returns a different or corrupted share is
+        // rejected here instead of being loaded as the requested identity. The
+        // store cannot forge a package whose verifying key matches `key` without
+        // an actual share for that group.
+        let derived = share
+            .verified_group_pubkey()
+            .map_err(|e| KeepMobileError::InvalidShare { msg: e.to_string() })?;
+        if !key.eq_ignore_ascii_case(&hex::encode(derived)) {
+            return Err(KeepMobileError::InvalidShare {
+                msg: "stored share does not match its group key; the secure storage returned a \
+                      different or corrupted share"
+                    .into(),
+            });
+        }
+        Ok(share)
     }
 
     fn load_stored_share_info(&self, key: String) -> Option<StoredShareInfo> {
@@ -3858,6 +3877,37 @@ mod import_teardown_tests {
             storage.get_active_share_key().as_deref(),
             Some(info.group_pubkey.as_str())
         );
+    }
+
+    #[test]
+    fn load_share_package_rejects_a_share_under_a_mismatched_key() {
+        let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
+        let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
+
+        let key_bytes = Zeroizing::new(hex::decode("03".repeat(32)).unwrap());
+        let (key_package, pubkey_package, vk_bytes) =
+            KeepMobile::build_nsec_packages(&key_bytes).unwrap();
+        let group_pubkey: [u8; 32] = vk_bytes[1..33].try_into().unwrap();
+        let metadata = ShareMetadata::new(1, 1, 1, group_pubkey, "share".into());
+        let share = SharePackage::new(metadata.clone(), &key_package, &pubkey_package).unwrap();
+        let info = mobile.store_share_package(&share).unwrap();
+
+        // Loaded under its own (correct) key: accepted.
+        assert!(mobile.load_share_package().is_ok());
+
+        // Simulate a compromised/buggy store returning this share under a
+        // different key: the cryptographic identity no longer matches, so the
+        // load must fail closed rather than use the wrong share.
+        let raw = storage
+            .load_share_by_key(info.group_pubkey.clone())
+            .unwrap();
+        let wrong_key = "ff".repeat(32);
+        storage
+            .store_share_by_key(wrong_key.clone(), raw, (&metadata).into())
+            .unwrap();
+        storage.set_active_share_key(Some(wrong_key)).unwrap();
+
+        assert!(mobile.load_share_package().is_err());
     }
 }
 


### PR DESCRIPTION
Addresses part of the SecureStorage-trust hardening (#785 / keep-io4). keep-mobile persists FROST shares as raw JSON through the foreign `SecureStorage` (Android Keystore / iOS Keychain), trusting the platform for confidentiality and integrity. Nothing in the Rust layer verified that a share loaded by key actually belongs to that key: `load_share_package` built a `SharePackage` from whatever the store returned for the active key and used it as-is. A compromised or buggy storage implementation that returned a different (or corrupted) share would be used silently, exactly the "return different shares than stored" concern.

## Change

- `SharePackage::verified_group_pubkey()` (keep-core): derive the group public key **cryptographically** from the public-key package, not from the plain `metadata.group_pubkey` field (which is untrusted data a store could rewrite). This detects a store that returns a *different* group's share (or a corrupted one). Because the verifying key is public data, it does not prove the share carries a valid secret for that group; a store that pairs the expected key with junk key material passes this check but fails at signing (a DoS, not key theft).
- `load_share_package` (keep-mobile): after loading, require the share's `verified_group_pubkey()` to equal the key it was requested under; otherwise fail closed. This detects a store returning a mismatched or corrupted share at load time rather than surfacing later as a confusing signing failure.

This does not require a Rust-held secret, so it works under the mobile trust model (biometric-gated Keystore, no vault password at the Rust layer). It is defense-in-depth: confidentiality and tamper-resistance of a *matching* share still rest on the platform secure storage the trait contract mandates. A pure Rust HMAC keyed against a *malicious* storage impl is not achievable here, since any key would live in that same store; that framing in #785 is not viable and should be re-scoped.

## Testing

- keep-core: `verified_group_pubkey` returns the real group key even when `metadata.group_pubkey` is forged to a different value (proves it uses the package, not the metadata).
- keep-mobile: a share stored under its correct key loads; the same share made active under a mismatched key fails closed.
- `cargo test` keep-core (375) + keep-mobile (232) pass; fmt, clippy clean.
