### PR TITLE
Surface the trusted-dealer caveat on the key generation entry points

### DIFF
--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1098,6 +1098,16 @@ impl KeepMobile {
             .transpose()
     }
 
+    /// Generates a threshold key set using a trusted dealer.
+    ///
+    /// **The full private key exists on this device during generation.** Every
+    /// share is derived here before being distributed, so a device compromised
+    /// at this moment exposes the key regardless of the threshold chosen. The
+    /// threshold protects signing afterwards; it does not protect generation.
+    ///
+    /// Prefer distributed key generation where each participant contributes
+    /// entropy and the whole key is never assembled anywhere. Use this only when
+    /// that is not available, and treat the generating device accordingly.
     pub fn frost_generate(
         &self,
         threshold: u16,
@@ -1115,6 +1125,14 @@ impl KeepMobile {
         Self::build_generation_result(&shares, &passphrase)
     }
 
+    /// Splits an existing private key into threshold shares using a trusted
+    /// dealer.
+    ///
+    /// **The key is present in full on this device**, both as the input being
+    /// split and while the shares are derived. The same caveat as
+    /// [`Self::frost_generate`] applies, and additionally the key existed before
+    /// this call, so it may already be recorded elsewhere: splitting it does not
+    /// retract earlier copies.
     pub fn frost_split(
         &self,
         mut existing_key: String,


### PR DESCRIPTION
## Summary

`frost_generate` and `frost_split` both construct a trusted dealer, which assembles the full private key on the calling device before deriving shares. keep-core marks that type as development-only in its own documentation, but neither mobile entry point carried any note, so a caller reading the generated bindings had no way to know the trust model differs from distributed generation.

Both are on a `#[uniffi::export]` impl, so the doc comments reach the generated bindings rather than staying Rust-side.

The wording is deliberately about what happens rather than a bare warning label. The distinction worth conveying is that the threshold protects signing afterwards and does not protect generation: choosing three-of-five does not mean no device ever held the whole key. A reader who only sees "testing only" tends to weigh it against shipping pressure, whereas a reader who knows the key exists in full on that device at that moment can judge the risk themselves.

The split entry point gets an additional note, because it differs in kind: the key existed before the call, so splitting it does not retract copies that may already exist elsewhere. Someone reaching for it to retroactively secure an existing key is the case worth naming.

Documentation only. No behavior change, and deliberately not a deprecation or a runtime warning: trusted-dealer generation is a legitimate choice for some deployments, and the gap here was that callers could not tell which model they were getting.

## Test plan

`cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and the full `cargo test -p keep-mobile` suite are clean, 286 tests passing. No test is added; there is nothing observable to assert.

Part of #792.