### PR TITLE
security: bump nostr to 0.44.5 for RUSTSEC-2026-0216 (NIP-44 v2 remote DoS)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5736,9 +5736,9 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "nostr"
-version = "0.44.3"
+version = "0.44.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d8f0fe13526800300a36bf3b7c5f752e62e32ab81c74a8e5caa2865708625a"
+checksum = "0112d3433a5550ba13481970d5b6844714510ddcdaca4d9d0aa6e7b83f270271"
 dependencies = [
  "aes 0.8.4",
  "base64 0.22.1",


### PR DESCRIPTION
## Problem
`main` went red at the `deny` (cargo-deny) job after the advisory database picked up **RUSTSEC-2026-0216**. The advisory was published between the previous merge's PR check and its push to `main`, so it flipped an already-merged commit red rather than being introduced by any code change.

**RUSTSEC-2026-0216 — Remote Denial of Service via malformed NIP-44 v2 payload.** The NIP-44 v2 decryption path in the `nostr` crate reads a 2-byte unpadded-length prefix (`buffer[0..2]`) after decryption without first checking the decrypted buffer holds at least 2 bytes. A sender holding the conversation key can craft a payload that decrypts to 0 or 1 bytes, causing an index-out-of-bounds panic. It is reachable remotely through any relay that delivers the crafted event, resulting in a denial of service. No key material, plaintext, or memory corruption is involved. Affected: `nostr` `0.26.0`..=`0.44.4`. Fixed in `0.44.5`.

This is directly reachable for Keep, which uses NIP-44 across the FROST-over-Nostr and NIP-46 paths.

## Fix
Bump the pinned `nostr` from `0.44.3` to `0.44.5` (`cargo update -p nostr --precise 0.44.5`). This is a lockfile-only patch bump: the `nostr-sdk = "0.44"` requirement already permits it, and no other crates move.

## Verification
- `cargo deny check advisories` -> `advisories ok` (exit 0); RUSTSEC-2026-0216 no longer reported.
- `cargo check --all-targets --features testing` (the CI check step) compiles clean.
- `cargo test --workspace --lib --bins` passes (exit 0).