### PR TITLE
keep-cli: keep the hardware signature share off the default console

### DIFF
--- a/keep-cli/src/commands/frost_network/hardware.rs
+++ b/keep-cli/src/commands/frost_network/hardware.rs
@@ -274,7 +274,10 @@ pub fn cmd_frost_network_sign_hardware(
         spinner.finish();
 
         let sig_share_hex = hex::encode(&sig_share);
-        out.field("Our signature share", &sig_share_hex);
+        // The share is published in the signature event below (its intended
+        // egress); keep the raw material off the default console and behind
+        // RUST_LOG=debug rather than printing it unconditionally (#788).
+        debug!(share = %sig_share_hex, "generated our signature share");
 
         let sig_response = serde_json::json!({
             "request_id": hex::encode(session_id),


### PR DESCRIPTION
From the keep-cli hardening backlog (#788). The hardware co-signer's round-2 signing path printed the raw signature share to the console unconditionally via `out.field("Our signature share", ...)`. The share is already published in the signature event that immediately follows (its intended egress), so the console print was redundant cryptographic material on stdout and in any captured terminal logs.

This moves the raw hex to a `tracing::debug!` line (already imported in this module), so it is available under `RUST_LOG=debug` for troubleshooting but not printed on the default console. User-facing feedback is unchanged: the flow still shows the round-2 spinner and the "Signature share published!" confirmation. No logic change. Build, clippy, and fmt clean.