### PR TITLE
keep-frost-net: use shared canonical_descriptor_hash in descriptor_session

### DIFF
--- a/keep-frost-net/src/descriptor_session.rs
+++ b/keep-frost-net/src/descriptor_session.rs
@@ -397,14 +397,16 @@ impl DescriptorSession {
             .as_ref()
             .ok_or_else(|| FrostNetError::Session("No finalized descriptor".into()))?;
 
-        let mut hasher = Sha256::new();
-        hasher.update((finalized.external.len() as u64).to_le_bytes());
-        hasher.update(finalized.external.as_bytes());
-        hasher.update((finalized.internal.len() as u64).to_le_bytes());
-        hasher.update(finalized.internal.as_bytes());
-        hasher.update(finalized.policy_hash);
-        keep_core::wallet::fold_descriptor_version_suffix(&mut hasher, self.policy.version);
-        let expected_hash: [u8; 32] = hasher.finalize().into();
+        // Shared with `WalletDescriptor::canonical_hash` and every other
+        // recompute site so the formula cannot drift; also rejects the invalid
+        // version==0 case that the old inline copy silently hashed.
+        let expected_hash = keep_core::wallet::canonical_descriptor_hash(
+            &finalized.external,
+            &finalized.internal,
+            &finalized.policy_hash,
+            self.policy.version,
+        )
+        .map_err(|e| FrostNetError::Session(format!("canonical descriptor hash: {e}")))?;
 
         if !bool::from(descriptor_hash.ct_eq(&expected_hash)) {
             return Err(FrostNetError::Session("Descriptor hash mismatch".into()));


### PR DESCRIPTION
The canonical descriptor-hash formula was already centralized in `keep_core::wallet::canonical_descriptor_hash`, and the PSBT path, inbound-finalize verifier, migrate verifier, and mobile completion handler all call it. One site still inlined the formula: `DescriptorSession`'s ack-verification path in `descriptor_session.rs`. This switches it to the shared function so the last copy cannot drift.

## Change

- Replace the inlined `Sha256` assembly (length-prefixed external/internal + policy_hash + `fold_descriptor_version_suffix`) with a call to `keep_core::wallet::canonical_descriptor_hash(...)`.

The inlined formula was byte-identical to the shared function for valid inputs. The shared function additionally rejects `version == 0` (returning an error the caller maps to a session error) instead of silently producing a v1-style hash, a small safety improvement, since a zero-version hash is invalid by construction and cannot match any other path.

## Verification

- keep-frost-net descriptor lib tests: 100 passed. Multinode descriptor integration tests: 2 passed (ack hash verification round-trips). `cargo clippy -p keep-frost-net --all-targets`: clean. `Sha256` remains used elsewhere in the file (no unused import).