### PR TITLE
security: erase recovery signing keypair and reject non-tier keys

### DIFF
--- a/keep-bitcoin/src/recovery_tx.rs
+++ b/keep-bitcoin/src/recovery_tx.rs
@@ -229,11 +229,9 @@ impl RecoveryTxBuilder {
                 psbt.inputs.len()
             )));
         }
-        let sk_bytes = Zeroizing::new(*secret_key);
-        let keypair = Keypair::from_seckey_slice(&self.secp, &*sk_bytes)
-            .map_err(|e| BitcoinError::InvalidSecretKey(e.to_string()))?;
-        let (x_only, _) = keypair.x_only_public_key();
-
+        // Compute everything fallible BEFORE loading the secret key, so no early
+        // return (missing witness UTXO, sighash error, etc.) can leave secret
+        // material resident in memory.
         let prevouts: Vec<TxOut> = psbt
             .inputs
             .iter()
@@ -246,9 +244,8 @@ impl RecoveryTxBuilder {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let mut sighash_cache = SighashCache::new(&psbt.unsigned_tx);
         let leaf_hash = tier.leaf_hash;
-
+        let mut sighash_cache = SighashCache::new(&psbt.unsigned_tx);
         let sighash = sighash_cache
             .taproot_script_spend_signature_hash(
                 0,
@@ -262,9 +259,28 @@ impl RecoveryTxBuilder {
             .map_err(|e| BitcoinError::Signing(e.to_string()))?;
 
         let aux_rand = crate::aux_rand()?;
+
+        let sk_bytes = Zeroizing::new(*secret_key);
+        let mut keypair = Keypair::from_seckey_slice(&self.secp, &*sk_bytes)
+            .map_err(|e| BitcoinError::InvalidSecretKey(e.to_string()))?;
+        let (x_only, _) = keypair.x_only_public_key();
+
+        // The signing key must belong to this tier. A non-member signature is dead
+        // weight (finalize only reads tier.keys), so reject it early rather than
+        // silently producing a PSBT that can never finalize. Erase the key first.
+        if !tier.keys.contains(&x_only) {
+            keypair.non_secure_erase();
+            return Err(BitcoinError::Recovery(format!(
+                "signing key is not a member of recovery tier {tier_index}"
+            )));
+        }
+
         let sig = self
             .secp
             .sign_schnorr_with_aux_rand(&msg, &keypair, &aux_rand);
+        // secp256k1's Keypair is not zeroize-on-drop; wipe its secret-key copy now
+        // rather than leaving it resident until the value drops.
+        keypair.non_secure_erase();
 
         psbt.inputs[0].tap_script_sigs.insert(
             (x_only, leaf_hash),
@@ -694,6 +710,50 @@ mod tests {
 
         let tx = builder.finalize_recovery(&mut psbt, 0).unwrap();
         assert!(!tx.input[0].witness.is_empty());
+    }
+
+    #[test]
+    fn sign_recovery_rejects_non_tier_key() {
+        let (_, pk1) = test_keypair_full(1);
+        let (_, pk2) = test_keypair_full(2);
+        let (sk_outsider, _) = test_keypair_full(9); // not a member of any tier
+        let secp = Secp256k1::new();
+
+        let config = RecoveryConfig {
+            primary: SpendingTier {
+                keys: vec![pk1],
+                threshold: 1,
+            },
+            recovery_tiers: vec![RecoveryTier {
+                keys: vec![pk2],
+                threshold: 1,
+                timelock_months: 6,
+            }],
+            network: Network::Testnet,
+        };
+        let output = config.build().unwrap();
+        let builder = RecoveryTxBuilder::new(output);
+
+        let utxo = OutPoint {
+            txid: bitcoin::Txid::all_zeros(),
+            vout: 0,
+        };
+        let xonly_pk1 = XOnlyPublicKey::from_slice(&pk1).unwrap();
+        let dest = ScriptBuf::new_p2tr(&secp, xonly_pk1, None);
+        let mut psbt = builder
+            .build_recovery_psbt(0, utxo, 100_000, &dest, 1_000)
+            .unwrap();
+
+        // Tier 0 is the recovery tier {pk2}; signing it with an outsider key must fail
+        // fast and insert nothing, rather than producing a PSBT that can never finalize.
+        let err = builder
+            .sign_recovery(&mut psbt, 0, &sk_outsider)
+            .unwrap_err();
+        assert!(
+            matches!(err, BitcoinError::Recovery(ref m) if m.contains("not a member")),
+            "expected tier-membership rejection, got {err:?}"
+        );
+        assert!(psbt.inputs[0].tap_script_sigs.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two hardening fixes to `RecoveryTxBuilder::sign_recovery` (keep-bitcoin), both from the keep-bitcoin hardening backlog (#789):

1. **Erase the signing keypair.** `sk_bytes` was already `Zeroizing`, but the secp256k1 `Keypair` built from it holds its own copy of the secret key and is **not** zeroize-on-drop, so the secret lingered in memory until the value dropped (and drop does not wipe it). The fix reorders all fallible preparation (prevouts, sighash, message, aux-rand) to run **before** the secret is loaded, so no early-return can leave key material resident, then calls `keypair.non_secure_erase()` immediately after signing (and on the membership-rejection path).

2. **Reject non-tier signing keys.** `sign_recovery` inserted the signature at `(x_only, leaf_hash)` without checking that `x_only` is a member of `tier.keys`. A non-member signature is dead weight (finalize only reads `tier.keys`), so signing with the wrong key silently produced a PSBT that can never finalize. It now fails fast with a clear error and inserts nothing. Not a forgery path (the CHECKSIGADD script ignores non-member sigs), but prevents a confusing later finalize failure and enforces the tier-membership invariant at signing time.

## Testing

- New test `sign_recovery_rejects_non_tier_key`: signing tier 0 with an outsider key returns a `not a member` error and inserts no signature.
- `cargo test -p keep-bitcoin` (98 passed), `cargo fmt --check`, `cargo clippy` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved recovery transaction signing to reduce the exposure of sensitive signing keys during failures.
  * Sensitive key material is now securely erased after signing or when validation fails.

* **Bug Fixes**
  * Recovery signing now correctly rejects keys that do not belong to the selected recovery tier.
  * Invalid signing attempts no longer add unintended script signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->