### PR TITLE
Cover reconstruct_descriptor paths that had no test

### DIFF
--- a/keep-frost-net/src/descriptor_session.rs
+++ b/keep-frost-net/src/descriptor_session.rs
@@ -1106,6 +1106,94 @@ mod tests {
         );
     }
 
+    /// Paths through `reconstruct_descriptor` not already covered by the
+    /// invalid-network and missing-contribution tests above: a contribution that
+    /// is present but unusable, an external key slot, and the tier-free wallet.
+    mod reconstruct {
+        use super::*;
+
+        fn contribution(xpub: &str) -> XpubContribution {
+            XpubContribution {
+                account_xpub: xpub.into(),
+                fingerprint: "aabbccdd".into(),
+            }
+        }
+
+        fn one_participant_policy() -> WalletPolicy {
+            WalletPolicy {
+                recovery_tiers: vec![PolicyTier {
+                    threshold: 1,
+                    key_slots: vec![KeySlot::Participant { share_index: 1 }],
+                    timelock_months: 6,
+                }],
+                version: 1,
+            }
+        }
+
+        #[test]
+        fn rejects_a_contribution_that_is_not_a_usable_xpub() {
+            let mut contributions = BTreeMap::new();
+            // Passes the session-level prefix check for a test network but is not
+            // decodable, so it fails at conversion rather than at validation.
+            contributions.insert(1u16, contribution("tpub1zzzzzzzzzzzzzzz"));
+
+            let err = reconstruct_descriptor(
+                &[1u8; 32],
+                &one_participant_policy(),
+                &contributions,
+                "signet",
+            )
+            .unwrap_err()
+            .to_string();
+            assert!(
+                err.contains("xpub conversion failed"),
+                "expected a conversion failure, got: {err}"
+            );
+        }
+
+        #[test]
+        fn an_external_key_slot_does_not_need_a_contribution() {
+            let policy = WalletPolicy {
+                recovery_tiers: vec![PolicyTier {
+                    threshold: 1,
+                    key_slots: vec![KeySlot::External {
+                        xpub: "tpub1zzzzzzzzzzzzzzz".into(),
+                        fingerprint: "aabbccdd".into(),
+                    }],
+                    timelock_months: 6,
+                }],
+                version: 1,
+            };
+
+            // No contributions at all: an external slot carries its own key, so the
+            // failure must come from the key itself, never from a lookup.
+            let err = reconstruct_descriptor(&[1u8; 32], &policy, &BTreeMap::new(), "signet")
+                .unwrap_err()
+                .to_string();
+            assert!(
+                !err.contains("missing xpub contribution"),
+                "external slots must not be looked up in contributions, got: {err}"
+            );
+        }
+
+        #[test]
+        fn a_policy_with_no_recovery_tiers_builds_a_descriptor_pair() {
+            let policy = WalletPolicy {
+                recovery_tiers: vec![],
+                version: 1,
+            };
+
+            let (external, internal) =
+                reconstruct_descriptor(&[1u8; 32], &policy, &BTreeMap::new(), "signet")
+                    .expect("a key-path-only wallet should reconstruct");
+            assert!(!external.is_empty() && !internal.is_empty());
+            assert_ne!(
+                external, internal,
+                "receive and change descriptors must differ"
+            );
+        }
+    }
+
     fn test_policy() -> WalletPolicy {
         WalletPolicy {
             recovery_tiers: vec![PolicyTier {


### PR DESCRIPTION
## Summary

Adds three unit tests for `reconstruct_descriptor`, covering paths that were previously exercised only through a full session or not at all.

A correction is owed here. An audit comment I posted on #790 stated this function had no test. That was wrong: two tests already existed, covering an invalid network string and a missing contribution. The grep behind that claim searched for lines containing both the function name and the word "test", and a test function's own name line contains neither the attribute nor the word, so it returned nothing. The function was never untested, and the item as written should not be closed on the basis I originally gave.

What was genuinely uncovered, and is covered here:

- A contribution that is present but not a usable extended key, so it passes the session-level prefix check and then fails at conversion. This is the only test that reaches the conversion error path.
- An external key slot, which carries its own key and must never be looked up in the contributions map. The test supplies no contributions at all and asserts the failure does not come from a lookup, so a regression that treated external slots as participants would fail rather than pass for the wrong reason.
- A policy with no recovery tiers, which takes the branch that builds no recovery configuration at all. This is the only success-path test, and it asserts the receive and change descriptors differ, since returning the same string twice would otherwise satisfy a weaker check.

The two pre-existing tests are left alone. Two further tests I initially wrote were dropped before pushing because they duplicated those.

## Test plan

`cargo test -p keep-frost-net --lib reconstruct` passes: 5 tests, the 2 existing and the 3 added. `cargo fmt --check` clean.

The new tests use placeholder extended keys in the same style as the surrounding tests. That is deliberate for the two error-path cases, which need a value that is well-formed enough to pass validation and not decodable. Note this means the conversion-failure test would still pass if conversion began rejecting for a different reason, so it pins the error path rather than the specific cause.

Part of #790.