### PR TITLE
security: lock the vault before the spend coordination wait

### DIFF
--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1536,6 +1536,16 @@ pub fn cmd_wallet_spend(
         None => keep.frost_get_share(&group_pubkey)?,
     };
 
+    // Snapshot the (non-secret) descriptor set while unlocked, then lock the vault so the
+    // master key is zeroized before the coordination wait instead of lingering in memory
+    // for the whole session. Spend only READS descriptors and single-vault-open rules out
+    // a concurrent writer, so the snapshot is equivalent to the live lookup for the
+    // session's bounded lifetime. The FROST signing share stays resident in the node (it
+    // is needed for transport ECDH throughout, and is zeroized on drop). See keep-1ij5.
+    let descriptor_snapshot = std::sync::Arc::new(keep.list_all_wallet_descriptor_versions()?);
+    keep.lock();
+    drop(keep);
+
     out.newline();
     out.header("WDC Recovery Spend Proposal");
     out.field("Group", &hex::encode(group_pubkey));
@@ -1558,13 +1568,16 @@ pub fn cmd_wallet_spend(
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
 
-    let keep = Arc::new(Mutex::new(keep));
-
     rt.block_on(async {
         let node = keep_frost_net::KfpNode::new(share, vec![relay.to_string()])
             .await
             .map_err(|e| KeepError::Frost(e.to_string()))?;
-        let node = node.with_descriptor_lookup(Arc::new(descriptor_lookup_for(keep.clone())));
+        let node = node.with_descriptor_lookup(Arc::new(keep_frost_net::KeepDescriptorLookup::new(
+            {
+                let snapshot = descriptor_snapshot.clone();
+                move || Some((*snapshot).clone())
+            },
+        )));
         let node = std::sync::Arc::new(node);
 
         node.announce()

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -1805,6 +1805,42 @@ mod tests {
     }
 
     #[test]
+    fn descriptor_snapshot_survives_lock() {
+        // cmd_wallet_spend (keep-1ij5) snapshots the descriptor set while unlocked, then
+        // locks the vault before the coordination wait so the master key is not resident.
+        // The snapshot is owned, non-secret metadata, so it must stay usable after lock.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("keep");
+        let mut keep = test_keep(&path);
+
+        let group_pubkey = [0x11u8; 32];
+        let descriptor = WalletDescriptor {
+            group_pubkey,
+            external_descriptor: format!("tr({})/0/*)", hex::encode(group_pubkey)),
+            internal_descriptor: format!("tr({})/1/*)", hex::encode(group_pubkey)),
+            network: "signet".into(),
+            created_at: 1_700_000_000,
+            device_registrations: Vec::new(),
+            policy_hash: [0x22; 32],
+            version: crate::wallet::INITIAL_DESCRIPTOR_VERSION,
+            previous_descriptor_hash: None,
+            policy: None,
+        };
+        keep.store_wallet_descriptor(&descriptor).unwrap();
+
+        // Snapshot while unlocked (as the spend path does), then lock.
+        let snapshot = keep.list_all_wallet_descriptor_versions().unwrap();
+        assert!(snapshot.iter().any(|d| d.group_pubkey == group_pubkey));
+
+        keep.lock();
+        assert!(!keep.is_unlocked());
+        // A live read now requires unlock, but the pre-lock snapshot the coordination
+        // wait relies on is unaffected.
+        assert!(keep.list_all_wallet_descriptor_versions().is_err());
+        assert!(snapshot.iter().any(|d| d.group_pubkey == group_pubkey));
+    }
+
+    #[test]
     fn rate_limit_trip_emits_audit_entry_on_next_unlock() {
         // The rate limiter trips after MAX_ATTEMPTS (5) failed unlocks. The
         // trip event must surface as a `RateLimitTripped` audit entry the


### PR DESCRIPTION
## Summary

`cmd_wallet_spend` unlocked the vault and then blocked waiting for PSBT coordination events with the vault still unlocked, keeping the master key (vault DEK) resident in process memory for the entire coordination window. It was only locked when the `Keep` dropped at function end. An attacker with later process access (core dump, swap, memory scraper) had a widened window to recover key material.

The DEK was resident during the wait *only* because the live descriptor-lookup closure (`descriptor_lookup_for`) needs an unlocked vault to read the encrypted-at-rest descriptors for validating incoming PSBT proposals. Wallet descriptors are **public metadata** (xpubs, descriptor strings, policy hash), not key material, so this snapshots them up-front and then locks the vault *before* the wait:

- Snapshot `list_all_wallet_descriptor_versions()` while unlocked, then `keep.lock()` + drop before the coordination loop.
- Feed the descriptor lookup from the owned snapshot (`KeepDescriptorLookup::new(move || Some(snapshot.clone()))`) instead of the live vault.

The snapshot is equivalent to the live lookup for the session: spend only *reads* descriptors, and single-vault-open rules out a concurrent writer, over the bounded session lifetime (the CLI already clamps spend to `SPEND_TIMEOUT_MAX_SECS` = 900s; the 24h figure in the report is the protocol-layer max, not reachable from spend). The FROST signing share necessarily stays resident in the node (it is needed for transport ECDH throughout the session) and is already `ZeroizeOnDrop`.

Scope: **spend only**. `frost network serve` and the other wallet commands keep their live closures (that node runs indefinitely and must observe descriptor changes).

## Testing

- New keep-core unit test `descriptor_snapshot_survives_lock`: stores a descriptor, snapshots it while unlocked, locks the vault, asserts the vault is locked, a live read now errors, and the pre-lock snapshot is unaffected.
- `cargo build -p keep-cli`, `cargo test -p keep-core`, `cargo fmt --check`, `cargo clippy` all clean.
- Behavioral note: end-to-end spend coordination (descriptor validation from the snapshot) needs live relays/peers and is not covered by unit tests; the descriptor-lookup trait path is unchanged and already covered by existing `descriptor_lookup_tests`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet spending sessions by preserving required descriptor information before the vault is locked.
  * Wallet coordination can now continue reliably without repeatedly accessing the locked vault.

* **Tests**
  * Added coverage confirming descriptor snapshots remain usable after vault locking.
  * Added validation that new descriptor reads are correctly blocked once the vault is locked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->