### PR TITLE
keep-mobile: hoist sign-policy selection state into the core

### DIFF
--- a/keep-mobile/src/signing_policy.rs
+++ b/keep-mobile/src/signing_policy.rs
@@ -101,6 +101,135 @@ pub enum PolicyMode {
     Auto,
 }
 
+/// The sign-policy SELECTION the user chose, distinct from the 2-value
+/// evaluation [`PolicyMode`]. Ordinals match keep-android's `SignPolicy`
+/// (Manual=0, Basic=1, Auto=2), so migrating the client's stored value is a
+/// pure read-through.
+///
+/// NOTE: `Basic` and `Auto` currently map to the SAME evaluation mode
+/// (`PolicyMode::Auto`), reproducing keep-android's present behavior where the
+/// two are indistinguishable at runtime (the only client branch collapses both
+/// to `PolicyMode::Auto`). Giving `Basic` a distinct curated-allow-set semantics
+/// is a separate product decision (#716) and is intentionally NOT implemented
+/// here; this type only hoists the SELECTION state into the core, behavior-neutral.
+#[derive(uniffi::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SignPolicySelection {
+    Manual,
+    Basic,
+    Auto,
+}
+
+impl SignPolicySelection {
+    fn to_ordinal(self) -> u8 {
+        match self {
+            SignPolicySelection::Manual => 0,
+            SignPolicySelection::Basic => 1,
+            SignPolicySelection::Auto => 2,
+        }
+    }
+
+    /// Parse an ordinal, defaulting to the safest mode (`Manual`) on any
+    /// unknown/garbage value, matching keep-android's `fromOrdinal`.
+    fn from_ordinal(ordinal: u8) -> Self {
+        match ordinal {
+            1 => SignPolicySelection::Basic,
+            2 => SignPolicySelection::Auto,
+            _ => SignPolicySelection::Manual,
+        }
+    }
+
+    /// Map the selection onto the evaluation mode. `Basic` and `Auto` both map
+    /// to `Auto` today (behavior-neutral hoist); see the type note.
+    pub fn policy_mode(self) -> PolicyMode {
+        match self {
+            SignPolicySelection::Manual => PolicyMode::Manual,
+            SignPolicySelection::Basic | SignPolicySelection::Auto => PolicyMode::Auto,
+        }
+    }
+}
+
+/// Persistence for the sign-policy selection (global + per-app override). A
+/// simple string key/value store; the Android side backs it with its encrypted
+/// sign-policy prefs. Mirrors [`SigningRateLimiterStorage`].
+#[uniffi::export(with_foreign)]
+pub trait SignPolicySelectionStorage: Send + Sync {
+    fn load(&self, key: String) -> Option<String>;
+    fn save(&self, key: String, value: String);
+    fn remove(&self, key: String);
+}
+
+const GLOBAL_SIGN_POLICY_KEY: &str = "global_sign_policy";
+
+fn app_override_key(package: &str) -> String {
+    format!("sign_policy_override:{package}")
+}
+
+/// Core-owned store for the sign-policy selection, so the selection state and
+/// its override -> global -> Manual precedence live in one place rather than
+/// being reimplemented in each client (#716). Feeds the existing evaluation via
+/// [`SignPolicyStore::effective_policy_mode`].
+#[derive(uniffi::Object)]
+pub struct SignPolicyStore {
+    storage: Arc<dyn SignPolicySelectionStorage>,
+}
+
+#[uniffi::export]
+impl SignPolicyStore {
+    #[uniffi::constructor]
+    pub fn new(storage: Arc<dyn SignPolicySelectionStorage>) -> Self {
+        Self { storage }
+    }
+
+    /// The global sign-policy selection, defaulting to `Manual` when unset or
+    /// unparseable (fail safe).
+    pub fn global_policy(&self) -> SignPolicySelection {
+        self.storage
+            .load(GLOBAL_SIGN_POLICY_KEY.to_string())
+            .and_then(|s| s.parse::<u8>().ok())
+            .map(SignPolicySelection::from_ordinal)
+            .unwrap_or(SignPolicySelection::Manual)
+    }
+
+    /// Persist the global sign-policy selection.
+    pub fn set_global_policy(&self, policy: SignPolicySelection) {
+        self.storage.save(
+            GLOBAL_SIGN_POLICY_KEY.to_string(),
+            policy.to_ordinal().to_string(),
+        );
+    }
+
+    /// The per-app override, or `None` if the app follows the global policy.
+    pub fn app_override(&self, package: String) -> Option<SignPolicySelection> {
+        self.storage
+            .load(app_override_key(&package))
+            .and_then(|s| s.parse::<u8>().ok())
+            .map(SignPolicySelection::from_ordinal)
+    }
+
+    /// Set (`Some`) or clear (`None`) the per-app override.
+    pub fn set_app_override(&self, package: String, policy: Option<SignPolicySelection>) {
+        match policy {
+            Some(p) => self
+                .storage
+                .save(app_override_key(&package), p.to_ordinal().to_string()),
+            None => self.storage.remove(app_override_key(&package)),
+        }
+    }
+
+    /// Resolve the effective selection for a package: per-app override, else the
+    /// global policy, else `Manual`. Mirrors keep-android's precedence.
+    pub fn effective_policy(&self, package: String) -> SignPolicySelection {
+        self.app_override(package)
+            .unwrap_or_else(|| self.global_policy())
+    }
+
+    /// The evaluation [`PolicyMode`] for a package, ready to feed the existing
+    /// `evaluate_sign_policy` / decision machinery.
+    pub fn effective_policy_mode(&self, package: String) -> PolicyMode {
+        self.effective_policy(package).policy_mode()
+    }
+}
+
 #[derive(uniffi::Record, Clone, Debug)]
 pub struct UsageStats {
     pub hourly_count: u32,
@@ -936,5 +1065,107 @@ mod tests {
         let ctx = test_ctx(Nip55RequestType::Nip44Encrypt, None);
         let result = evaluate_sign_policy(PolicyMode::Auto, ctx, true, allowed(1, 1));
         assert_eq!(result, SignPolicyEvaluation::FallToUi);
+    }
+
+    struct MockPolicyStorage {
+        map: Mutex<HashMap<String, String>>,
+    }
+    impl MockPolicyStorage {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                map: Mutex::new(HashMap::new()),
+            })
+        }
+    }
+    impl SignPolicySelectionStorage for MockPolicyStorage {
+        fn load(&self, key: String) -> Option<String> {
+            self.map.lock().unwrap().get(&key).cloned()
+        }
+        fn save(&self, key: String, value: String) {
+            self.map.lock().unwrap().insert(key, value);
+        }
+        fn remove(&self, key: String) {
+            self.map.lock().unwrap().remove(&key);
+        }
+    }
+
+    #[test]
+    fn sign_policy_selection_maps_to_policy_mode() {
+        assert_eq!(
+            SignPolicySelection::Manual.policy_mode(),
+            PolicyMode::Manual
+        );
+        // Basic and Auto both map to Auto today (behavior-neutral hoist).
+        assert_eq!(SignPolicySelection::Basic.policy_mode(), PolicyMode::Auto);
+        assert_eq!(SignPolicySelection::Auto.policy_mode(), PolicyMode::Auto);
+    }
+
+    #[test]
+    fn sign_policy_selection_ordinal_round_trip_and_defaults() {
+        for p in [
+            SignPolicySelection::Manual,
+            SignPolicySelection::Basic,
+            SignPolicySelection::Auto,
+        ] {
+            assert_eq!(SignPolicySelection::from_ordinal(p.to_ordinal()), p);
+        }
+        // Unknown ordinals fail safe to Manual.
+        assert_eq!(
+            SignPolicySelection::from_ordinal(9),
+            SignPolicySelection::Manual
+        );
+    }
+
+    #[test]
+    fn sign_policy_store_global_defaults_to_manual_then_persists() {
+        let store = SignPolicyStore::new(MockPolicyStorage::new());
+        assert_eq!(store.global_policy(), SignPolicySelection::Manual);
+        store.set_global_policy(SignPolicySelection::Auto);
+        assert_eq!(store.global_policy(), SignPolicySelection::Auto);
+    }
+
+    #[test]
+    fn sign_policy_store_persists_across_new_instances() {
+        let storage = MockPolicyStorage::new();
+        SignPolicyStore::new(storage.clone()).set_global_policy(SignPolicySelection::Basic);
+        // A fresh store over the same backend (a restart) reads it back.
+        assert_eq!(
+            SignPolicyStore::new(storage).global_policy(),
+            SignPolicySelection::Basic
+        );
+    }
+
+    #[test]
+    fn sign_policy_store_override_precedence_and_clear() {
+        let store = SignPolicyStore::new(MockPolicyStorage::new());
+        store.set_global_policy(SignPolicySelection::Manual);
+        // No override -> follows global.
+        assert!(store.app_override("com.app".into()).is_none());
+        assert_eq!(
+            store.effective_policy_mode("com.app".into()),
+            PolicyMode::Manual
+        );
+        // Override wins over global.
+        store.set_app_override("com.app".into(), Some(SignPolicySelection::Auto));
+        assert_eq!(
+            store.app_override("com.app".into()),
+            Some(SignPolicySelection::Auto)
+        );
+        assert_eq!(
+            store.effective_policy_mode("com.app".into()),
+            PolicyMode::Auto
+        );
+        // A different app still follows global.
+        assert_eq!(
+            store.effective_policy("com.other".into()),
+            SignPolicySelection::Manual
+        );
+        // Clearing the override reverts to global.
+        store.set_app_override("com.app".into(), None);
+        assert!(store.app_override("com.app".into()).is_none());
+        assert_eq!(
+            store.effective_policy("com.app".into()),
+            SignPolicySelection::Manual
+        );
     }
 }


### PR DESCRIPTION
Addresses the state-ownership half of #716: the keep-mobile core already owns policy *evaluation* (`PolicyMode`, `evaluate_sign_policy`) but not the *selection* (which policy the user chose), which lives entirely in the keep-android `SignPolicyStore` (encrypted prefs + a per-app Room override), so every client reimplements it.

## What this adds (behavior-neutral state hoist)
- `SignPolicySelection { Manual, Basic, Auto }` — the 3-value selection the user is offered, with ordinals matching keep-android's `SignPolicy` (Manual=0, Basic=1, Auto=2) so migrating the client's stored value is a pure read-through, and a `from_ordinal` that fails safe to `Manual`.
- `SignPolicyStore` (UniFFI object) over a small `SignPolicySelectionStorage` KV trait (mirroring the existing `SigningRateLimiterStorage`): `global_policy`/`set_global_policy`, `app_override`/`set_app_override`, and `effective_policy`/`effective_policy_mode` implementing the override -> global -> Manual precedence currently duplicated in `Nip55ContentProvider`.
- `SignPolicySelection::policy_mode()` feeds the existing evaluation unchanged.

## Deliberately behavior-neutral (per research)
Evidence (keep-android `Nip55ContentProvider.kt:227-228`): `BASIC` and `AUTO` collapse to the same `PolicyMode.Auto` today — they are indistinguishable at runtime; the real 'saved-only vs approve-everything' split is carried by the orthogonal per-app `is_opted_in` flag, not the label. So `Basic`/`Auto` both map to `PolicyMode::Auto` here, exactly as today. Whether to resurrect `BASIC` as a real mode with a curated allow-set (../Amber realizes it as MANUAL + a seeded benign-kind allowlist, which overlaps keep's sensitive-kinds) is a genuine product/security decision, documented as follow-up rather than guessed.

Non-breaking: a new `#[uniffi::export(with_foreign)]` trait + object only generate bindings the client adopts on migration; keep-android keeps building.

## Tests (5, all deterministic)
policy_mode mapping, ordinal round-trip + fail-safe defaults, global default(Manual)+persist, persistence across store instances (restart), and override precedence + clear.

## Follow-up (cross-repo / product)
keep-android migrates its two write sites (Settings + onboarding) to the FFI and drops `SignPolicyStore.kt`, with a one-time data migration; and the maintainer decides the BASIC-vs-AUTO semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selectable signing policies: Manual, Basic, and Auto.
  * Added global policy settings with optional per-app overrides.
  * Added automatic resolution of the effective policy for each app.
  * Added safe fallback to Manual when saved settings are missing or invalid.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->