### PR TITLE
ci: build and test the enclave binary on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,13 @@ jobs:
       - run: cargo test -p keep-core --features testing --test integration_tests
       - run: cargo test -p keep-frost-net --features testing --test multinode_test
       - run: cargo test -p keep-enclave-host --test integration_tests
+      # keep-enclave-bin (the Nitro Enclave binary) is a separate workspace excluded
+      # from the root workspace, so `cargo test --workspace` never builds it. It is
+      # target_os=linux gated (vsock), so build and test it explicitly on Linux only,
+      # otherwise a compile break or test regression in the enclave signer/policy code
+      # would not be caught by CI.
+      - if: matrix.os == 'ubuntu-latest'
+        run: cargo test --manifest-path keep-enclave/enclave/Cargo.toml
       # The MCP agent surface is behind the non-default `mcp` feature, so the
       # workspace test run above never compiles it; run its tests explicitly.
       - run: cargo test -p keep-agent --features mcp --lib


### PR DESCRIPTION
## Summary
`keep-enclave/enclave` (package `keep-enclave-bin`, the AWS Nitro Enclave binary) is its own workspace and is listed under `exclude` in the root `Cargo.toml`, so `cargo test --workspace` in CI never builds or tests it. Only `keep-enclave-host` runs. A compile break or test regression in the enclave's signing/policy code (`signer.rs`, `policy.rs`, `vsock_server.rs`) would therefore not be caught by CI.

Add a build+test step for it to the `build` job. The crate is `target_os = "linux"` gated (vsock), so the step is Linux-only (`matrix.os == 'ubuntu-latest'`), consistent with the existing per-OS gating in that job.

## Test plan
- `cargo test --manifest-path keep-enclave/enclave/Cargo.toml` locally: `12 passed; 0 failed`.
- The step runs only on the Linux matrix leg; the macOS leg skips it.
- YAML validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Continuous integration now explicitly runs tests for the Nitro Enclave workspace.
  - Enclave policy and signer compilation are verified automatically on supported Linux runners.
  - This improves build validation and helps detect enclave-related issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->