### PR TITLE
keep-mobile: align NIP-44 v3 method strings with the ecosystem convention

### DIFF
--- a/keep-mobile/src/audit.rs
+++ b/keep-mobile/src/audit.rs
@@ -391,8 +391,8 @@ impl std::fmt::Display for SigningRequestType {
             Self::KillSwitch => write!(f, "kill_switch"),
             Self::ExportNcryptsec => write!(f, "export_ncryptsec"),
             Self::ExportShare => write!(f, "export_share"),
-            Self::Nip44V3Encrypt => write!(f, "nip44_v3_encrypt"),
-            Self::Nip44V3Decrypt => write!(f, "nip44_v3_decrypt"),
+            Self::Nip44V3Encrypt => write!(f, "nip44v3_encrypt"),
+            Self::Nip44V3Decrypt => write!(f, "nip44v3_decrypt"),
         }
     }
 }

--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -1011,8 +1011,8 @@ fn parse_request_type(value: &str) -> Result<Nip55RequestType, KeepMobileError> 
         // intent-URI path still fails closed at dispatch because it cannot supply the
         // required kind/scope; this only makes v3 routable via a directly-constructed
         // request and pre-authorizable in the declared-permissions array.
-        "nip44_v3_encrypt" => Ok(Nip55RequestType::Nip44V3Encrypt),
-        "nip44_v3_decrypt" => Ok(Nip55RequestType::Nip44V3Decrypt),
+        "nip44v3_encrypt" => Ok(Nip55RequestType::Nip44V3Encrypt),
+        "nip44v3_decrypt" => Ok(Nip55RequestType::Nip44V3Decrypt),
         "decrypt_zap_event" => Ok(Nip55RequestType::DecryptZapEvent),
         _ => Err(KeepMobileError::InvalidSession),
     }
@@ -1245,29 +1245,29 @@ mod tests {
     #[test]
     fn parse_request_type_maps_v3_to_distinct_types() {
         assert_eq!(
-            parse_request_type("nip44_v3_encrypt").unwrap(),
+            parse_request_type("nip44v3_encrypt").unwrap(),
             Nip55RequestType::Nip44V3Encrypt
         );
         assert_eq!(
-            parse_request_type("nip44_v3_decrypt").unwrap(),
+            parse_request_type("nip44v3_decrypt").unwrap(),
             Nip55RequestType::Nip44V3Decrypt
         );
         // Distinct from v2, so a v2 grant never covers v3.
         assert_ne!(
-            parse_request_type("nip44_v3_encrypt").unwrap(),
+            parse_request_type("nip44v3_encrypt").unwrap(),
             Nip55RequestType::Nip44Encrypt
         );
     }
 
     #[test]
     fn parse_query_params_carries_v3_kind_and_scope() {
-        let p = parse_query_params("type=nip44_v3_encrypt&kind=4&scope=dm").unwrap();
+        let p = parse_query_params("type=nip44v3_encrypt&kind=4&scope=dm").unwrap();
         assert_eq!(p.request_type, Nip55RequestType::Nip44V3Encrypt);
         assert_eq!(p.kind, Some(4));
         assert_eq!(p.scope, Some("dm".to_string()));
         // A non-numeric kind stays None, so the v3 dispatch fails closed rather
         // than defaulting the context.
-        let bad = parse_query_params("type=nip44_v3_encrypt&kind=notanumber&scope=dm").unwrap();
+        let bad = parse_query_params("type=nip44v3_encrypt&kind=notanumber&scope=dm").unwrap();
         assert_eq!(bad.kind, None);
     }
 


### PR DESCRIPTION
## Summary

The NIP-44 v3 request-type strings exposed over the mobile FFI used `nip44_v3_encrypt` / `nip44_v3_decrypt` (underscore before `v3`). The established convention used by the reference signer and the NIP-44 v3 draft is `nip44v3_encrypt` / `nip44v3_decrypt` (no underscore before `v3`, matching the existing `nip44_encrypt` / `nip44_decrypt` v2 pair). A client sending the ecosystem string would have been rejected by `parse_request_type`, so v3 was not interoperable over the intent-URI and declared-permissions surfaces.

This aligns the wire-facing strings to the ecosystem convention:

- `parse_request_type` now accepts `nip44v3_encrypt` / `nip44v3_decrypt`. This is the single parser used for the intent-URI `type` query parameter and for the NIP-55 declared-permissions array, so both routes are fixed at once.
- The `SigningRequestType` `Display` (audit-log text) emits the same strings, keeping the logged method name consistent with the wire name.

Internal Rust identifiers (`handle_nip44_v3_encrypt`, `nip44_v3_seal`, `nip44_v3_open`) are unchanged; they are not protocol-facing. The `Nip55RequestType` enum variants and the permission keys (keyed by variant, not string) are unchanged, so v3 remains a distinct grantable permission from v2. NIP-44 v3 is a draft not yet in the official NIPs repository, so there is no spec string to diverge from.

## Test plan

- `cargo test -p keep-mobile` — 270 passed, 0 failed. Updated the v3 `parse_request_type` and `parse_query_params` unit tests to assert the new strings.