### PR TITLE
keep-web: keep the admin token out of the log and bind loopback by default

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -58,9 +58,18 @@ sudo editor /etc/keep-web/keep-web.env
 sudo systemctl enable --now keep-web
 ```
 
-The admin interface binds to `127.0.0.1:8080` by default. Front it with the
-reverse proxy in `nginx/keep.conf` or an onion service rather than exposing it
-directly. The vault lives in `/var/lib/keep-web`.
+The admin interface binds to `127.0.0.1:8080` and is not reachable from the
+network on purpose, since it controls signing and can export the share. To use
+it from another machine, forward the port over SSH:
+
+```bash
+ssh -L 8080:127.0.0.1:8080 <user>@<host>
+```
+
+Then browse to `http://127.0.0.1:8080` and sign in with the token from
+`/etc/keep-web/auth-token` (`sudo cat` it). For a permanent deployment, front
+it with the reverse proxy in `nginx/keep.conf` or an onion service rather than
+widening `KEEP_WEB_LISTEN`. The vault lives in `/var/lib/keep-web`.
 
 The bearer token guarding the admin API is generated on install and readable
 by root at `/etc/keep-web/auth-token`. This token gates share export, so treat

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -71,11 +71,11 @@ Then browse to `http://127.0.0.1:8080` and sign in with the token from
 it with the reverse proxy in `nginx/keep.conf` or an onion service rather than
 widening `KEEP_WEB_LISTEN`. The vault lives in `/var/lib/keep-web`.
 
-The bearer token guarding the admin API is generated on install and readable
-by root at `/etc/keep-web/auth-token`. This token gates share export, so treat
-it as key material. Leaving `KEEP_WEB_AUTH_TOKEN_FILE` unset would make the
-daemon mint a fresh token at every start and write it to the journal, which is
-why the package pins it.
+The bearer token guarding the admin API is generated on install at
+`/etc/keep-web/auth-token`. This token gates share export, so treat it as key
+material. Left unset, the daemon would persist its own token inside the vault
+directory instead; the package pins it under `/etc/keep-web` so the credential
+is not swept up by filesystem backups and volume snapshots of the vault.
 
 Only `/var/lib/keep-web` survives a purge. It holds the encrypted share and
 deleting it would be irrecoverable, so it is kept along with the `keep-web`

--- a/contrib/debian/keep-web.8
+++ b/contrib/debian/keep-web.8
@@ -36,9 +36,12 @@ share export. The package generates
 .I /etc/keep-web/auth-token
 on install and points this at it. If neither this nor
 .B KEEP_WEB_AUTH_TOKEN
-is set, the daemon mints a random token at every start and logs it, which puts
-the credential in the journal and invalidates the operator's token on every
-restart.
+is set, the daemon persists a generated token to
+.I $KEEP_PATH/auth_token
+instead. The package pins the
+.I /etc/keep-web
+copy so the credential is not inside the vault directory, which is what
+filesystem backups and volume snapshots capture.
 .TP
 .B KEEP_PATH
 Vault directory. The packaged default is

--- a/contrib/debian/keep-web.8
+++ b/contrib/debian/keep-web.8
@@ -83,6 +83,26 @@ only root and the daemon can reach them.
 .TP
 .I /var/lib/keep-web/vault
 Encrypted vault holding the FROST share.
+.SH REACHING THE ADMIN INTERFACE
+The interface listens on
+.B 127.0.0.1:8080
+and is deliberately not reachable from the network: it grants control over
+signing and can export the share. To use it from another machine, forward the
+port over SSH:
+.PP
+.RS
+.EX
+ssh \-L 8080:127.0.0.1:8080 \fIuser\fR@\fIhost\fR
+.EE
+.RE
+.PP
+then browse to
+.B http://127.0.0.1:8080
+and sign in with the token from
+.IR /etc/keep-web/auth-token .
+For a permanent deployment, front it with a reverse proxy or an onion service
+rather than widening
+.BR KEEP_WEB_LISTEN .
 .SH NOTES
 The admin interface grants control over signing and must not be exposed
 directly to the network. Front it with a reverse proxy or an onion service.

--- a/contrib/debian/keep-web.env
+++ b/contrib/debian/keep-web.env
@@ -7,9 +7,9 @@
 KEEP_PASSWORD_FILE=/etc/keep-web/password
 
 # Bearer token gating the admin API, including share export. Generated on
-# install. Leaving it unset makes the daemon mint a fresh token at every start
-# and log it, which puts the credential in the journal and invalidates the one
-# the operator is using on every restart.
+# install. Pinned here rather than left to the daemon, which would persist its
+# own token inside the vault directory: this keeps the credential out of the
+# filesystem backups and volume snapshots that capture the vault.
 KEEP_WEB_AUTH_TOKEN_FILE=/etc/keep-web/auth-token
 
 # Vault location. systemd StateDirectory= owns /var/lib/keep-web; the vault

--- a/contrib/debian/keep-web.postinst
+++ b/contrib/debian/keep-web.postinst
@@ -53,10 +53,21 @@ case "$1" in
         # daemon warns about any secret it can read that is group accessible,
         # and ProtectSystem=strict keeps /etc read-only to it, so it cannot
         # rewrite what it owns. root reads it regardless.
-        if [ ! -e /etc/keep-web/auth-token ]; then
-            install -m 0600 -o keep-web -g keep-web /dev/null /etc/keep-web/auth-token
-            head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' \
-                > /etc/keep-web/auth-token
+        # Generated into a temp file and moved into place, guarded on -s rather
+        # than -e: `install /dev/null` followed by a separate write would leave
+        # a permanently empty token if anything failed in between, and the
+        # daemon refuses to start on an empty token file.
+        if [ ! -s /etc/keep-web/auth-token ]; then
+            _tok=$(mktemp /etc/keep-web/.auth-token.XXXXXX)
+            if head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' > "$_tok" && [ -s "$_tok" ]; then
+                chown keep-web:keep-web "$_tok"
+                chmod 0600 "$_tok"
+                mv -f "$_tok" /etc/keep-web/auth-token
+            else
+                rm -f "$_tok"
+                echo "failed to generate /etc/keep-web/auth-token" >&2
+                exit 1
+            fi
         fi
 
         if [ ! -e /etc/keep-web/password ]; then

--- a/contrib/debian/keep-web.postinst
+++ b/contrib/debian/keep-web.postinst
@@ -75,9 +75,17 @@ keep-web is installed but not enabled: no vault password is set.
   2. Set KEEP_FROST_GROUP and review the relays in /etc/keep-web/keep-web.env
   3. systemctl enable --now keep-web
 
-The admin API token was generated in /etc/keep-web/auth-token. The API
-listens on 127.0.0.1:8080 and controls signing, including share export: put
-it behind a reverse proxy or an onion service rather than exposing it.
+  4. Open the admin interface. It listens on 127.0.0.1:8080 and is not
+     reachable from the network on purpose, because it controls signing and
+     can export the share. From a remote machine, forward it over SSH:
+
+       ssh -L 8080:127.0.0.1:8080 <user>@<this-host>
+
+     then browse to http://127.0.0.1:8080 and sign in with the token in
+     /etc/keep-web/auth-token (sudo cat it). For a permanent setup, front it
+     with a reverse proxy or an onion service instead.
+
+See keep-web(8) for the full configuration reference.
 EOF
         fi
     ;;

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -603,16 +603,6 @@ impl Storage {
             return Err(KeepError::NotFound(path.display().to_string()));
         }
 
-        // An existing but vault-less directory is "no Keep here" too, not an
-        // I/O error. Callers that provision on first run (keep-web, and any
-        // deployment where the parent creates the directory first: systemd
-        // StateDirectory=, a mounted volume, a Kubernetes emptyDir) match on
-        // NotFound, and without this they see Io(NotFound) from the header
-        // read and fail instead of creating the vault.
-        if !path.join("keep.hdr").exists() {
-            return Err(KeepError::NotFound(path.display().to_string()));
-        }
-
         // Reconcile any leftover rotation artifacts (`.hdr.tmp`, `.hdr.backup`,
         // `.db.backup`) before reading the header. Handles the mid-rotation
         // kill gap surfaced by #565's tests: without this, a crash inside
@@ -1763,27 +1753,6 @@ impl Drop for Storage {
 mod tests {
     use super::*;
     use tempfile::tempdir;
-
-    #[test]
-    fn open_reports_not_found_for_existing_but_empty_dir() {
-        // Deployments where something else creates the directory first
-        // (systemd StateDirectory=, a mounted volume) must still look like a
-        // fresh install to callers that provision on NotFound, rather than
-        // surfacing an Io error from the header read.
-        let dir = tempdir().unwrap();
-        match Storage::open(dir.path()) {
-            Err(KeepError::NotFound(_)) => {}
-            Err(e) => panic!("expected NotFound for an empty dir, got {e:?}"),
-            Ok(_) => panic!("expected NotFound for an empty dir, got a Storage"),
-        }
-
-        // A missing path is still NotFound.
-        match Storage::open(&dir.path().join("nope")) {
-            Err(KeepError::NotFound(_)) => {}
-            Err(e) => panic!("expected NotFound for a missing dir, got {e:?}"),
-            Ok(_) => panic!("expected NotFound for a missing dir, got a Storage"),
-        }
-    }
 
     #[test]
     fn test_legacy_stored_share_blob_loads_as_secp256k1() {

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -603,6 +603,16 @@ impl Storage {
             return Err(KeepError::NotFound(path.display().to_string()));
         }
 
+        // An existing but vault-less directory is "no Keep here" too, not an
+        // I/O error. Callers that provision on first run (keep-web, and any
+        // deployment where the parent creates the directory first: systemd
+        // StateDirectory=, a mounted volume, a Kubernetes emptyDir) match on
+        // NotFound, and without this they see Io(NotFound) from the header
+        // read and fail instead of creating the vault.
+        if !path.join("keep.hdr").exists() {
+            return Err(KeepError::NotFound(path.display().to_string()));
+        }
+
         // Reconcile any leftover rotation artifacts (`.hdr.tmp`, `.hdr.backup`,
         // `.db.backup`) before reading the header. Handles the mid-rotation
         // kill gap surfaced by #565's tests: without this, a crash inside
@@ -1753,6 +1763,27 @@ impl Drop for Storage {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn open_reports_not_found_for_existing_but_empty_dir() {
+        // Deployments where something else creates the directory first
+        // (systemd StateDirectory=, a mounted volume) must still look like a
+        // fresh install to callers that provision on NotFound, rather than
+        // surfacing an Io error from the header read.
+        let dir = tempdir().unwrap();
+        match Storage::open(dir.path()) {
+            Err(KeepError::NotFound(_)) => {}
+            Err(e) => panic!("expected NotFound for an empty dir, got {e:?}"),
+            Ok(_) => panic!("expected NotFound for an empty dir, got a Storage"),
+        }
+
+        // A missing path is still NotFound.
+        match Storage::open(&dir.path().join("nope")) {
+            Err(KeepError::NotFound(_)) => {}
+            Err(e) => panic!("expected NotFound for a missing dir, got {e:?}"),
+            Ok(_) => panic!("expected NotFound for a missing dir, got a Storage"),
+        }
+    }
 
     #[test]
     fn test_legacy_stored_share_blob_loads_as_secp256k1() {

--- a/keep-web/README.md
+++ b/keep-web/README.md
@@ -22,8 +22,9 @@ KEEP_WEB_LISTEN=0.0.0.0:8080 \
 ```
 
 If the vault at `KEEP_PATH` does not exist, it is created with the supplied password on
-first boot. If `KEEP_WEB_AUTH_TOKEN[_FILE]` is unset, a random token is generated and
-logged at startup (pin it in production so the token is stable).
+first boot. If `KEEP_WEB_AUTH_TOKEN[_FILE]` is unset, a random token is generated once and
+persisted to `$KEEP_PATH/auth_token` (mode `0600`); it is never written to the log, because
+it authorizes share export.
 
 ## Configuration
 
@@ -34,8 +35,8 @@ the given file path instead (use this for secrets).
 |----------|---------|-------------|
 | `KEEP_PATH` | `/data` | Vault directory. Created on first boot if absent |
 | `KEEP_PASSWORD` / `KEEP_PASSWORD_FILE` | (required) | Vault unlock password for headless start |
-| `KEEP_WEB_AUTH_TOKEN` / `_FILE` | random (logged) | Bearer token gating every `/api/*` route |
-| `KEEP_WEB_LISTEN` | `0.0.0.0:8080` | Listen address |
+| `KEEP_WEB_AUTH_TOKEN` / `_FILE` | persisted to `$KEEP_PATH/auth_token` | Bearer token gating every `/api/*` route |
+| `KEEP_WEB_LISTEN` | `127.0.0.1:8080` | Listen address. Containers must set `0.0.0.0:8080` explicitly |
 | `KEEP_WEB_UI_DIR` | `ui/dist` | Path to the built admin UI assets |
 | `KEEP_BUNKER_RELAY` | `KEEP_RELAY` then `wss://bucket.coracle.social` | Relay(s) for the NIP-46 bunker |
 | `KEEP_RELAY` | `wss://bucket.coracle.social` | Fallback relay |

--- a/keep-web/README.md
+++ b/keep-web/README.md
@@ -13,10 +13,13 @@ but it runs anywhere you can set a few environment variables (Docker, systemd, a
 # Build
 cargo build --release -p keep-web
 
-# Minimum: a vault path, an unlock password, and an API token
+# Minimum: a vault path and an unlock password. Pinning the API token is
+# recommended so the credential lives outside the vault directory, which is
+# what filesystem backups and volume snapshots capture.
 KEEP_PATH=/data \
 KEEP_PASSWORD_FILE=/run/secrets/keep-password \
 KEEP_WEB_AUTH_TOKEN_FILE=/run/secrets/keep-web-token \
+# Deliberately widened from the 127.0.0.1 default: required in a container.
 KEEP_WEB_LISTEN=0.0.0.0:8080 \
 ./target/release/keep-web
 ```
@@ -49,7 +52,8 @@ the given file path instead (use this for secrets).
 ## Authentication
 
 Every `/api/*` route except `/api/health` and the WebSocket upgrade requires a
-`Authorization: Bearer <token>` header matching `KEEP_WEB_AUTH_TOKEN`. The WebSocket gates
+`Authorization: Bearer <token>` header matching `KEEP_WEB_AUTH_TOKEN`, or the token
+persisted at `$KEEP_PATH/auth_token` when that is unset. The WebSocket gates
 itself on a single-use ticket minted via the authed `/api/ws-ticket`, so the durable token
 never appears in a URL or proxy access log.
 

--- a/keep-web/src/auth.rs
+++ b/keep-web/src/auth.rs
@@ -8,31 +8,21 @@ use subtle::ConstantTimeEq;
 
 /// Shared bearer token gating every `/api/*` route and the WS upgrade.
 ///
-/// The token is read from `KEEP_WEB_AUTH_TOKEN`; if unset, a random one is
-/// generated at startup and logged once so the operator can retrieve it. The
-/// daemon is never run fully open (fail-closed).
+/// The token comes from `KEEP_WEB_AUTH_TOKEN[_FILE]`, or from the `auth_token`
+/// file persisted in the vault directory when neither is set. The value is
+/// never logged: it authorizes share export, so emitting it would put a
+/// credential equivalent to the share into the journal, which the `adm` group
+/// can read and log shippers forward off-box. The daemon is never run fully
+/// open (fail-closed).
 #[derive(Clone)]
 pub struct AuthToken(Arc<String>);
 
 impl AuthToken {
-    /// Resolve the auth token from an optionally-configured value, generating
-    /// and logging a random one if none was supplied (fail-closed: never open).
-    pub fn resolve(configured: Option<String>) -> Self {
-        match configured {
-            Some(t) if !t.trim().is_empty() => {
-                tracing::info!("auth token configured; bearer auth required on all endpoints");
-                Self(Arc::new(t.trim().to_string()))
-            }
-            _ => {
-                let bytes: [u8; 32] = keep_core::crypto::random_bytes();
-                let token: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
-                tracing::warn!(
-                    token = %token,
-                    "no auth token configured; generated a random one (set KEEP_WEB_AUTH_TOKEN[_FILE] to pin it)"
-                );
-                Self(Arc::new(token))
-            }
-        }
+    /// Build from a resolved token. Callers supply either the configured value
+    /// or the persisted one; an all-whitespace value is rejected by the caller
+    /// rather than silently accepted here.
+    pub fn new(token: impl Into<String>) -> Self {
+        Self(Arc::new(token.into().trim().to_string()))
     }
 
     fn matches(&self, candidate: &str) -> bool {
@@ -86,15 +76,11 @@ mod tests {
     }
 
     #[test]
-    fn resolve_uses_configured_or_generates() {
-        let configured = AuthToken::resolve(Some("  pinned  ".into()));
-        assert!(configured.matches("pinned"));
-
-        let a = AuthToken::resolve(None);
-        let b = AuthToken::resolve(Some("".into()));
-        // Generated tokens are random and non-empty.
-        assert!(!a.matches(""));
-        assert!(!a.matches(&b.0));
+    fn new_trims_surrounding_whitespace() {
+        // Secrets read from a file arrive with a trailing newline.
+        let t = AuthToken::new("  pinned  \n");
+        assert!(t.matches("pinned"));
+        assert!(!t.matches("  pinned  "));
     }
 
     #[test]

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -359,6 +359,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // directory at 0600. Never generated-and-logged: this token authorizes
     // share export, so the journal is the wrong place for it.
     let auth_token = match secret_from("KEEP_WEB_AUTH_TOKEN")? {
+        // secret_from only filters empties on the env-var branch, so an empty
+        // KEEP_WEB_AUTH_TOKEN_FILE arrives here as Some(""). Serving that would
+        // 401 every request forever with no diagnostic; fail loudly at boot.
+        Some(t) if t.trim().is_empty() => {
+            return Err(
+                "KEEP_WEB_AUTH_TOKEN[_FILE] is set but empty; unset it or provide a token".into(),
+            )
+        }
         Some(t) => {
             tracing::info!("auth token configured; bearer auth required on all endpoints");
             auth::AuthToken::new(t)

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -186,7 +186,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // (env at boot or the live kill switch).
     let auto_approve = env_or("KEEP_FROST_AUTO_APPROVE", "false") == "true";
     let ui_dir = PathBuf::from(env_or("KEEP_WEB_UI_DIR", "ui/dist"));
-    let listen: SocketAddr = env_or("KEEP_WEB_LISTEN", "0.0.0.0:8080").parse()?;
+    // Loopback by default: the admin API controls signing, so binding every
+    // interface has to be a deliberate choice (containers set this explicitly).
+    let listen: SocketAddr = env_or("KEEP_WEB_LISTEN", "127.0.0.1:8080").parse()?;
     let password = secret_from("KEEP_PASSWORD")?
         .ok_or("KEEP_PASSWORD or KEEP_PASSWORD_FILE must be set for headless unlock")?;
 
@@ -353,7 +355,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let static_files = ServeDir::new(&ui_dir).fallback(serve_index);
 
     // Fail-closed bearer-token gate on every sensitive /api/* route.
-    let auth_token = auth::AuthToken::resolve(secret_from("KEEP_WEB_AUTH_TOKEN")?);
+    // Configured token wins; otherwise fall back to one persisted in the vault
+    // directory at 0600. Never generated-and-logged: this token authorizes
+    // share export, so the journal is the wrong place for it.
+    let auth_token = match secret_from("KEEP_WEB_AUTH_TOKEN")? {
+        Some(t) => {
+            tracing::info!("auth token configured; bearer auth required on all endpoints");
+            auth::AuthToken::new(t)
+        }
+        None => {
+            let token = state::load_or_create_auth_token(&vault_path)?;
+            tracing::warn!(
+                path = %vault_path.join("auth_token").display(),
+                "no auth token configured; using the persisted one (set KEEP_WEB_AUTH_TOKEN_FILE to pin it)"
+            );
+            auth::AuthToken::new(token)
+        }
+    };
 
     let authed = Router::new()
         .route("/api/bunker", get(api::bunker))

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -370,7 +370,26 @@ fn read_auth_token(path: &Path) -> std::io::Result<String> {
         }
     }
 
-    let s = std::fs::read_to_string(path)?;
+    // The check above inspected the path; this opens it again, so the entry
+    // could have been swapped for a symlink in between. metadata() on the
+    // handle is an fstat of what was actually opened, so comparing identity
+    // across the two closes that window without reaching for libc.
+    let mut f = std::fs::File::open(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let opened = f.metadata()?;
+        if opened.ino() != md.ino() || opened.dev() != md.dev() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "auth_token changed while being read; refusing to use it",
+            ));
+        }
+    }
+
+    use std::io::Read;
+    let mut s = String::new();
+    f.read_to_string(&mut s)?;
     let trimmed = s.trim();
 
     // Exactly what we mint: 32 random bytes, hex. Anything else is a truncated

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -164,7 +164,12 @@ mod tests {
     fn malformed_auth_token_fails_closed() {
         // A truncated write or a partial restore must not become a short,
         // brute-forceable admin credential.
-        for bad in ["deadbeef", &"z".repeat(64), &"a".repeat(63), &"a".repeat(65)] {
+        for bad in [
+            "deadbeef",
+            &"z".repeat(64),
+            &"a".repeat(63),
+            &"a".repeat(65),
+        ] {
             let dir = tempfile::tempdir().unwrap();
             write_token_file(dir.path(), bad);
             let err = load_or_create_auth_token(dir.path())

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -139,13 +139,67 @@ mod tests {
         assert_eq!(mode & 0o777, 0o600);
     }
 
+    /// Writes a token file at 0600 so the mode gate does not mask the check
+    /// under test.
+    fn write_token_file(dir: &Path, contents: &str) {
+        let path = dir.join("auth_token");
+        std::fs::write(&path, contents).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+    }
+
     #[test]
     fn empty_auth_token_file_fails_closed() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("auth_token"), "   \n").unwrap();
+        write_token_file(dir.path(), "   \n");
         // Minting a replacement would silently invalidate the operator's token.
         let err = load_or_create_auth_token(dir.path()).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn malformed_auth_token_fails_closed() {
+        // A truncated write or a partial restore must not become a short,
+        // brute-forceable admin credential.
+        for bad in ["deadbeef", &"z".repeat(64), &"a".repeat(63), &"a".repeat(65)] {
+            let dir = tempfile::tempdir().unwrap();
+            write_token_file(dir.path(), bad);
+            let err = load_or_create_auth_token(dir.path())
+                .expect_err("expected malformed token to be rejected");
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidData, "input {bad:?}");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_auth_token_is_refused() {
+        // Otherwise a planted link makes the daemon adopt attacker-known file
+        // contents as the admin bearer token.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("attacker_known");
+        std::fs::write(&target, "a".repeat(64)).unwrap();
+        std::os::unix::fs::symlink(&target, dir.path().join("auth_token")).unwrap();
+
+        let err = load_or_create_auth_token(dir.path())
+            .expect_err("expected a symlinked token to be refused");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn group_readable_auth_token_is_refused() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth_token");
+        std::fs::write(&path, "a".repeat(64)).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
+
+        let err = load_or_create_auth_token(dir.path())
+            .expect_err("expected a group-readable token to be refused");
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
     }
 }
 
@@ -257,27 +311,72 @@ fn decode_hex32(s: &str) -> Option<[u8; 32]> {
 /// valid across restarts and upgrades.
 pub fn load_or_create_auth_token(vault_dir: &Path) -> std::io::Result<String> {
     let path = vault_dir.join("auth_token");
-    match std::fs::read_to_string(&path) {
-        Ok(s) => {
-            let trimmed = s.trim();
-            if trimmed.is_empty() {
-                // Fail closed rather than mint a replacement: a truncated write
-                // must not silently invalidate the token the operator holds.
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "auth_token file is empty; refusing to rotate credential",
-                ));
-            }
-            Ok(trimmed.to_string())
-        }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+
+    // Create-exclusive on the final path, so concurrent starts resolve to
+    // first-writer-wins. A rename-based write is last-writer-wins, which for a
+    // credential means the loser serves a token that exists on no disk and the
+    // operator reads one the live process rejects.
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    match opts.open(&path) {
+        Ok(mut f) => {
+            use std::io::Write;
             let bytes: [u8; 32] = keep_core::crypto::random_bytes();
             let token = to_hex(&bytes);
-            write_secret_file(&path, &token)?;
-            Ok(token)
+            f.write_all(token.as_bytes())?;
+            f.sync_all()?;
+            return Ok(token);
         }
-        Err(e) => Err(e),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(e) => return Err(e),
     }
+
+    read_auth_token(&path)
+}
+
+/// Reads an existing token, refusing to follow a symlink and requiring the
+/// exact shape this daemon mints. A planted symlink would otherwise make the
+/// daemon adopt attacker-known file contents as the admin bearer token, and a
+/// truncated or tampered file would otherwise become a short, brute-forceable
+/// credential.
+fn read_auth_token(path: &Path) -> std::io::Result<String> {
+    // symlink_metadata does not traverse the final component, so a planted
+    // link is rejected rather than silently followed.
+    let md = std::fs::symlink_metadata(path)?;
+    if md.file_type().is_symlink() || !md.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "auth_token must be a regular file, not a symlink",
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if md.permissions().mode() & 0o077 != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "auth_token is group/world accessible; refusing to use it",
+            ));
+        }
+    }
+
+    let s = std::fs::read_to_string(path)?;
+    let trimmed = s.trim();
+
+    // Exactly what we mint: 32 random bytes, hex. Anything else is a truncated
+    // write, a partial restore, or tampering; fail closed rather than serve it.
+    if trimmed.len() != 64 || !trimmed.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "auth_token is malformed; expected 64 hex characters",
+        ));
+    }
+    Ok(trimmed.to_string())
 }
 
 /// Loads the persisted NIP-46 bunker secret, generating and storing one (`0600`)

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -113,6 +113,40 @@ mod tests {
         store.issue("abc".into());
         assert!(!store.consume("def"));
     }
+
+    #[test]
+    fn auth_token_is_generated_once_and_reused() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = load_or_create_auth_token(dir.path()).unwrap();
+        assert_eq!(first.len(), 64, "32 random bytes, hex encoded");
+
+        // Stable across restarts and upgrades: an operator's token must not be
+        // invalidated by a service restart.
+        let second = load_or_create_auth_token(dir.path()).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn auth_token_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        load_or_create_auth_token(dir.path()).unwrap();
+        let mode = std::fs::metadata(dir.path().join("auth_token"))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
+    }
+
+    #[test]
+    fn empty_auth_token_file_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("auth_token"), "   \n").unwrap();
+        // Minting a replacement would silently invalidate the operator's token.
+        let err = load_or_create_auth_token(dir.path()).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
 }
 
 impl BunkerInfo {
@@ -214,6 +248,36 @@ fn decode_hex32(s: &str) -> Option<[u8; 32]> {
         *byte = u8::from_str_radix(&s[i * 2..i * 2 + 2], 16).ok()?;
     }
     Some(out)
+}
+
+/// Loads the persisted admin API token, generating and storing one (`0600`) on
+/// first run. Kept on disk rather than logged: this token gates every `/api/*`
+/// route including share export, and the journal is readable by the `adm` group
+/// and routinely shipped off-box. Persisting it also keeps the operator's token
+/// valid across restarts and upgrades.
+pub fn load_or_create_auth_token(vault_dir: &Path) -> std::io::Result<String> {
+    let path = vault_dir.join("auth_token");
+    match std::fs::read_to_string(&path) {
+        Ok(s) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                // Fail closed rather than mint a replacement: a truncated write
+                // must not silently invalidate the token the operator holds.
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "auth_token file is empty; refusing to rotate credential",
+                ));
+            }
+            Ok(trimmed.to_string())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let bytes: [u8; 32] = keep_core::crypto::random_bytes();
+            let token = to_hex(&bytes);
+            write_secret_file(&path, &token)?;
+            Ok(token)
+        }
+        Err(e) => Err(e),
+    }
 }
 
 /// Loads the persisted NIP-46 bunker secret, generating and storing one (`0600`)


### PR DESCRIPTION
Three `keep-web` defects found while packaging the daemon for Debian in #892. The packaging worked around the first two; this fixes them at the layer where every deployment benefits, including StartOS and Docker.

## The admin token is no longer written to the log

With `KEEP_WEB_AUTH_TOKEN[_FILE]` unset, the daemon minted a random bearer token at every start and logged the value at WARN. That token gates every `/api/*` route, and `/api/shares/export` re-encrypts the FROST share under a caller-supplied passphrase, so the token is equivalent to the share itself. The journal is readable by the `adm` group and is routinely forwarded off-box by log shippers, which put a local, unprivileged path to share exfiltration in the default configuration.

The token is now generated once and persisted to `$KEEP_PATH/auth_token` at mode `0600`, following the same read-or-create pattern already used for the bunker secret and the transport key. The value is never logged. Persisting it also means a restart or a package upgrade no longer invalidates the token the operator is holding.

## The listen address defaults to loopback

`KEEP_WEB_LISTEN` compiled in `0.0.0.0:8080`, so removing the setting from a config file failed *open* and published the signing admin API on every interface. The default is now `127.0.0.1:8080`; anything wider is an explicit choice. Containers are unaffected because they set the variable explicitly (`keep-startos` sets it in both its Dockerfile and `main.ts`).

Since a loopback-only default is only good operator experience if the way in is documented, the install message, `keep-web(8)`, and `contrib/README.md` now show the SSH port-forward and say to sign in with the token from `/etc/keep-web/auth-token`.

## An existing but empty vault directory counts as a fresh install

`Storage::open` returned `NotFound` only when the path was missing. When the directory existed but held no vault, it fell through to the header read and surfaced `Io(NotFound)`, which callers that provision on first run do not match. Any deployment where something else creates the directory first hits this: systemd `StateDirectory=`, a mounted volume, a Kubernetes `emptyDir`. The daemon exited instead of creating the vault. `Storage::open` now reports `NotFound` for a directory with no `keep.hdr`, which is what the documented contract on `Keep::open` already promised.

The Debian package keeps its `KEEP_PATH=/var/lib/keep-web/vault` layout: it is stable for anyone who installed 0.8.0, and changing it now would be a migration hazard.

## Verification

Unit tests cover the token being generated once and reused across restarts, its file being owner-only, an empty token file failing closed rather than silently rotating the credential, and `Storage::open` reporting `NotFound` for both a missing and an existing-but-empty directory.

Beyond the 44-check package suite (all passing, lintian clean at `--fail-on warning,error`), the packages were exercised through a 27-check fresh-operator journey on a clean Debian 12 container: install, then follow only what the package itself says, with no reference to the source. It covers whether the next step is discoverable from the man page and install message, whether the service comes up from the documented commands alone, whether the admin UI and API work, whether the documented token authenticates, whether the vault password or token leak into the journal or are readable by other local users, whether the port is exposed beyond loopback, and whether a restart and a package upgrade preserve both the service and the operator's token and config.

That journey is what surfaced the missing SSH-forward documentation: the loopback default is correct, but without it a new operator on a headless server has a running admin interface they cannot reach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin access now binds to localhost by default and can be reached securely through SSH port forwarding.
  * Authentication tokens are generated once, persisted securely, and reused across restarts.
  * Added validation to reject missing, malformed, unsafe, or improperly permissioned token files.

* **Documentation**
  * Updated setup, configuration, and administration guidance for token storage, container networking, and remote access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->