### PR TITLE
keep-mobile: require a kind for NIP-44 v3 declared permissions

### DIFF
--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -126,14 +126,21 @@ pub fn nip55_parse_permissions(json: Option<String>) -> Vec<Nip55DeclaredPermiss
         if request_type == Nip55RequestType::GetPublicKey {
             continue;
         }
-        let kind = if request_type == Nip55RequestType::SignEvent {
+        let kind = if matches!(
+            request_type,
+            Nip55RequestType::SignEvent
+                | Nip55RequestType::Nip44V3Encrypt
+                | Nip55RequestType::Nip44V3Decrypt
+        ) {
             let Some(kind) = entry
                 .get("kind")
                 .and_then(|k| k.as_i64())
                 .and_then(|k| i32::try_from(k).ok())
                 .filter(|k| (0..=MAX_EVENT_KIND).contains(k))
             else {
-                // A sign_event permission with no (valid) kind cannot be granted.
+                // sign_event and NIP-44 v3 permissions are kind-scoped: an entry with
+                // no (valid) kind cannot be granted, so it is dropped rather than
+                // becoming a blanket all-kinds grant.
                 continue;
             };
             Some(kind)
@@ -1537,6 +1544,21 @@ mod tests {
             vec![Nip55DeclaredPermission {
                 request_type: Nip55RequestType::Nip04Encrypt,
                 kind: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_permissions_v3_requires_a_kind() {
+        // A kind-less v3 declared permission is dropped (never an all-kinds grant),
+        // mirroring sign_event; a v3 entry with a valid kind is kept, kind-scoped.
+        let json = r#"[{"type":"nip44v3_decrypt"},{"type":"nip44v3_encrypt","kind":4}]"#;
+        let perms = nip55_parse_permissions(Some(json.into()));
+        assert_eq!(
+            perms,
+            vec![Nip55DeclaredPermission {
+                request_type: Nip55RequestType::Nip44V3Encrypt,
+                kind: Some(4),
             }]
         );
     }


### PR DESCRIPTION
## Summary

The NIP-55 declared-permissions array (sent on a `get_public_key` connect to pre-authorize methods) mapped a v3 entry with no `kind` to an all-kinds grant. Because NIP-44 v3 authorizations are otherwise strictly kind-scoped, a client could declare `[{"type":"nip44v3_decrypt"}]`, and once approved with a remembered duration it would auto-authorize v3 decrypt requests of any kind, defeating the per-kind isolation the interactive path enforces.

`sign_event` already drops a kind-less declared permission for the same reason ("a sign grant must name a kind"). This applies the identical rule to the two v3 request types: a declared v3 permission without a valid kind (0..=65535) is dropped rather than granted. A v3 entry with a valid kind is kept and remains kind-scoped, matching how a v3 request is authorized at dispatch time.

Found by security review of the keep-android v3 wiring.

## Test plan

- `cargo test -p keep-mobile parse_permissions` — 11 passed, 0 failed. Added `parse_permissions_v3_requires_a_kind` asserting a kind-less v3 entry is dropped while a valid-kind v3 entry is kept.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission handling for NIP-44 v3 encryption and decryption requests.
  * Invalid or incomplete permissions are now rejected instead of being applied broadly.
  * Valid permissions are restricted to the specified event kind.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->