### PR TITLE
keep-frost-net: add reconstruct_descriptor error-path unit tests

### DIFF
--- a/keep-frost-net/src/descriptor_session.rs
+++ b/keep-frost-net/src/descriptor_session.rs
@@ -1080,6 +1080,32 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[test]
+    fn reconstruct_descriptor_rejects_invalid_network() {
+        let policy = WalletPolicy {
+            recovery_tiers: vec![],
+            version: 1,
+        };
+        let contributions = BTreeMap::new();
+        let result = reconstruct_descriptor(&[2u8; 32], &policy, &contributions, "notanetwork");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn reconstruct_descriptor_errors_on_missing_contribution() {
+        // test_policy references participants 1/2/3 but no xpubs are supplied,
+        // so reconstruction must fail on the first missing share rather than
+        // silently dropping the recovery tier.
+        let policy = test_policy();
+        let contributions = BTreeMap::new();
+        let result = reconstruct_descriptor(&[2u8; 32], &policy, &contributions, "signet");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("missing xpub contribution for share"),
+            "unexpected error: {err}"
+        );
+    }
+
     fn test_policy() -> WalletPolicy {
         WalletPolicy {
             recovery_tiers: vec![PolicyTier {


### PR DESCRIPTION
`reconstruct_descriptor` (the WDC descriptor-rebuild path used to independently validate a network-supplied descriptor) had no dedicated unit tests; it was only exercised indirectly through the integration test. Adds two deterministic error-path tests:

- rejects an unparseable network string.
- fails with `missing xpub contribution for share N` when a policy recovery tier references a participant whose xpub was not contributed, rather than silently dropping the tier.

Resolves one item of #790.