### PR TITLE
ci: pin release Dockerfile base images by digest

### DIFF
--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: © 2026 PrivKey LLC
 # SPDX-License-Identifier: MIT
 
-FROM rust:1.89.0-slim-bookworm AS builder
+# Pinned by digest (not just tag) so the build stays reproducible over time and
+# a moved tag cannot redirect it to a different base. Keep this digest in step
+# with contrib/debian/Dockerfile, which compiles the same binaries and must stay
+# bit-identical.
+FROM rust:1.89.0-slim-bookworm@sha256:d7fc7de78bb8c1469933aeecbf801314d30d7d6e9f0578bba4cfa285bfa37fe6 AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libudev-dev \

--- a/contrib/debian/Dockerfile
+++ b/contrib/debian/Dockerfile
@@ -12,7 +12,9 @@
 # Building on bookworm also holds the dependency floor low enough to install on
 # Debian 12 and Ubuntu 22.04. A newer base silently raises it.
 
-FROM rust:1.89.0-slim-bookworm AS rust-builder
+# Pinned by digest so a moved tag cannot redirect the release build. Keep this
+# digest in step with Dockerfile.reproducible (same base, bit-identical binaries).
+FROM rust:1.89.0-slim-bookworm@sha256:d7fc7de78bb8c1469933aeecbf801314d30d7d6e9f0578bba4cfa285bfa37fe6 AS rust-builder
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libudev-dev \
     libgtk-3-dev \
@@ -46,12 +48,12 @@ RUN cargo build --release --locked
 # Build the admin SPA. --ignore-scripts keeps dependency lifecycle hooks out of
 # the release pipeline: this bundle is what an operator reads when deciding
 # whether to approve a signature.
-FROM node:20-bookworm-slim AS ui-builder
+FROM node:20-bookworm-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0 AS ui-builder
 WORKDIR /ui
 COPY keep-web/ui/ ./
 RUN npm ci --ignore-scripts && npm run build
 
-FROM debian:bookworm-slim AS packager
+FROM debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818 AS packager
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dpkg-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
The release build pins its base images by tag (`rust:1.89.0-slim-bookworm`, `node:20-bookworm-slim`, `debian:bookworm-slim`), so whoever can move a tag can redirect the build to a different base image. This is the supply-chain equivalent of an unpinned action: the release pipeline compiles the signing binaries and builds the admin SPA an operator reads before approving a signature.

Pin all three base images by digest (keeping the tag for readability), resolved from the registry for the current tags:
- `rust:1.89.0-slim-bookworm@sha256:d7fc7de7…`
- `node:20-bookworm-slim@sha256:2cf067cf…`
- `debian:bookworm-slim@sha256:7b140f37…`

The rust base is pinned to the **same digest** in both `contrib/debian/Dockerfile` and `Dockerfile.reproducible`, preserving the bit-identical coupling those two files depend on (one SHA256SUMS describes both), and additionally making the reproducible build robust to base-tag drift over time.

The prior half of this hardening, `npm ci --ignore-scripts`, is already in place at `contrib/debian/Dockerfile`.

## Test plan
- A digest is the tag's exact current image, so build behavior is unchanged; the change is the `FROM` reference only.
- Verified each digest resolves and pulls from the registry (`docker buildx imagetools inspect` + `docker pull …@sha256:…`).
- `docker build --check` passes for both Dockerfiles (the pinned `FROM`s parse).
- The full builds run in the push-only `debian` and `reproducible` CI jobs on the merge to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build reproducibility by pinning container base images to specific SHA256 digests.
  * Aligned image versions across reproducible and Debian packaging builds.
  * Ensured future builds consistently use the same verified base images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
