### PR TITLE
docs: document nip55 audit-chain trust boundary + serialization safety

### DIFF
--- a/keep-mobile/src/nip55_audit.rs
+++ b/keep-mobile/src/nip55_audit.rs
@@ -52,6 +52,21 @@ fn audit_entry_hash_inner(
 ) -> String {
     // Must match keep-android `PermissionStore.calculateEntryHash` byte-for-byte:
     // pipe-delimited UTF-8, empty string for absent prev_hash / event_kind.
+    //
+    // Trust boundary & serialization safety (see #802): tamper-evidence rests
+    // entirely on `hmac_key` -- a Keystore-held secret an attacker with audit-DB
+    // write access cannot read -- NOT on the row's database id. The row `id` is a
+    // local ordering/display value and is deliberately absent from this pre-image;
+    // chain POSITION is authenticated instead by `previous_hash` linking each
+    // entry to its predecessor's `entry_hash`. The `|` delimiter needs no escaping
+    // because no field can contain it: `previous_hash` is hex, `event_kind` and
+    // `timestamp` are integers, `was_automatic` is a bool, `request_type` and
+    // `decision` are closed enums, and `caller` is either the reserved `"self"`
+    // sentinel or a runtime-VERIFIED Android package name (charset [A-Za-z0-9_.],
+    // via `Nip55ContentProvider.getVerifiedCaller`). A length-prefixed (TLV)
+    // framing would be more robust in the abstract but is a coordinated
+    // keep-android byte-format change + row migration, unnecessary given these
+    // field domains.
     let content = format!(
         "{}|{}|{}|{}|{}|{}|{}",
         previous_hash.unwrap_or(""),


### PR DESCRIPTION
keep #802 (audit-chain remaining integrity hardening), the 'authenticate the entry id / document the caller trust boundary' item.

Item 1 (reject unbounded leading empty-hash rows) already shipped in #842. This documents the deliberate design of the remaining two, which are verified non-exploitable:
- **entry-id authentication** — the row `id` is intentionally NOT in the hash pre-image (it's a local ordering/display value); chain position is authenticated by `previous_hash` linking, and tamper-evidence rests on the Keystore-held HMAC key.
- **pipe-serialization field escaping** — needs no escaping because no field can contain `|`: prev_hash is hex, event_kind/timestamp are ints, was_automatic is bool, request_type/decision are closed enums, and caller is the reserved `self` sentinel or a runtime-verified Android package name (charset [A-Za-z0-9_.]). A TLV framing would be a coordinated keep-android byte-format change + row migration, unnecessary given these domains.

Doc-only. `build`/`fmt` clean.