### PR TITLE
keep-frost-net: abstract co-signing transport behind CosignTransport trait

### DIFF
--- a/keep-frost-net/src/node/descriptor.rs
+++ b/keep-frost-net/src/node/descriptor.rs
@@ -124,10 +124,7 @@ impl KfpNode {
                 .sign_with_keys(&self.keys)
                 .map_err(|e| FrostNetError::Nostr(e.to_string()))?;
 
-            self.client
-                .send_event(&event)
-                .await
-                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+            self.transport.send_event(&event).await?;
         }
 
         info!(
@@ -504,10 +501,7 @@ impl KfpNode {
                 .sign_with_keys(&self.keys)
                 .map_err(|e| FrostNetError::Nostr(e.to_string()))?;
 
-            self.client
-                .send_event(&event)
-                .await
-                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+            self.transport.send_event(&event).await?;
         }
 
         let _ = self
@@ -712,10 +706,7 @@ impl KfpNode {
             .sign_with_keys(&self.keys)
             .map_err(|e| FrostNetError::Nostr(e.to_string()))?;
 
-        self.client
-            .send_event(&event)
-            .await
-            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+        self.transport.send_event(&event).await?;
 
         info!(session_id = %hex::encode(session_id), "Sent descriptor contribution");
         Ok(())
@@ -851,10 +842,7 @@ impl KfpNode {
                 .sign_with_keys(&self.keys)
                 .map_err(|e| FrostNetError::Nostr(e.to_string()))?;
 
-            self.client
-                .send_event(&event)
-                .await
-                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+            self.transport.send_event(&event).await?;
         }
 
         info!(session_id = %hex::encode(session_id), "Sent finalized descriptor");
@@ -1075,10 +1063,7 @@ impl KfpNode {
                 .sign_with_keys(&self.keys)
                 .map_err(|e| FrostNetError::Nostr(e.to_string()))?;
 
-            self.client
-                .send_event(&event)
-                .await
-                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+            self.transport.send_event(&event).await?;
         } else {
             let _ = descriptor_hash; // silence unused-variable warning when no ACK is sent
             debug!(
@@ -1176,7 +1161,7 @@ impl KfpNode {
             }
         };
 
-        if let Err(e) = self.client.send_event(&event).await {
+        if let Err(e) = self.transport.send_event(&event).await {
             debug!("Failed to send descriptor nack: {e}");
         }
     }

--- a/keep-frost-net/src/node/ecdh.rs
+++ b/keep-frost-net/src/node/ecdh.rs
@@ -106,10 +106,7 @@ impl KfpNode {
         );
 
         let event = KfpEventBuilder::ecdh_share(&self.keys, &from, payload)?;
-        self.client
-            .send_event(&event)
-            .await
-            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+        self.transport.send_event(&event).await?;
 
         debug!(
             session_id = %hex::encode(request.session_id),
@@ -289,17 +286,11 @@ impl KfpNode {
 
         for (share_index, pubkey) in participant_peers {
             let event = KfpEventBuilder::ecdh_request(&self.keys, &pubkey, request.clone())?;
-            self.client
-                .send_event(&event)
-                .await
-                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+            self.transport.send_event(&event).await?;
 
             let share_event =
                 KfpEventBuilder::ecdh_share(&self.keys, &pubkey, our_share_payload.clone())?;
-            self.client
-                .send_event(&share_event)
-                .await
-                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+            self.transport.send_event(&share_event).await?;
 
             debug!(share_index, "Sent ECDH request and share");
         }

--- a/keep-frost-net/src/node/enroll.rs
+++ b/keep-frost-net/src/node/enroll.rs
@@ -150,10 +150,7 @@ impl KfpNode {
                     share_bytes,
                 );
                 let event = KfpEventBuilder::oprf_enroll(&self.keys, &pubkey, payload)?;
-                self.client
-                    .send_event(&event)
-                    .await
-                    .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+                self.transport.send_event(&event).await?;
                 debug!(target_index, "Sent OPRF enrollment share");
             }
             Ok(())
@@ -381,10 +378,7 @@ impl KfpNode {
 
         let ack = OprfEnrollAckPayload::new(payload.session_id, self.share.metadata.identifier);
         let event = KfpEventBuilder::oprf_enroll_ack(&self.keys, &from, ack)?;
-        self.client
-            .send_event(&event)
-            .await
-            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+        self.transport.send_event(&event).await?;
 
         debug!(
             session_id = %hex::encode(payload.session_id),

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -6,9 +6,11 @@ mod enroll;
 mod oprf;
 mod psbt;
 mod signing;
+mod transport;
 
 pub use psbt::PsbtSessionSnapshot;
 pub(crate) use signing::SIGNING_ROUND_TIMEOUT;
+pub(crate) use transport::{CosignTransport, NostrTransport};
 
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
@@ -1040,7 +1042,7 @@ pub type DuressPersister = Arc<dyn Fn(&DuressFreeze) + Send + Sync>;
 
 pub struct KfpNode {
     pub(crate) keys: Keys,
-    pub(crate) client: Client,
+    pub(crate) transport: Arc<dyn CosignTransport>,
     pub(crate) share: SharePackage,
     pub(crate) group_pubkey: [u8; 32],
     pub(crate) sessions: Arc<RwLock<SessionManager>>,
@@ -1195,7 +1197,7 @@ pub(crate) fn sanitize_reason(reason: &str) -> String {
 /// single-flight guard bounds it to one copy at a time.
 struct AnnounceJob {
     keys: Keys,
-    client: Client,
+    transport: Arc<dyn CosignTransport>,
     group_pubkey: [u8; 32],
     share_index: u16,
     name: String,
@@ -1262,43 +1264,9 @@ impl KfpNode {
         }
 
         let keys = derive_keys_from_share(&share)?;
-        let client = match proxy {
-            Some(addr) => {
-                let connection = Connection::new().proxy(addr).target(ConnectionTarget::All);
-                let opts = ClientOptions::new().connection(connection);
-                Client::builder().signer(keys.clone()).opts(opts).build()
-            }
-            None => Client::new(keys.clone()),
-        };
-
-        let relay_opts = default_relay_opts();
-
-        for relay in &relays {
-            client
-                .pool()
-                .add_relay(relay, relay_opts.clone())
-                .await
-                .map_err(|e| {
-                    FrostNetError::Transport(format!("Failed to add relay {relay}: {e}"))
-                })?;
-        }
-
-        client.connect().await;
-
-        tokio::time::timeout(Duration::from_secs(10), async {
-            loop {
-                let relay_map = client.relays().await;
-                let any_connected = relay_map
-                    .values()
-                    .any(|r| matches!(r.status(), RelayStatus::Connected));
-                if any_connected {
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(100)).await;
-            }
-        })
-        .await
-        .map_err(|_| FrostNetError::Transport("Timed out waiting for relay connection".into()))?;
+        let transport = Arc::new(
+            NostrTransport::connect(keys.clone(), &relays, proxy, default_relay_opts()).await?,
+        ) as Arc<dyn CosignTransport>;
 
         let group_pubkey = *share.group_pubkey();
         let our_index = share.metadata.identifier;
@@ -1342,7 +1310,7 @@ impl KfpNode {
 
         Ok(Self {
             keys,
-            client,
+            transport,
             share,
             group_pubkey,
             sessions: Arc::new(RwLock::new(session_manager)),
@@ -1816,7 +1784,7 @@ impl KfpNode {
         let mut fail_count = 0usize;
         for pubkey in &peer_pubkeys {
             let event = KfpEventBuilder::xpub_announce(&self.keys, pubkey, payload.clone())?;
-            if let Err(e) = self.client.send_event(&event).await {
+            if let Err(e) = self.transport.send_event(&event).await {
                 warn!(peer = %pubkey, error = %e, "Failed to send xpub announcement");
                 fail_count += 1;
             }
@@ -2027,7 +1995,7 @@ impl KfpNode {
 
         Ok(AnnounceJob {
             keys: self.keys.clone(),
-            client: self.client.clone(),
+            transport: Arc::clone(&self.transport),
             group_pubkey: self.group_pubkey,
             share_index: self.share.metadata.identifier,
             name: self.share.metadata.name.clone(),
@@ -2076,10 +2044,7 @@ impl KfpNode {
             tpm_attestation,
         )?;
 
-        job.client
-            .send_event(&event)
-            .await
-            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+        job.transport.send_event(&event).await?;
 
         info!(share_index = job.share_index, "Announced presence");
         Ok(())
@@ -2128,7 +2093,7 @@ impl KfpNode {
             .await
             .take()
             .ok_or_else(|| FrostNetError::Session("run() has already been started".into()))?;
-        let mut notifications = self.client.notifications();
+        let mut notifications = self.transport.notifications();
 
         let since = Timestamp::now() - Duration::from_secs(300);
 
@@ -2156,15 +2121,9 @@ impl KfpNode {
             .pubkey(self.keys.public_key())
             .since(since);
 
-        self.client
-            .subscribe(group_filter.clone(), None)
-            .await
-            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+        self.transport.subscribe(group_filter.clone()).await?;
 
-        self.client
-            .subscribe(direct_filter, None)
-            .await
-            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+        self.transport.subscribe(direct_filter).await?;
 
         // Coercion resistance: a duress beacon arrives as a NIP-59 gift wrap
         // authored by an EPHEMERAL key (not a fixed beacon key or group member), so
@@ -2182,10 +2141,7 @@ impl KfpNode {
             let giftwrap_filter = Filter::new()
                 .kind(Kind::GiftWrap)
                 .pubkey(self.keys.public_key());
-            self.client
-                .subscribe(giftwrap_filter, None)
-                .await
-                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+            self.transport.subscribe(giftwrap_filter).await?;
         }
 
         let fetch_filter = Filter::new()
@@ -2198,7 +2154,7 @@ impl KfpNode {
             .since(since);
 
         match self
-            .client
+            .transport
             .fetch_events(fetch_filter, Duration::from_secs(5))
             .await
         {
@@ -2747,10 +2703,7 @@ impl KfpNode {
 
     async fn handle_ping(&self, from: PublicKey, payload: PingPayload) -> Result<()> {
         let event = KfpEventBuilder::pong(&self.keys, &from, payload.challenge)?;
-        self.client
-            .send_event(&event)
-            .await
-            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+        self.transport.send_event(&event).await?;
 
         self.peers.write().touch_by_pubkey(&from);
 
@@ -2826,7 +2779,7 @@ impl KfpNode {
         for (share_index, pubkey, _) in peers_snapshot {
             match KfpEventBuilder::ping(&self.keys, pubkey) {
                 Ok(event) => {
-                    if let Err(e) = self.client.send_event(&event).await {
+                    if let Err(e) = self.transport.send_event(&event).await {
                         warn!(
                             peer = %pubkey,
                             share_index,

--- a/keep-frost-net/src/node/oprf.rs
+++ b/keep-frost-net/src/node/oprf.rs
@@ -181,10 +181,7 @@ impl KfpNode {
         );
 
         let event = KfpEventBuilder::oprf_eval_share(&self.keys, &from, payload)?;
-        self.client
-            .send_event(&event)
-            .await
-            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+        self.transport.send_event(&event).await?;
 
         debug!(
             session_id = %hex::encode(request.session_id),
@@ -458,10 +455,7 @@ impl KfpNode {
             for (share_index, pubkey) in participant_peers {
                 let event =
                     KfpEventBuilder::oprf_eval_request(&self.keys, &pubkey, request.clone())?;
-                self.client
-                    .send_event(&event)
-                    .await
-                    .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+                self.transport.send_event(&event).await?;
                 debug!(share_index, "Sent OPRF eval request");
             }
             Ok(())

--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -695,10 +695,7 @@ impl KfpNode {
                     msg_type,
                     msg,
                 )?;
-                self.client
-                    .send_event(&event)
-                    .await
-                    .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+                self.transport.send_event(&event).await?;
                 Ok(())
             }
             .await;
@@ -930,10 +927,7 @@ impl KfpNode {
             &msg,
         )?;
 
-        self.client
-            .send_event(&event)
-            .await
-            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+        self.transport.send_event(&event).await?;
 
         {
             let mut sessions = self.psbt_sessions.write();

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -241,7 +241,7 @@ impl KfpNode {
 
         for pubkey in peer_pubkeys {
             let event = KfpEventBuilder::nonce_commitment(&self.keys, &pubkey, payload.clone())?;
-            if let Err(e) = self.client.send_event(&event).await {
+            if let Err(e) = self.transport.send_event(&event).await {
                 warn!(peer = %pubkey, error = %e, "Failed to broadcast nonce commitment to peer");
                 continue;
             }
@@ -267,10 +267,7 @@ impl KfpNode {
 
         let payload = self.build_nonce_commitment_payload(available)?;
         let event = KfpEventBuilder::nonce_commitment(&self.keys, pubkey, payload)?;
-        self.client
-            .send_event(&event)
-            .await
-            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+        self.transport.send_event(&event).await?;
 
         Ok(())
     }
@@ -284,10 +281,7 @@ impl KfpNode {
         session_id: [u8; 32],
     ) -> Result<()> {
         let event = KfpEventBuilder::error(&self.keys, to, code, message, Some(session_id))?;
-        self.client
-            .send_event(&event)
-            .await
-            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+        self.transport.send_event(&event).await?;
         Ok(())
     }
 
@@ -458,10 +452,7 @@ impl KfpNode {
             );
 
             let event = KfpEventBuilder::commitment(&self.keys, &from, payload)?;
-            self.client
-                .send_event(&event)
-                .await
-                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+            self.transport.send_event(&event).await?;
 
             debug!(
                 session_id = %hex::encode(request.session_id),
@@ -769,10 +760,7 @@ impl KfpNode {
         );
 
         let event = KfpEventBuilder::commitment(&self.keys, &from, payload)?;
-        self.client
-            .send_event(&event)
-            .await
-            .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+        self.transport.send_event(&event).await?;
 
         debug!(
             session_id = %hex::encode(request.session_id),
@@ -1009,10 +997,7 @@ impl KfpNode {
 
         for pubkey in peer_pubkeys {
             let event = KfpEventBuilder::signature_share(&self.keys, &pubkey, payload.clone())?;
-            self.client
-                .send_event(&event)
-                .await
-                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+            self.transport.send_event(&event).await?;
         }
 
         debug!(session_id = %hex::encode(session_id), "Sent signature share");
@@ -1572,10 +1557,7 @@ impl KfpNode {
         let send_result: Result<()> = async {
             for (share_index, pubkey) in participant_peers {
                 let event = KfpEventBuilder::sign_request(&self.keys, &pubkey, request.clone())?;
-                self.client
-                    .send_event(&event)
-                    .await
-                    .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+                self.transport.send_event(&event).await?;
 
                 if !using_pre_exchange {
                     let commit_event = KfpEventBuilder::commitment(
@@ -1583,10 +1565,7 @@ impl KfpNode {
                         &pubkey,
                         our_commit_payload.clone(),
                     )?;
-                    self.client
-                        .send_event(&commit_event)
-                        .await
-                        .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+                    self.transport.send_event(&commit_event).await?;
                 }
 
                 debug!(share_index, using_pre_exchange, "Sent sign request");

--- a/keep-frost-net/src/node/transport.rs
+++ b/keep-frost-net/src/node/transport.rs
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::time::Duration;
+
+use nostr_sdk::prelude::*;
+use tokio::sync::broadcast;
+
+use crate::error::{FrostNetError, Result};
+
+/// Transport seam between [`KfpNode`](super::KfpNode) and the relay layer. Moves
+/// opaque, already-signed nostr [`Event`]s and [`Filter`]s only; all crypto
+/// (event building, NIP-44/59, [`Keys`]) stays node-side. Each method folds the
+/// underlying transport error into [`FrostNetError::Transport`] so callers get a
+/// crate error directly.
+///
+/// Returns boxed futures rather than using `async fn` so the trait stays
+/// object-safe (`Arc<dyn CosignTransport>`), mirroring
+/// [`SigningHooks::approve_oprf_eval`](super::SigningHooks::approve_oprf_eval)
+/// and avoiding an `async-trait` dependency.
+pub(crate) trait CosignTransport: Send + Sync {
+    fn send_event<'a>(
+        &'a self,
+        event: &'a Event,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+    fn subscribe<'a>(
+        &'a self,
+        filter: Filter,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+    fn fetch_events<'a>(
+        &'a self,
+        filter: Filter,
+        timeout: Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<Event>>> + Send + 'a>>;
+    fn notifications(&self) -> broadcast::Receiver<RelayPoolNotification>;
+}
+
+/// [`CosignTransport`] backed by a concrete `nostr_sdk::Client`.
+pub(crate) struct NostrTransport {
+    client: Client,
+}
+
+impl NostrTransport {
+    /// Build the client, add the relays, connect, and wait (bounded) for at
+    /// least one relay to reach `Connected`. Relay URLs are validated by the
+    /// caller before this runs.
+    pub(crate) async fn connect(
+        keys: Keys,
+        relays: &[String],
+        proxy: Option<SocketAddr>,
+        relay_opts: RelayOptions,
+    ) -> Result<Self> {
+        let client = match proxy {
+            Some(addr) => {
+                let connection = Connection::new().proxy(addr).target(ConnectionTarget::All);
+                let opts = ClientOptions::new().connection(connection);
+                Client::builder().signer(keys.clone()).opts(opts).build()
+            }
+            None => Client::new(keys.clone()),
+        };
+
+        for relay in relays {
+            client
+                .pool()
+                .add_relay(relay, relay_opts.clone())
+                .await
+                .map_err(|e| {
+                    FrostNetError::Transport(format!("Failed to add relay {relay}: {e}"))
+                })?;
+        }
+
+        client.connect().await;
+
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                let relay_map = client.relays().await;
+                let any_connected = relay_map
+                    .values()
+                    .any(|r| matches!(r.status(), RelayStatus::Connected));
+                if any_connected {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        })
+        .await
+        .map_err(|_| FrostNetError::Transport("Timed out waiting for relay connection".into()))?;
+
+        Ok(Self { client })
+    }
+}
+
+impl CosignTransport for NostrTransport {
+    fn send_event<'a>(
+        &'a self,
+        event: &'a Event,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            self.client
+                .send_event(event)
+                .await
+                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+            Ok(())
+        })
+    }
+
+    fn subscribe<'a>(
+        &'a self,
+        filter: Filter,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            self.client
+                .subscribe(filter, None)
+                .await
+                .map_err(|e| FrostNetError::Transport(e.to_string()))?;
+            Ok(())
+        })
+    }
+
+    fn fetch_events<'a>(
+        &'a self,
+        filter: Filter,
+        timeout: Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<Event>>> + Send + 'a>> {
+        Box::pin(async move {
+            self.client
+                .fetch_events(filter, timeout)
+                .await
+                .map_err(|e| FrostNetError::Transport(e.to_string()))
+                .map(|evs| evs.into_iter().collect())
+        })
+    }
+
+    fn notifications(&self) -> broadcast::Receiver<RelayPoolNotification> {
+        self.client.notifications()
+    }
+}


### PR DESCRIPTION
Decouples `KfpNode` from the concrete `nostr_sdk::Client` behind a small `CosignTransport` trait, so the node's relay interaction can be swapped (notably for a deterministic in-process test transport, unblocking the multi-peer coordination test gaps #543/#436).

## Scope (behavior-preserving)
A full nostr-free decouple is infeasible (nostr `Event`/`Keys`/`Filter`/NIP-44/NIP-59 are woven through event building and every handler), and unnecessary. This is the pragmatic seam: the trait traffics only in opaque, already-signed `Event`s and `Filter`s; all crypto (event building, NIP-44/59, `Keys`) stays node-side.

- New `node/transport.rs`: `CosignTransport` (`send_event` / `subscribe` / `fetch_events` / `notifications`), object-safe via boxed futures (mirrors `SigningHooks::approve_oprf_eval`; no `async-trait` dependency). Each method folds the transport error into `FrostNetError::Transport`.
- `NostrTransport`: the concrete impl, forwarding to `nostr_sdk::Client`. Its `connect()` holds the exact client-construction logic (proxy, add-relay loop, connect, bounded `Connected` poll) moved verbatim from `with_nonce_store`, with identical error messages.
- `KfpNode.client: Client` → `transport: Arc<dyn CosignTransport>` (and the same on `AnnounceJob`). Every `self.client.<send_event|subscribe|fetch_events|notifications>` call routes through the trait; the redundant per-site `.map_err(...)` is folded in (net −110 lines).

No event-building, encryption, `Keys`, filter, or handler logic changed.

## Verification
The MockRelay multinode suite is the behavior-preservation proof and passes unchanged: 40 multinode tests + 512 unit/property tests green, clippy clean, fmt clean.

Resolves #576. Enables the deterministic in-process test transport for #543/#436.