### PR TITLE
keep-web: fail closed instead of panicking when the RNG health check trips

### DIFF
--- a/keep-web/src/api.rs
+++ b/keep-web/src/api.rs
@@ -46,9 +46,10 @@ pub struct WsTicket {
 /// Gated by the bearer middleware; the ticket (not the durable token) is what
 /// rides in the WS URL.
 pub async fn ws_ticket(State(state): State<AppState>) -> impl IntoResponse {
-    // Fail the request rather than panicking if the RNG health check trips: a
-    // guessable ticket would authorize a WebSocket upgrade, and an unwind inside
-    // the handler would take down an always-on co-signer over a recoverable fault.
+    // Refuse rather than issue a ticket the health check has flagged: the ticket
+    // authorizes a WebSocket upgrade, so a suspect value must never leave here.
+    // This covers the health-check verdict only; a hard OS-entropy failure still
+    // unwinds inside the RNG itself, which is tracked separately in keep-core.
     let Ok(bytes) = keep_core::crypto::try_random_bytes::<32>() else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,

--- a/keep-web/src/api.rs
+++ b/keep-web/src/api.rs
@@ -46,10 +46,19 @@ pub struct WsTicket {
 /// Gated by the bearer middleware; the ticket (not the durable token) is what
 /// rides in the WS URL.
 pub async fn ws_ticket(State(state): State<AppState>) -> impl IntoResponse {
-    let bytes: [u8; 32] = keep_core::crypto::random_bytes();
+    // Fail the request rather than panicking if the RNG health check trips: a
+    // guessable ticket would authorize a WebSocket upgrade, and an unwind inside
+    // the handler would take down an always-on co-signer over a recoverable fault.
+    let Ok(bytes) = keep_core::crypto::try_random_bytes::<32>() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "entropy unavailable, try again",
+        )
+            .into_response();
+    };
     let ticket: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
     state.ws_tickets.issue(ticket.clone());
-    Json(WsTicket { ticket })
+    Json(WsTicket { ticket }).into_response()
 }
 
 /// Returns the bunker connection details. The `url` carries the connection

--- a/keep-web/src/bunker.rs
+++ b/keep-web/src/bunker.rs
@@ -49,8 +49,14 @@ struct WebCallbacks {
 /// Random, unguessable approval id (defense-in-depth alongside the auth gate).
 /// Masked to 53 bits so the value round-trips losslessly through a JS Number
 /// (IEEE-754 double) in the browser client.
-fn random_approval_id() -> u64 {
-    u64::from_le_bytes(keep_core::crypto::random_bytes()) & ((1u64 << 53) - 1)
+///
+/// `None` when the RNG health check trips. Unguessability is the whole point of
+/// this value, so the caller refuses the approval rather than falling back to
+/// anything predictable.
+fn random_approval_id() -> Option<u64> {
+    keep_core::crypto::try_random_bytes::<8>()
+        .ok()
+        .map(|bytes| u64::from_le_bytes(bytes) & ((1u64 << 53) - 1))
 }
 
 impl ServerCallbacks for WebCallbacks {
@@ -80,7 +86,17 @@ impl ServerCallbacks for WebCallbacks {
             });
             return false.into();
         }
-        let id = random_approval_id();
+        // Fail closed: without a sound random id the approval channel would be
+        // guessable, so refuse the request the same way a disabled kill switch does.
+        let Some(id) = random_approval_id() else {
+            let _ = self.events.send(Event::Log {
+                app: "frost".into(),
+                action: "refused (entropy unavailable)".into(),
+                success: false,
+                detail: Some("random number generator health check failed".into()),
+            });
+            return false.into();
+        };
         let (tx, rx) = channel();
         if let Ok(mut map) = self.approvals.lock() {
             map.insert(id, tx);
@@ -424,7 +440,8 @@ mod tests {
     fn approval_id_is_js_safe() {
         const MAX_SAFE: u64 = (1u64 << 53) - 1;
         for _ in 0..10_000 {
-            assert!(random_approval_id() <= MAX_SAFE);
+            let id = random_approval_id().expect("healthy RNG yields an approval id");
+            assert!(id <= MAX_SAFE);
         }
     }
 

--- a/keep-web/src/state.rs
+++ b/keep-web/src/state.rs
@@ -448,7 +448,7 @@ fn write_secret_file(path: &Path, contents: &str) -> std::io::Result<()> {
     use std::io::Write;
     // Per-write temp name (PID + random suffix) so a concurrent writer cannot
     // clobber an in-flight temp file before its rename.
-    let suffix: [u8; 8] = keep_core::crypto::random_bytes();
+    let suffix: [u8; 8] = try_random()?;
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), to_hex(&suffix)));
 
     let write = || -> std::io::Result<()> {
@@ -598,7 +598,7 @@ pub fn load_or_create_auth_token_at(path: &Path) -> std::io::Result<String> {
     match opts.open(path) {
         Ok(mut f) => {
             use std::io::Write;
-            let bytes: [u8; 32] = keep_core::crypto::random_bytes();
+            let bytes: [u8; 32] = try_random()?;
             let token = to_hex(&bytes);
             f.write_all(token.as_bytes())?;
             f.sync_all()?;


### PR DESCRIPTION
## Summary

Four paths in the web co-signer drew randomness through the panicking `random_bytes()` helper. Two are reachable while the service is running, so an entropy health-check failure would unwind inside a live signer rather than being reported; the other two abort startup with a raw panic message instead of the clean error their `io::Result` signature already supports. All four now use the fallible helper and fail closed.

**Request paths**

- **WebSocket ticket** (`ws_ticket`): returns `503` with a retry hint instead of panicking. The ticket authorizes a WebSocket upgrade, so a value the health check has flagged must never be issued.
- **Approval id** (`random_approval_id`): returns `None` when the check trips, and the caller refuses the approval and logs it, mirroring the existing refusal used when co-signing is disabled. Unguessability is the entire purpose of this id (it is defense-in-depth alongside the auth gate), so refusing beats falling back to anything predictable. The refusal happens before the approval slot is registered or broadcast, so no half-created approval is left behind.

**Startup paths** (both already returned `io::Result`, and the crate already defines the fallible wrapper used by its siblings)

- The 32-byte admin bearer token.
- The per-write temp-file suffix used to avoid clobbering an in-flight temp file.

After this, no caller of the panicking helper remains anywhere in the crate.

Scope note: this covers the entropy health-check verdict. A hard OS-entropy failure still unwinds inside the RNG itself before the check can report it; that is a pre-existing keep-core issue and is tracked separately rather than papered over here.

Part of #803.

## Test plan

- `cargo test -p keep-web` — 54 passed, 0 failed. The existing approval-id range test now asserts the healthy path yields an id.
- `cargo clippy -p keep-web --all-targets -- -D warnings` and `cargo fmt --check` — clean.
- Verified by grep that no occurrence of the panicking helper remains in the crate.
