### PR TITLE
keep-nip46: disconnect client on connect_with setup-error path

### DIFF
--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -233,7 +233,13 @@ impl Nip46Client {
 
         match tokio::time::timeout(DEFAULT_REQUEST_TIMEOUT, setup).await {
             Ok(Ok(())) => {}
-            Ok(Err(e)) => return Err(e),
+            Ok(Err(e)) => {
+                // Disconnect before propagating so the relay connections and the
+                // nostr-sdk background tasks they spawn are torn down instead of
+                // leaking (Drop does not disconnect), matching the timeout arm.
+                client.disconnect().await;
+                return Err(e);
+            }
             Err(_) => {
                 client.disconnect().await;
                 return Err(NetworkError::timeout(


### PR DESCRIPTION
In `Nip46Client::connect_with`, the timeout arm disconnects the `Client` before returning, but the setup-error arm (`Ok(Err(e))`, reached when `add_relay` or `subscribe` fails within the timeout) returned the error while dropping the `Client` without disconnecting. nostr-sdk spawns background tasks per relay that `Drop` does not necessarily tear down, so a failed connect leaked relay connections/tasks.

## Change

- Call `client.disconnect().await` on the setup-error arm before propagating, matching the timeout arm. Both error paths now tear down the client.

## Verification

- `cargo test -p keep-nip46`: 167 passed. `cargo clippy -p keep-nip46 --all-targets`: clean.