### PR TITLE
keep-agent: tighten the MCP JSON-RPC test assertions

### DIFF
--- a/keep-agent/src/mcp/server.rs
+++ b/keep-agent/src/mcp/server.rs
@@ -556,9 +556,13 @@ mod tests {
         server.set_session(token, sid).await;
     }
 
-    fn rpc(method: &str, params: Value) -> String {
-        serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": method, "params": params})
+    fn rpc_id(id: i64, method: &str, params: Value) -> String {
+        serde_json::json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params})
             .to_string()
+    }
+
+    fn rpc(method: &str, params: Value) -> String {
+        rpc_id(1, method, params)
     }
 
     fn call(name: &str, arguments: Value) -> String {
@@ -572,12 +576,21 @@ mod tests {
     async fn mcp_initialize_handshake_over_jsonrpc() {
         let server = signing_server();
         let resp = server
-            .handle_request_async(&rpc("initialize", Value::Null))
+            .handle_request_async(&rpc_id(42, "initialize", Value::Null))
             .await;
         assert!(resp.error.is_none());
+        // The response must echo the request id (JSON-RPC correlation).
+        assert_eq!(resp.id, serde_json::json!(42));
         let r = resp.result.expect("initialize result");
-        assert!(r.get("protocolVersion").is_some());
-        assert!(r.get("serverInfo").is_some());
+        // Assert usable values, not just presence: `get()` also succeeds on null.
+        assert!(
+            r["protocolVersion"].as_str().is_some(),
+            "protocolVersion must be a non-null string"
+        );
+        assert!(
+            r["serverInfo"].as_object().is_some(),
+            "serverInfo must be a non-null object"
+        );
     }
 
     #[tokio::test]
@@ -719,8 +732,10 @@ mod tests {
     async fn mcp_unknown_method_is_rejected() {
         let server = signing_server();
         let resp = server
-            .handle_request_async(&rpc("does/not/exist", Value::Null))
+            .handle_request_async(&rpc_id(7, "does/not/exist", Value::Null))
             .await;
+        // The id is preserved even on the error path (JSON-RPC correlation).
+        assert_eq!(resp.id, serde_json::json!(7));
         let e = resp.error.expect("unknown method must error");
         assert!(e.message.contains("Unknown method"), "got: {}", e.message);
     }


### PR DESCRIPTION
## Summary
Follow-up strengthening of the MCP JSON-RPC surface tests (from automated review of the previous change):

- **Response id correlation.** The tests hardcoded request id `1` and never asserted the returned id, so a handler that emitted a wrong or static id would still pass. The request helper now takes a caller-provided id; the initialize test sends `42` and the unknown-method test sends `7`, and both assert the response echoes that id (covering the success and error paths).
- **Usable handshake values, not just presence.** `Value::get()` also succeeds for `null`, so the initialize test passed without a real protocol version. It now asserts `protocolVersion` is a non-null string and `serverInfo` is a non-null object.

Test-only; no production change.

## Test plan
- `cargo test -p keep-agent --features mcp --lib` green (12), `cargo clippy -p keep-agent --features mcp --all-targets` clean, `cargo fmt` clean. The CI step added previously runs these.