### PR TITLE
keep-nip46: fail closed instead of panicking on unrouted encryption method

### DIFF
--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -804,7 +804,14 @@ pub(crate) async fn dispatch_request(
                         .handle_nip04_decrypt(app_pubkey, peer, &request.params[1])
                         .await
                 }
-                _ => unreachable!(),
+                // The outer dispatch arm routes exactly the four methods above
+                // here, so this is unreachable today; fail closed instead of
+                // panicking so a future divergence between the two lists cannot
+                // let an attacker-supplied method string crash the signer.
+                other => {
+                    warn!(method = %other, "encryption dispatch received unrouted method");
+                    return Nip46Response::error(id, "Unsupported method");
+                }
             };
             match result {
                 Ok(data) => Nip46Response::ok(id, &data),


### PR DESCRIPTION
Hardening found by an audit of panic sites on untrusted-input decode paths.

The encryption dispatch in the NIP-46 server re-matches the client-supplied method string inside the arm that the outer dispatch routes `nip44_encrypt` / `nip44_decrypt` / `nip04_encrypt` / `nip04_decrypt` into, with `_ => unreachable!()`. The invariant holds today, but it couples two match arms in different places on an attacker-controlled string: if the outer list ever gains a method the inner match does not handle, an unsupported method string panics the signer process (denial of service) instead of returning an error.

## Changes

- Replace the `unreachable!()` arm with a logged, fail-closed `Unsupported method` error response.

## Audit context

A sweep of `unwrap()` / `expect()` / `panic!` / `unreachable!` in non-test code across the wire and IPC decode surfaces (keep-frost-net protocol/event/node, keep-nip46 request handling, keep-mobile FFI) found no attacker-reachable panic besides this fragile spot. The remaining sites are locally-verified invariants (`expect("just inserted")` immediately after a map insert), startup-time initialization, or environmental conditions, none reachable from untrusted input.

## Verification

- `cargo test -p keep-nip46`: 189 passed.
- `cargo clippy -p keep-nip46 --all-targets`: clean.