### PR TITLE
keep-web: refuse symlinked secret files instead of following them

### DIFF
--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -63,14 +63,23 @@ fn read_secret_file(path: &str) -> Result<String, Box<dyn std::error::Error>> {
             return Err(format!("secret file {path} must be a regular file, not a symlink").into());
         }
         let mode = md.permissions().mode() & 0o777;
-        if mode & 0o077 != 0 {
-            // A warning, not a rejection: these files are operator-provided and
-            // their ownership/mode legitimately varies (e.g. a 0640 root-managed
-            // secret). The symlink guard above is the security-critical part.
+        if mode & 0o022 != 0 {
+            // Group/world-WRITABLE: an attacker could rewrite the secret (admin
+            // token, vault password) in place, an integrity hole the symlink
+            // guard does not cover. Refuse, mirroring the vault-directory guard.
+            return Err(format!(
+                "secret file {path} is group/world-writable (mode {mode:o}); refusing to read it"
+            )
+            .into());
+        }
+        if mode & 0o044 != 0 {
+            // Merely group/world-READABLE is advisory hygiene, not a redirect or
+            // integrity hole: these files are operator-provided and their mode
+            // legitimately varies (e.g. a 0640 root-managed secret), so warn.
             tracing::warn!(
                 path,
                 mode = format!("{mode:o}"),
-                "secret file is group/world accessible; tighten to 0600"
+                "secret file is group/world-readable; tighten to 0600"
             );
         }
         // Reopen and confirm the opened file is the one just stat'd, closing the
@@ -535,10 +544,41 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn read_secret_file_reads_regular_file_trimmed() {
+        use std::os::unix::fs::PermissionsExt;
         let dir = tempdir().unwrap();
         let f = dir.path().join("token");
         std::fs::write(&f, "  the-token\n").unwrap();
+        // A correctly-provisioned secret file is owner-only; set it explicitly so
+        // the test is independent of the runner's umask.
+        std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o600)).unwrap();
         assert_eq!(read_secret_file(&f.to_string_lossy()).unwrap(), "the-token");
+    }
+
+    #[test]
+    fn read_secret_file_rejects_non_regular_file() {
+        // A directory (or a fifo/socket) at the path must be refused, not read:
+        // besides being wrong, reading a fifo would block startup indefinitely.
+        let dir = tempdir().unwrap();
+        let sub = dir.path().join("not-a-file");
+        std::fs::create_dir(&sub).unwrap();
+        assert!(
+            read_secret_file(&sub.to_string_lossy()).is_err(),
+            "a non-regular file must be refused"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_secret_file_rejects_group_or_world_writable() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("token");
+        std::fs::write(&f, "secret").unwrap();
+        std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o666)).unwrap();
+        assert!(
+            read_secret_file(&f.to_string_lossy()).is_err(),
+            "a group/world-writable secret file must be refused"
+        );
     }
 
     #[test]
@@ -551,7 +591,15 @@ mod tests {
     #[test]
     fn credential_token_reads_present_credential_trimmed() {
         let dir = tempdir().unwrap();
-        std::fs::write(dir.path().join(CREDENTIAL_NAME), "  operator-token  ").unwrap();
+        let cred = dir.path().join(CREDENTIAL_NAME);
+        std::fs::write(&cred, "  operator-token  ").unwrap();
+        // systemd credentials are owner-only (0400); set 0600 so the read is
+        // independent of the runner's umask.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&cred, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
         assert_eq!(
             credential_token_at(Some(dir.path())).unwrap().as_deref(),
             Some("operator-token")

--- a/keep-web/src/main.rs
+++ b/keep-web/src/main.rs
@@ -44,23 +44,50 @@ pub(crate) fn secret_from(key: &str) -> Result<Option<String>, Box<dyn std::erro
 }
 
 fn read_secret_file(path: &str) -> Result<String, Box<dyn std::error::Error>> {
-    // The permission check is Unix-only (keep-web runs on Linux/StartOS); on
-    // other platforms the file is read without the mode warning so the
-    // workspace still builds (e.g. Windows CI).
+    // The symlink/regular-file guard and the permission check are Unix-only
+    // (keep-web runs on Linux/StartOS); on other platforms the file is read
+    // plainly so the workspace still builds (e.g. Windows CI).
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let meta = std::fs::metadata(path)?;
-        let mode = meta.permissions().mode() & 0o777;
+        use std::io::Read;
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        let p = std::path::Path::new(path);
+        // Refuse a planted symlink (or any non-regular file) at the final
+        // component: following it would let whoever can create it redirect the
+        // read to an attacker-known file whose contents keep-web would then adopt
+        // as the secret (e.g. the admin bearer token gating share export).
+        // `symlink_metadata` does not traverse the final component. Mirrors the
+        // persisted-token reader `state::read_auth_token`.
+        let md = std::fs::symlink_metadata(p)?;
+        if md.file_type().is_symlink() || !md.is_file() {
+            return Err(format!("secret file {path} must be a regular file, not a symlink").into());
+        }
+        let mode = md.permissions().mode() & 0o777;
         if mode & 0o077 != 0 {
+            // A warning, not a rejection: these files are operator-provided and
+            // their ownership/mode legitimately varies (e.g. a 0640 root-managed
+            // secret). The symlink guard above is the security-critical part.
             tracing::warn!(
                 path,
                 mode = format!("{mode:o}"),
                 "secret file is group/world accessible; tighten to 0600"
             );
         }
+        // Reopen and confirm the opened file is the one just stat'd, closing the
+        // window where the path is swapped for a symlink between lstat and open.
+        let mut f = std::fs::File::open(p)?;
+        let opened = f.metadata()?;
+        if opened.ino() != md.ino() || opened.dev() != md.dev() {
+            return Err(format!("secret file {path} changed while being read; refusing").into());
+        }
+        let mut s = String::new();
+        f.read_to_string(&mut s)?;
+        Ok(s.trim().to_string())
     }
-    Ok(std::fs::read_to_string(path)?.trim().to_string())
+    #[cfg(not(unix))]
+    {
+        Ok(std::fs::read_to_string(path)?.trim().to_string())
+    }
 }
 
 /// Read an operator-provisioned admin token from systemd's `$CREDENTIALS_DIRECTORY`
@@ -490,6 +517,29 @@ mod tests {
     use super::*;
     use keep_core::Keep;
     use tempfile::tempdir;
+
+    #[cfg(unix)]
+    #[test]
+    fn read_secret_file_rejects_symlink() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("target");
+        std::fs::write(&target, "attacker-known-token").unwrap();
+        let link = dir.path().join("auth-token");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        assert!(
+            read_secret_file(&link.to_string_lossy()).is_err(),
+            "a symlinked secret file must be refused, not followed to its target"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_secret_file_reads_regular_file_trimmed() {
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("token");
+        std::fs::write(&f, "  the-token\n").unwrap();
+        assert_eq!(read_secret_file(&f.to_string_lossy()).unwrap(), "the-token");
+    }
 
     #[test]
     fn credential_token_none_when_dir_unset_or_absent() {


### PR DESCRIPTION
## Summary
`read_secret_file` (the reader behind `KEEP_WEB_AUTH_TOKEN_FILE`, `KEEP_PASSWORD_FILE`, and `KEEP_STORAGE_KEY_FILE`) used `std::fs::metadata` + `std::fs::read_to_string`, both of which follow symlinks. A symlink planted at a configured secret path would redirect the read to an attacker-known file, so whoever could create the link controls the content keep-web then adopts as the secret — including the admin bearer token that gates `/api/shares/export`. The permission warning also inspected the symlink target rather than the link itself.

This applies the same dependency-free, TOCTOU-safe pattern already used by the persisted-token reader (`state::read_auth_token`): `symlink_metadata` rejects a symlink or any non-regular file at the final component, the file is reopened, and the opened file's inode/device are compared against the stat to close the swap-between-lstat-and-open window. The mode check now inspects the real file.

The group/world-accessible mode remains a warning rather than a hard rejection: these files are operator-provided and their ownership/mode legitimately varies (for example a 0640 root-managed secret), whereas following a symlink is an unconditional vulnerability regardless of the mode. The persisted-token path (`read_auth_token`) was already symlink-safe and is unchanged; this closes the same gap on the operator-configured read path.

## Test plan
- New Unix tests: a symlinked secret file is refused (not followed to its target); a regular file is read and trimmed.
- `cargo test -p keep-web` green (44), `cargo clippy -p keep-web --all-targets` clean, `cargo fmt` clean.