### PR TITLE
keep-desktop: enforce relay cert pinning on nostrconnect bunker start

### DIFF
--- a/keep-desktop/src/nostrconnect.rs
+++ b/keep-desktop/src/nostrconnect.rs
@@ -87,9 +87,26 @@ impl App {
         let setup_arc = Arc::new(Mutex::new(None));
         self.bunker_pending_setup = Some(setup_arc.clone());
         let proxy = self.proxy_addr();
+        let cert_pins = self.certificate_pins.clone();
+        let keep_path = self.keep_path.clone();
+        let require_pinned = self.settings.strict_cert_pinning;
 
         Task::perform(
             async move {
+                // Enforce/establish SPKI pins before starting the bunker against
+                // these relays. The relay list comes from the (attacker-influenceable)
+                // nostrconnect request, so this fails closed on a corrupt pin store
+                // or a pin mismatch, and records TOFU pins otherwise, mirroring the
+                // interactive bunker-start path in bunker_service.rs.
+                crate::frost::verify_relay_certificates(
+                    &valid_relays,
+                    &cert_pins,
+                    &keep_path,
+                    require_pinned,
+                )
+                .await
+                .map_err(|e| format!("{e}"))?;
+
                 let keyring = tokio::task::spawn_blocking(move || extract_keyring(&keep_arc))
                     .await
                     .map_err(|_| "Background task failed".to_string())??;

--- a/keep-desktop/src/nostrconnect.rs
+++ b/keep-desktop/src/nostrconnect.rs
@@ -98,14 +98,16 @@ impl App {
                 // nostrconnect request, so this fails closed on a corrupt pin store
                 // or a pin mismatch, and records TOFU pins otherwise, mirroring the
                 // interactive bunker-start path in bunker_service.rs.
+                // Propagate the `ConnectionError` unchanged (via `?`) so a
+                // `PinMismatch` keeps its structured variant and reaches the
+                // dedicated cert-failure UI, matching the interactive path.
                 crate::frost::verify_relay_certificates(
                     &valid_relays,
                     &cert_pins,
                     &keep_path,
                     require_pinned,
                 )
-                .await
-                .map_err(|e| format!("{e}"))?;
+                .await?;
 
                 let keyring = tokio::task::spawn_blocking(move || extract_keyring(&keep_arc))
                     .await


### PR DESCRIPTION
The nostrconnect-approve flow (`handle_nostrconnect_approve`) started a NIP-46 bunker `Server` against the relay URLs carried in the `nostrconnect://` request without any TLS certificate pinning, while the interactive bunker-start path (`bunker_service.rs`) gates on `verify_relay_certificates` first. Because the relay list is attacker-influenceable (it comes from the request), this path did no SPKI pinning at all, even with a healthy pin store, and could not fail closed on a corrupt store or a pin mismatch.

## Change

- Route the nostrconnect relay list through `verify_relay_certificates` at the start of the bunker-start task, before the server is created, mirroring `bunker_service.rs`. Pin context (`certificate_pins`, `keep_path`, and the `strict_cert_pinning` policy) is captured before the async block.

This makes pin enforcement/establishment consistent across both bunker-start paths: a corrupt pin store or a mismatched certificate now fails the connection closed, and un-pinned relays record a TOFU pin (or are rejected under strict mode).

## Verification

- `cargo test -p keep-desktop`: 68 passed. `cargo clippy -p keep-desktop --all-targets`: clean.