### PR TITLE
nip46: assert connect authorization reason on the on_connect callback

### DIFF
--- a/keep-desktop/src/bunker_service.rs
+++ b/keep-desktop/src/bunker_service.rs
@@ -105,7 +105,12 @@ impl keep_nip46::types::ServerCallbacks for DesktopCallbacks {
         .into()
     }
 
-    fn on_connect(&self, pubkey: &str, _name: &str) {
+    fn on_connect(
+        &self,
+        pubkey: &str,
+        _name: &str,
+        _authorization: keep_nip46::types::ConnectAuthorization,
+    ) {
         let _ = self.tx.send(BunkerEvent::Connected {
             pubkey: pubkey.to_string(),
         });

--- a/keep-desktop/src/local_signer_service.rs
+++ b/keep-desktop/src/local_signer_service.rs
@@ -81,7 +81,12 @@ impl keep_nip46::types::ServerCallbacks for LocalSignerCallbacks {
         .into()
     }
 
-    fn on_connect(&self, client_id: &str, name: &str) {
+    fn on_connect(
+        &self,
+        client_id: &str,
+        name: &str,
+        _authorization: keep_nip46::types::ConnectAuthorization,
+    ) {
         let _ = self.tx.send(LocalSignerEvent::Connected {
             client_id: client_id.to_string(),
             name: name.to_string(),

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -127,14 +127,36 @@ pub fn parse_bunker_url(url: &str) -> Result<ParsedBunkerUrl, KeepMobileError> {
     })
 }
 
+/// Why a NIP-46 connect was authorized, asserted by the signer core. The Kotlin
+/// consumer should persist a client as authorized only for an explicit-consent
+/// reason (`SecretMatched`/`UserApproved`), never for `AutoApproved`, so that
+/// authorization does not depend on the callback merely having fired.
+#[derive(uniffi::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConnectAuthorization {
+    SecretMatched,
+    UserApproved,
+    AutoApproved,
+}
+
+impl From<keep_nip46::types::ConnectAuthorization> for ConnectAuthorization {
+    fn from(a: keep_nip46::types::ConnectAuthorization) -> Self {
+        match a {
+            keep_nip46::types::ConnectAuthorization::SecretMatched => Self::SecretMatched,
+            keep_nip46::types::ConnectAuthorization::UserApproved => Self::UserApproved,
+            keep_nip46::types::ConnectAuthorization::AutoApproved => Self::AutoApproved,
+        }
+    }
+}
+
 #[uniffi::export(with_foreign)]
 pub trait BunkerCallbacks: Send + Sync {
     fn on_log(&self, event: BunkerLogEvent);
     fn request_approval(&self, request: BunkerApprovalRequest) -> BunkerApprovalResult;
     /// Fired when an app completes the NIP-46 connect handshake. `pubkey` and
     /// `name` are untrusted, remote-derived values: render them as inert text,
-    /// never as markup.
-    fn on_connect(&self, pubkey: String, name: String);
+    /// never as markup. `authorization` states why the core authorized the
+    /// connect; persist authorization only for explicit-consent reasons.
+    fn on_connect(&self, pubkey: String, name: String, authorization: ConnectAuthorization);
 }
 
 struct CallbackBridge {
@@ -169,9 +191,14 @@ impl ServerCallbacks for CallbackBridge {
             .into()
     }
 
-    fn on_connect(&self, pubkey: &str, name: &str) {
+    fn on_connect(
+        &self,
+        pubkey: &str,
+        name: &str,
+        authorization: keep_nip46::types::ConnectAuthorization,
+    ) {
         self.callbacks
-            .on_connect(pubkey.to_string(), name.to_string());
+            .on_connect(pubkey.to_string(), name.to_string(), authorization.into());
     }
 
     fn persist_permissions(&self, grants: Vec<keep_core::relay::StoredBunkerPermission>) {

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -20,8 +20,8 @@ use crate::frost_signer::{FrostSigner, NetworkFrostSigner};
 use crate::permissions::{AppPermission, Permission, PermissionDuration, PermissionManager};
 use crate::rate_limit::{RateLimitConfig, RateLimiter};
 use crate::types::{
-    ApprovalRequest, ApprovalResult, HttpAuthDetails, RememberDuration, ServerCallbacks,
-    NIP98_HTTP_AUTH, NIP98_MAX_REMEMBER_SECS,
+    ApprovalRequest, ApprovalResult, ConnectAuthorization, HttpAuthDetails, RememberDuration,
+    ServerCallbacks, NIP98_HTTP_AUTH, NIP98_MAX_REMEMBER_SECS,
 };
 
 /// Max displayed length of a NIP-98 `u`/`method` value. A kilobyte-scale tag
@@ -397,13 +397,13 @@ impl SignerHandler {
         our_pubkey: Option<PublicKey>,
         secret: Option<String>,
         permissions: Option<String>,
-    ) -> Result<()> {
+    ) -> Result<ConnectAuthorization> {
         self.check_rate_limit(&app_pubkey).await?;
 
         let app_id = &app_pubkey.to_hex()[..8];
         let name = format!("App {app_id}");
 
-        if let Some(ref expected) = self.expected_secret {
+        let authorization = if let Some(ref expected) = self.expected_secret {
             let expected_hash = Sha256::digest(expected.as_bytes());
             let valid = match &secret {
                 Some(s) => {
@@ -420,6 +420,7 @@ impl SignerHandler {
                 );
                 return Err(KeepError::PermissionDenied("invalid secret".into()));
             }
+            ConnectAuthorization::SecretMatched
         } else if !self.auto_approve {
             // Connect-time approval ignores the remember-duration today: the
             // app-level lifetime is configured separately via the bunker's
@@ -439,7 +440,10 @@ impl SignerHandler {
             if !result.approved {
                 return Err(KeepError::UserRejected);
             }
-        }
+            ConnectAuthorization::UserApproved
+        } else {
+            ConnectAuthorization::AutoApproved
+        };
 
         if let Some(expected) = our_pubkey {
             // The client targets the transport (bunker URL) pubkey, which for a
@@ -479,7 +483,7 @@ impl SignerHandler {
             .log(AuditEntry::new(AuditAction::Connect, app_pubkey).with_app_name(&name));
 
         info!(app_id, "app connected");
-        Ok(())
+        Ok(authorization)
     }
 
     pub async fn handle_get_public_key(&self, app_pubkey: PublicKey) -> Result<PublicKey> {
@@ -1007,7 +1011,7 @@ mod tests {
             }
             ApprovalResult::approved_once()
         }
-        fn on_connect(&self, _pubkey: &str, _name: &str) {}
+        fn on_connect(&self, _pubkey: &str, _name: &str, _authorization: ConnectAuthorization) {}
     }
 
     #[tokio::test]
@@ -1327,6 +1331,32 @@ mod tests {
 
         let pm = handler.permissions.lock().await;
         assert!(pm.is_connected(&app_pubkey));
+    }
+
+    #[tokio::test]
+    async fn handle_connect_reports_authorization_reason() {
+        // auto_approve mode: no secret, no prompt -> AutoApproved.
+        let handler = setup_handler();
+        let app = Keys::generate().public_key();
+        assert_eq!(
+            handler.handle_connect(app, None, None, None).await.unwrap(),
+            ConnectAuthorization::AutoApproved
+        );
+
+        // expected_secret mode with the correct secret -> SecretMatched.
+        let keyring = setup_keyring();
+        let permissions = Arc::new(Mutex::new(PermissionManager::new()));
+        let audit = Arc::new(Mutex::new(AuditLog::new(100)));
+        let handler = SignerHandler::new(keyring, permissions, audit, None)
+            .with_expected_secret("correct_secret_value".into());
+        let app = Keys::generate().public_key();
+        assert_eq!(
+            handler
+                .handle_connect(app, None, Some("correct_secret_value".into()), None)
+                .await
+                .unwrap(),
+            ConnectAuthorization::SecretMatched
+        );
     }
 
     #[tokio::test]
@@ -1794,7 +1824,7 @@ mod tests {
                 remember: self.remember,
             }
         }
-        fn on_connect(&self, _pubkey: &str, _name: &str) {}
+        fn on_connect(&self, _pubkey: &str, _name: &str, _authorization: ConnectAuthorization) {}
     }
 
     #[tokio::test]
@@ -1979,7 +2009,7 @@ mod tests {
                 remember: RememberDuration::Forever,
             }
         }
-        fn on_connect(&self, _pubkey: &str, _name: &str) {}
+        fn on_connect(&self, _pubkey: &str, _name: &str, _authorization: ConnectAuthorization) {}
         fn persist_permissions(&self, grants: Vec<keep_core::relay::StoredBunkerPermission>) {
             self.snapshots.lock().unwrap().push(grants);
         }

--- a/keep-nip46/src/local_server.rs
+++ b/keep-nip46/src/local_server.rs
@@ -23,7 +23,7 @@ use crate::handler::SignerHandler;
 use crate::permissions::PermissionManager;
 use crate::rate_limit::RateLimitConfig;
 use crate::server::dispatch_request;
-use crate::types::{LogEvent, ServerCallbacks};
+use crate::types::{ConnectAuthorization, LogEvent, ServerCallbacks};
 
 const MAX_CONNECTIONS: usize = 32;
 const IDLE_TIMEOUT: Duration = Duration::from_secs(300);
@@ -286,7 +286,9 @@ async fn handle_connection(
     }
 
     if let Some(ref cb) = callbacks {
-        cb.on_connect(&client_id, &client_id);
+        // Local IPC connections are gated by OS socket permissions, not a per-connect
+        // secret or approval prompt, so they are reported as AutoApproved.
+        cb.on_connect(&client_id, &client_id, ConnectAuthorization::AutoApproved);
     }
 
     let user_pubkey = match handler.our_pubkey().await {
@@ -341,7 +343,18 @@ async fn handle_connection(
         };
 
         let method = request.method.clone();
-        let response = dispatch_request(&handler, user_pubkey, app_pubkey, request, max_size).await;
+        // Local IPC authorizes on the socket-accept path above, not on a connect
+        // method through dispatch_request, so the connect authorization is ignored here.
+        let mut connect_auth = None;
+        let response = dispatch_request(
+            &handler,
+            user_pubkey,
+            app_pubkey,
+            request,
+            max_size,
+            &mut connect_auth,
+        )
+        .await;
 
         let success = response.error.is_none();
         if let Some(ref cb) = callbacks {

--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -19,7 +19,9 @@ use crate::frost_signer::{FrostSigner, NetworkFrostSigner};
 use crate::handler::SignerHandler;
 use crate::permissions::{Permission, PermissionDuration, PermissionManager};
 use crate::rate_limit::RateLimitConfig;
-use crate::types::{LogEvent, Nip46Request, Nip46Response, PartialEvent, ServerCallbacks};
+use crate::types::{
+    ConnectAuthorization, LogEvent, Nip46Request, Nip46Response, PartialEvent, ServerCallbacks,
+};
 use keep_core::relay::TIMESTAMP_TWEAK_RANGE;
 
 pub struct ServerConfig {
@@ -638,12 +640,14 @@ impl Server {
         debug!(method = %request.method, app_id, "NIP-46 request");
 
         let method = request.method.clone();
+        let mut connect_auth = None;
         let response = dispatch_request(
             handler,
             keys.public_key(),
             app_pubkey,
             request,
             max_event_json_size,
+            &mut connect_auth,
         )
         .await;
 
@@ -656,8 +660,10 @@ impl Server {
                 detail: response.error.clone(),
             });
 
-            if method == "connect" && success {
-                cb.on_connect(&app_pubkey.to_hex(), &format!("App {app_id}"));
+            // connect_auth is Some only when handle_connect authorized the connect,
+            // so on_connect fires with the explicit authorization reason.
+            if let Some(auth) = connect_auth {
+                cb.on_connect(&app_pubkey.to_hex(), &format!("App {app_id}"), auth);
             }
         }
 
@@ -692,6 +698,7 @@ pub(crate) async fn dispatch_request(
     app_pubkey: PublicKey,
     request: Nip46Request,
     max_event_json_size: usize,
+    connect_auth: &mut Option<ConnectAuthorization>,
 ) -> Nip46Response {
     let id = request.id.clone();
 
@@ -707,7 +714,10 @@ pub(crate) async fn dispatch_request(
                 .handle_connect(app_pubkey, our_pubkey, secret, permissions)
                 .await
             {
-                Ok(()) => Nip46Response::ok(id, "ack"),
+                Ok(auth) => {
+                    *connect_auth = Some(auth);
+                    Nip46Response::ok(id, "ack")
+                }
                 Err(e) => {
                     warn!(error = %e, "connect failed");
                     Nip46Response::error(id, crate::error::sanitize_error_for_client(&e))

--- a/keep-nip46/src/types.rs
+++ b/keep-nip46/src/types.rs
@@ -117,10 +117,25 @@ impl From<bool> for ApprovalResult {
     }
 }
 
+/// Why a NIP-46 connect was authorized. Carried on `on_connect` so the consumer
+/// authorizes the client off an explicit assertion from the server, rather than
+/// inferring consent from the callback merely having fired.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConnectAuthorization {
+    /// The connect secret carried in the bunker URL matched the expected secret.
+    SecretMatched,
+    /// The user explicitly approved the connect via the approval prompt.
+    UserApproved,
+    /// The server was configured to auto-approve connects (no secret, no prompt).
+    /// Consumers that require explicit consent should NOT persist authorization
+    /// for this case.
+    AutoApproved,
+}
+
 pub trait ServerCallbacks: Send + Sync + 'static {
     fn on_log(&self, event: LogEvent);
     fn request_approval(&self, request: ApprovalRequest) -> ApprovalResult;
-    fn on_connect(&self, _pubkey: &str, _name: &str) {}
+    fn on_connect(&self, _pubkey: &str, _name: &str, _authorization: ConnectAuthorization) {}
     /// Called after the in-memory permission grants change (a remember-grant is
     /// written or a client is revoked), passing a full snapshot of the current
     /// grants so the consumer can persist them durably. Default no-op: keep-web


### PR DESCRIPTION
The NIP-46 `on_connect` callback fired with only `(pubkey, name)`, so a consumer that persists a client as authorized on `on_connect` (the mobile bunker does) was trusting an un-enforceable ordering invariant: "the core only fires `on_connect` after the connect was authorized." That invariant holds today (the callback fires only when `handle_connect` returns `Ok`), but nothing forces it — a future refactor (e.g. an `auto_approve` build with no secret and no prompt) could silently fire `on_connect` for an unconsented client and the consumer would persist it. Amber and bifrost both make authorization a direct product of an explicit decision, never a connect-callback side effect.

## Change

- `handle_connect` now returns `Result<ConnectAuthorization>` where `ConnectAuthorization ∈ { SecretMatched, UserApproved, AutoApproved }` — the reason it authorized (secret matched / user approved the prompt / server auto-approve). Every deny/timeout/wrong-secret path still returns `Err`, so nothing changes about when a connect succeeds.
- The reason is threaded through `dispatch_request` and passed to `ServerCallbacks::on_connect(pubkey, name, authorization)`, so the callback now carries an explicit authorization assertion from the core. The type change forces every present and future call site to state the reason, so a refactor cannot silently fire an unauthorized `on_connect`.
- keep-mobile exposes a mirrored `ConnectAuthorization` UniFFI enum on `BunkerCallbacks.on_connect`, so the Kotlin consumer can persist authorization only for explicit-consent reasons.
- Local IPC (`local_server`) reports `AutoApproved` (OS-socket-gated, no per-connect secret/prompt); keep-desktop callbacks thread the reason through unchanged.

This is defense-in-depth hardening (not an active bypass): it removes the fragile dependency on the callback ordering. The keep-android consumer change (authorize only on `SecretMatched`/`UserApproved`) lands separately once bindings are regenerated.

## Verification

- `cargo build --workspace`; `cargo clippy -p keep-nip46 -p keep-mobile` (clean); `cargo fmt --check`; `cargo test -p keep-nip46` (195 passed, incl. a new test asserting the returned authorization reason per mode); `cargo test -p keep-mobile` (238 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connection events now indicate how authorization was granted: secret match, user approval, or automatic approval.
  * Mobile integrations expose the authorization reason through the connection callback.
* **Bug Fixes**
  * Improved propagation of authorization details across connection handling, including local and desktop connections.
* **Tests**
  * Added coverage verifying authorization reporting for automatic approval and valid-secret connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->