### PR TITLE
keep-desktop: clear on-disk active_share pointer on vault lock

### DIFF
--- a/keep-desktop/src/app/helpers.rs
+++ b/keep-desktop/src/app/helpers.rs
@@ -28,6 +28,10 @@ impl App {
 
         let mut guard = lock_keep(&self.keep);
         if let Some(keep) = guard.as_mut() {
+            // Remove the on-disk active_share pointer before dropping the master
+            // key; set_active_share_key requires an unlocked vault, so it must
+            // precede lock().
+            let _ = keep.set_active_share_key(None);
             keep.lock();
         }
         *guard = None;


### PR DESCRIPTION
`do_lock` cleared the in-memory `active_share_hex` but left the `active_share` pointer file on disk, since `Keep::lock()` does not touch it. This removes the pointer via `set_active_share_key(None)` before locking (the call requires an unlocked vault, so it must precede `lock()`), so a locked vault leaves no on-disk record of which share was last active.

Resolves one item of #795.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cleared the active share selection when locking the vault, preventing stale share information from persisting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->