### PR TITLE
keep-frost-net: emit PsbtAborted on descriptor-hash mismatch

### DIFF
--- a/keep-frost-net/src/node/psbt.rs
+++ b/keep-frost-net/src/node/psbt.rs
@@ -562,7 +562,17 @@ impl KfpNode {
             ));
         }
 
-        self.verify_descriptor_hash_against_stored(&payload.descriptor_hash)?;
+        // A descriptor-hash mismatch is a fund-safety reject (the proposal spends
+        // from a descriptor we do not recognize). Surface it as PsbtAborted so
+        // observers see the abort, mirroring the session-creation-failure path
+        // below, rather than only propagating a warn-logged error (#803).
+        if let Err(e) = self.verify_descriptor_hash_against_stored(&payload.descriptor_hash) {
+            let _ = self.event_tx.send(KfpNodeEvent::PsbtAborted {
+                session_id: payload.session_id,
+                reason: format!("descriptor hash mismatch: {e}"),
+            });
+            return Err(e);
+        }
 
         // Canonicalize the wire-supplied fingerprints to lowercase once, mirroring
         // the proposer path (propose_psbt) and the stored recovery fingerprints.


### PR DESCRIPTION
From the keep-frost-net hardening backlog (#803).

When a PSBT proposal fails the descriptor-hash check in `handle_psbt_propose` (`verify_descriptor_hash_against_stored`), the responder returned an error that was only warn-logged upstream, emitting no `PsbtAborted` event. A descriptor-hash mismatch is a fund-safety reject (the proposal would spend from a descriptor the responder does not recognize), so observers (UI, peers, tests) should see the abort explicitly, exactly as the adjacent session-creation-failure path already does.

This emits `KfpNodeEvent::PsbtAborted { session_id, reason }` before propagating the error, mirroring the existing pattern a few lines below. Fail-closed behavior is unchanged (the proposal is still rejected); this only makes the rejection observable. keep-frost-net lib suite green (442 tests), clippy and fmt clean.