### PR TITLE
keep-frost-net: add in-process MemoryTransport for deterministic multi-node tests

### DIFF
--- a/keep-frost-net/src/lib.rs
+++ b/keep-frost-net/src/lib.rs
@@ -111,6 +111,8 @@ pub use enroll_session::{
 };
 pub use error::{FrostNetError, Result};
 pub use event::{verify_unwrapped_duress_beacon, KfpEventBuilder};
+#[cfg(feature = "testing")]
+pub use node::CosignTransport;
 pub use node::{
     DescriptorLookupUnavailable, DuressFreeze, DuressPersister, HealthCheckResult,
     KeepDescriptorLookup, KfpNode, KfpNodeEvent, NoOpHooks, OprfShareSealAck, PeerPolicy,

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -10,7 +10,8 @@ mod transport;
 
 pub use psbt::PsbtSessionSnapshot;
 pub(crate) use signing::SIGNING_ROUND_TIMEOUT;
-pub(crate) use transport::{CosignTransport, NostrTransport};
+pub use transport::CosignTransport;
+pub(crate) use transport::NostrTransport;
 
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
@@ -1242,16 +1243,6 @@ impl KfpNode {
         proxy: Option<SocketAddr>,
         session_timeout: Option<Duration>,
     ) -> Result<Self> {
-        let descriptor_manager = match session_timeout {
-            Some(t) => DescriptorSessionManager::with_timeout(t)?,
-            None => DescriptorSessionManager::new(),
-        };
-
-        let psbt_manager = match session_timeout {
-            Some(t) => PsbtSessionManager::with_timeout(t)?,
-            None => PsbtSessionManager::new(),
-        };
-
         for relay in &relays {
             let validate = if ALLOW_INTERNAL_HOSTS {
                 validate_relay_url_allow_internal
@@ -1267,6 +1258,30 @@ impl KfpNode {
         let transport = Arc::new(
             NostrTransport::connect(keys.clone(), &relays, proxy, default_relay_opts()).await?,
         ) as Arc<dyn CosignTransport>;
+
+        Self::assemble(share, keys, transport, nonce_store, session_timeout)
+    }
+
+    /// Synchronous assembly of a [`KfpNode`] from an already-connected
+    /// transport. Split out of [`Self::with_nonce_store`] so alternate
+    /// transports (e.g. an in-process test bus) can reuse the identical
+    /// wiring without a live relay connection.
+    fn assemble(
+        share: SharePackage,
+        keys: Keys,
+        transport: Arc<dyn CosignTransport>,
+        nonce_store: Option<Arc<dyn NonceStore>>,
+        session_timeout: Option<Duration>,
+    ) -> Result<Self> {
+        let descriptor_manager = match session_timeout {
+            Some(t) => DescriptorSessionManager::with_timeout(t)?,
+            None => DescriptorSessionManager::new(),
+        };
+
+        let psbt_manager = match session_timeout {
+            Some(t) => PsbtSessionManager::with_timeout(t)?,
+            None => PsbtSessionManager::new(),
+        };
 
         let group_pubkey = *share.group_pubkey();
         let our_index = share.metadata.identifier;
@@ -1350,6 +1365,19 @@ impl KfpNode {
             descriptor_lookup: None,
             recovery_signer_registry: None,
         })
+    }
+
+    /// Build a node over a caller-supplied [`CosignTransport`], bypassing the
+    /// relay connection. Test-only: lets an in-process bus stand in for nostr.
+    #[cfg(feature = "testing")]
+    pub fn with_transport(
+        share: SharePackage,
+        transport: Arc<dyn CosignTransport>,
+        nonce_store: Option<Arc<dyn NonceStore>>,
+        session_timeout: Option<Duration>,
+    ) -> Result<Self> {
+        let keys = derive_keys_from_share(&share)?;
+        Self::assemble(share, keys, transport, nonce_store, session_timeout)
     }
 
     pub fn with_descriptor_lookup(mut self, lookup: Arc<dyn PersistedDescriptorLookup>) -> Self {

--- a/keep-frost-net/src/node/transport.rs
+++ b/keep-frost-net/src/node/transport.rs
@@ -20,7 +20,7 @@ use crate::error::{FrostNetError, Result};
 /// object-safe (`Arc<dyn CosignTransport>`), mirroring
 /// [`SigningHooks::approve_oprf_eval`](super::SigningHooks::approve_oprf_eval)
 /// and avoiding an `async-trait` dependency.
-pub(crate) trait CosignTransport: Send + Sync {
+pub trait CosignTransport: Send + Sync {
     fn send_event<'a>(
         &'a self,
         event: &'a Event,

--- a/keep-frost-net/src/test_support.rs
+++ b/keep-frost-net/src/test_support.rs
@@ -40,3 +40,179 @@ pub fn build_signed_quote(
     let sig: Signature = sk.sign(&attest); // ECDSA-P256 over SHA-256(attest)
     (attest, sig.to_bytes().to_vec())
 }
+
+/// In-process [`CosignTransport`] bus for deterministic multi-node tests.
+///
+/// Peers share one [`MemoryBus`]; [`MemoryBus::transport`] hands each node its
+/// own [`MemoryTransport`]. A `send_event` fans the event out to every *other*
+/// peer whose subscribed filters match, mirroring nostr's rule that a client
+/// never receives its own events. No sockets, no relay, no timing races.
+#[cfg(feature = "testing")]
+mod memory_transport {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use nostr_sdk::prelude::*;
+    use tokio::sync::broadcast;
+
+    use crate::error::Result;
+    use crate::node::CosignTransport;
+
+    struct MemoryPeer {
+        sender: broadcast::Sender<RelayPoolNotification>,
+        filters: Vec<Filter>,
+    }
+
+    /// Shared in-process event bus. Clone to hand copies around; all clones
+    /// observe the same peers and retained event log.
+    #[derive(Clone)]
+    pub struct MemoryBus {
+        peers: Arc<Mutex<Vec<Arc<Mutex<MemoryPeer>>>>>,
+        log: Arc<Mutex<Vec<Event>>>,
+    }
+
+    impl Default for MemoryBus {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl MemoryBus {
+        pub fn new() -> Self {
+            Self {
+                peers: Arc::new(Mutex::new(Vec::new())),
+                log: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        /// Register a fresh peer and return its transport handle.
+        pub fn transport(&self) -> Arc<MemoryTransport> {
+            let (sender, _) = broadcast::channel(1000);
+            let me = Arc::new(Mutex::new(MemoryPeer {
+                sender,
+                filters: Vec::new(),
+            }));
+            self.peers.lock().unwrap().push(me.clone());
+            Arc::new(MemoryTransport {
+                bus: self.clone(),
+                me,
+            })
+        }
+    }
+
+    /// One node's view onto a [`MemoryBus`].
+    pub struct MemoryTransport {
+        bus: MemoryBus,
+        me: Arc<Mutex<MemoryPeer>>,
+    }
+
+    fn dummy_relay_url() -> RelayUrl {
+        RelayUrl::parse("wss://memory.invalid").unwrap()
+    }
+
+    fn dummy_subscription_id() -> SubscriptionId {
+        SubscriptionId::new("memory")
+    }
+
+    impl CosignTransport for MemoryTransport {
+        fn send_event<'a>(
+            &'a self,
+            event: &'a Event,
+        ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+            Box::pin(async move {
+                self.bus.log.lock().unwrap().push(event.clone());
+
+                let peers = self.bus.peers.lock().unwrap().clone();
+                for peer in peers {
+                    if Arc::ptr_eq(&peer, &self.me) {
+                        continue; // a client never receives its own events
+                    }
+                    let guard = peer.lock().unwrap();
+                    let matches = guard
+                        .filters
+                        .iter()
+                        .any(|f| f.match_event(event, MatchEventOptions::default()));
+                    if matches {
+                        let _ = guard.sender.send(RelayPoolNotification::Event {
+                            relay_url: dummy_relay_url(),
+                            subscription_id: dummy_subscription_id(),
+                            event: Box::new(event.clone()),
+                        });
+                    }
+                }
+                Ok(())
+            })
+        }
+
+        fn subscribe<'a>(
+            &'a self,
+            filter: Filter,
+        ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+            Box::pin(async move {
+                self.me.lock().unwrap().filters.push(filter);
+                Ok(())
+            })
+        }
+
+        fn fetch_events<'a>(
+            &'a self,
+            filter: Filter,
+            _timeout: Duration,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<Event>>> + Send + 'a>> {
+            Box::pin(async move {
+                let log = self.bus.log.lock().unwrap();
+                Ok(log
+                    .iter()
+                    .filter(|e| filter.match_event(e, MatchEventOptions::default()))
+                    .cloned()
+                    .collect())
+            })
+        }
+
+        fn notifications(&self) -> broadcast::Receiver<RelayPoolNotification> {
+            self.me.lock().unwrap().sender.subscribe()
+        }
+    }
+}
+
+#[cfg(feature = "testing")]
+pub use memory_transport::{MemoryBus, MemoryTransport};
+
+#[cfg(all(test, feature = "testing"))]
+mod memory_transport_tests {
+    use super::MemoryBus;
+    use crate::node::CosignTransport;
+    use nostr_sdk::prelude::*;
+    use std::sync::Arc;
+    use tokio::sync::broadcast::error::TryRecvError;
+
+    #[tokio::test]
+    async fn delivers_to_subscribers_but_not_sender() {
+        let bus = MemoryBus::new();
+        let a: Arc<dyn CosignTransport> = bus.transport();
+        let b: Arc<dyn CosignTransport> = bus.transport();
+
+        b.subscribe(Filter::new()).await.unwrap();
+
+        let mut a_rx = a.notifications();
+        let mut b_rx = b.notifications();
+
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::TextNote, "hello")
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        a.send_event(&event).await.unwrap();
+
+        match b_rx.try_recv() {
+            Ok(RelayPoolNotification::Event { event: got, .. }) => {
+                assert_eq!(got.id, event.id);
+            }
+            other => panic!("expected B to receive the event, got {other:?}"),
+        }
+
+        assert!(matches!(a_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+}


### PR DESCRIPTION
Builds on the `CosignTransport` seam (#576) to add a deterministic, relay-free test transport, so multi-peer coordination flows can be driven without MockRelay timing (unblocking #543 ECDH failure-path coverage and #436 DKG).

## Change (all test-only, gated behind the existing `testing` feature)
- **`assemble` extraction** (behavior-preserving): the synchronous node-assembly tail of `with_nonce_store` (all the session/ecdh/oprf/enroll/descriptor/psbt managers + `Ok(Self { .. })`) moves into a private `fn assemble(share, keys, transport, nonce_store, session_timeout)`. `with_nonce_store` now validates relays, derives keys, builds `NostrTransport`, and tail-calls `assemble`. The 40 MockRelay multinode tests pass unchanged, proving equivalence.
- **`with_transport`** (`#[cfg(feature = "testing")]`): constructs a `KfpNode` over a caller-supplied `Arc<dyn CosignTransport>`, bypassing relay setup.
- **`MemoryTransport`** (`test_support`): an in-process bus. `subscribe` records a node's `Filter`s; `send_event` fans a signed event to every *other* peer whose filters match (never to the sender, mirroring nostr); `fetch_events` replays a retained log; `notifications` yields the peer's receiver. Nodes still sign/encrypt/decrypt with their own `Keys`, so a matched event decrypts exactly as over a relay. `CosignTransport` is now `pub` (a legitimate extension point) and re-exported under `testing`.
- A unit test asserts the bus delivers to subscribers but not the sender.

## Verification
Build with and without `testing`; 443 lib + 40 multinode (unchanged) + the new bus test green; clippy clean both configs; fmt clean.

Part of #576; enables the deterministic tests for #543 and #436.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added testing support for creating nodes with custom transports.
  * Added an in-memory transport for deterministic communication between test nodes.
  * Exposed transport interfaces for testing-enabled builds.

* **Tests**
  * Added coverage verifying that messages reach subscribed peers without being delivered back to the sender.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->