### PR TITLE
keep-core: refuse to open a headerless directory that still holds vault data

### DIFF
--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -1932,10 +1932,13 @@ mod tests {
         std::fs::remove_file(path.join("keep.hdr")).unwrap();
         assert!(path.join("keep.db").exists(), "vault data still present");
         match Storage::open(&path) {
+            // The distinct corrupt-format error is the contract: pin it so a
+            // future fall-through to fs::read's Io(NotFound) is caught here.
+            Err(KeepError::StorageErr(StorageError::InvalidFormat { .. })) => {}
             Err(KeepError::NotFound(_)) => {
                 panic!("must NOT report NotFound while vault data is present")
             }
-            Err(_) => {} // a distinct corrupt-format error is correct
+            Err(e) => panic!("expected InvalidFormat, got {e:?}"),
             Ok(_) => panic!("must not open a vault with no header"),
         }
     }
@@ -1951,12 +1954,32 @@ mod tests {
         std::fs::write(path.join("keep.vault"), b"ciphertext").unwrap();
         std::fs::write(path.join("keep.db"), b"db").unwrap();
         match Storage::open(&path) {
+            Err(KeepError::StorageErr(StorageError::InvalidFormat { .. })) => {}
             Err(KeepError::NotFound(_)) => {
                 panic!("must NOT report NotFound for a hidden-volume directory")
             }
-            Err(_) => {}
+            Err(e) => panic!("expected InvalidFormat, got {e:?}"),
             Ok(_) => panic!("must not open a headerless hidden-volume directory"),
         }
+    }
+
+    #[test]
+    fn open_succeeds_with_valid_header_and_stale_rotation_backups() {
+        // The guard runs after recover_rotation_artifacts and must be a no-op when
+        // the header is present, even with stale rotation backups beside it: a
+        // valid vault must still open.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("v");
+        Storage::create(&path, "password", Argon2Params::TESTING).unwrap();
+        // A backup that differs from the live header is treated as stale (the
+        // rewrite completed), so recovery deletes it without touching keep.db.
+        std::fs::write(path.join("keep.hdr.backup"), b"stale-different-header").unwrap();
+        std::fs::write(path.join("keep.db.backup"), b"stale-db").unwrap();
+
+        let mut storage =
+            Storage::open(&path).expect("valid vault must open despite stale backups");
+        storage.unlock("password").expect("unlock after open");
+        assert!(storage.is_unlocked());
     }
 
     #[test]

--- a/keep-core/src/storage.rs
+++ b/keep-core/src/storage.rs
@@ -599,7 +599,10 @@ impl Storage {
 
     /// Open existing storage.
     pub fn open(path: &Path) -> Result<Self> {
-        if !path.exists() {
+        // `try_exists` (not `exists`) so a permission error surfaces as an error
+        // rather than being misread as "no vault here", which a provisioning
+        // caller would treat as a fresh install.
+        if !path.try_exists()? {
             return Err(KeepError::NotFound(path.display().to_string()));
         }
 
@@ -612,6 +615,25 @@ impl Storage {
         crate::rotation::recover_rotation_artifacts(path);
 
         let header_path = path.join("keep.hdr");
+        // Fund-safety guard: a directory holding vault artifacts (`keep.db`, or the
+        // hidden-volume `keep.vault`) but no header must never be reported as an
+        // empty path. A caller that provisions on "not found" would otherwise
+        // create a fresh vault over existing ciphertext (unrecoverable share loss)
+        // or over a hidden volume (breaking deniability). Report it as a distinct
+        // corrupt-format error, never `NotFound`, so the two states cannot be
+        // conflated regardless of how the header read's IO error maps.
+        if !header_path.try_exists()? {
+            let has_db = path.join("keep.db").try_exists()?;
+            let has_vault = path.join("keep.vault").try_exists()?;
+            if has_db || has_vault {
+                return Err(StorageError::invalid_format(
+                    "vault header (keep.hdr) missing but vault data is present; \
+                     refusing to open as an empty path",
+                )
+                .into());
+            }
+        }
+
         let header_bytes = fs::read(&header_path)?;
 
         if header_bytes.len() != HEADER_SIZE {
@@ -1886,6 +1908,54 @@ mod tests {
 
             storage.unlock("password").unwrap();
             assert!(storage.is_unlocked());
+        }
+    }
+
+    #[test]
+    fn open_missing_directory_reports_not_found() {
+        let dir = tempdir().unwrap();
+        match Storage::open(&dir.path().join("absent")) {
+            Err(KeepError::NotFound(_)) => {}
+            Err(e) => panic!("expected NotFound for a missing directory, got {e:?}"),
+            Ok(_) => panic!("expected NotFound for a missing directory, but open succeeded"),
+        }
+    }
+
+    #[test]
+    fn open_vault_missing_header_is_not_reported_as_not_found() {
+        // A vault whose header was deleted must never be mistaken for an empty
+        // path: a caller provisioning on NotFound would create a fresh vault over
+        // the existing keep.db, unrecoverably losing the shares it holds.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("v");
+        Storage::create(&path, "password", Argon2Params::TESTING).unwrap();
+        std::fs::remove_file(path.join("keep.hdr")).unwrap();
+        assert!(path.join("keep.db").exists(), "vault data still present");
+        match Storage::open(&path) {
+            Err(KeepError::NotFound(_)) => {
+                panic!("must NOT report NotFound while vault data is present")
+            }
+            Err(_) => {} // a distinct corrupt-format error is correct
+            Ok(_) => panic!("must not open a vault with no header"),
+        }
+    }
+
+    #[test]
+    fn open_hidden_volume_dir_without_header_is_not_reported_as_not_found() {
+        // keep.vault (+ keep.db) with no keep.hdr is a hidden-volume layout;
+        // reporting it as NotFound would let a caller provision a plain vault over
+        // it, landing a keep.hdr next to keep.vault and breaking deniability.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("hv");
+        std::fs::create_dir_all(&path).unwrap();
+        std::fs::write(path.join("keep.vault"), b"ciphertext").unwrap();
+        std::fs::write(path.join("keep.db"), b"db").unwrap();
+        match Storage::open(&path) {
+            Err(KeepError::NotFound(_)) => {
+                panic!("must NOT report NotFound for a hidden-volume directory")
+            }
+            Err(_) => {}
+            Ok(_) => panic!("must not open a headerless hidden-volume directory"),
         }
     }
 


### PR DESCRIPTION
## Summary
`Storage::open` returned `KeepError::NotFound` only for a missing directory, and a directory that existed but lacked `keep.hdr` fell through to the header read. A caller that provisions a fresh vault on `NotFound` (e.g. the keep-web admin daemon) must never be handed `NotFound` for a directory that still holds vault artifacts: doing so would create a new vault over an existing `keep.db` (unrecoverable share loss) or over a hidden-volume `keep.vault` (breaking deniability). Today that is averted only incidentally (the header read errors as `Io`, which keep-web does not treat as fresh-install) and was untested.

This makes the safety explicit and permanent:
- If the directory exists but has no `keep.hdr` while `keep.db` or `keep.vault` is present, `open` returns a distinct corrupt-format error, never `NotFound` — so the two states cannot be conflated regardless of how the header read's IO error maps or how a caller branches.
- The directory-existence and header/artifact checks use `try_exists()` instead of `exists()`, so a permission error (`EACCES`) surfaces as an error rather than being misread as "no vault here".

A genuinely empty/absent path still reports `NotFound` (unchanged), so the fresh-install path is preserved. This is scoped to `Storage::open`; the separate create-path behavior for a pre-existing empty directory is tracked independently.

## Test plan
- New tests: missing directory → `NotFound`; a created vault with `keep.hdr` deleted (but `keep.db` present) → not `NotFound`; a hidden-volume layout (`keep.vault` + `keep.db`, no header) → not `NotFound`.
- Existing `test_storage_create_and_unlock` confirms a valid vault still opens (header present, guard skipped).
- `cargo test -p keep-core --lib` green (381), clippy clean, fmt clean.