### PR TITLE
keep-state: persist delete-tombstones so revoked records reach standbys after a crash

### DIFF
--- a/keep-core/src/backend.rs
+++ b/keep-core/src/backend.rs
@@ -543,8 +543,9 @@ impl StorageBackend for RedbBackend {
         Ok(())
     }
 
-    // Each op must target a distinct table: redb errors on opening the same table twice in one write
-    // txn. The only caller passes exactly [data_table, STATE_VERSIONS_TABLE], always distinct.
+    // Ops are grouped by table so each table is opened exactly once (redb errors on opening the same
+    // table twice concurrently in one write txn); this lets a single batch carry several ops for the
+    // same table (e.g. deleting every descriptor version plus each version's tombstone) atomically.
     fn write_atomic(&self, ops: &[AtomicOp<'_>]) -> Result<()> {
         let wtxn = self.db.begin_write()?;
         // Group ops by table so each table is opened exactly once: redb forbids

--- a/keep-core/src/backend.rs
+++ b/keep-core/src/backend.rs
@@ -38,6 +38,13 @@ pub const SECRET_SEALS_TABLE: &str = "secret_seals";
 /// event that is not strictly newer (replay/rollback protection).
 pub const STATE_VERSIONS_TABLE: &str = "state_versions";
 
+/// Durable outbox of pending delete-tombstones for cross-node replication. Each
+/// entry (key `"<table>:<hex record id>"`) records that a replicable row was
+/// deleted so, if the process crashes before the delete is published, a fresh
+/// standby is not left with the revoked row still live. Cleared once the delete
+/// has been accepted by a relay.
+pub const PENDING_TOMBSTONES_TABLE: &str = "pending_tombstones";
+
 /// A single put-or-delete operation for [`StorageBackend::write_atomic`]. `value` `Some` is a put,
 /// `None` is a delete.
 pub struct AtomicOp<'a> {
@@ -95,8 +102,8 @@ pub trait StorageBackend: Send + Sync {
 
     /// Apply several put/delete operations across tables. The default implementation applies each op
     /// sequentially via `put`/`delete` and is NOT atomic; backends with transaction support should
-    /// override this so a crash mid-batch cannot leave the ops half-applied. Each op must target a
-    /// DISTINCT table.
+    /// override this so a crash mid-batch cannot leave the ops half-applied. Ops may target the same
+    /// table more than once; same-table ops are applied in the order given.
     fn write_atomic(&self, ops: &[AtomicOp<'_>]) -> Result<()> {
         for op in ops {
             match op.value {
@@ -151,6 +158,8 @@ const SECRETS_TABLE_DEF: TableDefinition<&[u8], &[u8]> = TableDefinition::new("s
 const SECRET_SEALS_TABLE_DEF: TableDefinition<&[u8], &[u8]> = TableDefinition::new("secret_seals");
 const STATE_VERSIONS_TABLE_DEF: TableDefinition<&[u8], &[u8]> =
     TableDefinition::new("state_versions");
+const PENDING_TOMBSTONES_TABLE_DEF: TableDefinition<&[u8], &[u8]> =
+    TableDefinition::new("pending_tombstones");
 
 /// Redb-based storage backend (default).
 pub struct RedbBackend {
@@ -213,6 +222,9 @@ impl RedbBackend {
             // Carried through a file-format upgrade so the keep-state rollback-guard high-water-marks
             // survive; otherwise they reset and the guard reverts to first-sync (TOFU) for every d-tag.
             STATE_VERSIONS_TABLE,
+            // Undelivered delete-tombstones must survive a file-format upgrade too, or a revoked
+            // record could be resurrected on a standby that never saw the delete.
+            PENDING_TOMBSTONES_TABLE,
         ];
 
         type TableEntries = Vec<(Vec<u8>, Vec<u8>)>;
@@ -386,6 +398,7 @@ impl RedbBackend {
             SECRETS_TABLE => Ok(SECRETS_TABLE_DEF),
             SECRET_SEALS_TABLE => Ok(SECRET_SEALS_TABLE_DEF),
             STATE_VERSIONS_TABLE => Ok(STATE_VERSIONS_TABLE_DEF),
+            PENDING_TOMBSTONES_TABLE => Ok(PENDING_TOMBSTONES_TABLE_DEF),
             _ => Err(StorageError::database(format!("unknown table: {name}")).into()),
         }
     }
@@ -534,14 +547,27 @@ impl StorageBackend for RedbBackend {
     // txn. The only caller passes exactly [data_table, STATE_VERSIONS_TABLE], always distinct.
     fn write_atomic(&self, ops: &[AtomicOp<'_>]) -> Result<()> {
         let wtxn = self.db.begin_write()?;
+        // Group ops by table so each table is opened exactly once: redb forbids
+        // holding two handles to the same table at once, and grouping lets a
+        // single call carry several ops for one table while keeping the whole
+        // batch in one transaction. Distinct tables are visited in first-seen
+        // order and each table's ops applied in their original order.
+        let mut tables: Vec<&str> = Vec::new();
         for op in ops {
-            let mut tbl = wtxn.open_table(self.table_def(op.table)?)?;
-            match op.value {
-                Some(v) => {
-                    tbl.insert(op.key, v)?;
-                }
-                None => {
-                    tbl.remove(op.key)?;
+            if !tables.contains(&op.table) {
+                tables.push(op.table);
+            }
+        }
+        for table in tables {
+            let mut tbl = wtxn.open_table(self.table_def(table)?)?;
+            for op in ops.iter().filter(|o| o.table == table) {
+                match op.value {
+                    Some(v) => {
+                        tbl.insert(op.key, v)?;
+                    }
+                    None => {
+                        tbl.remove(op.key)?;
+                    }
                 }
             }
         }
@@ -683,6 +709,53 @@ mod tests {
         let dir = tempdir().unwrap();
         let backend = RedbBackend::create(&dir.path().join("test.db")).unwrap();
         assert!(backend.create_table("unknown").is_err());
+    }
+
+    #[test]
+    fn write_atomic_applies_multiple_ops_to_the_same_table() {
+        let dir = tempdir().unwrap();
+        let backend = RedbBackend::create(&dir.path().join("test.db")).unwrap();
+        // A row a later op in the same batch will delete.
+        backend.put(KEYS_TABLE, b"gone", b"x").unwrap();
+        // One transaction carrying several ops for KEYS_TABLE (two puts and a
+        // delete) plus an op on a second table exercises the per-table grouping.
+        backend
+            .write_atomic(&[
+                AtomicOp {
+                    table: KEYS_TABLE,
+                    key: b"a",
+                    value: Some(b"1"),
+                },
+                AtomicOp {
+                    table: KEYS_TABLE,
+                    key: b"b",
+                    value: Some(b"2"),
+                },
+                AtomicOp {
+                    table: KEYS_TABLE,
+                    key: b"gone",
+                    value: None,
+                },
+                AtomicOp {
+                    table: STATE_VERSIONS_TABLE,
+                    key: b"v",
+                    value: Some(b"3"),
+                },
+            ])
+            .unwrap();
+        assert_eq!(
+            backend.get(KEYS_TABLE, b"a").unwrap().as_deref(),
+            Some(&b"1"[..])
+        );
+        assert_eq!(
+            backend.get(KEYS_TABLE, b"b").unwrap().as_deref(),
+            Some(&b"2"[..])
+        );
+        assert_eq!(backend.get(KEYS_TABLE, b"gone").unwrap(), None);
+        assert_eq!(
+            backend.get(STATE_VERSIONS_TABLE, b"v").unwrap().as_deref(),
+            Some(&b"3"[..])
+        );
     }
 
     #[test]

--- a/keep-core/src/lib.rs
+++ b/keep-core/src/lib.rs
@@ -154,6 +154,20 @@ impl Keep {
         self.storage.snapshot_replicable_records()
     }
 
+    /// Every undelivered delete-tombstone as `(table, record_id)`, for the
+    /// keep-state publisher to seed as pending deletes at startup so a revoked
+    /// record removed but never published still reaches standbys. See
+    /// [`Storage::pending_tombstones`].
+    pub fn pending_tombstones(&self) -> Result<Vec<(String, String)>> {
+        self.storage.pending_tombstones()
+    }
+
+    /// Clear a delete-tombstone once its delete has been accepted by a relay.
+    /// See [`Storage::clear_pending_tombstone`].
+    pub fn clear_pending_tombstone(&self, table: &str, record_id: &str) -> Result<()> {
+        self.storage.clear_pending_tombstone(table, record_id)
+    }
+
     /// Create a new Keep with the given password.
     ///
     /// # Example

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -9,8 +9,8 @@ use tracing::{debug, trace, warn};
 
 use crate::backend::{
     AtomicOp, RedbBackend, StorageBackend, CONFIG_TABLE, DESCRIPTORS_TABLE, HEALTH_STATUS_TABLE,
-    KEYS_TABLE, RELAY_CONFIGS_TABLE, SECRETS_TABLE, SECRET_SEALS_TABLE, SHARES_TABLE,
-    STATE_VERSIONS_TABLE,
+    KEYS_TABLE, PENDING_TOMBSTONES_TABLE, RELAY_CONFIGS_TABLE, SECRETS_TABLE, SECRET_SEALS_TABLE,
+    SHARES_TABLE, STATE_VERSIONS_TABLE,
 };
 use crate::crypto::{self, Argon2Params, EncryptedData, SecretKey, SALT_SIZE};
 use crate::error::{KeepError, Result, StorageError};
@@ -24,6 +24,22 @@ use crate::wallet::{KeyHealthStatus, WalletDescriptor};
 use bincode::Options;
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroizing;
+
+/// Marker value stored for a pending delete-tombstone. Only the entry KEY
+/// (`"<table>:<hex record id>"`) carries information; the delete is re-published
+/// with a fresh `created_at`, so no timestamp needs to persist here.
+const TOMBSTONE_MARKER: &[u8] = &[1u8];
+
+/// Split a pending-tombstone entry key (`"<table>:<hex record id>"`) back into
+/// `(table, record_id)`. Returns `None` for a malformed key.
+fn parse_tombstone_key(raw: &[u8]) -> Option<(String, String)> {
+    let s = std::str::from_utf8(raw).ok()?;
+    let (table, id) = s.split_once(':')?;
+    if table.is_empty() || id.is_empty() {
+        return None;
+    }
+    Some((table.to_string(), id.to_string()))
+}
 
 /// SOCKS5 proxy configuration stored in the vault.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -831,11 +847,68 @@ impl Storage {
         Ok(records)
     }
 
+    /// Atomically remove a replicable row AND persist a delete-tombstone intent,
+    /// so a crash after the row is gone but before the delete is replicated
+    /// cannot leave a revoked record live on a standby. `logical_table` is the
+    /// replication table name (`"keys"`/`"descriptors"`/`"relay_configs"`),
+    /// `backend_table` the physical redb table. Returns whether the row existed;
+    /// the caller emits `notify_delete` on `true`.
+    fn delete_replicable(
+        &self,
+        logical_table: &str,
+        backend_table: &str,
+        key: &[u8],
+    ) -> Result<bool> {
+        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
+        if backend.get(backend_table, key)?.is_none() {
+            return Ok(false);
+        }
+        let tombstone_key = format!("{logical_table}:{}", hex::encode(key));
+        // Row removal and tombstone persist commit together; the two ops target
+        // distinct tables as `write_atomic` requires.
+        backend.write_atomic(&[
+            AtomicOp {
+                table: backend_table,
+                key,
+                value: None,
+            },
+            AtomicOp {
+                table: PENDING_TOMBSTONES_TABLE,
+                key: tombstone_key.as_bytes(),
+                value: Some(TOMBSTONE_MARKER),
+            },
+        ])?;
+        Ok(true)
+    }
+
+    /// Every undelivered delete-tombstone, as `(logical_table, hex record id)`.
+    /// A fresh publisher seeds these as pending deletes so a revoked record that
+    /// was removed but never published still reaches standbys. Tolerates the
+    /// table not yet existing (no delete has ever been persisted).
+    pub fn pending_tombstones(&self) -> Result<Vec<(String, String)>> {
+        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
+        backend.create_table(PENDING_TOMBSTONES_TABLE)?;
+        Ok(backend
+            .list(PENDING_TOMBSTONES_TABLE)?
+            .into_iter()
+            .filter_map(|(k, _)| parse_tombstone_key(&k))
+            .collect())
+    }
+
+    /// Clear a delete-tombstone once its delete has been accepted by a relay, so
+    /// the outbox does not grow without bound or re-publish an already-delivered
+    /// delete on the next restart.
+    pub fn clear_pending_tombstone(&self, logical_table: &str, record_id: &str) -> Result<()> {
+        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
+        let tombstone_key = format!("{logical_table}:{record_id}");
+        backend.delete(PENDING_TOMBSTONES_TABLE, tombstone_key.as_bytes())?;
+        Ok(())
+    }
+
     /// Delete a key record.
     pub fn delete_key(&self, id: &[u8; 32]) -> Result<()> {
         debug!(id = %hex::encode(id), "deleting key");
-        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
-        if backend.delete(KEYS_TABLE, id)? {
+        if self.delete_replicable("keys", KEYS_TABLE, id)? {
             self.notify_delete("keys", &hex::encode(id));
             Ok(())
         } else {
@@ -1284,9 +1357,10 @@ impl Storage {
     }
 
     /// Delete every stored version of the wallet descriptor for a group.
-    /// All version rows are removed via the backend's `delete_batch`; on
-    /// backends that implement it atomically (redb does) a crash mid-delete
-    /// cannot leave a partial set behind.
+    /// All version rows are removed, each with a persisted delete-tombstone, in
+    /// one atomic transaction; on backends that implement `write_atomic`
+    /// atomically (redb does) a crash mid-delete cannot leave a partial set
+    /// behind, nor a deleted version without its replication tombstone.
     pub fn delete_descriptor(&self, group_pubkey: &[u8; 32]) -> Result<()> {
         debug!(group = %hex::encode(group_pubkey), "deleting wallet descriptor (all versions)");
         let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
@@ -1305,8 +1379,27 @@ impl Storage {
             )));
         }
 
-        let refs: Vec<&[u8]> = keys.iter().map(|k| k.as_slice()).collect();
-        backend.delete_batch(DESCRIPTORS_TABLE, &refs)?;
+        // Remove every version row and persist a delete-tombstone for each in a
+        // single atomic transaction, so a crash cannot leave a revoked
+        // descriptor live on a standby that never observed the delete.
+        let tombstone_keys: Vec<String> = keys
+            .iter()
+            .map(|k| format!("descriptors:{}", hex::encode(k)))
+            .collect();
+        let mut ops: Vec<AtomicOp> = Vec::with_capacity(keys.len() * 2);
+        for (k, tk) in keys.iter().zip(&tombstone_keys) {
+            ops.push(AtomicOp {
+                table: DESCRIPTORS_TABLE,
+                key: k,
+                value: None,
+            });
+            ops.push(AtomicOp {
+                table: PENDING_TOMBSTONES_TABLE,
+                key: tk.as_bytes(),
+                value: Some(TOMBSTONE_MARKER),
+            });
+        }
+        backend.write_atomic(&ops)?;
         for k in &keys {
             self.notify_delete("descriptors", &hex::encode(k));
         }
@@ -1315,9 +1408,8 @@ impl Storage {
 
     /// Delete a single version of a wallet descriptor for a group.
     pub fn delete_descriptor_version(&self, group_pubkey: &[u8; 32], version: u32) -> Result<()> {
-        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
         let key = descriptor_storage_key(group_pubkey, version);
-        if backend.delete(DESCRIPTORS_TABLE, &key)? {
+        if self.delete_replicable("descriptors", DESCRIPTORS_TABLE, &key)? {
             self.notify_delete("descriptors", &hex::encode(key));
             Ok(())
         } else {
@@ -1385,8 +1477,7 @@ impl Storage {
     /// Delete a relay configuration.
     pub fn delete_relay_config(&self, group_pubkey: &[u8; 32]) -> Result<()> {
         debug!(group = %hex::encode(group_pubkey), "deleting relay config");
-        let backend = self.backend.as_ref().ok_or(KeepError::Locked)?;
-        if backend.delete(RELAY_CONFIGS_TABLE, group_pubkey)? {
+        if self.delete_replicable("relay_configs", RELAY_CONFIGS_TABLE, group_pubkey)? {
             self.notify_delete("relay_configs", &hex::encode(group_pubkey));
             Ok(())
         } else {
@@ -1976,6 +2067,53 @@ mod tests {
         storage.delete_key(&record.id).unwrap();
         let keys = storage.list_keys().unwrap();
         assert_eq!(keys.len(), 0);
+    }
+
+    #[test]
+    fn delete_key_persists_tombstone_across_reopen_until_cleared() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test-keep");
+        let record = KeyRecord::new(
+            crypto::random_bytes(),
+            crate::keys::KeyType::Nostr,
+            "revoked".into(),
+            vec![1, 2, 3, 4],
+        );
+        let record_id = hex::encode(record.id);
+
+        {
+            let storage = Storage::create(&path, "password", Argon2Params::TESTING).unwrap();
+            storage.store_key(&record).unwrap();
+            // No delete yet -> no outbox entry.
+            assert!(storage.pending_tombstones().unwrap().is_empty());
+            storage.delete_key(&record.id).unwrap();
+            assert_eq!(
+                storage.pending_tombstones().unwrap(),
+                vec![("keys".to_string(), record_id.clone())]
+            );
+        }
+
+        // Simulate a crash/restart: the tombstone must survive so the delete
+        // still reaches a standby that never saw it.
+        let mut storage = Storage::open(&path).unwrap();
+        storage.unlock("password").unwrap();
+        assert_eq!(
+            storage.pending_tombstones().unwrap(),
+            vec![("keys".to_string(), record_id.clone())]
+        );
+
+        // Once the delete is acknowledged by a relay, clearing drops it for good.
+        storage.clear_pending_tombstone("keys", &record_id).unwrap();
+        assert!(storage.pending_tombstones().unwrap().is_empty());
+    }
+
+    #[test]
+    fn delete_missing_key_writes_no_tombstone() {
+        let dir = tempdir().unwrap();
+        let storage =
+            Storage::create(&dir.path().join("v"), "password", Argon2Params::TESTING).unwrap();
+        assert!(storage.delete_key(&[9u8; 32]).is_err());
+        assert!(storage.pending_tombstones().unwrap().is_empty());
     }
 
     #[test]

--- a/keep-web/src/state_replication.rs
+++ b/keep-web/src/state_replication.rs
@@ -215,9 +215,15 @@ async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys)
         // the per-d-tag coalescing keeps the map bounded by record count. Each seeded record is then
         // published with a created_at seeded from its own persisted mark by the loop below.
         let mut record_dtags: HashSet<String> = HashSet::new();
-        match keep.lock().await.snapshot_replicable_records() {
-            Ok(records) => {
-                {
+        // Hold the keep lock across BOTH the record snapshot and the tombstone
+        // read so `record_dtags` is a view consistent with the tombstone set: a
+        // delete takes the same mutex, so it cannot commit a fresh, legitimate
+        // tombstone between the two reads and then have it wrongly cleared as
+        // obsolete below. There is no `.await` inside the guard's scope.
+        {
+            let keep_guard = keep.lock().await;
+            match keep_guard.snapshot_replicable_records() {
+                Ok(records) => {
                     let mut guard = pending.lock().unwrap();
                     for (table, id, encrypted) in records {
                         let dtag = format!("{table}:{id}");
@@ -229,45 +235,44 @@ async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys)
                         });
                     }
                 }
-                notify.notify_one();
+                Err(e) => tracing::error!(
+                    "keep-state: initial snapshot failed; a fresh standby may miss records written before replication started: {e}"
+                ),
             }
-            Err(e) => tracing::error!(
-                "keep-state: initial snapshot failed; a fresh standby may miss records written before replication started: {e}"
-            ),
-        }
 
-        // Seed undelivered delete-tombstones: a record removed locally but never
-        // published must still tombstone on standbys, or a revoked key stays live
-        // there. A tombstone whose record still exists (deleted then re-created
-        // before the delete published) is obsolete -- clear it rather than seed a
-        // delete that would resurrect-then-remove the live record. `or_insert`
-        // also yields to a delete/record the hook captured between install and
-        // this drain (same storage).
-        match keep.lock().await.pending_tombstones() {
-            Ok(tombstones) => {
-                for (table, id) in tombstones {
-                    let dtag = format!("{table}:{id}");
-                    if record_dtags.contains(&dtag) {
-                        if let Err(e) = keep.lock().await.clear_pending_tombstone(&table, &id) {
-                            tracing::warn!(
-                                dtag = %dtag,
-                                "keep-state: could not clear obsolete delete-tombstone: {e}"
-                            );
+            // Seed undelivered delete-tombstones: a record removed locally but
+            // never published must still tombstone on standbys, or a revoked key
+            // stays live there. A tombstone whose record still exists (deleted
+            // then re-created before the delete published) is obsolete -- clear
+            // it rather than seed a delete that would resurrect-then-remove the
+            // live record. `or_insert` also yields to a record/delete the hook
+            // captured between install and this drain (same storage).
+            match keep_guard.pending_tombstones() {
+                Ok(tombstones) => {
+                    for (table, id) in tombstones {
+                        let dtag = format!("{table}:{id}");
+                        if record_dtags.contains(&dtag) {
+                            if let Err(e) = keep_guard.clear_pending_tombstone(&table, &id) {
+                                tracing::warn!(
+                                    dtag = %dtag,
+                                    "keep-state: could not clear obsolete delete-tombstone: {e}"
+                                );
+                            }
+                            continue;
                         }
-                        continue;
+                        pending
+                            .lock()
+                            .unwrap()
+                            .entry(dtag)
+                            .or_insert(Change::Delete { table, id });
                     }
-                    pending
-                        .lock()
-                        .unwrap()
-                        .entry(dtag)
-                        .or_insert(Change::Delete { table, id });
                 }
-                notify.notify_one();
+                Err(e) => tracing::error!(
+                    "keep-state: pending-tombstone seed failed; a revoked record may stay live on a standby: {e}"
+                ),
             }
-            Err(e) => tracing::error!(
-                "keep-state: pending-tombstone seed failed; a revoked record may stay live on a standby: {e}"
-            ),
         }
+        notify.notify_one();
 
         // `last_ts` is an in-memory per-d-tag high-water-mark guaranteeing strict per-d-tag monotonicity
         // of created_at within a run: a record and its immediate delete (or two rapid writes) must not

--- a/keep-web/src/state_replication.rs
+++ b/keep-web/src/state_replication.rs
@@ -24,7 +24,7 @@
 //! clock jump followed by a correction makes the consumer reject legitimate newer writes until wall-clock
 //! catches up. Seeding the publisher floor from stored marks covers a promoted standby, but not a live
 //! active whose own clock regresses.
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex as StdMutex};
 
 use nostr_sdk::prelude::*;
@@ -214,24 +214,58 @@ async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys)
         // the hook captured between installing it and this snapshot (both read the same storage), and
         // the per-d-tag coalescing keeps the map bounded by record count. Each seeded record is then
         // published with a created_at seeded from its own persisted mark by the loop below.
+        let mut record_dtags: HashSet<String> = HashSet::new();
         match keep.lock().await.snapshot_replicable_records() {
             Ok(records) => {
                 {
                     let mut guard = pending.lock().unwrap();
                     for (table, id, encrypted) in records {
-                        guard
-                            .entry(format!("{table}:{id}"))
-                            .or_insert(Change::Record {
-                                table: table.to_string(),
-                                id,
-                                encrypted,
-                            });
+                        let dtag = format!("{table}:{id}");
+                        record_dtags.insert(dtag.clone());
+                        guard.entry(dtag).or_insert(Change::Record {
+                            table: table.to_string(),
+                            id,
+                            encrypted,
+                        });
                     }
                 }
                 notify.notify_one();
             }
             Err(e) => tracing::error!(
                 "keep-state: initial snapshot failed; a fresh standby may miss records written before replication started: {e}"
+            ),
+        }
+
+        // Seed undelivered delete-tombstones: a record removed locally but never
+        // published must still tombstone on standbys, or a revoked key stays live
+        // there. A tombstone whose record still exists (deleted then re-created
+        // before the delete published) is obsolete -- clear it rather than seed a
+        // delete that would resurrect-then-remove the live record. `or_insert`
+        // also yields to a delete/record the hook captured between install and
+        // this drain (same storage).
+        match keep.lock().await.pending_tombstones() {
+            Ok(tombstones) => {
+                for (table, id) in tombstones {
+                    let dtag = format!("{table}:{id}");
+                    if record_dtags.contains(&dtag) {
+                        if let Err(e) = keep.lock().await.clear_pending_tombstone(&table, &id) {
+                            tracing::warn!(
+                                dtag = %dtag,
+                                "keep-state: could not clear obsolete delete-tombstone: {e}"
+                            );
+                        }
+                        continue;
+                    }
+                    pending
+                        .lock()
+                        .unwrap()
+                        .entry(dtag)
+                        .or_insert(Change::Delete { table, id });
+                }
+                notify.notify_one();
+            }
+            Err(e) => tracing::error!(
+                "keep-state: pending-tombstone seed failed; a revoked record may stay live on a standby: {e}"
             ),
         }
 
@@ -297,7 +331,21 @@ async fn spawn_publisher(keep: Arc<Mutex<Keep>>, client: Client, identity: Keys)
                 match event {
                     Ok(ev) => match client.send_event(&ev).await {
                         Ok(out) => match classify_send(&out) {
-                            SendOutcome::Accepted => {}
+                            SendOutcome::Accepted => {
+                                // A delete is now durably replicated; drop its
+                                // persisted tombstone so the outbox neither
+                                // re-publishes it on the next restart nor grows.
+                                if let Change::Delete { table, id } = &change {
+                                    if let Err(e) =
+                                        keep.lock().await.clear_pending_tombstone(table, id)
+                                    {
+                                        tracing::warn!(
+                                            dtag = ?dtag,
+                                            "keep-state: could not clear delivered delete-tombstone: {e}"
+                                        );
+                                    }
+                                }
+                            }
                             // Replicated, but some relay said no; never discard the reasons.
                             SendOutcome::PartiallyRejected => tracing::warn!(
                                 dtag = ?dtag,


### PR DESCRIPTION
In cross-node replication, record writes survive a restart (the publisher re-seeds them from a storage snapshot), but **deletes did not**: a delete removed the row from redb and enqueued the tombstone only in an in-memory map. A crash after the row was gone but before the tombstone published left the delete lost forever, so a revoked key/descriptor/relay-config stayed live on a standby. This is a key-revocation-integrity gap.

## Change
- New durable `pending_tombstones` redb table. Each replicable delete (`delete_key`, `delete_descriptor`, `delete_descriptor_version`, `delete_relay_config`) now removes the row **and** records a delete-tombstone in a single atomic `write_atomic`, so the two commit together.
- The keep-state publisher seeds these tombstones as pending deletes at startup (alongside the existing record snapshot), and clears a tombstone once its delete is accepted by a relay, so a crash-interrupted delete still reaches standbys and the outbox neither grows nor re-publishes a delivered delete.
- A tombstone whose record was re-created before the delete published is obsolete; it is cleared at seed time (zero hot-path cost) rather than resurrecting-then-removing the live record.
- `write_atomic` now groups ops per table so one atomic batch may carry several ops for the same table (needed to delete every descriptor version + its tombstone in one transaction); distinct-table batches are unchanged.

## Tests
- `delete_key_persists_tombstone_across_reopen_until_cleared`: delete persists a tombstone that survives a reopen (crash/restart) and is removed by `clear_pending_tombstone`.
- `delete_missing_key_writes_no_tombstone`: a no-op delete records nothing.
- `write_atomic_applies_multiple_ops_to_the_same_table`: multiple same-table puts+delete plus a second-table op all apply in one transaction.

Addresses the persistent-outbox item of #799.