### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,14 @@ jobs:
   deny:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
 
   lint:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft != true && github.event_name != 'schedule'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install dependencies
         run: |
           # GitHub-hosted runners preload third-party apt repos (Microsoft, Google)
@@ -36,7 +36,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo fmt -- --check
       - run: cargo clippy -- -D warnings
       # keep-agent-py and keep-agent-ts are excluded from the workspace (cdylib
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest", "macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install dependencies (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -69,7 +69,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: xcode-select --install || true
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.os }}
       - run: cargo build --release
@@ -96,9 +96,9 @@ jobs:
     runs-on: windows-latest
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: windows-latest
       - run: cargo build --release
@@ -120,7 +120,7 @@ jobs:
       CARGO_NDK_VERSION: "4.1.2"
       ANDROID_TARGET: aarch64-linux-android
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install dependencies
         run: |
           # GitHub-hosted runners preload third-party apt repos (Microsoft, Google)
@@ -131,11 +131,11 @@ jobs:
           # aws-lc-sys (via rustls) compiles bundled C through the NDK's cmake
           # toolchain, which only reliably supports the Ninja generator.
           sudo apt-get install -y ninja-build
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: temurin
           java-version: "21"
-      - uses: android-actions/setup-android@v4
+      - uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
       - name: Install Android NDK
         run: sdkmanager --install "ndk;$NDK_VERSION"
       # rust-toolchain.toml pins the channel, so the Android target has to be added
@@ -144,10 +144,10 @@ jobs:
         with:
           toolchain: "1.89.0"
           targets: aarch64-linux-android
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: android
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2
         with:
           tool: cargo-ndk@${{ env.CARGO_NDK_VERSION }}
       - name: Cross-compile keep-mobile for Android
@@ -174,7 +174,7 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install dependencies
         run: |
           # GitHub-hosted runners preload third-party apt repos (Microsoft, Google)
@@ -186,7 +186,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.89"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: msrv
       - run: cargo check --all-targets --features testing
@@ -195,7 +195,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Build twice and compare
         run: |
           docker build -f Dockerfile.reproducible -o type=local,dest=./dist1 .
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Build Debian packages
         run: docker build -f contrib/debian/Dockerfile -o type=local,dest=./dist .
       - name: Check package metadata
@@ -250,7 +250,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft != true
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install dependencies
         run: |
           # GitHub-hosted runners preload third-party apt repos (Microsoft, Google)

--- a/.github/workflows/property-tests.yml
+++ b/.github/workflows/property-tests.yml
@@ -7,10 +7,10 @@ jobs:
   property-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config libssl-dev libudev-dev
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Run property tests (keep-core)
         run: cargo test -p keep-core --features testing --test property_tests
       - name: Run property tests (keep-frost-net)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Build reproducible binary
         run: docker build -f Dockerfile.reproducible -o type=local,dest=./dist .
       - name: Rename binaries
@@ -20,7 +20,7 @@ jobs:
           mv dist/keep keep-linux-x86_64
           mv dist/keep-desktop keep-desktop-linux-x86_64
           mv dist/keep-web keep-web-linux-x86_64
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: linux
           path: |
@@ -31,7 +31,7 @@ jobs:
   build-deb:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
       # The package version comes from Cargo.toml while the release comes from
@@ -49,7 +49,7 @@ jobs:
           docker build -f contrib/debian/Dockerfile \
             --build-arg SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)" \
             -o type=local,dest=./dist .
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: debian
           path: dist/*.deb
@@ -58,15 +58,15 @@ jobs:
   build-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - run: xcode-select --install || true
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo build --release --locked
       - run: |
           mv target/release/keep keep-macos-x86_64
           mv target/release/keep-desktop keep-desktop-macos-x86_64
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: macos
           path: |
@@ -76,19 +76,19 @@ jobs:
   build-macos-arm:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - run: xcode-select --install || true
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: macos-arm
       - run: cargo build --release --locked --target aarch64-apple-darwin
       - run: |
           mv target/aarch64-apple-darwin/release/keep keep-macos-aarch64
           mv target/aarch64-apple-darwin/release/keep-desktop keep-desktop-macos-aarch64
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: macos-arm
           path: |
@@ -98,14 +98,14 @@ jobs:
   build-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo build --release --locked
       - run: |
           mv target/release/keep.exe keep-windows-x86_64.exe
           mv target/release/keep-desktop.exe keep-desktop-windows-x86_64.exe
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: windows
           path: |
@@ -118,7 +118,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
           merge-multiple: true
@@ -127,7 +127,7 @@ jobs:
           cd artifacts
           sha256sum * > SHA256SUMS
       - name: Create release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           files: artifacts/*
           generate_release_notes: true


### PR DESCRIPTION
## Summary
Pins the third-party GitHub Actions used across the CI, release, and property-test workflows to full commit SHAs (35 references, 9 distinct actions), keeping the human-readable tag as a trailing comment. A mutable tag like `@v7` lets whoever can move that tag (a compromised or malicious maintainer, or a repo takeover) run arbitrary code in the workflow, which for these workflows has repository and release-publishing privileges (`softprops/action-gh-release`, `actions/upload-artifact`) and secret access. A SHA cannot be moved, so the exact reviewed action version is what runs.

Each SHA was resolved from the GitHub API for the currently-referenced tag:
`actions/checkout@v7`, `actions/download-artifact@v8`, `actions/setup-java@v5`, `actions/upload-artifact@v7`, `android-actions/setup-android@v4`, `EmbarkStudios/cargo-deny-action@v2`, `softprops/action-gh-release@v3`, `Swatinem/rust-cache@v2`, `taiki-e/install-action@v2`.

`dtolnay/rust-toolchain` is intentionally left for a separate change: it selects the toolchain from the git ref name, so a bare SHA pin needs an explicit `with: toolchain:` input added on the `@stable` usages (a functional change, not a mechanical pin). Tracked as a follow-up.

## Test plan
- All three workflow files parse as valid YAML.
- CI on this PR runs every pinned action; green confirms each SHA resolves to a working action version (checkout, cargo-deny, rust-cache, setup-android/java, install-action all execute).