### PR TITLE
keep-agent: cover the MCP JSON-RPC surface and permission model end to end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
       - run: cargo test -p keep-core --features testing --test integration_tests
       - run: cargo test -p keep-frost-net --features testing --test multinode_test
       - run: cargo test -p keep-enclave-host --test integration_tests
+      # The MCP agent surface is behind the non-default `mcp` feature, so the
+      # workspace test run above never compiles it; run its tests explicitly.
+      - run: cargo test -p keep-agent --features mcp --lib
       # End-to-end CLI tests drive the release `keep` binary built above as a
       # subprocess (the tests locate `target/release/keep`), so run them in
       # --release too. Previously only compile-checked, never executed in CI.

--- a/keep-agent/src/mcp/server.rs
+++ b/keep-agent/src/mcp/server.rs
@@ -534,4 +534,167 @@ mod tests {
         let tools = result.get("tools").unwrap().as_array().unwrap();
         assert!(!tools.is_empty());
     }
+
+    // End-to-end coverage of the JSON-RPC surface (#461): drive real requests
+    // through `handle_request_async` and assert the initialize handshake, the
+    // advertised toolset, per-tool call results, and the session permission
+    // model (which gates every signing tool).
+    use crate::scope::SessionScope;
+    use crate::session::SessionConfig;
+
+    fn signing_server() -> McpServer {
+        // Deterministic key so a produced signature is reproducible in shape.
+        let secret = [7u8; 32];
+        let keys = nostr_sdk::Keys::parse(&hex::encode(secret)).expect("valid key");
+        let pubkey: [u8; 32] = keys.public_key().to_bytes();
+        McpServer::with_signing(pubkey, secret)
+    }
+
+    async fn install_session(server: &McpServer, scope: SessionScope) {
+        let config = SessionConfig::new(scope).with_duration_hours(1);
+        let (token, sid) = server.create_session(config).await.expect("create session");
+        server.set_session(token, sid).await;
+    }
+
+    fn rpc(method: &str, params: Value) -> String {
+        serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": method, "params": params})
+            .to_string()
+    }
+
+    fn call(name: &str, arguments: Value) -> String {
+        rpc(
+            "tools/call",
+            serde_json::json!({"name": name, "arguments": arguments}),
+        )
+    }
+
+    #[tokio::test]
+    async fn mcp_initialize_handshake_over_jsonrpc() {
+        let server = signing_server();
+        let resp = server
+            .handle_request_async(&rpc("initialize", Value::Null))
+            .await;
+        assert!(resp.error.is_none());
+        let r = resp.result.expect("initialize result");
+        assert!(r.get("protocolVersion").is_some());
+        assert!(r.get("serverInfo").is_some());
+    }
+
+    #[tokio::test]
+    async fn mcp_tools_list_reports_the_signing_toolset() {
+        let server = signing_server();
+        let resp = server
+            .handle_request_async(&rpc("tools/list", Value::Null))
+            .await;
+        let r = resp.result.expect("tools/list result");
+        let names: Vec<String> = r["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|t| t["name"].as_str().unwrap().to_string())
+            .collect();
+        for expected in [
+            "sign_nostr_event",
+            "sign_bitcoin_psbt",
+            "get_nostr_pubkey",
+            "get_bitcoin_address",
+            "get_session_info",
+        ] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "tools/list missing {expected}; got {names:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn mcp_tools_call_requires_an_active_session() {
+        // Fail-closed: with no session established, a signing tool is refused
+        // rather than executed.
+        let server = signing_server();
+        let resp = server
+            .handle_request_async(&call("get_nostr_pubkey", serde_json::json!({})))
+            .await;
+        let e = resp.error.expect("no-session call must error");
+        assert!(
+            e.message.contains("No active session"),
+            "got: {}",
+            e.message
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_get_nostr_pubkey_succeeds_within_scope() {
+        let server = signing_server();
+        install_session(&server, SessionScope::nostr_only()).await;
+        let resp = server
+            .handle_request_async(&call("get_nostr_pubkey", serde_json::json!({})))
+            .await;
+        assert!(resp.error.is_none());
+        let r = resp.result.expect("result");
+        assert_eq!(r["isError"], serde_json::json!(false));
+        let text = r["content"][0]["text"].as_str().unwrap();
+        let payload: Value = serde_json::from_str(text).unwrap();
+        assert!(payload.get("npub").is_some() && payload.get("hex").is_some());
+    }
+
+    #[tokio::test]
+    async fn mcp_sign_nostr_event_produces_a_signed_event() {
+        let server = signing_server();
+        install_session(&server, SessionScope::nostr_only()).await;
+        let resp = server
+            .handle_request_async(&call(
+                "sign_nostr_event",
+                serde_json::json!({"kind": 1, "content": "hello from the mcp test", "tags": []}),
+            ))
+            .await;
+        assert!(resp.error.is_none(), "sign failed: {:?}", resp.error);
+        let r = resp.result.expect("result");
+        assert_eq!(r["isError"], serde_json::json!(false));
+        let text = r["content"][0]["text"].as_str().unwrap();
+        let event: Value = serde_json::from_str(text).unwrap();
+        assert!(event.get("id").is_some() && event.get("sig").is_some());
+        assert_eq!(event["kind"], serde_json::json!(1));
+    }
+
+    #[tokio::test]
+    async fn mcp_enforces_the_operation_scope() {
+        // The permission model: a bitcoin-only session must NOT be able to sign a
+        // Nostr event; the operation is refused before any key is used.
+        let server = signing_server();
+        install_session(&server, SessionScope::bitcoin_only()).await;
+        let resp = server
+            .handle_request_async(&call(
+                "sign_nostr_event",
+                serde_json::json!({"kind": 1, "content": "x", "tags": []}),
+            ))
+            .await;
+        assert!(
+            resp.error.is_some(),
+            "an out-of-scope operation must be refused, got {:?}",
+            resp.result
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_unknown_method_is_rejected() {
+        let server = signing_server();
+        let resp = server
+            .handle_request_async(&rpc("does/not/exist", Value::Null))
+            .await;
+        let e = resp.error.expect("unknown method must error");
+        assert!(e.message.contains("Unknown method"), "got: {}", e.message);
+    }
+
+    #[tokio::test]
+    async fn mcp_unknown_tool_returns_a_tool_error() {
+        let server = signing_server();
+        install_session(&server, SessionScope::nostr_only()).await;
+        let resp = server
+            .handle_request_async(&call("no_such_tool", serde_json::json!({})))
+            .await;
+        // Unknown tool is a tool-level error (isError), not a JSON-RPC error.
+        let r = resp.result.expect("result");
+        assert_eq!(r["isError"], serde_json::json!(true));
+    }
 }

--- a/keep-agent/src/mcp/server.rs
+++ b/keep-agent/src/mcp/server.rs
@@ -669,11 +669,50 @@ mod tests {
                 serde_json::json!({"kind": 1, "content": "x", "tags": []}),
             ))
             .await;
+        // Assert it failed for the RIGHT reason (the scope check), not some
+        // unrelated error that would also set `error`.
+        let e = resp
+            .error
+            .unwrap_or_else(|| panic!("out-of-scope op must be refused, got {:?}", resp.result));
         assert!(
-            resp.error.is_some(),
-            "an out-of-scope operation must be refused, got {:?}",
-            resp.result
+            e.message.contains("not allowed"),
+            "expected an operation-not-allowed refusal, got: {}",
+            e.message
         );
+    }
+
+    #[tokio::test]
+    async fn mcp_get_bitcoin_address_succeeds_within_scope() {
+        let server = signing_server();
+        install_session(&server, SessionScope::bitcoin_only()).await;
+        let resp = server
+            .handle_request_async(&call(
+                "get_bitcoin_address",
+                serde_json::json!({"type": "p2tr", "network": "testnet"}),
+            ))
+            .await;
+        assert!(
+            resp.error.is_none(),
+            "get_bitcoin_address failed: {:?}",
+            resp.error
+        );
+        let r = resp.result.expect("result");
+        assert_eq!(r["isError"], serde_json::json!(false));
+        let payload: Value =
+            serde_json::from_str(r["content"][0]["text"].as_str().unwrap()).unwrap();
+        assert!(payload.get("address").is_some());
+    }
+
+    #[tokio::test]
+    async fn mcp_get_session_info_reports_the_active_session() {
+        let server = signing_server();
+        install_session(&server, SessionScope::nostr_only()).await;
+        let resp = server
+            .handle_request_async(&call("get_session_info", serde_json::json!({})))
+            .await;
+        assert!(resp.error.is_none());
+        let r = resp.result.expect("result");
+        assert_eq!(r["isError"], serde_json::json!(false));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
The MCP agent server (`keep agent mcp`) exposes a JSON-RPC signing surface over stdio, and it was untested. This drives the surface end to end through the request dispatcher and pins both the protocol and, importantly, the permission model that gates every signing tool.

Added tests (all through `handle_request_async`, i.e. real JSON-RPC in, structured response out):
- `initialize` handshake returns a protocol version and server info.
- `tools/list` advertises the expected signing toolset (`sign_nostr_event`, `sign_bitcoin_psbt`, `get_nostr_pubkey`, `get_bitcoin_address`, `get_session_info`).
- `tools/call` for `get_nostr_pubkey` and `sign_nostr_event` succeed within scope and return the documented shapes (the signed event carries `id`/`sig`/`kind`).
- **Permission model (fail-closed):** `tools/call` with no active session is refused ("No active session"); an operation outside the session scope is refused before any key is used (a bitcoin-only session cannot sign a Nostr event).
- Unknown method returns a JSON-RPC error; an unknown tool returns a tool-level `isError` result.

Also wires the tests into CI: the MCP surface is behind the non-default `mcp` feature, so the workspace `cargo test --lib` run never compiled it; a dedicated `cargo test -p keep-agent --features mcp --lib` step now runs it.

Note on scope: this server signs with a provided key rather than through a `Keep` vault, so there is no `Keep`-backed audit log to assert against here; successful calls are accounted through the session manager (`record_request`) and gated by the session scope, which the tests exercise.

Closes #461

## Test plan
- `cargo test -p keep-agent --features mcp --lib` green (48), `cargo clippy -p keep-agent --features mcp --all-targets` clean, `cargo fmt` clean. New CI step runs the same command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for MCP JSON-RPC interactions, including initialization, tool discovery, session handling, signing, and error responses.
  * Added validation for operation scope restrictions and unknown requests.
  * Extended CI testing to cover the MCP-enabled agent configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->