### PR TITLE
keep-nip46: surface malformed register_wallet hmac hex as InvalidInput

### DIFF
--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -366,8 +366,12 @@ impl Nip46Client {
                 }
                 let decode_result = hex::decode(hex_str.trim());
                 hex_str.zeroize();
+                // Malformed hex (odd length, non-hex chars) is an untrusted-input
+                // validation failure, same class as the too-long / wrong-length
+                // checks around it; surface it as InvalidInput so callers can
+                // handle all three consistently, not as a StorageErr.
                 let decoded = decode_result.map_err(|e| {
-                    StorageError::invalid_format(format!("register_wallet hmac hex: {e}"))
+                    KeepError::InvalidInput(format!("register_wallet hmac hex: {e}"))
                 })?;
                 if decoded.len() != HMAC_SHA256_LEN {
                     return Err(KeepError::InvalidInput(format!(


### PR DESCRIPTION
In `Nip46Client::register_wallet`, the device-returned hmac hex string is validated in three ways: too long -> `KeepError::InvalidInput`, wrong decoded length -> `KeepError::InvalidInput`, but malformed hex within the length bound (odd length, non-hex chars) was wrapped as `StorageError::invalid_format` -> `KeepError::StorageErr`. All three are untrusted-input validation failures at the same boundary and should share the `InvalidInput` variant so callers surface them consistently.

## Change

- Map the `hex::decode` failure to `KeepError::InvalidInput` instead of `StorageError::invalid_format`.

## Verification

- `cargo test -p keep-nip46`: 167 passed. `cargo clippy -p keep-nip46 --all-targets`: clean. `StorageError` remains used elsewhere in the file (no unused import).