### PR TITLE
keep-nip46: GC expired timed grants on the request path

### DIFF
--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -666,11 +666,7 @@ mod tests {
         // ...and the next request through record_usage garbage-collects it.
         pm.record_usage(&pubkey);
         assert!(
-            pm.apps
-                .get(&pubkey)
-                .unwrap()
-                .timed_kind_grants
-                .is_empty(),
+            pm.apps.get(&pubkey).unwrap().timed_kind_grants.is_empty(),
             "expired timed grant must be garbage-collected on the request path"
         );
     }

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -450,6 +450,12 @@ impl PermissionManager {
         if let Some(app) = self.apps.get_mut(pubkey) {
             app.last_used = Timestamp::now();
             app.request_count += 1;
+            // GC the app's expired per-kind timed grants on its request path.
+            // `has_unexpired_timed_grant` / `needs_approval` only skip expired
+            // entries without removing them, so without this they linger until
+            // the app's next timed grant. Dropping an already-expired entry
+            // never changes an authorization decision.
+            app.prune_expired_kind_grants();
         }
     }
 
@@ -638,6 +644,35 @@ mod tests {
 
         pm.revoke(&pubkey);
         assert!(!pm.is_connected(&pubkey));
+    }
+
+    #[test]
+    fn record_usage_gcs_expired_timed_grants() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "App".into());
+
+        // Inject an already-expired timed grant directly (the write path always
+        // sets a future expiry, so simulate a grant whose window has passed).
+        let past = now_unix_secs().saturating_sub(100);
+        pm.apps
+            .get_mut(&pubkey)
+            .unwrap()
+            .timed_kind_grants
+            .insert(Kind::from(9999u16), past);
+
+        // The read path already treats it as expired...
+        assert!(pm.needs_approval(&pubkey, Kind::from(9999u16)));
+        // ...and the next request through record_usage garbage-collects it.
+        pm.record_usage(&pubkey);
+        assert!(
+            pm.apps
+                .get(&pubkey)
+                .unwrap()
+                .timed_kind_grants
+                .is_empty(),
+            "expired timed grant must be garbage-collected on the request path"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`has_unexpired_timed_grant` / `needs_approval` skip expired per-kind timed grants but never remove them, and `prune_expired_kind_grants` previously ran only inside `grant_kind_for`. Stale `(kind, expiry)` entries therefore lingered on an app until its next timed grant. Low severity (bounded by the small set of distinct kinds), but unbounded in time.

## Change

- Prune the app's expired timed grants in `record_usage`, which runs on every request for that app (handler.rs:643). Removing an already-expired entry never changes an authorization decision (`needs_approval` already treats it as expired), so this is pure memory hygiene on the read path.

## Verification

- New test `record_usage_gcs_expired_timed_grants`: an injected expired grant is still treated as expired by `needs_approval`, then garbage-collected on the next `record_usage`.
- `cargo test -p keep-nip46`: 168 passed. `cargo clippy -p keep-nip46 --all-targets`: clean.