### PR TITLE
keep-mobile: take ncryptsec export password as zeroable bytes, not String

### DIFF
--- a/keep-mobile/src/keep_mobile.udl
+++ b/keep-mobile/src/keep_mobile.udl
@@ -287,7 +287,7 @@ interface KeepMobile {
     string export_share(string passphrase);
 
     [Throws=KeepMobileError]
-    string export_ncryptsec(string password);
+    string export_ncryptsec(sequence<u8> password);
 
     sequence<StoredShareInfo> list_shares();
 

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -3938,11 +3938,20 @@ mod import_teardown_tests {
         let metadata = ShareMetadata::new(1, 1, 1, group_pubkey, "share".into());
         let share = SharePackage::new(metadata, &key_package, &pubkey_package).unwrap();
         mobile.store_share_package(&share).unwrap();
+        let expected_secret = key_package.signing_share().serialize();
 
         let ncryptsec = mobile
             .export_ncryptsec("correct horse battery".as_bytes().to_vec())
             .unwrap();
         assert!(ncryptsec.starts_with("ncryptsec1"));
+
+        // Round-trip: the password bytes must actually drive the encryption, so
+        // decrypting with the same password recovers the signing share, and a
+        // different password does not.
+        let recovered =
+            keep_core::keys::nip49::decrypt(&ncryptsec, "correct horse battery").unwrap();
+        assert_eq!(recovered.as_slice(), expected_secret.as_slice());
+        assert!(keep_core::keys::nip49::decrypt(&ncryptsec, "wrong password").is_err());
     }
 
     #[test]

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -877,9 +877,10 @@ impl KeepMobile {
         // ByteArray instead of an immutable String that lingers on the JVM heap. The
         // bytes are borrowed as UTF-8 in place; no owned String copy is made here.
         let password = Zeroizing::new(password);
-        let password = std::str::from_utf8(&password).map_err(|_| KeepMobileError::InvalidInput {
-            msg: "password must be valid UTF-8".into(),
-        })?;
+        let password =
+            std::str::from_utf8(&password).map_err(|_| KeepMobileError::InvalidInput {
+                msg: "password must be valid UTF-8".into(),
+            })?;
         let share = self.load_share_package()?;
 
         if share.metadata.threshold != 1 || share.metadata.total_shares != 1 {

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -872,8 +872,14 @@ impl KeepMobile {
             .map_err(|e| KeepMobileError::FrostError { msg: e.to_string() })
     }
 
-    pub fn export_ncryptsec(&self, password: String) -> Result<String, KeepMobileError> {
+    pub fn export_ncryptsec(&self, password: Vec<u8>) -> Result<String, KeepMobileError> {
+        // Accept the password as raw bytes so the caller (Kotlin) can pass a wipeable
+        // ByteArray instead of an immutable String that lingers on the JVM heap. The
+        // bytes are borrowed as UTF-8 in place; no owned String copy is made here.
         let password = Zeroizing::new(password);
+        let password = std::str::from_utf8(&password).map_err(|_| KeepMobileError::InvalidInput {
+            msg: "password must be valid UTF-8".into(),
+        })?;
         let share = self.load_share_package()?;
 
         if share.metadata.threshold != 1 || share.metadata.total_shares != 1 {
@@ -894,7 +900,7 @@ impl KeepMobile {
                 }
             })?);
 
-        keep_core::keys::nip49::encrypt(&secret, &password, Some(14))
+        keep_core::keys::nip49::encrypt(&secret, password, Some(14))
             .map_err(|e| KeepMobileError::EncryptionError { msg: e.to_string() })
     }
 
@@ -3917,6 +3923,46 @@ mod import_teardown_tests {
         assert!(
             matches!(&result, Err(KeepMobileError::InvalidShare { msg }) if msg.contains("does not match its group key")),
             "expected a group-key mismatch rejection"
+        );
+    }
+
+    #[test]
+    fn export_ncryptsec_accepts_utf8_password_bytes() {
+        let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
+        let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
+
+        let key_bytes = Zeroizing::new(hex::decode("03".repeat(32)).unwrap());
+        let (key_package, pubkey_package, vk_bytes) =
+            KeepMobile::build_nsec_packages(&key_bytes).unwrap();
+        let group_pubkey: [u8; 32] = vk_bytes[1..33].try_into().unwrap();
+        let metadata = ShareMetadata::new(1, 1, 1, group_pubkey, "share".into());
+        let share = SharePackage::new(metadata, &key_package, &pubkey_package).unwrap();
+        mobile.store_share_package(&share).unwrap();
+
+        let ncryptsec = mobile
+            .export_ncryptsec("correct horse battery".as_bytes().to_vec())
+            .unwrap();
+        assert!(ncryptsec.starts_with("ncryptsec1"));
+    }
+
+    #[test]
+    fn export_ncryptsec_rejects_non_utf8_password_bytes() {
+        let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
+        let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
+
+        let key_bytes = Zeroizing::new(hex::decode("03".repeat(32)).unwrap());
+        let (key_package, pubkey_package, vk_bytes) =
+            KeepMobile::build_nsec_packages(&key_bytes).unwrap();
+        let group_pubkey: [u8; 32] = vk_bytes[1..33].try_into().unwrap();
+        let metadata = ShareMetadata::new(1, 1, 1, group_pubkey, "share".into());
+        let share = SharePackage::new(metadata, &key_package, &pubkey_package).unwrap();
+        mobile.store_share_package(&share).unwrap();
+
+        // 0xFF is never valid UTF-8: reject rather than silently mangle the password.
+        let result = mobile.export_ncryptsec(vec![0xff, 0xfe]);
+        assert!(
+            matches!(&result, Err(KeepMobileError::InvalidInput { msg }) if msg.contains("UTF-8")),
+            "expected an InvalidInput UTF-8 rejection, got {result:?}"
         );
     }
 }


### PR DESCRIPTION
`KeepMobile::export_ncryptsec` took the NIP-49 export password as a `String`. Over the UniFFI boundary that forces the Kotlin caller to hand in an immutable `kotlin.String`, which cannot be zeroed and lingers on the JVM heap until GC. The Rust side already wraps everything in `Zeroizing`, so the plaintext copy on the Kotlin heap was the only unwipeable residue of the secret.

## Change

- `export_ncryptsec(password: String)` becomes `export_ncryptsec(password: Vec<u8>)`. UniFFI maps `Vec<u8>` to a Kotlin `ByteArray`, which the caller can wipe after the call. The bytes are wrapped in `Zeroizing` and borrowed as UTF-8 in place (`std::str::from_utf8`), so no owned `String` copy is created in Rust either. Invalid UTF-8 is rejected with `InvalidInput` rather than silently mangled.
- Sync the vestigial `keep_mobile.udl` declaration to `sequence<u8>` (bindings are generated in library mode from the `#[uniffi::export]` proc-macros, so this line has no build effect; kept honest for readers).
- Add two unit tests: a UTF-8 password roundtrip producing an `ncryptsec1...` string, and a non-UTF-8 rejection.

This is the Rust half of moving the ncryptsec export password off the immutable-String path; the Kotlin caller change (pass a wiped `ByteArray`) lands separately in the app repo once bindings are regenerated against this commit.

## Verification

- `cargo build -p keep-mobile`, `cargo clippy -p keep-mobile` (clean), `cargo test -p keep-mobile` (234 passed).