### PR TITLE
security: lock the vault before coordination wait in announce-keys and approve-psbt

### DIFF
--- a/keep-cli/src/commands/wallet.rs
+++ b/keep-cli/src/commands/wallet.rs
@@ -1337,6 +1337,14 @@ pub fn cmd_wallet_announce_keys(
         None => keep.frost_get_share(&group_pubkey)?,
     };
 
+    // Snapshot the (non-secret) descriptor set while unlocked, then lock the vault so the
+    // master key is zeroized before the coordination wait instead of lingering for the
+    // whole session. This command only READS descriptors during the wait (single-vault-open
+    // rules out a concurrent writer), so the snapshot is equivalent. See keep-1ij5 / keep-0tdx.
+    let descriptor_snapshot = std::sync::Arc::new(keep.list_all_wallet_descriptor_versions()?);
+    keep.lock();
+    drop(keep);
+
     out.newline();
     out.header("Announce Recovery Keys");
     out.field("Group", &hex::encode(group_pubkey));
@@ -1351,13 +1359,15 @@ pub fn cmd_wallet_announce_keys(
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
 
-    let keep = Arc::new(Mutex::new(keep));
-
     rt.block_on(async {
         let node = keep_frost_net::KfpNode::new(share, vec![relay.to_string()])
             .await
             .map_err(|e| KeepError::Frost(e.to_string()))?;
-        let node = node.with_descriptor_lookup(Arc::new(descriptor_lookup_for(keep.clone())));
+        let node =
+            node.with_descriptor_lookup(Arc::new(keep_frost_net::KeepDescriptorLookup::new({
+                let snapshot = descriptor_snapshot.clone();
+                move || Some((*snapshot).clone())
+            })));
         let node = std::sync::Arc::new(node);
 
         node.announce()
@@ -1777,7 +1787,7 @@ fn parse_session_id(s: &str) -> Result<[u8; 32]> {
 #[allow(clippy::too_many_arguments)]
 async fn approve_psbt_session(
     out: &Output,
-    keep: Arc<Mutex<Keep>>,
+    descriptors: Arc<Vec<WalletDescriptor>>,
     node: Arc<keep_frost_net::KfpNode>,
     session_id: [u8; 32],
     group_pubkey: [u8; 32],
@@ -1809,20 +1819,15 @@ async fn approve_psbt_session(
     // the spend under the wrong policy/keys. All spend-side checks below
     // (policy, xpub, network, input bindings) derive from this descriptor.
     // Fail closed if no persisted version matches.
-    let descriptor = {
-        let guard = keep.lock().expect("keep mutex poisoned");
-        guard
-            .list_all_wallet_descriptor_versions()?
-            .into_iter()
-            .find(|d| {
-                d.group_pubkey == group_pubkey && d.canonical_hash() == session_descriptor_hash
-            })
-            .ok_or_else(|| {
-                KeepError::Frost(
-                    "no persisted descriptor matches the PSBT session descriptor_hash".into(),
-                )
-            })?
-    };
+    let descriptor = descriptors
+        .iter()
+        .find(|d| d.group_pubkey == group_pubkey && d.canonical_hash() == session_descriptor_hash)
+        .cloned()
+        .ok_or_else(|| {
+            KeepError::Frost(
+                "no persisted descriptor matches the PSBT session descriptor_hash".into(),
+            )
+        })?;
     let policy_json = descriptor.policy.clone().ok_or_else(|| {
         KeepError::InvalidInput(
             "persisted descriptor has no WalletPolicy; cannot derive recovery tier metadata".into(),
@@ -2053,6 +2058,13 @@ pub fn cmd_wallet_approve_psbt(
         None => keep.frost_get_share(&group_pubkey)?,
     };
 
+    // Snapshot the (non-secret) descriptor set while unlocked, then lock the vault so the
+    // master key is zeroized before the coordination wait. Approval only READS descriptors
+    // during the wait (signing runs via the NIP-46 bunker, not the vault). See keep-0tdx.
+    let descriptor_snapshot = std::sync::Arc::new(keep.list_all_wallet_descriptor_versions()?);
+    keep.lock();
+    drop(keep);
+
     out.newline();
     out.header("WDC Recovery Spend Approval");
     out.field("Group", &hex::encode(group_pubkey));
@@ -2070,8 +2082,6 @@ pub fn cmd_wallet_approve_psbt(
 
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| KeepError::Runtime(format!("tokio: {e}")))?;
-    let keep = Arc::new(Mutex::new(keep));
-
     rt.block_on(async {
         let registry = Arc::new(keep_frost_net::InMemoryRecoverySignerRegistry::new());
         for (fp, uri) in &registry_entries {
@@ -2081,7 +2091,12 @@ pub fn cmd_wallet_approve_psbt(
         let node = keep_frost_net::KfpNode::new(share, vec![relay.to_string()])
             .await
             .map_err(|e| KeepError::Frost(e.to_string()))?;
-        let node = node.with_descriptor_lookup(Arc::new(descriptor_lookup_for(keep.clone())));
+        let node = node.with_descriptor_lookup(Arc::new(keep_frost_net::KeepDescriptorLookup::new(
+            {
+                let snapshot = descriptor_snapshot.clone();
+                move || Some((*snapshot).clone())
+            },
+        )));
         let node = node.with_recovery_signer_registry(registry.clone());
         let node = Arc::new(node);
 
@@ -2143,7 +2158,7 @@ pub fn cmd_wallet_approve_psbt(
                     let bunker = registry_entries[idx].1.clone();
                     approve_psbt_session(
                         out,
-                        keep.clone(),
+                        descriptor_snapshot.clone(),
                         node.clone(),
                         session_id,
                         group_pubkey,


### PR DESCRIPTION
## Summary

Extends the #843 key-residency fix (lock the vault before the coordination wait) to the other CLI wallet commands that hold the vault unlocked for the whole PSBT/coordination `block_on` while only *reading* descriptors:

- **`cmd_wallet_announce_keys`** — spend-identical: snapshot `list_all_wallet_descriptor_versions()` while unlocked, `keep.lock()` + drop before the wait, feed the node lookup from the owned snapshot. The wait only reads descriptors (the FROST share is in the node).
- **`cmd_wallet_approve_psbt`** — same shape; its `approve_psbt_session` helper took `Arc<Mutex<Keep>>` only to read descriptors, so its signature now takes `Arc<Vec<WalletDescriptor>>` (the snapshot) and resolves the session descriptor from it. Signing runs via the NIP-46 bunker, not the vault, so nothing else needs the unlocked vault during the wait.

**`cmd_wallet_propose` is intentionally not changed:** it writes `store_wallet_descriptor` at the end of the coordination round (wallet.rs:1243), so it genuinely needs the vault unlocked for the whole session — the residency is inherent there.

Same safety rationale as #843: descriptors are public metadata, single-vault-open rules out a concurrent writer, the session is bounded, and the master-key DEK is zeroized on `lock()` before the wait. No behavioral change beyond narrowing key residency.

## Testing

- `cargo test -p keep-cli` (131 + 41 passed), `cargo build -p keep-cli`, `cargo fmt --check`, `cargo clippy` clean.
