### PR TITLE
keep-core: zeroize NIP-49 ncryptsec assembly buffer on drop

### DIFF
--- a/keep-core/src/keys.rs
+++ b/keep-core/src/keys.rs
@@ -322,7 +322,11 @@ pub mod nip49 {
             .encrypt(&XNonce::from(nonce), payload)
             .map_err(|_| CryptoError::encryption("NIP-49 encryption failed"))?;
 
-        let mut concat = Vec::with_capacity(91);
+        // Zeroize the assembled buffer on drop. It holds only the salt, nonce,
+        // and ciphertext (the plaintext key never enters it), but the salt and
+        // nonce are still worth clearing from memory. `with_capacity(91)` is the
+        // exact ncryptsec length, so no reallocation leaves an un-zeroed copy.
+        let mut concat = Zeroizing::new(Vec::with_capacity(91));
         concat.push(VERSION);
         concat.push(log_n);
         concat.extend_from_slice(&salt);


### PR DESCRIPTION
`Ncryptsec::encrypt` assembles the version/log_n/salt/nonce/security-byte/ciphertext into a plain `Vec<u8>` for bech32 encoding, then drops it without clearing. It never holds the plaintext key (that stays in the `Zeroizing` symmetric key and the `secret_key` slice), but the salt and nonce are worth clearing from memory rather than leaving them for a later heap read.

## Change

- Wrap the assembly buffer in `Zeroizing` so it is cleared on drop. `Vec::with_capacity(91)` is the exact ncryptsec byte length, so no reallocation leaves an un-zeroed intermediate copy behind.

No behavior change: the bech32 output is byte-identical.

## Verification

- `cargo test -p keep-core --lib keys`: passed (ncryptsec encrypt/decrypt round-trips). `cargo clippy -p keep-core --all-targets`: clean.