### PR TITLE
keep-mobile: refuse auto-signing when usage counters cannot be recorded

### DIFF
--- a/keep-mobile/src/signing_policy.rs
+++ b/keep-mobile/src/signing_policy.rs
@@ -92,6 +92,12 @@ pub enum AutoSignDecision {
     CoolingOff {
         until_ms: u64,
     },
+    /// The usage counters could not be durably recorded, so this request cannot
+    /// be counted toward the hourly and daily ceilings. Auto-signing is refused
+    /// rather than allowed: continuing would let every subsequent request reuse
+    /// the same un-incremented window and bypass the limits entirely. Appended
+    /// last so the existing variants keep their wire ordinals.
+    StorageUnavailable,
 }
 
 #[derive(uniffi::Enum, Clone, Debug, PartialEq, Eq)]
@@ -417,9 +423,18 @@ struct UsageWindow {
 #[uniffi::export(with_foreign)]
 pub trait SigningRateLimiterStorage: Send + Sync {
     fn load(&self, key: String) -> Option<String>;
-    fn save(&self, key: String, value: String);
-    fn remove(&self, key: String);
-    fn clear(&self);
+    /// Persist `value` under `key`. Returns whether it durably persisted.
+    ///
+    /// As with [`SignPolicySelectionStorage`], the return must be the platform's
+    /// own durable-write result, not a "did not throw" flag. These counters are
+    /// not telemetry: [`SigningRateLimiter::check_and_record`] gates auto-signing
+    /// on them, so a write that silently vanishes means the request is never
+    /// counted, the hourly and daily ceilings never accumulate toward their
+    /// limits, and a cooling-off penalty is dropped. That widens the sustained
+    /// auto-approval rate rather than losing a statistic.
+    fn save(&self, key: String, value: String) -> bool;
+    fn remove(&self, key: String) -> bool;
+    fn clear(&self) -> bool;
 }
 
 /// Per-package velocity limiter for opt-in auto-signing. Hourly and daily
@@ -500,8 +515,16 @@ impl SigningRateLimiter {
             return AutoSignDecision::UnusualActivity;
         }
 
-        self.save_window(HOURLY_KEY_PREFIX, &package_name, &hourly, now_wall_ms);
-        self.save_window(DAILY_KEY_PREFIX, &package_name, &daily, now_wall_ms);
+        // Both counters must land before this request can be called allowed. If
+        // either write is lost, the window stays un-incremented and every later
+        // request reads the same count, so the hourly and daily ceilings would
+        // never be reached and auto-signing would be effectively unlimited.
+        // Refusing costs a prompt; continuing removes the limit.
+        let hourly_saved = self.save_window(HOURLY_KEY_PREFIX, &package_name, &hourly, now_wall_ms);
+        let daily_saved = self.save_window(DAILY_KEY_PREFIX, &package_name, &daily, now_wall_ms);
+        if !hourly_saved || !daily_saved {
+            return AutoSignDecision::StorageUnavailable;
+        }
 
         AutoSignDecision::Allowed {
             hourly_count: hourly.count,
@@ -612,17 +635,19 @@ impl SigningRateLimiter {
         }
     }
 
+    /// Returns whether the counter durably persisted. A `false` here means this
+    /// request was not counted, so the caller must not report it as allowed.
     fn save_window(
         &self,
         prefix: &str,
         package_name: &str,
         window: &UsageWindow,
         now_wall_ms: u64,
-    ) {
+    ) -> bool {
         self.storage.save(
             key(prefix, package_name),
             serialize_window(window, now_wall_ms),
-        );
+        )
     }
 
     /// Increment the in-memory unusual-activity window (60s); not persisted.
@@ -997,15 +1022,69 @@ mod tests {
         fn load(&self, key: String) -> Option<String> {
             self.map.lock().unwrap().get(&key).cloned()
         }
-        fn save(&self, key: String, value: String) {
+        fn save(&self, key: String, value: String) -> bool {
             self.map.lock().unwrap().insert(key, value);
+            true
         }
-        fn remove(&self, key: String) {
+        fn remove(&self, key: String) -> bool {
             self.map.lock().unwrap().remove(&key);
+            true
         }
-        fn clear(&self) {
+        fn clear(&self) -> bool {
             self.map.lock().unwrap().clear();
+            true
         }
+    }
+
+    /// Storage whose writes never persist while reads keep working, modelling a
+    /// backing file that fails silently. Drives the path where the usage counters
+    /// cannot be recorded.
+    struct UnwritableStorage;
+    impl SigningRateLimiterStorage for UnwritableStorage {
+        fn load(&self, _key: String) -> Option<String> {
+            None
+        }
+        fn save(&self, _key: String, _value: String) -> bool {
+            false
+        }
+        fn remove(&self, _key: String) -> bool {
+            false
+        }
+        fn clear(&self) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn unrecordable_usage_refuses_instead_of_allowing() {
+        // The counters cannot be persisted, so this request cannot be counted
+        // toward the ceilings. Allowing it would let every later request reuse
+        // the same un-incremented window and never reach a limit.
+        let limiter = SigningRateLimiter::new(Arc::new(UnwritableStorage));
+        for i in 0..5 {
+            let result = limiter.check_and_record("com.test".to_string(), 1000 + i, 1000 + i);
+            assert_eq!(
+                result,
+                AutoSignDecision::StorageUnavailable,
+                "an uncounted request must not be reported as allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn unrecordable_usage_does_not_auto_approve() {
+        // The decision path must treat it as a refusal, not just the limiter.
+        let ctx = test_ctx(Nip55RequestType::SignEvent, Some(1));
+        assert_eq!(
+            evaluate_sign_policy_selection(
+                SignPolicySelection::Auto,
+                ctx,
+                true,
+                AutoSignDecision::StorageUnavailable,
+                12,
+            ),
+            SignPolicyEvaluation::FallToUi
+        );
     }
 
     #[test]

--- a/keep-mobile/src/signing_policy.rs
+++ b/keep-mobile/src/signing_policy.rs
@@ -160,6 +160,42 @@ impl SignPolicySelection {
     }
 }
 
+/// Outcome of reading a usage window: a live window, a legitimately fresh one,
+/// or a read that could not be trusted. Internal to the limiter.
+enum WindowRead {
+    Active(UsageWindow),
+    Fresh,
+    Unavailable,
+}
+
+impl WindowRead {
+    /// Count for reporting only, where an unreadable window shows as zero. The
+    /// authorization path must not use this: it has to distinguish "no usage"
+    /// from "unknown usage" and refuse on the latter.
+    fn display_count(&self) -> u32 {
+        match self {
+            WindowRead::Active(w) => w.count,
+            WindowRead::Fresh | WindowRead::Unavailable => 0,
+        }
+    }
+}
+
+/// Outcome of a rate-limiter storage read.
+///
+/// The distinction between `Absent` and `Unavailable` is load-bearing. A missing
+/// key legitimately means "no usage recorded yet", so the window starts fresh. A
+/// read that failed means nothing is known, and starting fresh there would reset
+/// the count on every request and make the hourly and daily ceilings unreachable.
+#[derive(uniffi::Enum, Clone, Debug, PartialEq, Eq)]
+pub enum StorageRead {
+    /// The key holds this value.
+    Found { value: String },
+    /// The key is genuinely not present.
+    Absent,
+    /// The value could not be read or decoded. Callers must fail closed.
+    Unavailable,
+}
+
 /// Persistence for the sign-policy selection (global + per-app override). A
 /// simple string key/value store; the Android side backs it with its encrypted
 /// sign-policy prefs.
@@ -422,7 +458,11 @@ struct UsageWindow {
 /// `nip55_auto_signing` prefs.
 #[uniffi::export(with_foreign)]
 pub trait SigningRateLimiterStorage: Send + Sync {
-    fn load(&self, key: String) -> Option<String>;
+    /// Read `key`. `Absent` and `Unavailable` must not be conflated: a counter
+    /// that could not be read is not the same as a package with no history, and
+    /// treating the former as the latter restarts the window at zero on every
+    /// request, which removes the ceiling just as effectively as a lost write.
+    fn load(&self, key: String) -> StorageRead;
     /// Persist `value` under `key`. Returns whether it durably persisted.
     ///
     /// As with [`SignPolicySelectionStorage`], the return must be the platform's
@@ -475,7 +515,13 @@ impl SigningRateLimiter {
     ) -> AutoSignDecision {
         let _guard = self.guard.lock().unwrap_or_else(|e| e.into_inner());
 
-        let cooled = self.cooled_off_state(&package_name, now_elapsed_ms, now_wall_ms);
+        // Every read below fails closed. Unknown prior usage is not "no prior
+        // usage": treating it as none would restart the window on each request
+        // and make the ceilings unreachable, which is the same bypass a lost
+        // write produces.
+        let Some(cooled) = self.cooled_off_state(&package_name, now_elapsed_ms, now_wall_ms) else {
+            return AutoSignDecision::StorageUnavailable;
+        };
         if cooled.active() {
             return AutoSignDecision::CoolingOff {
                 until_ms: cooled.until_wall_ms(now_elapsed_ms, now_wall_ms),
@@ -485,25 +531,29 @@ impl SigningRateLimiter {
         // Compute would-be counts first; a denied request must not increment the
         // persisted counter, so the windows are only saved once every limit
         // passes.
-        let hourly = self.next_window(
+        let Some(hourly) = self.next_window(
             HOURLY_KEY_PREFIX,
             &package_name,
             HOUR_MS,
             now_elapsed_ms,
             now_wall_ms,
-        );
+        ) else {
+            return AutoSignDecision::StorageUnavailable;
+        };
         if hourly.count > HOURLY_LIMIT {
             self.set_cooled_off(&package_name, now_elapsed_ms, now_wall_ms);
             return AutoSignDecision::HourlyLimitExceeded;
         }
 
-        let daily = self.next_window(
+        let Some(daily) = self.next_window(
             DAILY_KEY_PREFIX,
             &package_name,
             DAY_MS,
             now_elapsed_ms,
             now_wall_ms,
-        );
+        ) else {
+            return AutoSignDecision::StorageUnavailable;
+        };
         if daily.count > DAILY_LIMIT {
             self.set_cooled_off(&package_name, now_elapsed_ms, now_wall_ms);
             return AutoSignDecision::DailyLimitExceeded;
@@ -571,8 +621,7 @@ impl SigningRateLimiter {
                 now_elapsed_ms,
                 now_wall_ms,
             )
-            .map(|w| w.count)
-            .unwrap_or(0);
+            .display_count();
         let daily_count = self
             .read_window(
                 DAILY_KEY_PREFIX,
@@ -581,8 +630,7 @@ impl SigningRateLimiter {
                 now_elapsed_ms,
                 now_wall_ms,
             )
-            .map(|w| w.count)
-            .unwrap_or(0);
+            .display_count();
         UsageStats {
             hourly_count,
             daily_count,
@@ -603,13 +651,26 @@ impl SigningRateLimiter {
         window_ms: u64,
         now_elapsed_ms: u64,
         now_wall_ms: u64,
-    ) -> Option<UsageWindow> {
-        let raw = self.storage.load(key(prefix, package_name))?;
-        let window = parse_window(&raw, now_elapsed_ms, now_wall_ms)?;
+    ) -> WindowRead {
+        let raw = match self.storage.load(key(prefix, package_name)) {
+            StorageRead::Found { value } => value,
+            // No history yet: a genuinely fresh window, not a fault.
+            StorageRead::Absent => return WindowRead::Fresh,
+            StorageRead::Unavailable => return WindowRead::Unavailable,
+        };
+        // Stored but undecodable is a fault, not a fresh window: treating corrupt
+        // data as "no usage" would reset the counter on every request.
+        let Some(window) = parse_window(&raw, now_elapsed_ms, now_wall_ms) else {
+            return WindowRead::Unavailable;
+        };
         let active = now_elapsed_ms
             .checked_sub(window.start_elapsed)
             .is_some_and(|elapsed| elapsed < window_ms);
-        active.then_some(window)
+        if active {
+            WindowRead::Active(window)
+        } else {
+            WindowRead::Fresh
+        }
     }
 
     /// Compute the window the next increment would produce, without persisting
@@ -622,16 +683,18 @@ impl SigningRateLimiter {
         window_ms: u64,
         now_elapsed_ms: u64,
         now_wall_ms: u64,
-    ) -> UsageWindow {
+    ) -> Option<UsageWindow> {
         match self.read_window(prefix, package_name, window_ms, now_elapsed_ms, now_wall_ms) {
-            Some(mut w) => {
+            WindowRead::Active(mut w) => {
                 w.count = w.count.saturating_add(1);
-                w
+                Some(w)
             }
-            None => UsageWindow {
+            WindowRead::Fresh => Some(UsageWindow {
                 count: 1,
                 start_elapsed: now_elapsed_ms,
-            },
+            }),
+            // Unknown prior usage: the caller must refuse rather than assume none.
+            WindowRead::Unavailable => None,
         }
     }
 
@@ -695,19 +758,23 @@ impl SigningRateLimiter {
         package_name: &str,
         now_elapsed_ms: u64,
         now_wall_ms: u64,
-    ) -> CooledOffState {
+    ) -> Option<CooledOffState> {
+        // An unreadable penalty must not read as "not penalised": that is how a
+        // cooling-off period would be skipped by a store that cannot be read.
         let wall_until = self
             .load_u64(&key(COOLED_OFF_KEY_PREFIX, package_name))
+            .ok()?
             .filter(|&u| u > 0 && now_wall_ms < u);
         let elapsed_until = self
             .load_u64(&key(COOLED_OFF_ELAPSED_KEY_PREFIX, package_name))
+            .ok()?
             .filter(|&u| {
                 u > 0 && now_elapsed_ms < u && u - now_elapsed_ms <= COOLING_OFF_PERIOD_MS
             });
-        CooledOffState {
+        Some(CooledOffState {
             wall_until,
             elapsed_until,
-        }
+        })
     }
 
     fn set_cooled_off(&self, package_name: &str, now_elapsed_ms: u64, now_wall_ms: u64) {
@@ -721,8 +788,16 @@ impl SigningRateLimiter {
         );
     }
 
-    fn load_u64(&self, key: &str) -> Option<u64> {
-        self.storage.load(key.to_string())?.parse::<u64>().ok()
+    /// `Ok(None)` is a genuinely unset key; `Err(())` is a read that failed or a
+    /// value that would not decode, which callers must treat as unknown rather
+    /// than as "no penalty recorded".
+    #[allow(clippy::result_unit_err)]
+    fn load_u64(&self, key: &str) -> Result<Option<u64>, ()> {
+        match self.storage.load(key.to_string()) {
+            StorageRead::Found { value } => value.parse::<u64>().map(Some).map_err(|_| ()),
+            StorageRead::Absent => Ok(None),
+            StorageRead::Unavailable => Err(()),
+        }
     }
 }
 
@@ -1019,8 +1094,13 @@ mod tests {
         }
     }
     impl SigningRateLimiterStorage for MockStorage {
-        fn load(&self, key: String) -> Option<String> {
-            self.map.lock().unwrap().get(&key).cloned()
+        fn load(&self, key: String) -> StorageRead {
+            match self.map.lock().unwrap().get(&key) {
+                Some(value) => StorageRead::Found {
+                    value: value.clone(),
+                },
+                None => StorageRead::Absent,
+            }
         }
         fn save(&self, key: String, value: String) -> bool {
             self.map.lock().unwrap().insert(key, value);
@@ -1041,8 +1121,8 @@ mod tests {
     /// cannot be recorded.
     struct UnwritableStorage;
     impl SigningRateLimiterStorage for UnwritableStorage {
-        fn load(&self, _key: String) -> Option<String> {
-            None
+        fn load(&self, _key: String) -> StorageRead {
+            StorageRead::Absent
         }
         fn save(&self, _key: String, _value: String) -> bool {
             false
@@ -1053,6 +1133,84 @@ mod tests {
         fn clear(&self) -> bool {
             false
         }
+    }
+
+    /// Writes land, but reads never do. Before reads failed closed this was the
+    /// wider hole: an unreadable counter looked like a fresh window, so the count
+    /// restarted every request and the hourly ceiling was never approached.
+    struct UnreadableStorage {
+        map: Mutex<HashMap<String, String>>,
+    }
+    impl SigningRateLimiterStorage for UnreadableStorage {
+        fn load(&self, key: String) -> StorageRead {
+            // Only the usage counters are unreadable. The cooling-off keys answer
+            // normally so this isolates the window path: without that, the
+            // cooling-off read fails closed first and the test would pass even if
+            // an unreadable window were still treated as a fresh one.
+            if key.starts_with(HOURLY_KEY_PREFIX) || key.starts_with(DAILY_KEY_PREFIX) {
+                StorageRead::Unavailable
+            } else {
+                StorageRead::Absent
+            }
+        }
+        fn save(&self, key: String, value: String) -> bool {
+            self.map.lock().unwrap().insert(key, value);
+            true
+        }
+        fn remove(&self, key: String) -> bool {
+            self.map.lock().unwrap().remove(&key);
+            true
+        }
+        fn clear(&self) -> bool {
+            self.map.lock().unwrap().clear();
+            true
+        }
+    }
+
+    #[test]
+    fn unreadable_usage_refuses_instead_of_restarting_the_window() {
+        let limiter = SigningRateLimiter::new(Arc::new(UnreadableStorage {
+            map: Mutex::new(HashMap::new()),
+        }));
+        // Well past the hourly ceiling: if an unreadable counter were treated as
+        // a fresh window, every one of these would come back Allowed.
+        for i in 0..(HOURLY_LIMIT + 20) {
+            let result =
+                limiter.check_and_record("com.test".to_string(), 1000 + i as u64, 1000 + i as u64);
+            assert_eq!(
+                result,
+                AutoSignDecision::StorageUnavailable,
+                "unknown prior usage must not be treated as no prior usage"
+            );
+        }
+    }
+
+    /// Stored data that will not decode is a fault, not an empty window.
+    struct CorruptStorage;
+    impl SigningRateLimiterStorage for CorruptStorage {
+        fn load(&self, _key: String) -> StorageRead {
+            StorageRead::Found {
+                value: "not-a-window".to_string(),
+            }
+        }
+        fn save(&self, _key: String, _value: String) -> bool {
+            true
+        }
+        fn remove(&self, _key: String) -> bool {
+            true
+        }
+        fn clear(&self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn undecodable_counter_refuses_instead_of_restarting_the_window() {
+        let limiter = SigningRateLimiter::new(Arc::new(CorruptStorage));
+        assert_eq!(
+            limiter.check_and_record("com.test".to_string(), 1000, 1000),
+            AutoSignDecision::StorageUnavailable
+        );
     }
 
     #[test]

--- a/keep-mobile/src/signing_policy.rs
+++ b/keep-mobile/src/signing_policy.rs
@@ -1188,9 +1188,16 @@ mod tests {
     /// Stored data that will not decode is a fault, not an empty window.
     struct CorruptStorage;
     impl SigningRateLimiterStorage for CorruptStorage {
-        fn load(&self, _key: String) -> StorageRead {
-            StorageRead::Found {
-                value: "not-a-window".to_string(),
+        fn load(&self, key: String) -> StorageRead {
+            // Only the counters are corrupt, for the same reason UnreadableStorage
+            // is scoped: an undecodable cooling-off value would refuse first and
+            // the window decode path would never run.
+            if key.starts_with(HOURLY_KEY_PREFIX) || key.starts_with(DAILY_KEY_PREFIX) {
+                StorageRead::Found {
+                    value: "not-a-window".to_string(),
+                }
+            } else {
+                StorageRead::Absent
             }
         }
         fn save(&self, _key: String, _value: String) -> bool {
@@ -1207,6 +1214,39 @@ mod tests {
     #[test]
     fn undecodable_counter_refuses_instead_of_restarting_the_window() {
         let limiter = SigningRateLimiter::new(Arc::new(CorruptStorage));
+        assert_eq!(
+            limiter.check_and_record("com.test".to_string(), 1000, 1000),
+            AutoSignDecision::StorageUnavailable
+        );
+    }
+
+    /// An undecodable cooling-off value must refuse too, rather than read as
+    /// "no penalty recorded" and let a cooled-off package straight through.
+    struct CorruptCoolingOffStorage;
+    impl SigningRateLimiterStorage for CorruptCoolingOffStorage {
+        fn load(&self, key: String) -> StorageRead {
+            if key.starts_with(COOLED_OFF_KEY_PREFIX) {
+                StorageRead::Found {
+                    value: "not-a-timestamp".to_string(),
+                }
+            } else {
+                StorageRead::Absent
+            }
+        }
+        fn save(&self, _key: String, _value: String) -> bool {
+            true
+        }
+        fn remove(&self, _key: String) -> bool {
+            true
+        }
+        fn clear(&self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn undecodable_cooling_off_refuses_instead_of_reading_as_no_penalty() {
+        let limiter = SigningRateLimiter::new(Arc::new(CorruptCoolingOffStorage));
         assert_eq!(
             limiter.check_and_record("com.test".to_string(), 1000, 1000),
             AutoSignDecision::StorageUnavailable


### PR DESCRIPTION
## Summary

The opt-in auto-signing limiter persisted its hourly and daily counters through a storage trait that could not report whether a write landed, and `check_and_record` returned `Allowed` regardless. A store that drops writes silently therefore leaves the window un-incremented, so every subsequent request reads the same count, neither ceiling is ever approached, and the cooling-off penalty is never persisted. The limiter's result is a hard gate on auto-approval rather than telemetry, so this widens the sustained auto-signing rate instead of losing a statistic.

This applies the contract already adopted for the selection store:

- `SigningRateLimiterStorage::save`, `::remove` and `::clear` now return whether the write durably persisted, documented as the platform's own durable-write result rather than a "did not throw" flag.
- `check_and_record` refuses when either counter fails to persist, via a new `AutoSignDecision::StorageUnavailable`. An uncounted request must not be reported as allowed, because allowing it is what makes the limit unreachable. Refusing costs a prompt.

The new variant is appended last so existing variants keep their wire ordinals, and the policy evaluator already treats any non-`Allowed` result as "fall to the UI", so it is fail-closed on arrival without further changes.

A correction to an earlier description in this area: this storage was previously characterised as advisory, on the basis that a lost counter could not change an authorization outcome. That is wrong, and the comment asserting it has been removed.

## Test plan

- `cargo test -p keep-mobile` — 281 passed, 0 failed (279 before).
- New coverage drives a storage double whose writes never persist: the limiter refuses on every attempt rather than allowing, and the decision path treats the refusal as "fall to the UI" rather than auto-approving.
- The guard was falsified before being trusted. With it removed, the limiter returns `Allowed { hourly_count: 1, ... }` on every one of five consecutive calls, which is the un-incrementing window this change exists to prevent.
- `cargo clippy -p keep-mobile --all-targets -- -D warnings` and `cargo fmt --check` — clean.
- These types are proc-macro uniffi and absent from the UDL, so no interface-definition change is required.

## Client impact

Breaking for implementors of the storage trait. The Android implementation must return its real durable-write result and is updated when its pinned core is bumped; an unchanged client fails loudly rather than silently, since trait-method return types are covered by the generated API checksum and the regenerated bindings also change the method signatures.

Separately filed: the Android implementation of this trait is not exception-wrapped, so a keystore fault currently panics across the FFI boundary on the signing path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Signing decisions now safely fall back to user confirmation when usage limits cannot be durably saved.
  * Prevented automatic signing from proceeding when rate-limit data storage fails.
  * Improved handling of persistence failures for hourly and daily usage tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->