### PR TITLE
keep-frost-net: document residual brute-force risk of OPRF auto-approve

### DIFF
--- a/keep-cli/src/cli.rs
+++ b/keep-cli/src/cli.rs
@@ -718,6 +718,12 @@ pub(crate) enum FrostNetworkCommands {
         /// to have VERIFIED attestation and is rate-limited; this is the explicit
         /// opt-in for an autonomous holder (e.g. a replica) that must answer
         /// attested requests unattended. Leave off to gate each eval behind a human.
+        /// RESIDUAL RISK: the rate limiter is best-effort (an admitted peer can
+        /// rotate transport identity to reset it), so attestation becomes the sole
+        /// human-free gate and a single compromised-but-Verified peer can obtain
+        /// effectively unbounded evaluations of the low-entropy unlock input,
+        /// removing brute-force protection. Enable ONLY where every Verified peer
+        /// is fully trusted, and pin strict PCRs.
         #[arg(long)]
         oprf_auto_approve: bool,
         /// Attach a TPM quote to this node's announces (e.g. device:/dev/tpmrm0)

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -541,7 +541,23 @@ impl SigningHooks for RefuseRawAndRequireStructuredHooks {
 /// admitted transport pubkey and is
 /// best-effort abuse control against a genuinely-admitted holder's accidental or
 /// naive over-querying, NOT a barrier against a compromised member (who is already
-/// inside the trust boundary). This flag lets an autonomous holder (e.g. a replica) answer
+/// inside the trust boundary).
+///
+/// RESIDUAL BRUTE-FORCE RISK: with auto-approve on, VERIFIED attestation is the
+/// SOLE human-free gate on evaluations. The per-requester rate limiter keys on
+/// the admitted transport pubkey, which an admitted peer can rotate to reset its
+/// bucket, so it does not bound the total number of evaluations. A single
+/// compromised-but-Verified holder can therefore obtain effectively unbounded
+/// evaluations of the fixed, low-entropy OPRF unlock input, which is exactly the
+/// oracle a brute-force / offline-dictionary attack on that input needs; the
+/// human-gated flow (auto-approve off) is what otherwise caps attempts. This is
+/// a deliberate trade-off for unattended holders, not a bug. Enable it ONLY where
+/// every Verified peer is fully trusted to hold the vault, and pin a strict PCR
+/// policy so attestation actually constrains WHO is admitted. An absolute
+/// per-input evaluation cap independent of requester identity would be a useful
+/// defense-in-depth here and is worth adding before relying on this at scale.
+///
+/// This flag lets an autonomous holder (e.g. a replica) answer
 /// verified requests unattended; leave it off for a holder that gates each evaluation
 /// behind a human (e.g. a phone).
 pub struct ServeHooks {


### PR DESCRIPTION
`--oprf-auto-approve` makes VERIFIED attestation the sole human-free gate on OPRF evaluations. The per-requester rate limiter keys on the admitted transport pubkey, which an admitted peer can rotate to reset, so it does not bound the total number of evaluations. A single compromised-but-Verified holder can therefore obtain effectively unbounded evaluations of the fixed, low-entropy OPRF unlock input, the exact oracle a brute-force / offline-dictionary attack needs, with no human gate. This is a deliberate trade-off for unattended holders, not a bug, but the residual risk and the operator conditions for using it safely were not spelled out at the flag.

## Changes

- Expand the `ServeHooks` doc comment with an explicit "residual brute-force risk" paragraph: why the rate limiter does not bound total evaluations, the brute-force consequence on the low-entropy unlock input, the operator conditions (only where every Verified peer is fully trusted; pin strict PCRs), and a note that an absolute per-input evaluation cap independent of requester identity would be useful defense-in-depth.
- Add a concise residual-risk warning to the `--oprf-auto-approve` CLI `--help` text.

Documentation only; no behavior change.

## Verification

- `cargo check` / `cargo clippy` for keep-frost-net and keep-cli: clean. `cargo fmt --check`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified security considerations for automatically approving OPRF evaluations.
  * Documented that rate limiting is best-effort and attestation is the primary unattended safeguard.
  * Added guidance to enable the option only with trusted peers and strict PCR pinning.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->