### PR TITLE
Route hardware signing randomness through the checked entropy helper

### DIFF
--- a/keep-cli/src/commands/frost_network/hardware.rs
+++ b/keep-cli/src/commands/frost_network/hardware.rs
@@ -5,7 +5,6 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::path::Path;
 
-use ::rand::Rng;
 use nostr_sdk::prelude::*;
 use tracing::debug;
 
@@ -37,8 +36,9 @@ pub fn cmd_frost_network_sign_hardware(
     let mut message_arr = [0u8; 32];
     message_arr.copy_from_slice(&message_bytes);
 
-    let mut session_id = [0u8; 32];
-    ::rand::rng().fill_bytes(&mut session_id);
+    // Route through the core helper rather than a thread RNG: it applies the
+    // entropy health check and fails closed, which a direct `rand::rng()` skips.
+    let session_id: [u8; 32] = keep_core::entropy::try_random_bytes()?;
 
     out.newline();
     out.header("FROST Hardware Sign via Relay");
@@ -380,12 +380,12 @@ pub fn cmd_frost_network_nonce_precommit(
     let spinner = out.spinner(&format!("Generating {count} nonce commitments..."));
     let mut nonces = Vec::new();
     let mut commitments_hex = Vec::new();
-    let mut rng = ::rand::rng();
     for i in 0..count {
-        let mut dummy_session = [0u8; 32];
-        let mut dummy_message = [0u8; 32];
-        rng.fill_bytes(&mut dummy_session);
-        rng.fill_bytes(&mut dummy_message);
+        // Named dummy, but these are the session and message the device binds
+        // its nonce commitment to, so they get the same checked entropy as a
+        // real signing session rather than a thread RNG.
+        let dummy_session: [u8; 32] = keep_core::entropy::try_random_bytes()?;
+        let dummy_message: [u8; 32] = keep_core::entropy::try_random_bytes()?;
         let (commitment, _) = signer
             .frost_commit(group, &dummy_session, &dummy_message)
             .map_err(|e| KeepError::FrostErr(FrostError::commitment(format!("nonce {i}: {e}"))))?;

--- a/keep-cli/src/commands/frost_network/hardware.rs
+++ b/keep-cli/src/commands/frost_network/hardware.rs
@@ -380,14 +380,27 @@ pub fn cmd_frost_network_nonce_precommit(
     let spinner = out.spinner(&format!("Generating {count} nonce commitments..."));
     let mut nonces = Vec::new();
     let mut commitments_hex = Vec::new();
-    for i in 0..count {
-        // Named dummy, but these are the session and message the device binds
-        // its nonce commitment to, so they get the same checked entropy as a
-        // real signing session rather than a thread RNG.
-        let dummy_session: [u8; 32] = keep_core::entropy::try_random_bytes()?;
-        let dummy_message: [u8; 32] = keep_core::entropy::try_random_bytes()?;
+
+    // Draw every pair up front. The device allocates a session slot and writes a
+    // nonce checkpoint for each commitment, and the host keeps only the
+    // commitment hex, so it can never clear one it did not record. Failing
+    // partway through the loop would leave those behind; failing here leaves
+    // nothing behind, because no commitment has been requested yet.
+    //
+    // These are named dummy because they stand in for a real request, but they
+    // are the session and message the device binds its commitment to, so they
+    // get the same checked entropy as a real signing session. They do not feed
+    // the nonce itself: the device seeds that from its own RNG.
+    let mut pairs = Vec::with_capacity(count as usize);
+    for _ in 0..count {
+        let session: [u8; 32] = keep_core::entropy::try_random_bytes()?;
+        let message: [u8; 32] = keep_core::entropy::try_random_bytes()?;
+        pairs.push((session, message));
+    }
+
+    for (i, (dummy_session, dummy_message)) in pairs.iter().enumerate() {
         let (commitment, _) = signer
-            .frost_commit(group, &dummy_session, &dummy_message)
+            .frost_commit(group, dummy_session, dummy_message)
             .map_err(|e| KeepError::FrostErr(FrostError::commitment(format!("nonce {i}: {e}"))))?;
         let commitment_hex = hex::encode(&commitment);
         commitments_hex.push(commitment_hex.clone());


### PR DESCRIPTION
## Summary

Two randomness sites in the hardware signing path drew from a thread RNG directly instead of the core entropy helper the rest of the codebase uses.

Worth being precise about why this matters, because the tracker entry framed it as weak randomness and that is not the defect. The thread RNG is a CSPRNG, so the bytes themselves were fine. What it skipped is the entropy health check that `keep_core::entropy::try_random_bytes` applies and that fails closed on an unhealthy source. Every other security-relevant draw in this crate routes through that helper, including the sibling module in the same directory, so this was the odd one out rather than a broken primitive.

Also drops the `rand::Rng` import, which no longer has a user in this module.

## Correction to an earlier version of this description

This originally claimed the second site's values bind the device's nonce commitment, implying nonce-secrecy impact. Review traced the path into the device firmware and that is wrong: the binding and hiding nonce seeds are generated on the device from its own RNG and are independent of the session and message the host supplies, and the device gates on its own RNG health check before committing. Host-side entropy at that site has no bearing on nonce secrecy.

The change is still worth making, for a narrower and real reason. The device rejects duplicate session ids from a bounded ring buffer, so a repeat outside that window would not be caught there; on the host it would clobber the previous session's checkpoint and collide on the relay correlation id. Failing closed on a degraded host RNG is the right behavior for that.

## Test plan

`cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` and `cargo test` all clean on `keep-cli`: 136 unit plus 41 integration tests pass. Full CI green.

No behavioral test is added. Both call sites produce 32 random bytes before and after, so the change is observable only as which generator supplies them and whether an unhealthy RNG surfaces as an error rather than silently proceeding; asserting that would mean injecting a failing entropy source, which the helper does not currently expose a seam for.

## Follow-up identified

The entropy module documents that all production callers were migrated to the checked helper. That is currently untrue: four attestation-nonce sites in the enclave command still use a thread RNG, one of which is the anti-replay binding that is later verified. Tracked separately, along with the absence of any lint that would prevent the next regression.

Part of #788.
