### PR TITLE
keep-desktop: extract switch_identity and confirm_delete_identity from the message match

### DIFF
--- a/keep-desktop/src/app/identity.rs
+++ b/keep-desktop/src/app/identity.rs
@@ -82,187 +82,189 @@ impl App {
                 }
                 Task::none()
             }
-            Message::SwitchIdentity(pubkey_hex) => {
-                if self.active_share_hex.as_deref() == Some(&pubkey_hex) {
-                    return Task::none();
-                }
-
-                self.save_relay_urls();
-                self.save_bunker_relays();
-
-                self.handle_disconnect_relay();
-                self.stop_bunker();
-
-                if let Some(key) = parse_hex_key(&pubkey_hex) {
-                    let config = {
-                        let guard = lock_keep(&self.keep);
-                        guard.as_ref().map(|keep| {
-                            keep.get_relay_config_or_default(&key)
-                                .unwrap_or_else(|_| keep_core::RelayConfig::with_defaults(key))
-                        })
-                    };
-                    if let Some(config) = config {
-                        self.apply_relay_config(config);
-                    }
-                }
-
-                {
-                    let guard = lock_keep(&self.keep);
-                    if let Some(keep) = guard.as_ref() {
-                        let _ = keep.set_active_share_key(Some(&pubkey_hex));
-                    }
-                }
-
-                let is_nsec = self
-                    .identities
-                    .iter()
-                    .any(|i| i.pubkey_hex == pubkey_hex && matches!(i.kind, IdentityKind::Nsec));
-                if is_nsec {
-                    if let Some(pubkey_bytes) = parse_hex_key(&pubkey_hex) {
-                        let mut guard = lock_keep(&self.keep);
-                        if let Some(keep) = guard.as_mut() {
-                            let _ = keep.keyring_mut().set_primary(pubkey_bytes);
-                        }
-                    }
-                }
-
-                self.active_share_hex = Some(pubkey_hex);
-                self.identity_switcher_open = false;
-                self.delete_identity_confirm = None;
-
-                let shares = self.current_shares();
-                match &self.screen {
-                    Screen::ShareList(_) => {
-                        self.screen = Screen::ShareList(shares::State::new(
-                            shares,
-                            self.active_share_hex.clone(),
-                        ));
-                    }
-                    Screen::Relay(_) => {
-                        self.screen = Screen::Relay(relay::State::new(
-                            shares,
-                            self.relay_urls.clone(),
-                            self.frost_status.clone(),
-                            self.frost_peers.clone(),
-                            self.pending_sign_display.clone(),
-                            self.frost_event_log.clone(),
-                        ));
-                    }
-                    Screen::Bunker(_) => {
-                        self.screen = Screen::Bunker(Box::new(self.create_bunker_screen()));
-                    }
-                    Screen::NsecKeys(_) => {
-                        self.set_nsec_keys_screen();
-                    }
-                    _ => {}
-                }
-
-                self.set_toast("Identity switched".into(), ToastKind::Success);
-                Task::none()
-            }
+            Message::SwitchIdentity(pubkey_hex) => self.switch_identity(pubkey_hex),
             Message::RequestDeleteIdentity(pubkey_hex) => {
                 self.delete_identity_confirm = Some(pubkey_hex);
                 Task::none()
             }
-            Message::ConfirmDeleteIdentity(pubkey_hex) => {
-                self.delete_identity_confirm = None;
-
-                let identity = self
-                    .identities
-                    .iter()
-                    .find(|i| i.pubkey_hex == pubkey_hex)
-                    .cloned();
-                let Some(identity) = identity else {
-                    self.set_toast("Identity not found".into(), ToastKind::Error);
-                    return Task::none();
-                };
-
-                let is_active = self.active_share_hex.as_deref() == Some(&pubkey_hex);
-                if is_active {
-                    self.handle_disconnect_relay();
-                    self.stop_bunker();
-                }
-
-                let result = match &identity.kind {
-                    IdentityKind::Frost { .. } => {
-                        let shares = self.current_shares();
-                        let group_shares: Vec<_> = shares
-                            .iter()
-                            .filter(|s| s.group_pubkey_hex == pubkey_hex)
-                            .collect();
-                        let total = group_shares.len();
-                        let mut deleted = 0usize;
-                        let mut delete_err: Option<String> = None;
-                        for share in &group_shares {
-                            let res = {
-                                let mut guard = lock_keep(&self.keep);
-                                guard.as_mut().map(|keep| {
-                                    keep.frost_delete_share(&share.group_pubkey, share.identifier)
-                                })
-                            };
-                            match res {
-                                Some(Ok(())) => deleted += 1,
-                                Some(Err(e)) => {
-                                    delete_err = Some(super::friendly_err(e));
-                                    break;
-                                }
-                                None => {
-                                    delete_err = Some("Vault is locked".into());
-                                    break;
-                                }
-                            }
-                        }
-                        if let Some(err_msg) = delete_err {
-                            self.refresh_shares();
-                            self.set_toast(
-                                format!("Deleted {deleted}/{total} shares: {err_msg}"),
-                                ToastKind::Error,
-                            );
-                            false
-                        } else {
-                            true
-                        }
-                    }
-                    IdentityKind::Nsec => {
-                        let Some(pubkey_bytes) = parse_hex_key(&pubkey_hex) else {
-                            return Task::none();
-                        };
-                        let delete_result = {
-                            let mut guard = lock_keep(&self.keep);
-                            guard.as_mut().map(|keep| keep.delete_key(&pubkey_bytes))
-                        };
-                        match delete_result {
-                            Some(Ok(())) => true,
-                            Some(Err(e)) => {
-                                self.set_toast(super::friendly_err(e), ToastKind::Error);
-                                false
-                            }
-                            None => {
-                                self.set_toast("Vault is locked".into(), ToastKind::Error);
-                                false
-                            }
-                        }
-                    }
-                };
-
-                if result {
-                    if let Some(key) = parse_hex_key(&pubkey_hex) {
-                        let guard = lock_keep(&self.keep);
-                        if let Some(keep) = guard.as_ref() {
-                            let _ = keep.delete_relay_config(&key);
-                        }
-                    }
-                    self.refresh_shares();
-                    self.set_toast(format!("'{}' deleted", identity.name), ToastKind::Success);
-                }
-
-                Task::none()
-            }
+            Message::ConfirmDeleteIdentity(pubkey_hex) => self.confirm_delete_identity(pubkey_hex),
             Message::CancelDeleteIdentity => {
                 self.delete_identity_confirm = None;
                 Task::none()
             }
             _ => Task::none(),
         }
+    }
+
+    fn switch_identity(&mut self, pubkey_hex: String) -> Task<Message> {
+        if self.active_share_hex.as_deref() == Some(&pubkey_hex) {
+            return Task::none();
+        }
+
+        self.save_relay_urls();
+        self.save_bunker_relays();
+
+        self.handle_disconnect_relay();
+        self.stop_bunker();
+
+        if let Some(key) = parse_hex_key(&pubkey_hex) {
+            let config = {
+                let guard = lock_keep(&self.keep);
+                guard.as_ref().map(|keep| {
+                    keep.get_relay_config_or_default(&key)
+                        .unwrap_or_else(|_| keep_core::RelayConfig::with_defaults(key))
+                })
+            };
+            if let Some(config) = config {
+                self.apply_relay_config(config);
+            }
+        }
+
+        {
+            let guard = lock_keep(&self.keep);
+            if let Some(keep) = guard.as_ref() {
+                let _ = keep.set_active_share_key(Some(&pubkey_hex));
+            }
+        }
+
+        let is_nsec = self
+            .identities
+            .iter()
+            .any(|i| i.pubkey_hex == pubkey_hex && matches!(i.kind, IdentityKind::Nsec));
+        if is_nsec {
+            if let Some(pubkey_bytes) = parse_hex_key(&pubkey_hex) {
+                let mut guard = lock_keep(&self.keep);
+                if let Some(keep) = guard.as_mut() {
+                    let _ = keep.keyring_mut().set_primary(pubkey_bytes);
+                }
+            }
+        }
+
+        self.active_share_hex = Some(pubkey_hex);
+        self.identity_switcher_open = false;
+        self.delete_identity_confirm = None;
+
+        let shares = self.current_shares();
+        match &self.screen {
+            Screen::ShareList(_) => {
+                self.screen =
+                    Screen::ShareList(shares::State::new(shares, self.active_share_hex.clone()));
+            }
+            Screen::Relay(_) => {
+                self.screen = Screen::Relay(relay::State::new(
+                    shares,
+                    self.relay_urls.clone(),
+                    self.frost_status.clone(),
+                    self.frost_peers.clone(),
+                    self.pending_sign_display.clone(),
+                    self.frost_event_log.clone(),
+                ));
+            }
+            Screen::Bunker(_) => {
+                self.screen = Screen::Bunker(Box::new(self.create_bunker_screen()));
+            }
+            Screen::NsecKeys(_) => {
+                self.set_nsec_keys_screen();
+            }
+            _ => {}
+        }
+
+        self.set_toast("Identity switched".into(), ToastKind::Success);
+        Task::none()
+    }
+
+    fn confirm_delete_identity(&mut self, pubkey_hex: String) -> Task<Message> {
+        self.delete_identity_confirm = None;
+
+        let identity = self
+            .identities
+            .iter()
+            .find(|i| i.pubkey_hex == pubkey_hex)
+            .cloned();
+        let Some(identity) = identity else {
+            self.set_toast("Identity not found".into(), ToastKind::Error);
+            return Task::none();
+        };
+
+        let is_active = self.active_share_hex.as_deref() == Some(&pubkey_hex);
+        if is_active {
+            self.handle_disconnect_relay();
+            self.stop_bunker();
+        }
+
+        let result = match &identity.kind {
+            IdentityKind::Frost { .. } => {
+                let shares = self.current_shares();
+                let group_shares: Vec<_> = shares
+                    .iter()
+                    .filter(|s| s.group_pubkey_hex == pubkey_hex)
+                    .collect();
+                let total = group_shares.len();
+                let mut deleted = 0usize;
+                let mut delete_err: Option<String> = None;
+                for share in &group_shares {
+                    let res = {
+                        let mut guard = lock_keep(&self.keep);
+                        guard.as_mut().map(|keep| {
+                            keep.frost_delete_share(&share.group_pubkey, share.identifier)
+                        })
+                    };
+                    match res {
+                        Some(Ok(())) => deleted += 1,
+                        Some(Err(e)) => {
+                            delete_err = Some(super::friendly_err(e));
+                            break;
+                        }
+                        None => {
+                            delete_err = Some("Vault is locked".into());
+                            break;
+                        }
+                    }
+                }
+                if let Some(err_msg) = delete_err {
+                    self.refresh_shares();
+                    self.set_toast(
+                        format!("Deleted {deleted}/{total} shares: {err_msg}"),
+                        ToastKind::Error,
+                    );
+                    false
+                } else {
+                    true
+                }
+            }
+            IdentityKind::Nsec => {
+                let Some(pubkey_bytes) = parse_hex_key(&pubkey_hex) else {
+                    return Task::none();
+                };
+                let delete_result = {
+                    let mut guard = lock_keep(&self.keep);
+                    guard.as_mut().map(|keep| keep.delete_key(&pubkey_bytes))
+                };
+                match delete_result {
+                    Some(Ok(())) => true,
+                    Some(Err(e)) => {
+                        self.set_toast(super::friendly_err(e), ToastKind::Error);
+                        false
+                    }
+                    None => {
+                        self.set_toast("Vault is locked".into(), ToastKind::Error);
+                        false
+                    }
+                }
+            }
+        };
+
+        if result {
+            if let Some(key) = parse_hex_key(&pubkey_hex) {
+                let guard = lock_keep(&self.keep);
+                if let Some(keep) = guard.as_ref() {
+                    let _ = keep.delete_relay_config(&key);
+                }
+            }
+            self.refresh_shares();
+            self.set_toast(format!("'{}' deleted", identity.name), ToastKind::Success);
+        }
+
+        Task::none()
     }
 }


### PR DESCRIPTION
`handle_identity_message` had grown to 192 lines because two of its message arms carried large multi-step bodies: `SwitchIdentity` (relay teardown, config apply, active-key update, primary-key handling, screen rebuild) and `ConfirmDeleteIdentity` (per-kind share/key deletion with error accounting). This extracts each into its own method.

## Changes

- `switch_identity(&mut self, pubkey_hex)` and `confirm_delete_identity(&mut self, pubkey_hex)` hold the two arm bodies verbatim.
- `handle_identity_message` (192 → 22 lines) is now a flat dispatch: the two arms delegate to the new methods, the small arms stay inline.

## Behavior

Pure code motion. The extracted bodies are unchanged, the arm bindings (`pubkey_hex`) become the method parameters, and every early return / toast / screen transition is preserved.

## Verification

- `cargo clippy -p keep-desktop --all-targets`: clean.
- keep-desktop suite: 65 passed.
