### PR TITLE
keep-mobile: report whether a sign-policy selection write persisted

### DIFF
--- a/keep-mobile/src/signing_policy.rs
+++ b/keep-mobile/src/signing_policy.rs
@@ -158,20 +158,31 @@ impl SignPolicySelection {
 /// simple string key/value store; the Android side backs it with its encrypted
 /// sign-policy prefs.
 ///
-/// `save` and `remove` report whether the write actually persisted, and the
-/// implementation must answer honestly: return the platform's own durable-write
-/// result rather than `true` for "did not throw". A caller cannot re-read to
-/// check, because a store that caches in memory ahead of its backing file will
-/// serve the value a failed write left behind. Selection state gates signing, so
-/// a caller that cannot confirm a write has to assume the old value still
-/// applies. Unlike [`SigningRateLimiterStorage`], which is advisory.
+/// `save` and `remove` report whether the write durably persisted. The return
+/// must be the platform's own durable-write result, NOT a "did not throw" flag:
+/// wrapping the call and reporting that no exception escaped is the same as
+/// reporting nothing, and reintroduces the defect this signal exists to remove.
+///
+/// `false` means INDETERMINATE, not "the old value survived". A store that
+/// caches in memory ahead of its backing file will serve the value a failed
+/// write left behind, so after `false` either value may be the one in force, and
+/// the selection is read straight from here on every signing decision. A caller
+/// must therefore treat `false` as "I do not know what is stored" and repair it
+/// by re-asserting the stricter of the old and new selections (or `Manual`),
+/// rather than assuming the change simply did not happen.
 #[uniffi::export(with_foreign)]
 pub trait SignPolicySelectionStorage: Send + Sync {
     fn load(&self, key: String) -> Option<String>;
     /// Persist `value` under `key`. Returns whether it durably persisted.
     fn save(&self, key: String, value: String) -> bool;
-    /// Delete `key`. Returns whether the deletion durably persisted. Deleting a
-    /// key that is already absent is a success.
+    /// Delete `key`. Returns whether the deletion reached the durable store.
+    ///
+    /// A key that is genuinely absent from the durable store is a success. A
+    /// lookup that could not determine absence is NOT: an implementation whose
+    /// key derivation or index is unavailable must return `false` rather than
+    /// treat "I cannot see it" as "it is gone", or a live entry stays on disk
+    /// and becomes enforceable again once lookup recovers. Do not short-circuit
+    /// on a cached `contains`.
     fn remove(&self, key: String) -> bool;
 }
 
@@ -207,9 +218,12 @@ impl SignPolicyStore {
             .unwrap_or(SignPolicySelection::Manual)
     }
 
-    /// Persist the global sign-policy selection. Returns whether it persisted;
-    /// on `false` the previously stored selection is still the one in force, so
-    /// a caller must not report the change as applied.
+    /// Persist the global sign-policy selection. `true` means the global key
+    /// reached the durable store, not that this selection now governs any given
+    /// package: a per-app override still wins (see [`Self::effective_policy`]).
+    ///
+    /// `false` is indeterminate, so the caller must repair rather than assume
+    /// the old value held; see [`SignPolicySelectionStorage`].
     pub fn set_global_policy(&self, policy: SignPolicySelection) -> bool {
         self.storage.save(
             GLOBAL_SIGN_POLICY_KEY.to_string(),
@@ -232,7 +246,8 @@ impl SignPolicyStore {
     /// global policy, so a caller that treats an unconfirmed clear as done can
     /// drop the record that the override still exists and leave it in force with
     /// nothing tracking it. Callers must keep their own index until this reports
-    /// `true`.
+    /// `true`, and must re-attempt on `false` rather than assume the override
+    /// was left untouched, since `false` does not say which value is stored.
     pub fn set_app_override(&self, package: String, policy: Option<SignPolicySelection>) -> bool {
         match policy {
             Some(p) => self

--- a/keep-mobile/src/signing_policy.rs
+++ b/keep-mobile/src/signing_policy.rs
@@ -156,12 +156,23 @@ impl SignPolicySelection {
 
 /// Persistence for the sign-policy selection (global + per-app override). A
 /// simple string key/value store; the Android side backs it with its encrypted
-/// sign-policy prefs. Mirrors [`SigningRateLimiterStorage`].
+/// sign-policy prefs.
+///
+/// `save` and `remove` report whether the write actually persisted, and the
+/// implementation must answer honestly: return the platform's own durable-write
+/// result rather than `true` for "did not throw". A caller cannot re-read to
+/// check, because a store that caches in memory ahead of its backing file will
+/// serve the value a failed write left behind. Selection state gates signing, so
+/// a caller that cannot confirm a write has to assume the old value still
+/// applies. Unlike [`SigningRateLimiterStorage`], which is advisory.
 #[uniffi::export(with_foreign)]
 pub trait SignPolicySelectionStorage: Send + Sync {
     fn load(&self, key: String) -> Option<String>;
-    fn save(&self, key: String, value: String);
-    fn remove(&self, key: String);
+    /// Persist `value` under `key`. Returns whether it durably persisted.
+    fn save(&self, key: String, value: String) -> bool;
+    /// Delete `key`. Returns whether the deletion durably persisted. Deleting a
+    /// key that is already absent is a success.
+    fn remove(&self, key: String) -> bool;
 }
 
 const GLOBAL_SIGN_POLICY_KEY: &str = "global_sign_policy";
@@ -196,12 +207,14 @@ impl SignPolicyStore {
             .unwrap_or(SignPolicySelection::Manual)
     }
 
-    /// Persist the global sign-policy selection.
-    pub fn set_global_policy(&self, policy: SignPolicySelection) {
+    /// Persist the global sign-policy selection. Returns whether it persisted;
+    /// on `false` the previously stored selection is still the one in force, so
+    /// a caller must not report the change as applied.
+    pub fn set_global_policy(&self, policy: SignPolicySelection) -> bool {
         self.storage.save(
             GLOBAL_SIGN_POLICY_KEY.to_string(),
             policy.to_ordinal().to_string(),
-        );
+        )
     }
 
     /// The per-app override, or `None` if the app follows the global policy.
@@ -212,8 +225,15 @@ impl SignPolicyStore {
             .map(SignPolicySelection::from_ordinal)
     }
 
-    /// Set (`Some`) or clear (`None`) the per-app override.
-    pub fn set_app_override(&self, package: String, policy: Option<SignPolicySelection>) {
+    /// Set (`Some`) or clear (`None`) the per-app override. Returns whether the
+    /// write persisted.
+    ///
+    /// A failed clear matters most: an override is typically stricter than the
+    /// global policy, so a caller that treats an unconfirmed clear as done can
+    /// drop the record that the override still exists and leave it in force with
+    /// nothing tracking it. Callers must keep their own index until this reports
+    /// `true`.
+    pub fn set_app_override(&self, package: String, policy: Option<SignPolicySelection>) -> bool {
         match policy {
             Some(p) => self
                 .storage
@@ -1294,12 +1314,46 @@ mod tests {
         fn load(&self, key: String) -> Option<String> {
             self.map.lock().unwrap().get(&key).cloned()
         }
-        fn save(&self, key: String, value: String) {
+        fn save(&self, key: String, value: String) -> bool {
             self.map.lock().unwrap().insert(key, value);
+            true
         }
-        fn remove(&self, key: String) {
+        fn remove(&self, key: String) -> bool {
             self.map.lock().unwrap().remove(&key);
+            true
         }
+    }
+
+    /// A store whose writes never persist, modelling a backing file that fails
+    /// while an in-memory cache still answers reads. Proves the setters report
+    /// the failure instead of it being invisible.
+    struct FailingPolicyStorage;
+    impl SignPolicySelectionStorage for FailingPolicyStorage {
+        fn load(&self, _key: String) -> Option<String> {
+            None
+        }
+        fn save(&self, _key: String, _value: String) -> bool {
+            false
+        }
+        fn remove(&self, _key: String) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn setters_report_whether_the_write_persisted() {
+        let ok = SignPolicyStore::new(MockPolicyStorage::new());
+        assert!(ok.set_global_policy(SignPolicySelection::Basic));
+        assert!(ok.set_app_override("com.example".into(), Some(SignPolicySelection::Manual)));
+        assert!(ok.set_app_override("com.example".into(), None));
+
+        // A store that cannot persist must say so, for both the set and the
+        // clear: a caller that assumed success would drop the only record that
+        // the old, possibly looser, selection is still in force.
+        let bad = SignPolicyStore::new(Arc::new(FailingPolicyStorage));
+        assert!(!bad.set_global_policy(SignPolicySelection::Auto));
+        assert!(!bad.set_app_override("com.example".into(), Some(SignPolicySelection::Auto)));
+        assert!(!bad.set_app_override("com.example".into(), None));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The sign-policy selection store could not tell a caller whether a write actually landed. `save` and `remove` on the storage trait returned nothing, so the setters returned nothing, and a client had no way to distinguish a durable write from a call that merely did not throw.

That gap is not academic. A client attempting to migrate per-app overrides onto this store had to invent verification on its own side, and could not: the Android preferences implementation updates its in-memory map before returning the disk result, so a read-back observes the very memory a failed write already changed. Three review rounds on that client change narrowed the resulting defects without closing them, because the missing signal was here rather than there. The signal already exists on the platform (the underlying commit returns the disk result); it was simply discarded at this boundary.

- `SignPolicySelectionStorage::save` and `::remove` now return whether the write durably persisted, and both setters propagate it.
- The trait states that the return must be the platform's own durable-write result, not a "did not throw" flag. That distinction is the whole point: wrapping the call and reporting that no exception escaped conveys nothing, and the smallest possible port of the current client does exactly that.
- `false` is defined as **indeterminate**, not "the old value survived". A caching store serves the value a failed write left behind, so after `false` either value may be in force, and the selection is read from storage on every signing decision. A caller must repair by re-asserting the stricter of the old and new selections rather than assuming the change did not happen.
- `remove` succeeds only when the key is genuinely absent from the durable store. An implementation that cannot determine absence must report failure, or a live entry stays on disk and becomes enforceable again once lookup recovers.

## What this does and does not do

It relocates an unverifiable assumption rather than eliminating one. Before, the assumption was "the client can re-read to check", which is provably false. Now it is "the implementation reports honestly", which cannot be validated from this side. That is a real improvement, because the signal only exists at the implementation, but an implementation that returns `true` unconditionally leaves a caller exactly where it started. The contract is written to make that misuse obvious rather than to pretend it is impossible.

The store still exposes no way to enumerate per-app overrides, so a caller must keep its own index to reconcile an orphan. Removing that duplicated state needs a list operation the key/value trait does not have.

## Breaking change

This changes an exported foreign trait signature and two exported methods. Mismatch fails loudly rather than silently: trait-method return types are covered by the generated API checksum, and regenerated bindings also change the Kotlin method signature, so a stale implementation fails its own override check at compile time. The Android client is updated in a coordinated change that bumps its pinned core.

A correction to an earlier draft of this description: it claimed the neighbouring rate-limiter storage is advisory and that a lost counter cannot change an authorization outcome. That is wrong. The limiter's result is a hard gate on auto-approval, and silently dropped writes there materially widen the sustained auto-sign ceiling. The claim has been removed from the code comment and the gap is filed separately.

## Test plan

- `cargo test -p keep-mobile` — 279 passed, 0 failed (278 before).
- New coverage uses a storage double whose writes never persist, asserting both setters report `false` for a set and for a clear, alongside the success case, so the reporting is proven rather than assumed.
- `cargo clippy -p keep-mobile --all-targets -- -D warnings` and `cargo fmt --check` — clean.
- These types are proc-macro uniffi, not declared in the UDL, so no interface-definition change is required.
