### PR TITLE
keep-mobile: cert-pin bunker relays via shared verify_and_pin_relays

### DIFF
--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -2706,6 +2706,89 @@ impl KeepMobile {
         }
     }
 
+    /// Verify each relay's TLS certificate against the stored pins (trust-on-
+    /// first-use, or strict when configured), persist any newly learned pins,
+    /// and return the subset that passed. Fails closed if none pass.
+    ///
+    /// The caller must hold `cert_pin_lock` across this call so the read-modify-
+    /// write of the persisted pin set cannot lose an update to a concurrent
+    /// stage/remove/clear FFI call.
+    async fn verify_and_pin_relays(
+        &self,
+        relays: &[String],
+    ) -> Result<Vec<String>, KeepMobileError> {
+        // Opt-in strict pinning: when enabled, an un-pinned relay is not
+        // trusted-on-first-use; it is skipped (see the per-relay handling
+        // below) rather than pinned. Disabled by default.
+        let require_pinned =
+            persistence::load_strict_pin_config(&self.storage, STRICT_PIN_CONFIG_STORAGE_KEY)?
+                .unwrap_or_default()
+                .enabled;
+        let mut pins = persistence::load_cert_pins(&self.storage)?.unwrap_or_default();
+        let mut pins_changed = false;
+        for relay in relays {
+            // Strict mode: skip an un-pinned relay rather than aborting for the
+            // whole set. It is excluded from `verified_relays` below, and the
+            // empty-set check there fails closed if none are pinned. A pinned
+            // relay presenting a mismatched cert stays a fatal MitM.
+            if require_pinned && wss_relay_lacks_pin(relay, &pins) {
+                tracing::warn!(
+                    relay = %relay,
+                    "strict pinning: skipping relay with no provisioned pin"
+                );
+                continue;
+            }
+            match keep_frost_net::verify_relay_certificate(relay, &pins, require_pinned).await {
+                Ok((_hash, new_pin)) => {
+                    if let Some((hostname, hash)) = new_pin {
+                        if !pins.is_pinned(&hostname) {
+                            pins.add_pin(hostname, hash);
+                            pins_changed = true;
+                        }
+                    }
+                }
+                Err(
+                    e @ (keep_frost_net::FrostNetError::CertificatePinMismatch { .. }
+                    | keep_frost_net::FrostNetError::CertificatePinMissing { .. }),
+                ) => {
+                    // Fail closed on both a changed pin and, under strict mode,
+                    // an un-provisioned relay; do not silently skip.
+                    return Err(e.into());
+                }
+                Err(e) => {
+                    tracing::warn!(relay = %relay, error = %e, "TLS certificate verification failed, skipping relay");
+                }
+            }
+        }
+        if pins_changed {
+            persistence::persist_cert_pins(&self.storage, &pins)?;
+        }
+
+        let verified_relays: Vec<String> = relays
+            .iter()
+            .filter(|r| {
+                let url = match url::Url::parse(r) {
+                    Ok(u) => u,
+                    Err(_) => return false,
+                };
+                if url.scheme() != "wss" {
+                    return true;
+                }
+                url.host_str().map(|h| pins.is_pinned(h)).unwrap_or(false)
+            })
+            .cloned()
+            .collect();
+
+        if verified_relays.is_empty() {
+            return Err(keep_frost_net::FrostNetError::Transport(
+                "No relays passed TLS certificate verification".into(),
+            )
+            .into());
+        }
+
+        Ok(verified_relays)
+    }
+
     fn do_initialize(
         &self,
         relays: Vec<String>,
@@ -2737,76 +2820,7 @@ impl KeepMobile {
         let share = self.load_share_package()?;
 
         self.runtime.block_on(async {
-            // Opt-in strict pinning: when enabled, an un-pinned relay is not
-            // trusted-on-first-use; it is skipped (see the per-relay handling
-            // below) rather than pinned. Disabled by default.
-            let require_pinned =
-                persistence::load_strict_pin_config(&self.storage, STRICT_PIN_CONFIG_STORAGE_KEY)?
-                    .unwrap_or_default()
-                    .enabled;
-            let mut pins = persistence::load_cert_pins(&self.storage)?.unwrap_or_default();
-            let mut pins_changed = false;
-            for relay in &relays {
-                // Strict mode: skip an un-pinned relay rather than aborting init
-                // for the whole set. It is excluded from `verified_relays` below,
-                // and the empty-set check there fails closed if none are pinned.
-                // A pinned relay presenting a mismatched cert stays a fatal MitM.
-                if require_pinned && wss_relay_lacks_pin(relay, &pins) {
-                    tracing::warn!(
-                        relay = %relay,
-                        "strict pinning: skipping relay with no provisioned pin"
-                    );
-                    continue;
-                }
-                match keep_frost_net::verify_relay_certificate(relay, &pins, require_pinned).await {
-                    Ok((_hash, new_pin)) => {
-                        if let Some((hostname, hash)) = new_pin {
-                            if !pins.is_pinned(&hostname) {
-                                pins.add_pin(hostname, hash);
-                                pins_changed = true;
-                            }
-                        }
-                    }
-                    Err(
-                        e @ (keep_frost_net::FrostNetError::CertificatePinMismatch { .. }
-                        | keep_frost_net::FrostNetError::CertificatePinMissing { .. }),
-                    ) => {
-                        // Fail closed on both a changed pin and, under strict
-                        // mode, an un-provisioned relay; do not silently skip.
-                        return Err(e.into());
-                    }
-                    Err(e) => {
-                        tracing::warn!(relay = %relay, error = %e, "TLS certificate verification failed, skipping relay");
-                    }
-                }
-            }
-            if pins_changed {
-                persistence::persist_cert_pins(&self.storage, &pins)?;
-            }
-
-            let verified_relays: Vec<String> = relays
-                .iter()
-                .filter(|r| {
-                    let url = match url::Url::parse(r) {
-                        Ok(u) => u,
-                        Err(_) => return false,
-                    };
-                    if url.scheme() != "wss" {
-                        return true;
-                    }
-                    url.host_str()
-                        .map(|h| pins.is_pinned(h))
-                        .unwrap_or(false)
-                })
-                .cloned()
-                .collect();
-
-            if verified_relays.is_empty() {
-                return Err(keep_frost_net::FrostNetError::Transport(
-                    "No relays passed TLS certificate verification".into(),
-                )
-                .into());
-            }
+            let verified_relays = self.verify_and_pin_relays(&relays).await?;
 
             let node = match proxy {
                 Some(addr) => KfpNode::new_with_proxy(share, verified_relays, addr).await?,
@@ -2822,11 +2836,10 @@ impl KeepMobile {
                 })
                 .clone()
             {
-                let store_path =
-                    std::path::PathBuf::from(path).join("descriptor-sessions.redb");
+                let store_path = std::path::PathBuf::from(path).join("descriptor-sessions.redb");
                 match keep_frost_net::FileDescriptorSessionStore::new(&store_path) {
                     Ok(store) => node.with_descriptor_session_store(
-                        Arc::new(store) as Arc<dyn keep_frost_net::DescriptorSessionStore>,
+                        Arc::new(store) as Arc<dyn keep_frost_net::DescriptorSessionStore>
                     ),
                     Err(e) => {
                         tracing::warn!(

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -554,7 +554,20 @@ impl BunkerHandler {
             });
         }
 
+        // Cert-pin the bunker relays before serving, matching do_initialize.
+        // Held on the sync stack across the block_on (like do_initialize) so the
+        // trust-on-first-use pin persist cannot race a concurrent cert-pin FFI
+        // call. Lock order start_rotate_lock -> cert_pin_lock is acyclic: the
+        // cert-pin FFI methods and init never take start_rotate_lock.
+        let _cert_pins = self
+            .mobile
+            .cert_pin_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
         let result = self.mobile.runtime.block_on(async {
+            let verified_relays = self.mobile.verify_and_pin_relays(&relays).await?;
+
             let node_guard = self.mobile.node.read().await;
             let node = node_guard.as_ref().ok_or(KeepMobileError::NotInitialized)?;
 
@@ -640,7 +653,7 @@ impl BunkerHandler {
                 Server::new_frost_with_proxy(
                     frost_signer,
                     *transport_secret,
-                    &relays,
+                    &verified_relays,
                     server_callbacks,
                     config,
                     proxy,
@@ -654,7 +667,7 @@ impl BunkerHandler {
                 Server::new_network_frost_with_proxy(
                     network_signer,
                     *transport_secret,
-                    &relays,
+                    &verified_relays,
                     server_callbacks,
                     config,
                     proxy,


### PR DESCRIPTION
`do_start_bunker` validated relay URL syntax but skipped the TLS certificate-pinning that `do_initialize` performs, so a bunker session could connect to relays without the trust-on-first-use / strict-pin check that guards the rest of the app.

The pin-verification loop (load strict-pin config, verify each relay against stored pins, fail closed on a changed or missing pin, persist newly learned pins, and return only the verified relays) is extracted from `do_initialize` into a shared `KeepMobile::verify_and_pin_relays` helper. Both paths now call it:

- `do_initialize` is a behavior-preserving refactor (existing tests pass unchanged).
- `do_start_bunker` acquires `cert_pin_lock` on the sync stack across its `block_on` (matching `do_initialize`, so the trust-on-first-use pin persist cannot race a concurrent cert-pin FFI call) and feeds the verified relay set to the bunker server. The new lock order `start_rotate_lock -> cert_pin_lock` is acyclic: neither the cert-pin FFI methods nor init ever take `start_rotate_lock`.

Real-world impact is bounded because bunker traffic is NIP-44 end-to-end encrypted, so this is defense-in-depth against a hostile relay (metadata/censorship), brought in line with the initialization path.

Resolves one item of #792.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added TLS certificate verification and pinning for relay connections.
  * Strict pinning mode now skips unverified secure relays and fails closed when no verified relays remain.
  * Bunker startup now uses only verified relays for local and network connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->