### PR TITLE
Release v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "keep-agent"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "chrono",
@@ -4526,7 +4526,7 @@ dependencies = [
 
 [[package]]
 name = "keep-bitcoin"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bitcoin",
  "getrandom 0.4.3",
@@ -4545,7 +4545,7 @@ dependencies = [
 
 [[package]]
 name = "keep-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64 0.23.0",
@@ -4596,7 +4596,7 @@ dependencies = [
 
 [[package]]
 name = "keep-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "aes 0.9.1",
  "argon2",
@@ -4645,7 +4645,7 @@ dependencies = [
 
 [[package]]
 name = "keep-desktop"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64 0.23.0",
  "bitcoin",
@@ -4678,14 +4678,14 @@ dependencies = [
 
 [[package]]
 name = "keep-enclave"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "keep-enclave-host",
 ]
 
 [[package]]
 name = "keep-enclave-host"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "aes-gcm",
  "base64 0.23.0",
@@ -4716,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "keep-frost-net"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64 0.23.0",
  "bitcoin",
@@ -4757,7 +4757,7 @@ dependencies = [
 
 [[package]]
 name = "keep-mobile"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64 0.23.0",
  "bitcoin",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "keep-nip46"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64 0.23.0",
  "bitflags 2.13.1",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "keep-web"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "axum",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps the workspace version to 0.9.0 ahead of tagging. The release workflow verifies the tag matches this value, so the bump has to land first.

Minor rather than patch, because two foreign-implemented FFI traits changed shape in this range and required matching client work: the rate-limiter storage read became a three-state result so an unreadable counter is no longer indistinguishable from an absent one (#920), and sign-policy selection writes now report whether they actually persisted (#919). A client built against 0.8.0 does not satisfy either contract. The auto-sign decision enum also gained a variant, appended so existing ordinals are unchanged.

For comparison, the previous patch release carried two commits; this range carries thirty-five.

## Test plan

Ran the exact commands CI runs rather than approximations:

- `cargo clippy -- -D warnings` clean
- `cargo test --workspace --lib --bins` clean, 989 tests across the workspace
- `cargo build --workspace` and `cargo fmt --all --check` clean

`cargo update -w` regenerated the lockfile; the only changes are the workspace crates' own version fields.

Checked for stray references to the old version in manifests, workflows, and docs; there are none, so nothing else needs to move in lockstep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the workspace package version from 0.8.0 to 0.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->