### PR TITLE
security: bound leading legacy rows in nip55 audit-chain verification

### DIFF
--- a/keep-mobile/src/nip55_audit.rs
+++ b/keep-mobile/src/nip55_audit.rs
@@ -145,6 +145,14 @@ pub fn nip55_verify_audit_chain(
         .filter(|h| !h.is_empty())
         .collect();
 
+    // A legitimate log has at most a small run of leading empty-hash ("legacy") rows,
+    // from the pre-hash-chain migration (v0.1.0..v0.4.0 rows, the oldest, and time-pruned
+    // at 30 days). Bound that run so an attacker with audit-DB write access cannot prepend
+    // an unbounded number of unauthenticated leading rows to mask the genesis or downgrade
+    // the verdict. The bound is generous (no real early-adopter chain approaches it) so it
+    // never false-flags a legitimate legacy prefix; exceeding it is treated as tampering.
+    const MAX_LEADING_LEGACY: u32 = 1024;
+
     let mut in_legacy = true;
     let mut legacy_skipped: u32 = 0;
     let mut truncated = false;
@@ -154,6 +162,9 @@ pub fn nip55_verify_audit_chain(
         if in_legacy {
             if entry.entry_hash.is_empty() {
                 legacy_skipped += 1;
+                if legacy_skipped > MAX_LEADING_LEGACY {
+                    return Nip55ChainStatus::Tampered { entry_id: entry.id };
+                }
                 continue;
             }
             in_legacy = false;
@@ -531,6 +542,81 @@ mod tests {
             Nip55ChainStatus::PartiallyVerified {
                 legacy_entries_skipped: 1
             }
+        );
+    }
+
+    fn legacy_entry(id: i64) -> Nip55AuditEntry {
+        Nip55AuditEntry {
+            id,
+            timestamp: id,
+            caller: "old".to_string(),
+            request_type: "SIGN_EVENT".to_string(),
+            event_kind: None,
+            decision: "allow".to_string(),
+            was_automatic: false,
+            previous_hash: None,
+            entry_hash: String::new(),
+        }
+    }
+
+    #[test]
+    fn leading_legacy_at_cap_still_partial() {
+        // Exactly MAX_LEADING_LEGACY (1024) legacy rows + a valid tail stays
+        // PartiallyVerified: a legitimate (if large) pre-hash-chain prefix is not flagged.
+        let mut entries: Vec<Nip55AuditEntry> = (1..=1024).map(legacy_entry).collect();
+        entries.push(entry(2000, None, "com.app", Some(1), "allow", 5000, false));
+        assert_eq!(
+            nip55_verify_audit_chain(entries, KEY.to_vec()),
+            Nip55ChainStatus::PartiallyVerified {
+                legacy_entries_skipped: 1024
+            }
+        );
+    }
+
+    #[test]
+    fn leading_legacy_over_cap_is_tampered() {
+        // One row past the cap trips before the tail is reached, so a prepended-blank-row
+        // downgrade/injection is bounded rather than unbounded.
+        let mut entries: Vec<Nip55AuditEntry> = (1..=1025).map(legacy_entry).collect();
+        entries.push(entry(2000, None, "com.app", Some(1), "allow", 5000, false));
+        assert_eq!(
+            nip55_verify_audit_chain(entries, KEY.to_vec()),
+            Nip55ChainStatus::Tampered { entry_id: 1025 }
+        );
+    }
+
+    #[test]
+    fn all_legacy_over_cap_is_tampered() {
+        // An all-empty-hash log past the cap is tampering, not Valid/PartiallyVerified.
+        let entries: Vec<Nip55AuditEntry> = (1..=1025).map(legacy_entry).collect();
+        assert_eq!(
+            nip55_verify_audit_chain(entries, KEY.to_vec()),
+            Nip55ChainStatus::Tampered { entry_id: 1025 }
+        );
+    }
+
+    #[test]
+    fn small_legacy_prefix_still_partial() {
+        // A small legacy-only log (early adopter, no post-upgrade activity) is unaffected.
+        let entries: Vec<Nip55AuditEntry> = (1..=10).map(legacy_entry).collect();
+        assert_eq!(
+            nip55_verify_audit_chain(entries, KEY.to_vec()),
+            Nip55ChainStatus::PartiallyVerified {
+                legacy_entries_skipped: 10
+            }
+        );
+    }
+
+    #[test]
+    fn tip_path_inherits_legacy_cap() {
+        // The tip-MAC entry point delegates to the base verifier, so a conclusive base
+        // Tampered (from the cap) short-circuits and is returned as-is.
+        let mut entries: Vec<Nip55AuditEntry> = (1..=1025).map(legacy_entry).collect();
+        entries.push(entry(2000, None, "com.app", Some(1), "allow", 5000, false));
+        let tip = tip_of(&entries);
+        assert_eq!(
+            nip55_verify_audit_chain_with_tip(entries, KEY.to_vec(), Some(tip)),
+            Nip55ChainStatus::Tampered { entry_id: 1025 }
         );
     }
 


### PR DESCRIPTION
## Summary

The nip55 audit-chain verifier (`nip55_verify_audit_chain`) tolerated an **unbounded** run of leading empty-hash ("legacy") rows: it skipped them as pre-hash-chain migration rows and still returned `PartiallyVerified`. An attacker with audit-DB write access could prepend an unbounded number of unauthenticated leading rows to mask the genesis or downgrade a `Valid` chain to `PartiallyVerified` while injecting attacker-chosen (unverified) rows.

This caps the tolerated leading-legacy run at `MAX_LEADING_LEGACY = 1024` and returns `Tampered` when exceeded.

### Why 1024 (and why it is safe)

Legacy empty-hash rows are real but narrow: the audit table shipped without a hash chain in v0.1.0, and the chain columns were added by `MIGRATION_3_4` in v0.4.0 (~1 week of small-audience beta). Those pre-chain rows are the **oldest** rows and are pruned at 30 days, so on any device that has run cleanup they are long gone. No legitimate early-adopter chain approaches 1024 un-pruned legacy rows, so the cap never false-flags a real log, while eliminating the unbounded property. The Android Keystore anchor (which binds the *total* row count, including legacy rows) already backstops practical post-seed prepend; this hardens the Rust primitive itself.

### Cross-repo

No keep-android change required: the fix reuses the existing `Nip55ChainStatus::Tampered` variant, and Kotlin (`PermissionStore.verifyAuditChain`) delegates verification to Rust 1:1 and never inspects empty hashes itself. `nip55_verify_audit_chain_with_tip` delegates to the base verifier, so it inherits the cap.

The residual trust-on-first-use seed case (an Android `AuditAnchor.shouldSeed` baselining a `PartiallyVerified` chain with legacy rows on the very first verify of an upgraded install) is tracked as an optional follow-up on the Android side.

## Testing

- `cargo test -p keep-mobile nip55_audit` - 20 passed (5 new: at-cap stays PartiallyVerified, over-cap Tampered, all-legacy-over-cap Tampered, small-prefix unaffected, tip-path inherits cap)
- `cargo fmt --check` clean, `cargo clippy` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit-chain verification by detecting excessively long sequences of legacy entries.
  * Such chains are now correctly marked as tampered instead of continuing verification.
  * Tip-based verification now consistently reports the same tampering result.

* **Tests**
  * Added coverage for legacy-only chains, maximum-length prefixes, and over-limit scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->