### PR TITLE
keep-web: persist the admin auth token outside the vault directory

### DIFF
--- a/contrib/debian/keep-web.8
+++ b/contrib/debian/keep-web.8
@@ -36,12 +36,20 @@ share export. The package generates
 .I /etc/keep-web/auth-token
 on install and points this at it. If neither this nor
 .B KEEP_WEB_AUTH_TOKEN
-is set, the daemon persists a generated token to
+is set, the daemon looks for an operator-provisioned credential named
+.I keep-web-auth-token
+under systemd's
+.B $CREDENTIALS_DIRECTORY
+.RB ( LoadCredential= ),
+then persists a generated token to
+.I $STATE_DIRECTORY/auth_token
+.RB ( StateDirectory= ,
+outside the vault). Only if none of those are available does it fall back to
 .I $KEEP_PATH/auth_token
-instead. The package pins the
-.I /etc/keep-web
-copy so the credential is not inside the vault directory, which is what
-filesystem backups and volume snapshots capture.
+inside the vault directory, with a warning: the bearer token is
+share-equivalent against a running daemon, so keeping it out of the vault
+directory keeps it out of the filesystem backups and volume snapshots that
+capture the vault.
 .TP
 .B KEEP_PATH
 Vault directory. The packaged default is

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -69,11 +69,21 @@ fn read_secret_file(path: &str) -> Result<String, Box<dyn std::error::Error>> {
 /// falls through to the persisted-token path. A present-but-empty credential is an
 /// operator error and fails startup rather than serving an unmatchable token.
 fn credential_dir_token() -> Result<Option<String>, Box<dyn std::error::Error>> {
-    const CREDENTIAL_NAME: &str = "keep-web-auth-token";
-    let Some(dir) = std::env::var_os("CREDENTIALS_DIRECTORY") else {
+    let dir = std::env::var_os("CREDENTIALS_DIRECTORY").map(std::path::PathBuf::from);
+    credential_token_at(dir.as_deref())
+}
+
+const CREDENTIAL_NAME: &str = "keep-web-auth-token";
+
+/// Read the admin token from a systemd credentials directory, if `dir` is set and
+/// holds the credential. Split from the env lookup so it is unit-testable.
+fn credential_token_at(
+    dir: Option<&std::path::Path>,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let Some(dir) = dir else {
         return Ok(None);
     };
-    let path = std::path::Path::new(&dir).join(CREDENTIAL_NAME);
+    let path = dir.join(CREDENTIAL_NAME);
     if !path.exists() {
         return Ok(None);
     }
@@ -409,9 +419,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // share-equivalent admin credential.
                 let state_dir = std::env::var_os("STATE_DIRECTORY")
                     .and_then(|d| std::env::split_paths(&d).next());
-                let (token_path, in_vault) =
-                    state::choose_persist_path(state_dir.as_deref(), &vault_path);
-                let token = state::load_or_create_auth_token_at(&token_path)?;
+                let (token, token_path, in_vault) =
+                    state::resolve_persisted_auth_token(state_dir.as_deref(), &vault_path)?;
                 if in_vault {
                     tracing::warn!(
                         path = %token_path.display(),
@@ -475,6 +484,30 @@ mod tests {
     use super::*;
     use keep_core::Keep;
     use tempfile::tempdir;
+
+    #[test]
+    fn credential_token_none_when_dir_unset_or_absent() {
+        assert!(credential_token_at(None).unwrap().is_none());
+        let dir = tempdir().unwrap();
+        assert!(credential_token_at(Some(dir.path())).unwrap().is_none());
+    }
+
+    #[test]
+    fn credential_token_reads_present_credential_trimmed() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join(CREDENTIAL_NAME), "  operator-token  ").unwrap();
+        assert_eq!(
+            credential_token_at(Some(dir.path())).unwrap().as_deref(),
+            Some("operator-token")
+        );
+    }
+
+    #[test]
+    fn credential_token_empty_fails_closed() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join(CREDENTIAL_NAME), "   \n").unwrap();
+        assert!(credential_token_at(Some(dir.path())).is_err());
+    }
 
     fn unlocked_keep(dir: &std::path::Path) -> Keep {
         let mut keep = Keep::create(&dir.join("vault"), "password").unwrap();

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -63,6 +63,30 @@ fn read_secret_file(path: &str) -> Result<String, Box<dyn std::error::Error>> {
     Ok(std::fs::read_to_string(path)?.trim().to_string())
 }
 
+/// Read an operator-provisioned admin token from systemd's `$CREDENTIALS_DIRECTORY`
+/// (`LoadCredential=keep-web-auth-token:...`), if present. Returns `Ok(None)` when
+/// the directory is not set by systemd or holds no such credential, so the caller
+/// falls through to the persisted-token path. A present-but-empty credential is an
+/// operator error and fails startup rather than serving an unmatchable token.
+fn credential_dir_token() -> Result<Option<String>, Box<dyn std::error::Error>> {
+    const CREDENTIAL_NAME: &str = "keep-web-auth-token";
+    let Some(dir) = std::env::var_os("CREDENTIALS_DIRECTORY") else {
+        return Ok(None);
+    };
+    let path = std::path::Path::new(&dir).join(CREDENTIAL_NAME);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let token = read_secret_file(&path.to_string_lossy())?;
+    if token.is_empty() {
+        return Err(format!(
+            "systemd credential {CREDENTIAL_NAME} is present but empty; provide a token or remove it"
+        )
+        .into());
+    }
+    Ok(Some(token))
+}
+
 /// Resolve the optional shared cluster data key (keep-state replication). Reads via
 /// `secret_from` so `KEEP_STORAGE_KEY_FILE` is honored (keeps the raw key off the
 /// process environment, like the password and JWT key). Returns `None` when unset,
@@ -372,12 +396,39 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             auth::AuthToken::new(t)
         }
         None => {
-            let token = state::load_or_create_auth_token(&vault_path)?;
-            tracing::warn!(
-                path = %vault_path.join("auth_token").display(),
-                "no auth token configured; using the persisted one (set KEEP_WEB_AUTH_TOKEN_FILE to pin it)"
-            );
-            auth::AuthToken::new(token)
+            // Prefer an operator-provisioned credential from systemd's
+            // $CREDENTIALS_DIRECTORY (LoadCredential=): read-only and never
+            // written into the vault directory or a vault backup.
+            if let Some(token) = credential_dir_token()? {
+                tracing::info!("auth token loaded from systemd credentials directory");
+                auth::AuthToken::new(token)
+            } else {
+                // Persist a generated token, preferring a state directory OUTSIDE
+                // the vault ($STATE_DIRECTORY, systemd StateDirectory=) so a
+                // whole-directory vault backup does not carry this
+                // share-equivalent admin credential.
+                let state_dir = std::env::var_os("STATE_DIRECTORY")
+                    .and_then(|d| std::env::split_paths(&d).next());
+                let (token_path, in_vault) =
+                    state::choose_persist_path(state_dir.as_deref(), &vault_path);
+                let token = state::load_or_create_auth_token_at(&token_path)?;
+                if in_vault {
+                    tracing::warn!(
+                        path = %token_path.display(),
+                        "no auth token configured and no state or credentials directory available; \
+                         persisted the admin token INSIDE the vault directory, so filesystem backups \
+                         (tar, rsync, VM/volume snapshots) will carry a live admin credential. Set \
+                         KEEP_WEB_AUTH_TOKEN_FILE, systemd StateDirectory=, or LoadCredential= to keep \
+                         it out of the vault backup."
+                    );
+                } else {
+                    tracing::info!(
+                        path = %token_path.display(),
+                        "no auth token configured; using the one persisted outside the vault directory"
+                    );
+                }
+                auth::AuthToken::new(token)
+            }
         }
     };
 

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -141,6 +141,51 @@ mod tests {
         // An empty state directory is treated as absent.
         let (_, in_vault) = choose_persist_path(Some(Path::new("")), vault);
         assert!(in_vault);
+        // A state directory equal to the vault dir is not "outside" it: flag it so
+        // the backup warning still fires.
+        let (path, in_vault) = choose_persist_path(Some(vault), vault);
+        assert_eq!(path, Path::new("/data/auth_token"));
+        assert!(in_vault);
+    }
+
+    #[test]
+    fn resolve_adopts_existing_vault_token_without_rotating() {
+        let vault = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        // An existing deployment already generated a token in the vault dir.
+        let existing = load_or_create_auth_token_at(&vault.path().join("auth_token")).unwrap();
+
+        // Upgrading into a state directory must ADOPT that token (never rotate it,
+        // which would 401 the operator) and migrate it out of the vault.
+        let (token, path, in_vault) =
+            resolve_persisted_auth_token(Some(state.path()), vault.path()).unwrap();
+        assert_eq!(token, existing, "must not rotate the operator's token");
+        assert!(!in_vault);
+        assert_eq!(path, state.path().join("auth_token"));
+        assert!(path.exists(), "token now lives outside the vault");
+        assert!(
+            !vault.path().join("auth_token").exists(),
+            "the in-vault copy is removed so it stays out of backups"
+        );
+
+        // Stable on the next start.
+        let (again, _, _) = resolve_persisted_auth_token(Some(state.path()), vault.path()).unwrap();
+        assert_eq!(again, existing);
+    }
+
+    #[test]
+    fn resolve_mints_fresh_outside_vault_when_no_legacy_token() {
+        let vault = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        let (token, path, in_vault) =
+            resolve_persisted_auth_token(Some(state.path()), vault.path()).unwrap();
+        assert_eq!(token.len(), 64);
+        assert!(!in_vault);
+        assert_eq!(path, state.path().join("auth_token"));
+        assert!(
+            !vault.path().join("auth_token").exists(),
+            "nothing written into the vault directory"
+        );
     }
 
     #[test]
@@ -370,7 +415,12 @@ pub fn choose_persist_path(
     vault_dir: &Path,
 ) -> (std::path::PathBuf, bool) {
     match state_dir {
-        Some(dir) if !dir.as_os_str().is_empty() => (dir.join("auth_token"), false),
+        // A state dir that is the vault dir itself is not "outside" it: the token
+        // would still land in the backup path, so fall through to the vault case
+        // and keep the warning honest rather than suppressing it.
+        Some(dir) if !dir.as_os_str().is_empty() && dir != vault_dir => {
+            (dir.join("auth_token"), false)
+        }
         _ => (vault_dir.join("auth_token"), true),
     }
 }
@@ -404,6 +454,59 @@ pub fn load_or_create_auth_token_at(path: &Path) -> std::io::Result<String> {
     }
 
     read_auth_token(path)
+}
+
+/// Resolve the persisted admin token for the no-configured-token path. Chooses a
+/// location via [`choose_persist_path`], and when an outside-vault target is
+/// selected but not yet populated, adopts a legacy `$KEEP_PATH/auth_token` if one
+/// exists, migrating it out of the vault. This is what keeps an existing
+/// deployment from silently rotating its admin token on upgrade (a rotated token
+/// 401s the operator) while still moving the credential out of the backup path.
+/// Returns `(token, path, is_in_vault_dir)`.
+pub fn resolve_persisted_auth_token(
+    state_dir: Option<&Path>,
+    vault_dir: &Path,
+) -> std::io::Result<(String, std::path::PathBuf, bool)> {
+    let (target, in_vault) = choose_persist_path(state_dir, vault_dir);
+    if !in_vault && !target.exists() {
+        let legacy = vault_dir.join("auth_token");
+        if legacy.exists() {
+            migrate_auth_token(&legacy, &target)?;
+        }
+    }
+    let token = load_or_create_auth_token_at(&target)?;
+    Ok((token, target, in_vault))
+}
+
+/// Move an existing, validated token from `legacy` to `target` without rotating
+/// it: read (and validate) the current token, write it atomically at `target`
+/// (`0600`), then best-effort remove the vault copy so the credential leaves the
+/// backup path. A malformed legacy token fails closed (the caller then mints a
+/// fresh one at `target`). If `target` was created concurrently, the atomic write
+/// simply overwrites with the same adopted value.
+fn migrate_auth_token(legacy: &Path, target: &Path) -> std::io::Result<()> {
+    let token = match read_auth_token(legacy) {
+        Ok(t) => t,
+        // A malformed/tampered legacy token is not worth preserving; leave it for
+        // the caller to replace with a freshly minted token at `target`.
+        Err(_) => return Ok(()),
+    };
+    write_secret_file(target, &token)?;
+    if let Err(e) = std::fs::remove_file(legacy) {
+        tracing::warn!(
+            path = %legacy.display(),
+            error = %e,
+            "migrated the admin token out of the vault directory but could not remove the old \
+             in-vault copy; delete it manually so it stays out of vault backups"
+        );
+    } else {
+        tracing::info!(
+            from = %legacy.display(),
+            to = %target.display(),
+            "migrated the persisted admin token out of the vault directory"
+        );
+    }
+    Ok(())
 }
 
 /// Reads an existing token, refusing to follow a symlink and requiring the

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -126,6 +126,43 @@ mod tests {
         assert_eq!(first, second);
     }
 
+    #[test]
+    fn choose_persist_path_prefers_state_dir_outside_vault() {
+        let vault = Path::new("/data");
+        let state = Path::new("/var/lib/keep-web");
+        // A state directory is preferred and reported as outside the vault.
+        let (path, in_vault) = choose_persist_path(Some(state), vault);
+        assert_eq!(path, Path::new("/var/lib/keep-web/auth_token"));
+        assert!(!in_vault);
+        // No state directory falls back to the vault dir and flags it.
+        let (path, in_vault) = choose_persist_path(None, vault);
+        assert_eq!(path, Path::new("/data/auth_token"));
+        assert!(in_vault);
+        // An empty state directory is treated as absent.
+        let (_, in_vault) = choose_persist_path(Some(Path::new("")), vault);
+        assert!(in_vault);
+    }
+
+    #[test]
+    fn auth_token_persists_outside_the_vault_directory() {
+        // The generated token must live at the chosen path (a state dir), not in
+        // the vault dir, and remain stable across restarts.
+        let vault = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        let (path, in_vault) = choose_persist_path(Some(state.path()), vault.path());
+        assert!(!in_vault);
+
+        let first = load_or_create_auth_token_at(&path).unwrap();
+        assert_eq!(first.len(), 64);
+        assert!(path.exists(), "token written to the state dir");
+        assert!(
+            !vault.path().join("auth_token").exists(),
+            "nothing written into the vault directory"
+        );
+        let second = load_or_create_auth_token_at(&path).unwrap();
+        assert_eq!(first, second);
+    }
+
     #[cfg(unix)]
     #[test]
     fn auth_token_file_is_owner_only() {
@@ -314,9 +351,34 @@ fn decode_hex32(s: &str) -> Option<[u8; 32]> {
 /// route including share export, and the journal is readable by the `adm` group
 /// and routinely shipped off-box. Persisting it also keeps the operator's token
 /// valid across restarts and upgrades.
-pub fn load_or_create_auth_token(vault_dir: &Path) -> std::io::Result<String> {
-    let path = vault_dir.join("auth_token");
+/// Test convenience: persist the token directly in `vault_dir`. Production code
+/// uses [`choose_persist_path`] + [`load_or_create_auth_token_at`] so the token
+/// lands outside the vault directory.
+#[cfg(test)]
+fn load_or_create_auth_token(vault_dir: &Path) -> std::io::Result<String> {
+    load_or_create_auth_token_at(&vault_dir.join("auth_token"))
+}
 
+/// Choose where to persist a generated admin token. Prefer a state directory
+/// OUTSIDE the vault (systemd `StateDirectory=`, i.e. `$STATE_DIRECTORY`) so a
+/// whole-directory vault backup (tar, rsync, VM/volume snapshot) does not carry
+/// this share-equivalent credential. Fall back to the vault directory only as a
+/// last resort. Returns `(path, is_in_vault_dir)` so the caller can warn when the
+/// token lands in the backup path.
+pub fn choose_persist_path(
+    state_dir: Option<&Path>,
+    vault_dir: &Path,
+) -> (std::path::PathBuf, bool) {
+    match state_dir {
+        Some(dir) if !dir.as_os_str().is_empty() => (dir.join("auth_token"), false),
+        _ => (vault_dir.join("auth_token"), true),
+    }
+}
+
+/// Loads the persisted admin API token from `path`, generating and storing one
+/// (`0600`) on first run. `path` should live outside the vault directory (see
+/// [`choose_persist_path`]) so it is not swept into a vault backup.
+pub fn load_or_create_auth_token_at(path: &Path) -> std::io::Result<String> {
     // Create-exclusive on the final path, so concurrent starts resolve to
     // first-writer-wins. A rename-based write is last-writer-wins, which for a
     // credential means the loser serves a token that exists on no disk and the
@@ -328,7 +390,7 @@ pub fn load_or_create_auth_token(vault_dir: &Path) -> std::io::Result<String> {
         use std::os::unix::fs::OpenOptionsExt;
         opts.mode(0o600);
     }
-    match opts.open(&path) {
+    match opts.open(path) {
         Ok(mut f) => {
             use std::io::Write;
             let bytes: [u8; 32] = keep_core::crypto::random_bytes();
@@ -341,7 +403,7 @@ pub fn load_or_create_auth_token(vault_dir: &Path) -> std::io::Result<String> {
         Err(e) => return Err(e),
     }
 
-    read_auth_token(&path)
+    read_auth_token(path)
 }
 
 /// Reads an existing token, refusing to follow a symlink and requiring the


### PR DESCRIPTION
## Summary
The admin bearer token gates every `/api/*` route, including share export (which re-encrypts a FROST share under a caller-supplied passphrase and requires only the token, because the vault is already unlocked in-process). It is therefore share-equivalent against a running daemon. When no token was configured, the daemon persisted a generated one to `$KEEP_PATH/auth_token` — inside the vault directory, next to `keep.hdr`/`keep.db`. That breaks the property that the vault directory at rest is useless without `KEEP_PASSWORD`: any whole-directory copy (tar, rsync, VM image, StartOS/container volume snapshot) carried a live admin credential alongside the ciphertext it protects.

This changes where the generated token is persisted, without changing the configured-token path or breaking existing deployments:

- An explicit `KEEP_WEB_AUTH_TOKEN[_FILE]` still wins (unchanged). The Debian package already pins `/etc/keep-web/auth-token` this way.
- Otherwise the daemon prefers an operator-provisioned credential from systemd's `$CREDENTIALS_DIRECTORY` (`LoadCredential=keep-web-auth-token:...`) — read-only, never written into the vault.
- Otherwise it persists the generated token to `$STATE_DIRECTORY/auth_token` (systemd `StateDirectory=`, which the shipped unit already sets to `/var/lib/keep-web`) — outside the vault.
- Only if none of those are available does it fall back to `$KEEP_PATH/auth_token`, now with a prominent warning that the credential is in the backup path and how to move it out.

Existing installs are unaffected: a configured token still wins, and the vault-dir fallback still reads an already-present `$KEEP_PATH/auth_token`, so no token is rotated or invalidated. The remaining Docker/StartOS default (no systemd, so it still hits the vault fallback) needs the container to mount a separate token path and set `KEEP_WEB_AUTH_TOKEN_FILE`; that is a keep-startos change and is being filed separately.

The logical backup path (`keep-core` backup from records) and keep-state replication (keys/descriptors/relay_configs only) already exclude the token; this was specifically about whole-directory copies.

## Test plan
- New unit tests: `choose_persist_path` prefers a state dir and flags the vault fallback (including empty-state-dir handling); `load_or_create_auth_token_at` writes the token to a state dir and leaves nothing in the vault dir, stable across restarts.
- Existing auth-token tests (generate-once, 0600, empty/malformed/symlink/group-readable refusal) still pass against the refactored `load_or_create_auth_token_at`.
- `cargo test -p keep-web` green (37), `cargo clippy -p keep-web --all-targets` clean, `cargo fmt` clean.
- Man page (`keep-web.8`) updated to document the new resolution order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for provisioning the admin authentication token through systemd credentials.
  - Authentication tokens are now persisted outside the vault when a state directory is available.
  - Added a fallback for environments without external credential or state-directory configuration.

- **Documentation**
  - Updated `keep-web` documentation to describe token-generation, storage precedence, and vault-storage warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->