### PR TITLE
fix: guard send_request against returning unparseable NIP-46 responses

### DIFF
--- a/keep-agent/src/client.rs
+++ b/keep-agent/src/client.rs
@@ -518,10 +518,15 @@ impl AgentClient {
                     continue;
                 };
                 if let Some(ref expected_id) = request_id {
-                    if let Ok(resp) = serde_json::from_str::<serde_json::Value>(&decrypted) {
-                        if resp.get("id").and_then(|v| v.as_str()) != Some(expected_id) {
-                            continue;
-                        }
+                    // Only accept a well-formed response whose id matches. An
+                    // unparseable payload is not our response, so keep waiting
+                    // rather than returning malformed content as valid (previously
+                    // a parse failure fell through to the return below).
+                    let Ok(resp) = serde_json::from_str::<serde_json::Value>(&decrypted) else {
+                        continue;
+                    };
+                    if resp.get("id").and_then(|v| v.as_str()) != Some(expected_id) {
+                        continue;
                     }
                 }
                 return Ok(decrypted);


### PR DESCRIPTION
keep-agent #794 item. When `request_id` is `Some`, `send_request` only ran the id-match check *inside* `if let Ok(resp) = serde_json::from_str(...)`; on a parse failure it fell through to `return Ok(decrypted)`, returning malformed content as a valid response instead of waiting for the real one.

Now a parse failure `continue`s (keep waiting), so a well-formed, id-matching response is required before returning. The event is already from the authenticated signer channel (nip44-decryptable + `pubkey == signer_pubkey`), so this is a robustness fix, not an injection fix, but it prevents a malformed signer reply from being surfaced as the response.

- `cargo build/test -p keep-agent` (38 passed), `fmt`/`clippy` clean. (The fix is inside an async event-stream loop; a dedicated test would require a mock relay stream — control-flow correctness verified by inspection.)