### PR TITLE
security: commit PSBT finalize state before broadcast to avoid peer desync

### DIFF
--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -1091,27 +1091,33 @@ impl KfpNode {
         final_tx: Option<(Vec<u8>, [u8; 32])>,
     ) -> Result<()> {
         let txid = final_tx.as_ref().map(|(_, id)| *id);
+        let self_pk = self.keys.public_key();
 
+        // Commit the local Finalized state atomically BEFORE broadcasting: check the
+        // initiator invariant and flip to Finalized under a single write lock, so a
+        // concurrent abort/remove_session cannot slip between the check and the commit
+        // and leave peers finalized while our session errored out. If the session is
+        // gone or in the wrong state we return here WITHOUT telling peers to finalize.
+        // `set_finalized` is synchronous (no await), so holding the guard is safe; the
+        // async broadcast happens after the guard is released.
         let (expected_signers, initiator) = {
-            let sessions = self.psbt_sessions.read();
+            let mut sessions = self.psbt_sessions.write();
             let session = sessions
-                .get_session(&session_id)
+                .get_session_mut(&session_id)
                 .ok_or_else(|| FrostNetError::Session("unknown PSBT session".into()))?;
-            (
-                session.expected_signers().clone(),
-                session.initiator().copied(),
-            )
+            let initiator = session.initiator().copied();
+            if initiator != Some(self_pk) {
+                return Err(FrostNetError::PolicyViolation(
+                    "Only the session initiator may finalize the PSBT".into(),
+                ));
+            }
+            let expected_signers = session.expected_signers().clone();
+            session.set_finalized(finalized_psbt.clone(), final_tx.clone())?;
+            (expected_signers, initiator)
         };
 
-        if initiator != Some(self.keys.public_key()) {
-            return Err(FrostNetError::PolicyViolation(
-                "Only the session initiator may finalize the PSBT".into(),
-            ));
-        }
-
-        let mut payload =
-            PsbtFinalizePayload::new(session_id, self.group_pubkey, finalized_psbt.clone());
-        if let Some((tx, id)) = final_tx.clone() {
+        let mut payload = PsbtFinalizePayload::new(session_id, self.group_pubkey, finalized_psbt);
+        if let Some((tx, id)) = final_tx {
             payload = payload.with_final_tx(tx, id);
         }
         let msg = KfpMessage::PsbtFinalize(payload);
@@ -1138,8 +1144,7 @@ impl KfpNode {
                 .collect()
         };
 
-        // Broadcast before flipping local state so a broadcast failure doesn't
-        // leave peers in the dark while we believe the session is finalized.
+        // Local state is already committed; notifying peers is best-effort.
         let (_reached, broadcast_err) = self
             .broadcast_psbt_event_partial(&msg, &session_id, "psbt_finalize", &target_peers)
             .await;
@@ -1147,16 +1152,8 @@ impl KfpNode {
             warn!(
                 session_id = %hex::encode(session_id),
                 error = %e,
-                "finalize broadcast had failures; committing local state anyway so caller sees finalization",
+                "finalize broadcast had failures; local state already committed",
             );
-        }
-
-        {
-            let mut sessions = self.psbt_sessions.write();
-            let session = sessions
-                .get_session_mut(&session_id)
-                .ok_or_else(|| FrostNetError::Session("unknown PSBT session".into()))?;
-            session.set_finalized(finalized_psbt, final_tx)?;
         }
 
         let _ = self


### PR DESCRIPTION
## Summary

`finalize_psbt_session` broadcast `PsbtFinalize` to peers **before** committing local `Finalized` state under a separate write lock. A concurrent `abort`/`remove_session` landing between the initial read and the `set_finalized` write made `set_finalized` fail with `?` **after** peers had already been told to finalize — a state desync: peers finalized while the local session errored out. (Same window for any `set_finalized` failure, e.g. a regressed threshold.)

This restructures so the initiator check and `set_finalized` happen **atomically under one `psbt_sessions.write()` lock**, committing local state **first**; peer target computation and the best-effort broadcast happen after the guard is released. If the session is gone or in the wrong state, it returns before broadcasting — no phantom finalize reaches peers. If the broadcast fails, local state is already committed (matching the previous "commit local anyway" intent).

Verified against the codebases lock discipline: `set_finalized` is synchronous (no `.await`, safe under the `parking_lot` guard); the guard is released before the async broadcast; `psbt_sessions` and `peers` locks are acquired sequentially, never nested (mirrors `start_psbt_session`); the peer-side `handle_psbt_finalize` is one-way (no finalize ACK), so committing before broadcast races nothing. This also closes the pre-existing TOCTOU where the initiator was checked under a read lock then re-fetched under a separate write lock.

Behavioral change (intended): a `set_finalized` failure that previously still broadcast now does **not** notify peers — the fix.

## Testing

- `cargo test -p keep-frost-net --lib` (434 passed), `cargo fmt --check`, `cargo clippy` clean.
- The `set_finalized` failure modes are covered by existing deterministic state-machine tests (`psbt_session.rs` `test_set_finalized_from_proposed_rejected` / `_below_threshold_rejected` / `test_cannot_finalize_twice` / `test_abort_blocks_further_changes`).
- A deterministic "no broadcast on failed finalize" regression test needs a relay-client trait seam (the client is a concrete `nostr_sdk::Client`) or a two-node MockRelay harness — filed as a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PSBT session finalization reliability by committing local state before notifying peers.
  * Prevented invalid or missing sessions from sending finalize notifications.
  * Finalization now remains successful locally even if peer notification fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->