### PR TITLE
keep-mobile: bound rate-limit map, graceful session-store fallback, granular error mapping

### DIFF
--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -2477,7 +2477,11 @@ fn nip46_to_mobile_error(e: keep_core::error::KeepError) -> KeepMobileError {
     use keep_core::error::{KeepError, NetworkError};
     match e {
         KeepError::InvalidInput(msg) => KeepMobileError::InvalidInput { msg },
+        KeepError::UserRejected => KeepMobileError::InvalidInput {
+            msg: "request rejected".into(),
+        },
         KeepError::RateLimited(_) => KeepMobileError::RateLimited,
+        KeepError::CapacityExceeded(_) => KeepMobileError::RateLimited,
         KeepError::NetworkErr(NetworkError::Timeout { .. }) => KeepMobileError::Timeout,
         KeepError::NetworkErr(e) => KeepMobileError::NetworkError { msg: e.to_string() },
         KeepError::StorageErr(e) => KeepMobileError::StorageError { msg: e.to_string() },
@@ -2820,15 +2824,18 @@ impl KeepMobile {
             {
                 let store_path =
                     std::path::PathBuf::from(path).join("descriptor-sessions.redb");
-                let store = keep_frost_net::FileDescriptorSessionStore::new(&store_path)
-                    .map_err(|e| KeepMobileError::StorageError {
-                        msg: format!(
-                            "Failed to create descriptor session store: {e}"
-                        ),
-                    })?;
-                node.with_descriptor_session_store(
-                    Arc::new(store) as Arc<dyn keep_frost_net::DescriptorSessionStore>,
-                )
+                match keep_frost_net::FileDescriptorSessionStore::new(&store_path) {
+                    Ok(store) => node.with_descriptor_session_store(
+                        Arc::new(store) as Arc<dyn keep_frost_net::DescriptorSessionStore>,
+                    ),
+                    Err(e) => {
+                        tracing::warn!(
+                            "descriptor session store unavailable ({e}); \
+                             continuing with in-memory sessions"
+                        );
+                        node
+                    }
+                }
             } else {
                 node
             };

--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -740,7 +740,7 @@ impl Nip55Handler {
         let mut limits = self.rate_limits.lock().unwrap_or_else(|e| e.into_inner());
         let now = Instant::now();
 
-        self.evict_stale_entries(&mut limits, now);
+        Self::evict_stale_entries(&mut limits, now);
 
         let state = limits.entry(caller_id.to_string()).or_default();
 
@@ -779,7 +779,7 @@ impl Nip55Handler {
         }
     }
 
-    fn evict_stale_entries(&self, limits: &mut HashMap<String, RateLimitState>, now: Instant) {
+    fn evict_stale_entries(limits: &mut HashMap<String, RateLimitState>, now: Instant) {
         if limits.len() <= MAX_RATE_LIMIT_ENTRIES {
             return;
         }
@@ -792,6 +792,24 @@ impl Nip55Handler {
             let in_backoff = state.backoff_until.is_some_and(|b| now < b);
             recent || in_backoff
         });
+
+        // A flood of distinct, still-recent caller_ids survives the retain above
+        // and would grow the map without bound; enforce a hard cap by dropping the
+        // least-recently-active entries.
+        if limits.len() > MAX_RATE_LIMIT_ENTRIES {
+            let mut activity: Vec<(String, Instant)> = limits
+                .iter()
+                .map(|(id, state)| {
+                    let last = state.requests.iter().copied().max().unwrap_or(now);
+                    (id.clone(), last)
+                })
+                .collect();
+            activity.sort_by_key(|(_, last)| *last);
+            let excess = limits.len() - MAX_RATE_LIMIT_ENTRIES;
+            for (id, _) in activity.into_iter().take(excess) {
+                limits.remove(&id);
+            }
+        }
     }
 }
 
@@ -1486,6 +1504,27 @@ mod tests {
     // Amber's batch wire format puts the signature in BOTH `signature` and
     // `result` and never emits the assembled event; the per-request `event`
     // payload is only for the single-result intent path.
+    #[test]
+    fn evict_stale_entries_enforces_hard_cap_under_distinct_recent_flood() {
+        // A flood of distinct caller_ids that are all still "recent" (so the
+        // staleness retain keeps them) must not grow the map past the cap.
+        let now = Instant::now();
+        let mut limits: HashMap<String, RateLimitState> = HashMap::new();
+        for i in 0..(MAX_RATE_LIMIT_ENTRIES + 500) {
+            limits.insert(
+                format!("caller-{i}"),
+                RateLimitState {
+                    requests: vec![now],
+                    backoff_until: None,
+                    consecutive_failures: 0,
+                },
+            );
+        }
+        assert!(limits.len() > MAX_RATE_LIMIT_ENTRIES);
+        Nip55Handler::evict_stale_entries(&mut limits, now);
+        assert_eq!(limits.len(), MAX_RATE_LIMIT_ENTRIES);
+    }
+
     #[test]
     fn batch_results_sign_event_uses_signature_not_event() {
         let responses = vec![Nip55Response {


### PR DESCRIPTION
Three independent hardening fixes from the keep-mobile backlog:

- **Rate-limit map hard cap.** `evict_stale_entries` only dropped stale entries, so a flood of distinct but still-recent `caller_id`s survived the staleness retain and grew the map without bound. It now enforces `MAX_RATE_LIMIT_ENTRIES` by evicting the least-recently-active entries once the retain leaves the map over cap. Added a unit test that floods the map past the cap and asserts it is bounded.
- **Graceful descriptor-session-store fallback.** A failed `FileDescriptorSessionStore::new` aborted the entire node initialization via `?`; a transient filesystem error would leave the signer unusable. It now logs a warning and continues with in-memory sessions, matching the desktop behavior.
- **Granular NIP-46 error mapping.** `nip46_to_mobile_error` mapped `UserRejected` and `CapacityExceeded` through the generic `NetworkError` catch-all; they now map to `InvalidInput` and `RateLimited` respectively so callers see the correct typed error.

Resolves three items of #792.