### PR TITLE
keep-web: fail closed on credential stat errors and catch nested state dirs

### DIFF
--- a/contrib/debian/keep-web.8
+++ b/contrib/debian/keep-web.8
@@ -44,7 +44,10 @@ under systemd's
 then persists a generated token to
 .I $STATE_DIRECTORY/auth_token
 .RB ( StateDirectory= ,
-outside the vault). Only if none of those are available does it fall back to
+which must be configured outside
+.IR $KEEP_PATH ;
+a state directory nested inside the vault is treated as in-vault and warned).
+Only if none of those are available does it fall back to
 .I $KEEP_PATH/auth_token
 inside the vault directory, with a warning: the bearer token is
 share-equivalent against a running daemon, so keeping it out of the vault

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -84,8 +84,14 @@ fn credential_token_at(
         return Ok(None);
     };
     let path = dir.join(CREDENTIAL_NAME);
-    if !path.exists() {
-        return Ok(None);
+    // Distinguish a genuinely absent credential (fall through to the persisted
+    // token) from a stat failure such as EACCES: `Path::exists` collapses both to
+    // false, which would silently mint a fallback token when a credential is
+    // present but unreadable. Fail closed on anything other than NotFound.
+    match path.try_exists() {
+        Ok(false) => return Ok(None),
+        Ok(true) => {}
+        Err(e) => return Err(e.into()),
     }
     let token = read_secret_file(&path.to_string_lossy())?;
     if token.is_empty() {

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -146,6 +146,17 @@ mod tests {
         let (path, in_vault) = choose_persist_path(Some(vault), vault);
         assert_eq!(path, Path::new("/data/auth_token"));
         assert!(in_vault);
+        // A state dir NESTED inside the vault is still in the backup path.
+        let (_, in_vault) = choose_persist_path(Some(Path::new("/data/state")), vault);
+        assert!(in_vault);
+        // A state dir that is a PARENT of the vault is genuinely outside it (the
+        // packaged /var/lib/keep-web vs vault /var/lib/keep-web/vault).
+        let (path, in_vault) = choose_persist_path(
+            Some(Path::new("/var/lib/keep-web")),
+            Path::new("/var/lib/keep-web/vault"),
+        );
+        assert_eq!(path, Path::new("/var/lib/keep-web/auth_token"));
+        assert!(!in_vault);
     }
 
     #[test]
@@ -415,10 +426,14 @@ pub fn choose_persist_path(
     vault_dir: &Path,
 ) -> (std::path::PathBuf, bool) {
     match state_dir {
-        // A state dir that is the vault dir itself is not "outside" it: the token
-        // would still land in the backup path, so fall through to the vault case
-        // and keep the warning honest rather than suppressing it.
-        Some(dir) if !dir.as_os_str().is_empty() && dir != vault_dir => {
+        // A state dir that is the vault dir, or nested inside it, is not "outside"
+        // the backup path: the token would still be swept into a vault snapshot.
+        // `starts_with` is component-wise, so `/data/state` under vault `/data` is
+        // caught, while a state dir that is a PARENT of the vault (the packaged
+        // `/var/lib/keep-web` vs vault `/var/lib/keep-web/vault`) is correctly
+        // treated as outside. Fall through to the vault case so the warning stays
+        // honest rather than being suppressed.
+        Some(dir) if !dir.as_os_str().is_empty() && !dir.starts_with(vault_dir) => {
             (dir.join("auth_token"), false)
         }
         _ => (vault_dir.join("auth_token"), true),


### PR DESCRIPTION
## Summary
Follow-up hardening on the admin-token persistence path (from automated review of the previous change):

- `credential_token_at` used `Path::exists()`, which collapses every stat failure (including `EACCES`) to "absent" and would silently mint a fallback token when a systemd credential is present but unreadable. It now uses `try_exists()`: only `NotFound` falls through; any other error fails startup.
- `choose_persist_path` classified only an exact `state_dir == vault_dir` match as in-vault. It now uses a component-wise `starts_with` check, so a state directory nested inside the vault (e.g. `/data/state` under vault `/data`) is also treated as in-vault and warned, while a state dir that is a parent of the vault (the packaged `/var/lib/keep-web` vs vault `/var/lib/keep-web/vault`) is correctly outside.
- Man page: `StateDirectory=` must be configured outside `$KEEP_PATH`; a nested state dir is treated as in-vault.

## Test plan
- `choose_persist_path` test extended for the nested-inside-vault (in-vault) and parent-of-vault (outside) cases.
- `cargo test -p keep-web` green (42), `cargo clippy -p keep-web --all-targets` clean, `cargo fmt` clean.