### PR TITLE
deps: update nostr to 0.44.6 for the NIP-04 IV length panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5737,9 +5737,9 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "nostr"
-version = "0.44.5"
+version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0112d3433a5550ba13481970d5b6844714510ddcdaca4d9d0aa6e7b83f270271"
+checksum = "e826dd648489de2c5b293920e20b92932ef820302007c1987c758d4d06eeb2cf"
 dependencies = [
  "aes 0.8.4",
  "base64 0.22.1",


### PR DESCRIPTION
## Summary

RUSTSEC-2026-0219: the `nostr` crate did not validate the length of the initialization vector decoded from the `?iv=` portion of a NIP-04 message. A decoded IV that is not exactly 16 bytes panics before the ciphertext is decrypted, so `?iv=AAAA` (three bytes) is enough. Lockfile-only update to the patched release.

This is reachable here rather than theoretical. The NIP-46 bunker handler decrypts NIP-04 content from a remote peer using the affected crate, so a malicious or compromised client can crash the signer with a malformed IV before any decryption is attempted. That is a remote denial of service against an always-available co-signer.

Scope of exposure, for the record:

- **keep-nip46** uses the affected implementation on peer-supplied ciphertext. Affected.
- **keep-mobile** routes its NIP-04 paths through the in-tree implementation in keep-core rather than the crate, so it is not affected by this advisory.

CI surfaced this as a `deny` failure on an unrelated branch; it reproduces on `main` and is not caused by any in-flight change.

## Test plan

- `cargo deny check advisories` — now reports `advisories ok`; previously failed with RUSTSEC-2026-0219.
- `cargo test -p keep-nip46` — 201 passed, 0 failed across the crate's targets.
- Lockfile-only change: `nostr 0.44.5 -> 0.44.6`, a patch release within the existing range, so no manifest or API change.