### PR TITLE
keep-cli: gate write_secret_file tests to unix (fixes build-windows on main)

### DIFF
--- a/keep-cli/src/commands/frost_network/mod.rs
+++ b/keep-cli/src/commands/frost_network/mod.rs
@@ -1777,12 +1777,17 @@ mod tests {
         assert!(!auto_approve_conflicts(false, false));
     }
 
+    #[cfg(unix)]
     fn temp_path_for(path: &Path) -> std::path::PathBuf {
         let mut s = path.as_os_str().to_owned();
         s.push(".tmp");
         std::path::PathBuf::from(s)
     }
 
+    // `write_secret_file` fsyncs the containing directory, which requires opening
+    // it as a file handle; that errors on Windows, so this appliance-only writer is
+    // exercised on Unix only (matching `write_secret_file_is_owner_only`).
+    #[cfg(unix)]
     #[test]
     fn write_secret_file_round_trips_and_leaves_no_temp() {
         let dir = tempfile::tempdir().unwrap();
@@ -1814,6 +1819,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn write_secret_file_writes_empty_and_binary_payloads() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Two `write_secret_file` tests were added without the `#[cfg(unix)]` gate their siblings carry, turning `main` red on the `build-windows` job (which runs only on push-to-main, not on PRs, so it passed pre-merge).

`write_secret_file` fsyncs the containing directory for crash durability, which requires opening the directory as a file handle. That operation errors on Windows, and the writer is a Linux-appliance-only path (the NixOS boot gate for LUKS key / OPRF share / duress state). The existing `write_secret_file_is_owner_only` and `persist_freeze_roundtrips_through_the_state_file` tests are already `#[cfg(unix)]` for exactly this reason; `write_secret_file_round_trips_and_leaves_no_temp` and `write_secret_file_writes_empty_and_binary_payloads` simply missed it.

## Changes

- Gate both tests (and the `temp_path_for` test helper they use) with `#[cfg(unix)]`, matching the sibling tests.

## Verification

- Linux: `cargo test -p keep-cli --bin keep write_secret_file` — 3 passed.
- Windows target: `cargo check --target x86_64-pc-windows-gnu -p keep-cli --tests --bins` — compiles clean; the two gated tests are excluded from the Windows build, so they can no longer fail there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Limited platform-specific secret file tests to Unix environments.
  * Added documentation clarifying the Unix-only test behavior.
  * Prevented unsupported tests from running on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->