### PR TITLE
keep-frost-net: test handle_oprf_eval_share rejects unannounced peer

### DIFF
--- a/keep-frost-net/src/node/oprf.rs
+++ b/keep-frost-net/src/node/oprf.rs
@@ -692,4 +692,18 @@ mod tests {
             Err(FrostNetError::PolicyViolation(_))
         ));
     }
+
+    #[tokio::test]
+    async fn handle_oprf_eval_share_rejects_unannounced_peer() {
+        // The share-ingestion handler binds the sender's pubkey to its claimed
+        // share index first, so a partial from an unannounced peer is rejected
+        // rather than fed into a session.
+        let (node, _relay) = test_node().await;
+        let from = Keys::generate().public_key();
+        let payload = OprfEvalSharePayload::new([1u8; 32], 2, vec![0u8; 32]);
+        assert!(matches!(
+            node.handle_oprf_eval_share(from, payload).await,
+            Err(FrostNetError::UntrustedPeer(_))
+        ));
+    }
 }


### PR DESCRIPTION
Completes the OPRF handler gate coverage started in #858: `handle_oprf_eval_share` (the requester-side partial-eval ingestion) binds the sender's pubkey to its claimed share index before touching any session, so a partial from an unannounced peer is rejected with UntrustedPeer. This mirrors the existing `handle_ecdh_share_rejects_unannounced_peer` and `handle_oprf_enroll_ack_rejects_unannounced_peer` tests, so both oprf.rs handlers now have deterministic gate coverage.

Resolves one item of #788.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of OPRF responses from untrusted senders.
  * Invalid responses are now rejected without modifying the active session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->