### PR TITLE
keep-mobile: make the stricter Basic sign-policy tier live in the decision path

### DIFF
--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -42,9 +42,10 @@ pub use nip55_decision::{
 pub use policy::{PolicyDecision, PolicyInfo, TransactionContext};
 pub use psbt::{PsbtInfo, PsbtInputSighash, PsbtOutputInfo, PsbtParser};
 pub use signing_policy::{
-    assess_signing_risk, evaluate_sign_policy, is_sensitive_kind, sensitive_kind_warning,
-    AutoSignDecision, PolicyMode, SignPolicyEvaluation, SigningAuthLevel, SigningRateLimiter,
-    SigningRequestContext, SigningRiskAssessment, SigningRiskFactor, UsageStats,
+    assess_signing_risk, evaluate_sign_policy, evaluate_sign_policy_selection, is_sensitive_kind,
+    sensitive_kind_warning, AutoSignDecision, PolicyMode, SignPolicyEvaluation,
+    SignPolicySelection, SigningAuthLevel, SigningRateLimiter, SigningRequestContext,
+    SigningRiskAssessment, SigningRiskFactor, UsageStats,
 };
 pub use storage::{SecureStorage, ShareInfo, ShareMetadataInfo, StoredShareInfo};
 pub use types::{

--- a/keep-mobile/src/nip55_decision.rs
+++ b/keep-mobile/src/nip55_decision.rs
@@ -758,6 +758,43 @@ mod tests {
         assert!(is_require_ui(&evaluate_nip55_request(i)));
     }
 
+    // Gate 6 must score against `inputs.current_hour` (the caller's LOCAL hour),
+    // not any clock of its own. A new app (+15) sits just under BASIC_RISK_THRESHOLD
+    // (20) at a normal hour, so the extra UnusualTime (+10) at an unusual hour is
+    // what tips it to the UI. Pinning both ends here means substituting a fixed
+    // hour, or reintroducing a wall-clock read, fails this test rather than
+    // silently widening the Basic band at night.
+    fn new_app_basic_base() -> Nip55DecisionInputs {
+        let mut i = base();
+        i.is_opted_in = true;
+        i.policy_selection = SignPolicySelection::Basic;
+        i.app_age_ms = Some(DAY_MS / 2);
+        i.opt_in_rate_check = Some(allowed());
+        i
+    }
+
+    #[test]
+    fn basic_auto_approves_a_new_app_at_a_normal_local_hour() {
+        let mut i = new_app_basic_base();
+        i.current_hour = 12;
+        assert_eq!(evaluate_nip55_request(i), Nip55Outcome::AutoApprove);
+    }
+
+    #[test]
+    fn basic_falls_to_ui_for_the_same_request_at_an_unusual_local_hour() {
+        let mut i = new_app_basic_base();
+        i.current_hour = 3;
+        match evaluate_nip55_request(i) {
+            Nip55Outcome::RequireUi { risk, .. } => {
+                assert_eq!(
+                    risk.score, 25,
+                    "the unusual local hour must add UnusualTime on top of NewApp"
+                );
+            }
+            other => panic!("expected RequireUi at an unusual local hour, got {other:?}"),
+        }
+    }
+
     #[test]
     fn low_risk_auto_approves_under_both_basic_and_auto() {
         for selection in [SignPolicySelection::Basic, SignPolicySelection::Auto] {

--- a/keep-mobile/src/nip55_decision.rs
+++ b/keep-mobile/src/nip55_decision.rs
@@ -9,7 +9,7 @@
 //! DENY-wins rules across two files -- a divergence risk in security-critical
 //! signing. This module hoists that decision into Rust so both paths share one
 //! source of truth. It composes the existing policy primitives
-//! (`nip55_relay_auth_gate`, `evaluate_sign_policy`, `nip55_resolve_decision`,
+//! (`nip55_relay_auth_gate`, `evaluate_sign_policy_selection`, `nip55_resolve_decision`,
 //! `assess_signing_risk`) in the exact gate order:
 //!
 //!   caller-verified -> kill-switch -> lock -> front-door rate limit ->
@@ -29,8 +29,8 @@ use crate::nip55::{
 };
 use crate::nip55_policy::{nip55_resolve_decision, Nip55PermissionDecision, Nip55StoredPermission};
 use crate::signing_policy::{
-    assess_signing_risk, evaluate_sign_policy, AutoSignDecision, PolicyMode, SignPolicyEvaluation,
-    SigningAuthLevel, SigningRequestContext, SigningRiskAssessment,
+    assess_signing_risk, evaluate_sign_policy_selection, AutoSignDecision, SignPolicyEvaluation,
+    SignPolicySelection, SigningAuthLevel, SigningRequestContext, SigningRiskAssessment,
 };
 
 const KIND_NIP42_AUTH: u32 = 22242;
@@ -47,9 +47,9 @@ pub enum Nip55VelocityCheck {
 }
 
 // When a caller is not opted in to auto-signing, the sign-policy gate is fed a
-// synthetic "allowed" rate-check so `evaluate_sign_policy` runs; the not-opted-in
-// denial itself happens inside `evaluate_sign_policy` via its `!is_opted_in`
-// check. These limits are cosmetic (only the variant and `recent_count` reach the
+// synthetic "allowed" rate-check so `evaluate_sign_policy_selection` runs; the
+// not-opted-in denial itself happens inside it via its `!is_opted_in` check.
+// These limits are cosmetic (only the variant and `recent_count` reach the
 // decision) and mirror the Android `VelocityConfig` defaults.
 const NON_OPT_IN_HOURLY_LIMIT: u32 = 1000;
 const NON_OPT_IN_DAILY_LIMIT: u32 = 5000;
@@ -88,9 +88,11 @@ pub struct Nip55DecisionInputs {
     /// Whether reading the whitelist failed; `true` forces an auto-reject.
     pub relay_whitelist_read_failed: bool,
 
-    /// The resolved sign policy (per-app override -> global -> Manual default),
-    /// mapped to Auto/Manual by the caller.
-    pub policy_mode: PolicyMode,
+    /// The user's resolved 3-value sign-policy selection (per-app override ->
+    /// global -> Manual default): Manual / Basic / Auto. `Basic` is a stricter
+    /// auto-approval tier than `Auto`, auto-approving only requests the risk model
+    /// rates as needing no extra authentication.
+    pub policy_selection: SignPolicySelection,
     /// Whether the caller is opted in to auto-signing.
     pub is_opted_in: bool,
     /// The opt-in rate-limiter result. `None` (limiter unavailable, or its check
@@ -264,21 +266,19 @@ pub fn evaluate_nip55_request(inputs: Nip55DecisionInputs) -> Nip55Outcome {
 
     // Gate 6: sign policy. When opted in, use the limiter result (an unavailable
     // limiter fails open to the UI, i.e. falls through to gate 7). When not opted
-    // in, feed a synthetic "allowed" so evaluate_sign_policy runs and applies its
-    // own not-opted-in denial.
+    // in, feed a synthetic "allowed" so evaluate_sign_policy_selection runs and
+    // applies its own not-opted-in denial.
     //
-    // This path takes the 2-value `PolicyMode`, so `Basic` and `Auto` behave
-    // identically here (both `PolicyMode::Auto`). The stricter `Basic` tier
-    // (`evaluate_sign_policy_selection`) becomes live once `Nip55DecisionInputs`
-    // carries the 3-value `SignPolicySelection` instead of the collapsed mode --
-    // a breaking FFI input change gated on the client version bump (#716). Until
-    // then this is fail-safe: `Basic` is never looser than `Auto`.
+    // This path takes the user's 3-value `SignPolicySelection`, so each tier gets
+    // its own behavior: `Manual` never auto-approves, `Basic` auto-approves only
+    // below the stricter `BASIC_RISK_THRESHOLD`, and `Auto` auto-approves up to
+    // `RISK_ESCALATION_THRESHOLD`. `Basic` is therefore a strict subset of `Auto`.
     let (policy_result, recent_count) = if inputs.is_opted_in {
         match &inputs.opt_in_rate_check {
             None => (SignPolicyEvaluation::FallToUi, 0),
             Some(rate_check) => (
-                evaluate_sign_policy(
-                    inputs.policy_mode.clone(),
+                evaluate_sign_policy_selection(
+                    inputs.policy_selection,
                     ctx.clone(),
                     true,
                     rate_check.clone(),
@@ -295,7 +295,7 @@ pub fn evaluate_nip55_request(inputs: Nip55DecisionInputs) -> Nip55Outcome {
             daily_limit: NON_OPT_IN_DAILY_LIMIT,
         };
         (
-            evaluate_sign_policy(inputs.policy_mode.clone(), ctx.clone(), false, fabricated),
+            evaluate_sign_policy_selection(inputs.policy_selection, ctx.clone(), false, fabricated),
             0,
         )
     };
@@ -384,7 +384,7 @@ mod tests {
             velocity_check: Nip55VelocityCheck::Allowed,
             relay_whitelist: vec![],
             relay_whitelist_read_failed: false,
-            policy_mode: PolicyMode::Manual,
+            policy_selection: SignPolicySelection::Manual,
             is_opted_in: false,
             opt_in_rate_check: None,
             has_signed_kind_before: true,
@@ -548,7 +548,7 @@ mod tests {
         i.event_json = relay_auth_event("relay.notallowed.com");
         i.relay_whitelist = vec!["relay.allowed.com".to_string()];
         i.is_opted_in = true;
-        i.policy_mode = PolicyMode::Auto;
+        i.policy_selection = SignPolicySelection::Auto;
         i.opt_in_rate_check = Some(allowed());
         assert_eq!(
             reject_reason(&evaluate_nip55_request(i)),
@@ -588,7 +588,7 @@ mod tests {
             .to_string();
         i.relay_whitelist = vec!["relay.allowed.com".to_string()];
         i.is_opted_in = true;
-        i.policy_mode = PolicyMode::Auto;
+        i.policy_selection = SignPolicySelection::Auto;
         i.opt_in_rate_check = Some(allowed());
         assert_eq!(
             reject_reason(&evaluate_nip55_request(i)),
@@ -634,7 +634,7 @@ mod tests {
         let mut i = base();
         i.event_json = r#"{"kind":4}"#.to_string();
         i.is_opted_in = true;
-        i.policy_mode = PolicyMode::Auto;
+        i.policy_selection = SignPolicySelection::Auto;
         i.opt_in_rate_check = Some(allowed());
         assert!(is_require_ui(&evaluate_nip55_request(i)));
     }
@@ -644,7 +644,7 @@ mod tests {
     fn opted_in_auto_policy_benign_auto_approves() {
         let mut i = base();
         i.is_opted_in = true;
-        i.policy_mode = PolicyMode::Auto;
+        i.policy_selection = SignPolicySelection::Auto;
         i.opt_in_rate_check = Some(allowed());
         assert_eq!(evaluate_nip55_request(i), Nip55Outcome::AutoApprove);
     }
@@ -653,7 +653,7 @@ mod tests {
     fn not_opted_in_auto_policy_never_auto_approves() {
         let mut i = base();
         i.is_opted_in = false;
-        i.policy_mode = PolicyMode::Auto;
+        i.policy_selection = SignPolicySelection::Auto;
         // Falls through to gate 7; no stored grant -> RequireUi (not AutoApprove).
         assert!(is_require_ui(&evaluate_nip55_request(i)));
     }
@@ -662,7 +662,7 @@ mod tests {
     fn opted_in_sensitive_kind_falls_to_ui() {
         let mut i = base();
         i.is_opted_in = true;
-        i.policy_mode = PolicyMode::Auto;
+        i.policy_selection = SignPolicySelection::Auto;
         i.event_json = r#"{"kind":4}"#.to_string(); // sensitive (NIP-04 DM)
         i.opt_in_rate_check = Some(allowed());
         assert!(is_require_ui(&evaluate_nip55_request(i)));
@@ -672,7 +672,7 @@ mod tests {
     fn opted_in_limiter_unavailable_falls_to_ui() {
         let mut i = base();
         i.is_opted_in = true;
-        i.policy_mode = PolicyMode::Auto;
+        i.policy_selection = SignPolicySelection::Auto;
         i.opt_in_rate_check = None;
         assert!(is_require_ui(&evaluate_nip55_request(i)));
     }
@@ -681,7 +681,7 @@ mod tests {
     fn opted_in_rate_limited_falls_to_ui() {
         let mut i = base();
         i.is_opted_in = true;
-        i.policy_mode = PolicyMode::Auto;
+        i.policy_selection = SignPolicySelection::Auto;
         i.opt_in_rate_check = Some(AutoSignDecision::HourlyLimitExceeded);
         assert!(is_require_ui(&evaluate_nip55_request(i)));
     }
@@ -692,10 +692,75 @@ mod tests {
         // standing ALLOW grant.
         let mut i = base();
         i.is_opted_in = true;
-        i.policy_mode = PolicyMode::Auto;
+        i.policy_selection = SignPolicySelection::Auto;
         i.opt_in_rate_check = None;
         i.stored_exact_permission = Some(perm("allow"));
         assert_eq!(evaluate_nip55_request(i), Nip55Outcome::AutoApprove);
+    }
+
+    // Gate 6: the Basic tier is a strictly stricter auto-approval band than Auto.
+    // A benign SignEvent from an app of unknown age (+5) inside a high-frequency
+    // burst (+20) scores 25, between BASIC_RISK_THRESHOLD (20) and
+    // RISK_ESCALATION_THRESHOLD (40).
+    fn mid_band_risk_base() -> Nip55DecisionInputs {
+        let mut i = base();
+        i.is_opted_in = true;
+        i.app_age_ms = None;
+        i.opt_in_rate_check = Some(AutoSignDecision::Allowed {
+            hourly_count: 12,
+            daily_count: 12,
+            recent_count: 11,
+            hourly_limit: 100,
+            daily_limit: 500,
+        });
+        i
+    }
+
+    #[test]
+    fn mid_band_risk_auto_approves_under_auto() {
+        let mut i = mid_band_risk_base();
+        i.policy_selection = SignPolicySelection::Auto;
+        assert_eq!(evaluate_nip55_request(i), Nip55Outcome::AutoApprove);
+    }
+
+    #[test]
+    fn mid_band_risk_falls_to_ui_under_basic() {
+        let mut i = mid_band_risk_base();
+        i.policy_selection = SignPolicySelection::Basic;
+        match evaluate_nip55_request(i) {
+            Nip55Outcome::RequireUi { risk, .. } => {
+                assert!(
+                    risk.score > 20 && risk.score < 40,
+                    "expected a score between the Basic and Auto thresholds, got {}",
+                    risk.score
+                );
+            }
+            other => panic!("expected RequireUi, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn manual_policy_never_auto_approves() {
+        let mut i = base();
+        i.is_opted_in = true;
+        i.policy_selection = SignPolicySelection::Manual;
+        i.opt_in_rate_check = Some(allowed());
+        assert!(is_require_ui(&evaluate_nip55_request(i)));
+    }
+
+    #[test]
+    fn low_risk_auto_approves_under_both_basic_and_auto() {
+        for selection in [SignPolicySelection::Basic, SignPolicySelection::Auto] {
+            let mut i = base();
+            i.is_opted_in = true;
+            i.policy_selection = selection;
+            i.opt_in_rate_check = Some(allowed());
+            assert_eq!(
+                evaluate_nip55_request(i),
+                Nip55Outcome::AutoApprove,
+                "{selection:?} should auto-approve a low-risk request"
+            );
+        }
     }
 
     // Gate 7: expiry, lookup, standing decision.
@@ -808,7 +873,7 @@ mod tests {
         let mut i = base();
         i.request_type = Nip55RequestType::Nip44Encrypt;
         i.is_opted_in = true;
-        i.policy_mode = PolicyMode::Auto;
+        i.policy_selection = SignPolicySelection::Auto;
         i.opt_in_rate_check = Some(allowed());
         match evaluate_nip55_request(i) {
             Nip55Outcome::RequireUi { risk, .. } => {

--- a/keep-mobile/src/nip55_decision.rs
+++ b/keep-mobile/src/nip55_decision.rs
@@ -102,7 +102,9 @@ pub struct Nip55DecisionInputs {
     pub has_signed_kind_before: bool,
     /// Age of the app's first grant, if known.
     pub app_age_ms: Option<u64>,
-    /// Current local hour (0-23) for risk scoring.
+    /// The caller's current LOCAL hour (0-23) for risk scoring. It drives both
+    /// the gate-6 auto-approve decision and the gate-7 risk shown in the prompt,
+    /// so the score that gates the decision cannot diverge from the displayed one.
     pub current_hour: u32,
 
     /// Whether the app grant is expired: `None` (a lookup timeout) and
@@ -271,8 +273,10 @@ pub fn evaluate_nip55_request(inputs: Nip55DecisionInputs) -> Nip55Outcome {
     //
     // This path takes the user's 3-value `SignPolicySelection`, so each tier gets
     // its own behavior: `Manual` never auto-approves, `Basic` auto-approves only
-    // below the stricter `BASIC_RISK_THRESHOLD`, and `Auto` auto-approves up to
-    // `RISK_ESCALATION_THRESHOLD`. `Basic` is therefore a strict subset of `Auto`.
+    // below the stricter `BASIC_RISK_THRESHOLD`, and `Auto` auto-approves only
+    // below `RISK_ESCALATION_THRESHOLD`. `Basic` is therefore a strict subset of
+    // `Auto`. Both tiers score against `inputs.current_hour`, the same local hour
+    // gate 7 displays.
     let (policy_result, recent_count) = if inputs.is_opted_in {
         match &inputs.opt_in_rate_check {
             None => (SignPolicyEvaluation::FallToUi, 0),
@@ -282,6 +286,7 @@ pub fn evaluate_nip55_request(inputs: Nip55DecisionInputs) -> Nip55Outcome {
                     ctx.clone(),
                     true,
                     rate_check.clone(),
+                    inputs.current_hour,
                 ),
                 recent_count_of(rate_check),
             ),
@@ -295,7 +300,13 @@ pub fn evaluate_nip55_request(inputs: Nip55DecisionInputs) -> Nip55Outcome {
             daily_limit: NON_OPT_IN_DAILY_LIMIT,
         };
         (
-            evaluate_sign_policy_selection(inputs.policy_selection, ctx.clone(), false, fabricated),
+            evaluate_sign_policy_selection(
+                inputs.policy_selection,
+                ctx.clone(),
+                false,
+                fabricated,
+                inputs.current_hour,
+            ),
             0,
         )
     };
@@ -700,8 +711,8 @@ mod tests {
 
     // Gate 6: the Basic tier is a strictly stricter auto-approval band than Auto.
     // A benign SignEvent from an app of unknown age (+5) inside a high-frequency
-    // burst (+20) scores 25, between BASIC_RISK_THRESHOLD (20) and
-    // RISK_ESCALATION_THRESHOLD (40).
+    // burst (+20) scores exactly 25 at the fixture's normal local hour (12),
+    // between BASIC_RISK_THRESHOLD (20) and RISK_ESCALATION_THRESHOLD (40).
     fn mid_band_risk_base() -> Nip55DecisionInputs {
         let mut i = base();
         i.is_opted_in = true;
@@ -729,10 +740,9 @@ mod tests {
         i.policy_selection = SignPolicySelection::Basic;
         match evaluate_nip55_request(i) {
             Nip55Outcome::RequireUi { risk, .. } => {
-                assert!(
-                    risk.score > 20 && risk.score < 40,
-                    "expected a score between the Basic and Auto thresholds, got {}",
-                    risk.score
+                assert_eq!(
+                    risk.score, 25,
+                    "expected the deterministic mid-band score between the Basic and Auto thresholds"
                 );
             }
             other => panic!("expected RequireUi, got {other:?}"),

--- a/keep-mobile/src/signing_policy.rs
+++ b/keep-mobile/src/signing_policy.rs
@@ -4,7 +4,6 @@
 use crate::nip55::Nip55RequestType;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 const HIGH_FREQUENCY_THRESHOLD: u32 = 10;
 const NEW_APP_THRESHOLD_MS: u64 = 24 * 60 * 60 * 1000;
@@ -173,8 +172,8 @@ fn app_override_key(package: &str) -> String {
 
 /// Core-owned store for the sign-policy selection, so the selection state and
 /// its override -> global -> Manual precedence live in one place rather than
-/// being reimplemented in each client (#716). Feeds the existing evaluation via
-/// [`SignPolicyStore::effective_policy_mode`].
+/// being reimplemented in each client (#716). Feeds the evaluation via
+/// [`SignPolicyStore::effective_policy`] + [`evaluate_sign_policy_selection`].
 #[derive(uniffi::Object)]
 pub struct SignPolicyStore {
     storage: Arc<dyn SignPolicySelectionStorage>,
@@ -230,8 +229,11 @@ impl SignPolicyStore {
             .unwrap_or_else(|| self.global_policy())
     }
 
-    /// The evaluation [`PolicyMode`] for a package, ready to feed the existing
-    /// `evaluate_sign_policy` / decision machinery.
+    /// Legacy bridge to the 2-value [`PolicyMode`], for callers still on the
+    /// 2-value [`evaluate_sign_policy`]. It collapses `Basic` onto
+    /// [`PolicyMode::Auto`], which silently re-disables the stricter `Basic` tier
+    /// -- do NOT route the decision path through it. Use [`Self::effective_policy`]
+    /// with [`evaluate_sign_policy_selection`] instead.
     pub fn effective_policy_mode(&self, package: String) -> PolicyMode {
         self.effective_policy(package).policy_mode()
     }
@@ -353,13 +355,6 @@ pub fn assess_signing_risk(
         factors,
         required_auth,
     }
-}
-
-fn now_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system clock before UNIX epoch")
-        .as_millis() as u64
 }
 
 const HOURLY_KEY_PREFIX: &str = "hourly_";
@@ -739,11 +734,16 @@ fn serialize_window(window: &UsageWindow, now_wall_ms: u64) -> String {
 /// it, and the assessed risk stays below `max_auto_score`; everything else falls
 /// to the UI. The only knob between the tiers is `max_auto_score`, so a stricter
 /// tier is a strict subset of a looser one.
+///
+/// `current_hour` is the caller's LOCAL hour (0-23), the same value fed to
+/// [`assess_signing_risk`] for display, so the score that gates this decision is
+/// the score the user is shown.
 fn evaluate_auto(
     ctx: SigningRequestContext,
     is_opted_in: bool,
     rate_check: AutoSignDecision,
     max_auto_score: u32,
+    current_hour: u32,
 ) -> SignPolicyEvaluation {
     if ctx.operation != Nip55RequestType::SignEvent {
         return SignPolicyEvaluation::FallToUi;
@@ -758,7 +758,6 @@ fn evaluate_auto(
         _ => 0,
     };
 
-    let current_hour = ((now_ms() / 1000 % 86400) / 3600) as u32;
     let risk = assess_signing_risk(ctx, recent_count, current_hour);
 
     if !is_opted_in || risk.score >= max_auto_score {
@@ -771,16 +770,29 @@ fn evaluate_auto(
     }
 }
 
+/// Evaluate a request against the legacy 2-value [`PolicyMode`].
+///
+/// `current_hour` is the caller's LOCAL hour (0-23), NOT a UTC hour, and it must
+/// be the same hour the caller passes to [`assess_signing_risk`] for the prompt.
+/// The `UnusualTime` risk factor is time-of-day sensitive, so a divergent hour
+/// would gate the decision on a different score than the one shown to the user.
 #[uniffi::export]
 pub fn evaluate_sign_policy(
     policy_mode: PolicyMode,
     ctx: SigningRequestContext,
     is_opted_in: bool,
     rate_check: AutoSignDecision,
+    current_hour: u32,
 ) -> SignPolicyEvaluation {
     match policy_mode {
         PolicyMode::Manual => SignPolicyEvaluation::FallToUi,
-        PolicyMode::Auto => evaluate_auto(ctx, is_opted_in, rate_check, RISK_ESCALATION_THRESHOLD),
+        PolicyMode::Auto => evaluate_auto(
+            ctx,
+            is_opted_in,
+            rate_check,
+            RISK_ESCALATION_THRESHOLD,
+            current_hour,
+        ),
     }
 }
 
@@ -797,19 +809,25 @@ pub fn evaluate_sign_policy(
 ///   the UI. This realizes the documented "Basic implies some prompting" without
 ///   ever adding a blind-approve mode: neither tier auto-approves a sensitive
 ///   kind, an encryption op, a rate-limited burst, or a high-risk request.
+///
+/// `current_hour` is the caller's LOCAL hour (0-23), NOT a UTC hour, and it must
+/// be the same hour the caller passes to [`assess_signing_risk`] for the prompt.
+/// The `UnusualTime` risk factor is time-of-day sensitive, so a divergent hour
+/// would gate the decision on a different score than the one shown to the user.
 #[uniffi::export]
 pub fn evaluate_sign_policy_selection(
     selection: SignPolicySelection,
     ctx: SigningRequestContext,
     is_opted_in: bool,
     rate_check: AutoSignDecision,
+    current_hour: u32,
 ) -> SignPolicyEvaluation {
     let max_auto_score = match selection {
         SignPolicySelection::Manual => return SignPolicyEvaluation::FallToUi,
         SignPolicySelection::Basic => BASIC_RISK_THRESHOLD,
         SignPolicySelection::Auto => RISK_ESCALATION_THRESHOLD,
     };
-    evaluate_auto(ctx, is_opted_in, rate_check, max_auto_score)
+    evaluate_auto(ctx, is_opted_in, rate_check, max_auto_score, current_hour)
 }
 
 #[cfg(test)]
@@ -1073,28 +1091,28 @@ mod tests {
     #[test]
     fn test_evaluate_sign_policy_manual() {
         let ctx = test_ctx(Nip55RequestType::SignEvent, None);
-        let result = evaluate_sign_policy(PolicyMode::Manual, ctx, false, allowed(0, 0));
+        let result = evaluate_sign_policy(PolicyMode::Manual, ctx, false, allowed(0, 0), 12);
         assert_eq!(result, SignPolicyEvaluation::FallToUi);
     }
 
     #[test]
     fn test_evaluate_sign_policy_auto_sensitive() {
         let ctx = test_ctx(Nip55RequestType::SignEvent, Some(4));
-        let result = evaluate_sign_policy(PolicyMode::Auto, ctx, true, allowed(1, 1));
+        let result = evaluate_sign_policy(PolicyMode::Auto, ctx, true, allowed(1, 1), 12);
         assert_eq!(result, SignPolicyEvaluation::FallToUi);
     }
 
     #[test]
     fn test_evaluate_sign_policy_auto_approved() {
         let ctx = test_ctx(Nip55RequestType::SignEvent, Some(1));
-        let result = evaluate_sign_policy(PolicyMode::Auto, ctx, true, allowed(1, 1));
+        let result = evaluate_sign_policy(PolicyMode::Auto, ctx, true, allowed(1, 1), 12);
         assert_eq!(result, SignPolicyEvaluation::AutoApprove);
     }
 
     #[test]
     fn test_evaluate_sign_policy_auto_not_opted_in() {
         let ctx = test_ctx(Nip55RequestType::SignEvent, Some(1));
-        let result = evaluate_sign_policy(PolicyMode::Auto, ctx, false, allowed(0, 0));
+        let result = evaluate_sign_policy(PolicyMode::Auto, ctx, false, allowed(0, 0), 12);
         assert_eq!(result, SignPolicyEvaluation::FallToUi);
     }
 
@@ -1106,6 +1124,7 @@ mod tests {
             ctx,
             true,
             AutoSignDecision::HourlyLimitExceeded,
+            12,
         );
         assert_eq!(result, SignPolicyEvaluation::FallToUi);
     }
@@ -1113,7 +1132,7 @@ mod tests {
     #[test]
     fn test_evaluate_sign_policy_encrypt_falls_to_ui() {
         let ctx = test_ctx(Nip55RequestType::Nip44Encrypt, None);
-        let result = evaluate_sign_policy(PolicyMode::Auto, ctx, true, allowed(1, 1));
+        let result = evaluate_sign_policy(PolicyMode::Auto, ctx, true, allowed(1, 1), 12);
         assert_eq!(result, SignPolicyEvaluation::FallToUi);
     }
 
@@ -1131,8 +1150,13 @@ mod tests {
     fn selection_manual_always_falls_to_ui() {
         // Even a zero-risk request prompts under Manual.
         let ctx = test_ctx(Nip55RequestType::SignEvent, Some(1));
-        let result =
-            evaluate_sign_policy_selection(SignPolicySelection::Manual, ctx, true, allowed(1, 1));
+        let result = evaluate_sign_policy_selection(
+            SignPolicySelection::Manual,
+            ctx,
+            true,
+            allowed(1, 1),
+            12,
+        );
         assert_eq!(result, SignPolicyEvaluation::FallToUi);
     }
 
@@ -1142,7 +1166,7 @@ mod tests {
         // below the None ceiling, so both tiers auto-approve it.
         for selection in [SignPolicySelection::Basic, SignPolicySelection::Auto] {
             let ctx = test_ctx(Nip55RequestType::SignEvent, Some(1));
-            let result = evaluate_sign_policy_selection(selection, ctx, true, allowed(1, 1));
+            let result = evaluate_sign_policy_selection(selection, ctx, true, allowed(1, 1), 12);
             assert_eq!(
                 result,
                 SignPolicyEvaluation::AutoApprove,
@@ -1161,6 +1185,7 @@ mod tests {
             test_ctx(Nip55RequestType::SignEvent, Some(1)),
             true,
             allowed_recent(HIGH_FREQUENCY_THRESHOLD + 1),
+            12,
         );
         assert_eq!(
             auto,
@@ -1173,6 +1198,7 @@ mod tests {
             test_ctx(Nip55RequestType::SignEvent, Some(1)),
             true,
             allowed_recent(HIGH_FREQUENCY_THRESHOLD + 1),
+            12,
         );
         assert_eq!(
             basic,
@@ -1186,7 +1212,7 @@ mod tests {
         // Neither tier auto-approves a sensitive kind (no blind-approve mode).
         for selection in [SignPolicySelection::Basic, SignPolicySelection::Auto] {
             let ctx = test_ctx(Nip55RequestType::SignEvent, Some(4));
-            let result = evaluate_sign_policy_selection(selection, ctx, true, allowed(1, 1));
+            let result = evaluate_sign_policy_selection(selection, ctx, true, allowed(1, 1), 12);
             assert_eq!(
                 result,
                 SignPolicyEvaluation::FallToUi,
@@ -1196,10 +1222,60 @@ mod tests {
     }
 
     #[test]
+    fn selection_uses_the_callers_local_hour_not_a_utc_clock() {
+        // A newly installed app (+15) is under the Basic ceiling (20) at a normal
+        // local hour, but the UnusualTime factor (+10) pushes it to 25 at 03:00
+        // local, crossing the ceiling. The evaluator must see the caller's local
+        // hour, otherwise a user in a non-UTC zone gets a silent auto-approval at
+        // a time the risk model rates as unusual.
+        let new_app = || SigningRequestContext {
+            operation: Nip55RequestType::SignEvent,
+            package_name: "com.test".to_string(),
+            event_kind: Some(1),
+            has_signed_kind_before: true,
+            app_age_ms: Some(0),
+        };
+
+        assert_eq!(
+            assess_signing_risk(new_app(), 0, 12).score,
+            15,
+            "normal-hour score must sit under the Basic ceiling"
+        );
+        assert_eq!(
+            assess_signing_risk(new_app(), 0, 3).score,
+            25,
+            "unusual-hour score must cross the Basic ceiling"
+        );
+
+        assert_eq!(
+            evaluate_sign_policy_selection(
+                SignPolicySelection::Basic,
+                new_app(),
+                true,
+                allowed(1, 1),
+                12,
+            ),
+            SignPolicyEvaluation::AutoApprove,
+            "auto-approves at a normal local hour"
+        );
+        assert_eq!(
+            evaluate_sign_policy_selection(
+                SignPolicySelection::Basic,
+                new_app(),
+                true,
+                allowed(1, 1),
+                3,
+            ),
+            SignPolicyEvaluation::FallToUi,
+            "falls to the UI at an unusual local hour"
+        );
+    }
+
+    #[test]
     fn selection_both_tiers_prompt_when_not_opted_in() {
         for selection in [SignPolicySelection::Basic, SignPolicySelection::Auto] {
             let ctx = test_ctx(Nip55RequestType::SignEvent, Some(1));
-            let result = evaluate_sign_policy_selection(selection, ctx, false, allowed(1, 1));
+            let result = evaluate_sign_policy_selection(selection, ctx, false, allowed(1, 1), 12);
             assert_eq!(result, SignPolicyEvaluation::FallToUi);
         }
     }


### PR DESCRIPTION
## Summary

The core has exposed a selection-aware policy evaluator (`evaluate_sign_policy_selection`) giving `Basic` a stricter auto-approval band than `Auto`, but the production resolve path still took the collapsed 2-value `PolicyMode`. Both `Basic` and `Auto` therefore behaved identically at runtime: a user who chose the stricter Basic tier silently got Auto's looser threshold. This wires the selection through so the tier the user picked is the one that runs.

- `Nip55DecisionInputs` now carries `policy_selection: SignPolicySelection` (Manual / Basic / Auto) in place of `policy_mode: PolicyMode`, and both sign-policy call sites in `nip55_resolve_decision` use `evaluate_sign_policy_selection`.
- The selection replaces the collapsed mode rather than sitting alongside it: two policy fields at an auto-approval decision point could disagree, and the resolved selection is the single source of truth. `PolicyMode` and `evaluate_sign_policy` remain exported for callers that use them directly, so nothing leaves the public surface.

Effect at runtime: `Manual` never auto-approves; `Basic` auto-approves only below the stricter Basic risk threshold; `Auto` keeps its existing escalation threshold. `Basic` is a strict subset of `Auto`, so this only ever tightens behavior.

## Second commit: score the decision on the caller's local hour

Review of the first commit surfaced a defect that this change makes decisive, so it is fixed here rather than deferred. `evaluate_auto` derived the risk hour from the **UTC** wall clock, ignoring `Nip55DecisionInputs.current_hour` (the device-local hour the client already supplies and the prompt already displays). The `UnusualTime` factor is worth 10 points against a Basic ceiling of 20, so the divergence ran in the permissive direction: a user at UTC+10 signing at 03:00 local saw UTC hour 17, the factor never fired, and a request that should score 25 scored 15 and was auto-approved by the newly-live Basic tier. The score that gated the decision could also differ from the score shown on the prompt.

Both evaluators now take the caller's local hour and the decision path passes `inputs.current_hour`, so gate 6 and gate 7 read the same field in the same call and cannot diverge. Out-of-range hours are clamped by the existing risk scorer into the "unusual" band, which fails closed. Deleting the wall-clock helper also removes a reachable `expect` panic from the signing path.

The doc on `SignPolicyStore::effective_policy_mode` now states plainly that it collapses `Basic` onto `Auto` and must not carry the decision path, so a migrating client is not steered back onto the collapsing bridge.

This is a breaking change to the decision-input record. The Android client is updated in a coordinated change that bumps its pinned core; the selection ordinals already match the client's policy enum (Manual 0 / Basic 1 / Auto 2), and its resolver falls back to Manual on an unknown ordinal.

Closes #881.

## Test plan

- `cargo test -p keep-mobile` — 278 passed, 0 failed (271 before; 7 new).
- Tier coverage: a mid-band request auto-approves under `Auto` but falls to the UI under `Basic`; `Manual` never auto-approves; a low-risk request auto-approves under both, proving Basic is gated rather than disabled.
- Local-hour coverage: the same new-app request auto-approves under `Basic` at hour 12 but falls to the UI at hour 3, asserted both at the evaluator and end to end through `evaluate_nip55_request`.
- Each new guard was falsified before being trusted: widening `Basic` to the `Auto` threshold breaks the tier test, and substituting a fixed hour for `inputs.current_hour` at the gate-6 call sites breaks the unusual-hour test.
- `cargo clippy -p keep-mobile --all-targets -- -D warnings` and `cargo fmt --check` — clean.

Deferred follow-ups, tracked separately: retiring the legacy Basic-collapsing evaluator pair once no caller remains, and a CI check that regenerates the client bindings and diffs them (the FFI checksum covers record names, not field types, so a stale binding would be silent).
