### PR TITLE
keep-mobile: return seed words as zeroable bytes, not String

### DIFF
--- a/keep-mobile/src/keep_mobile.udl
+++ b/keep-mobile/src/keep_mobile.udl
@@ -308,7 +308,7 @@ interface KeepMobile {
     void rename_share(string group_pubkey, string name);
 
     [Throws=KeepMobileError]
-    string? get_seed_words(string group_pubkey);
+    sequence<u8>? get_seed_words(string group_pubkey);
 
     [Throws=KeepMobileError]
     sequence<CertificatePin> get_certificate_pins();

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1052,7 +1052,7 @@ impl KeepMobile {
     }
 
     // Caller is responsible for re-authentication before calling this method
-    pub fn get_seed_words(&self, group_pubkey: String) -> Result<Option<String>, KeepMobileError> {
+    pub fn get_seed_words(&self, group_pubkey: String) -> Result<Option<Vec<u8>>, KeepMobileError> {
         validate_hex_pubkey(&group_pubkey)?;
 
         let data = self.storage.load_share_by_key(group_pubkey)?;
@@ -1062,10 +1062,12 @@ impl KeepMobile {
         stored
             .plaintext_mnemonic
             .map(|bytes| {
-                let s = std::str::from_utf8(&bytes).map_err(|_| KeepMobileError::StorageError {
+                // Validate UTF-8 (as before) but return the raw bytes so the caller holds a
+                // wipeable ByteArray instead of an immutable String on the JVM heap.
+                std::str::from_utf8(&bytes).map_err(|_| KeepMobileError::StorageError {
                     msg: "mnemonic contains invalid UTF-8".to_string(),
                 })?;
-                Ok(s.to_owned())
+                Ok(bytes.to_vec())
             })
             .transpose()
     }
@@ -3861,6 +3863,24 @@ mod import_teardown_tests {
             mobile.create_account_from_mnemonic(vec![0xff, 0xfe], String::new(), "x".into()),
             Err(KeepMobileError::InvalidInput { .. })
         ));
+    }
+
+    #[test]
+    fn get_seed_words_returns_stored_mnemonic_bytes() {
+        let storage: Arc<dyn SecureStorage> = Arc::new(MemStorage::default());
+        let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
+
+        let mnemonic = mobile.generate_mnemonic(12).unwrap();
+        let expected = mnemonic.clone().into_bytes();
+        let info = mobile
+            .create_account_from_mnemonic(mnemonic.into_bytes(), String::new(), "acct".into())
+            .unwrap();
+
+        // The seed is returned as the raw stored bytes, matching what was imported.
+        assert_eq!(
+            mobile.get_seed_words(info.group_pubkey).unwrap(),
+            Some(expected)
+        );
     }
 
     // A re-initialize that replaces a live node aborts the prior tasks and, like


### PR DESCRIPTION
`get_seed_words` returned the stored BIP-39 seed phrase as an owned `String`. Over the UniFFI boundary that hands the caller (Kotlin) an immutable `String` that cannot be zeroed and lingers on the JVM heap. The mnemonic is already stored as `Zeroizing<Vec<u8>>`, so the code was allocating an extra un-wipeable String copy purely to cross the FFI.

## Change

- `get_seed_words(...) -> Result<Option<String>, _>` becomes `-> Result<Option<Vec<u8>>, _>`, returning the stored bytes directly (UniFFI maps this to a Kotlin `ByteArray` the caller can wipe). The UTF-8 validity check is retained (still returns `StorageError` on corruption) but the value is returned as bytes instead of an owned `String`.
- Sync the vestigial udl declaration to `sequence<u8>?`.
- Add a round-trip test: create an account from a generated mnemonic, then `get_seed_words` returns exactly those bytes.

The keep-android caller (hold the returned `ByteArray` in a wipeable buffer instead of a `String`) lands separately once bindings are regenerated against this commit.

## Verification

- `cargo build -p keep-mobile`, `cargo clippy -p keep-mobile` (clean), `cargo fmt --check`, `cargo test -p keep-mobile` (238 passed).