### PR TITLE
fix: derive PSBT change from the output script so spend policies cannot be bypassed

### DIFF
--- a/keep-agent/src/mcp/server.rs
+++ b/keep-agent/src/mcp/server.rs
@@ -1017,6 +1017,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mcp_sign_bitcoin_psbt_rejects_forged_change_paying_a_non_allowlisted_address() {
+        // A malicious client cannot bypass the allowlist by forging change: an output
+        // paying an attacker address (seed 2) while attaching the signer's own x-only
+        // key (seed 7) as tap_internal_key is NOT genuine change, because change is
+        // determined from the actual scriptPubKey (must pay the signer's own key-path
+        // output), not from forgeable PSBT metadata. So it is subject to the allowlist
+        // and refused, even though output 0 pays the allowlisted address.
+        let server = signing_server();
+        let allowed = testnet_p2tr_address(3);
+        let attacker = testnet_p2tr_address(2);
+        install_session(
+            &server,
+            SessionScope::bitcoin_only().with_address_allowlist([allowed.to_string()]),
+        )
+        .await;
+        let psbt = psbt_base64_spend_and_change(
+            allowed.script_pubkey(),
+            1_000,
+            attacker.script_pubkey(),
+            5_000,
+            xonly_for_seed(7),
+            10_000,
+        );
+        let resp = server
+            .handle_request_async(&call(
+                "sign_bitcoin_psbt",
+                serde_json::json!({"psbt": psbt, "network": "testnet"}),
+            ))
+            .await;
+        let e = resp.error.unwrap_or_else(|| {
+            panic!(
+                "forged-change output to a non-allowlisted address must be refused, got {:?}",
+                resp.result
+            )
+        });
+        assert!(
+            e.message.contains("Address not allowed") && e.message.contains(&attacker.to_string()),
+            "expected an allowlist refusal naming the forged-change output, got: {}",
+            e.message
+        );
+    }
+
+    #[tokio::test]
     async fn mcp_sign_nostr_event_rejects_kind_above_u16_max() {
         let server = signing_server();
         install_session(&server, SessionScope::nostr_only()).await;

--- a/keep-bitcoin/src/psbt.rs
+++ b/keep-bitcoin/src/psbt.rs
@@ -206,20 +206,18 @@ impl PsbtSigner {
     }
 
     fn is_change_output(&self, psbt: &Psbt, index: usize) -> bool {
-        if let Some(output) = psbt.outputs.get(index) {
-            for pubkey in output.tap_key_origins.keys() {
-                if pubkey == &self.x_only_pubkey {
-                    return true;
-                }
-            }
-
-            if let Some(internal_key) = &output.tap_internal_key {
-                if internal_key == &self.x_only_pubkey {
-                    return true;
-                }
-            }
-        }
-        false
+        // Genuine change pays the signer's own key-path output. Derive the expected
+        // scriptPubKey from the signer's key and compare it against the actual
+        // output script, rather than trusting client-supplied PSBT metadata
+        // (tap_internal_key / tap_key_origins). That metadata is forgeable by an
+        // untrusted PSBT author, who could otherwise attach the signer's x-only key
+        // to an arbitrary-destination output to mark it as "change" and slip it past
+        // spend policies (amount / allowlist) that exempt change.
+        let Some(txout) = psbt.unsigned_tx.output.get(index) else {
+            return false;
+        };
+        let own_spk = bitcoin::ScriptBuf::new_p2tr(&self.secp, self.x_only_pubkey, None);
+        txout.script_pubkey == own_spk
     }
 }
 
@@ -393,6 +391,73 @@ mod tests {
         assert!(
             psbt.inputs[0].tap_key_sig.is_some(),
             "a signature must be written for our own input"
+        );
+    }
+
+    // Build a PSBT paying `out_sats` to `output_spk`, funded by an `in_sats` input,
+    // optionally forging `output_internal_key` into the output's PSBT metadata.
+    fn psbt_paying(
+        output_spk: bitcoin::ScriptBuf,
+        out_sats: u64,
+        in_sats: u64,
+        output_internal_key: Option<XOnlyPublicKey>,
+    ) -> Psbt {
+        use bitcoin::{
+            absolute::LockTime, hashes::Hash, transaction::Version, Amount, OutPoint, Sequence,
+            Transaction, TxIn, Witness,
+        };
+        let tx = Transaction {
+            version: Version(2),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: bitcoin::Txid::all_zeros(),
+                    vout: 0,
+                },
+                script_sig: bitcoin::ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(out_sats),
+                script_pubkey: output_spk,
+            }],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(in_sats),
+            script_pubkey: bitcoin::ScriptBuf::new(),
+        });
+        psbt.outputs[0].tap_internal_key = output_internal_key;
+        psbt
+    }
+
+    #[test]
+    fn change_is_the_signers_own_key_path_output_not_forged_metadata() {
+        let mut secret = [3u8; 32];
+        let signer = PsbtSigner::new(&mut secret, Network::Testnet).unwrap();
+        let own = own_address(&signer);
+        let mut attacker_secret = [9u8; 32];
+        let attacker = other_address(&mut attacker_secret);
+
+        // An output paying the signer's own key-path address is change...
+        let change = psbt_paying(own.script_pubkey(), 10_000, 20_000, None);
+        assert!(
+            signer.analyze(&change).unwrap().outputs[0].is_change,
+            "an output paying the signer's own key-path address must be change"
+        );
+
+        // ...but an output paying an attacker address is NOT change, even with the
+        // signer's x-only key forged into the output's tap_internal_key.
+        let forged = psbt_paying(
+            attacker.script_pubkey(),
+            10_000,
+            20_000,
+            Some(signer.x_only_public_key()),
+        );
+        assert!(
+            !signer.analyze(&forged).unwrap().outputs[0].is_change,
+            "forged tap_internal_key must not make an attacker-destination output change"
         );
     }
 }


### PR DESCRIPTION
## Summary
`PsbtSigner::is_change_output` (`keep-bitcoin/src/psbt.rs`) classified an output as change whenever the output's PSBT metadata (`tap_internal_key` or a `tap_key_origins` entry) carried the signer's x-only key. That metadata is supplied by the PSBT author. In the MCP signing surface the PSBT comes from the (untrusted) client, and the signer's x-only key is discoverable (`get_nostr_pubkey` returns the same key that seeds the Bitcoin signer). A malicious client could therefore attach the signer's x-only key to an arbitrary-destination output to mark it as "change", and spend policies that exempt change would skip it:

- the `sign_bitcoin_psbt` `address_allowlist` guard skips change, so a forged-change output to a non-allowlisted address was signed;
- `BitcoinSigner::check_policy` excludes change from its spend-amount sum.

Fix: determine change from the output's **actual scriptPubKey**. An output is change only when its script equals the signer's own key-path p2tr output (`ScriptBuf::new_p2tr(secp, x_only_pubkey, None)`), derived from the signer's key rather than trusting forgeable PSBT metadata. This preserves the existing single-key "change back to self" semantic (a real change output pays exactly that script) and does not affect signing (`should_sign_input` inspects input metadata, not output `is_change`).

## Test plan
- keep-bitcoin: new unit test `change_is_the_signers_own_key_path_output_not_forged_metadata` (own key-path output is change; an attacker output with the signer's key forged into `tap_internal_key` is not). `cargo test -p keep-bitcoin --lib`: `99 passed`.
- keep-agent: new e2e test `mcp_sign_bitcoin_psbt_rejects_forged_change_paying_a_non_allowlisted_address` (forged change to a non-allowlisted address is refused through the tool arm). `cargo test -p keep-agent --features mcp --lib`: `19 passed`.
- `cargo clippy` (both crates, mcp feature) clean; `cargo fmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bitcoin transaction validation to prevent forged PSBT metadata from misidentifying attacker-controlled outputs as change.
  * Added safeguards ensuring only outputs that actually match the signer’s derived address are treated as change.
  * Added end-to-end coverage confirming unauthorized destinations are rejected with a clear error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->