### PR TITLE
keep-mobile: return generated mnemonic as zeroable bytes, not String

### DIFF
--- a/keep-mobile/src/keep_mobile.udl
+++ b/keep-mobile/src/keep_mobile.udl
@@ -256,7 +256,7 @@ interface KeepMobile {
     ShareInfo import_share(string data, string passphrase, string name);
 
     [Throws=KeepMobileError]
-    string generate_mnemonic(u32 word_count);
+    sequence<u8> generate_mnemonic(u32 word_count);
 
     [Throws=KeepMobileError]
     void validate_mnemonic(sequence<u8> mnemonic);

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -703,10 +703,13 @@ impl KeepMobile {
         self.do_import_nsec(&hex_key, name, None)
     }
 
-    pub fn generate_mnemonic(&self, word_count: u32) -> Result<String, KeepMobileError> {
+    pub fn generate_mnemonic(&self, word_count: u32) -> Result<Vec<u8>, KeepMobileError> {
+        // Return the generated phrase as bytes so the caller (Kotlin) can hold it in a
+        // wipeable ByteArray instead of an immutable String. The internal phrase is
+        // zeroized on drop; only the returned bytes leave the crate.
         let mnemonic = keep_core::mnemonic::generate_mnemonic(word_count)
             .map_err(|e| KeepMobileError::InvalidInput { msg: e.to_string() })?;
-        Ok((*mnemonic).clone())
+        Ok(mnemonic.as_bytes().to_vec())
     }
 
     pub fn validate_mnemonic(&self, mnemonic: Vec<u8>) -> Result<(), KeepMobileError> {
@@ -3831,7 +3834,7 @@ mod import_teardown_tests {
         let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
 
         let mnemonic = mobile.generate_mnemonic(12).unwrap();
-        assert!(mobile.validate_mnemonic(mnemonic.into_bytes()).is_ok());
+        assert!(mobile.validate_mnemonic(mnemonic).is_ok());
 
         // Well-formed UTF-8 but not a valid BIP-39 phrase.
         assert!(mobile
@@ -3851,7 +3854,7 @@ mod import_teardown_tests {
 
         let mnemonic = mobile.generate_mnemonic(12).unwrap();
         let info = mobile
-            .create_account_from_mnemonic(mnemonic.into_bytes(), String::new(), "acct".into())
+            .create_account_from_mnemonic(mnemonic, String::new(), "acct".into())
             .unwrap();
         assert!(!info.group_pubkey.is_empty());
         assert_eq!(
@@ -3871,9 +3874,9 @@ mod import_teardown_tests {
         let mobile = KeepMobile::new(Arc::clone(&storage)).unwrap();
 
         let mnemonic = mobile.generate_mnemonic(12).unwrap();
-        let expected = mnemonic.clone().into_bytes();
+        let expected = mnemonic.clone();
         let info = mobile
-            .create_account_from_mnemonic(mnemonic.into_bytes(), String::new(), "acct".into())
+            .create_account_from_mnemonic(mnemonic, String::new(), "acct".into())
             .unwrap();
 
         // The seed is returned as the raw stored bytes, matching what was imported.


### PR DESCRIPTION
`generate_mnemonic` returned the freshly generated BIP-39 phrase as an owned `String`, handing the caller (Kotlin) an immutable seed `String` that cannot be zeroed. This is the last seed path still crossing the FFI as a `String` (import, validation, account-creation, and seed-view were already moved to bytes).

## Change

- `generate_mnemonic(...) -> Result<String, _>` becomes `-> Result<Vec<u8>, _>`, returning `mnemonic.as_bytes().to_vec()`. The internal generated phrase is zeroized on drop; only the returned bytes leave the crate, and the caller receives a wipeable `ByteArray`.
- Sync the vestigial udl declaration to `sequence<u8>`.
- Update the three tests that call `generate_mnemonic` to consume the bytes directly (drop the now-redundant `.into_bytes()`); they already assert the output is a valid mnemonic (accepted by `validate_mnemonic` and usable by `create_account_from_mnemonic`).

The keep-android caller (store the generated phrase in a wipeable buffer via `updateFromBytes` instead of `update(String)`) lands separately once bindings are regenerated.

## Verification

- `cargo build -p keep-mobile`, `cargo clippy -p keep-mobile` (clean), `cargo fmt --check`, `cargo test -p keep-mobile` (238 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mnemonic generation compatibility by returning mnemonic data in a byte-based format.
  * Updated mnemonic validation and account creation flows to work seamlessly with the new format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->