### PR TITLE
Carry the request label and requester through to the approval prompt

### DIFF
--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -217,6 +217,35 @@ fn init_logging() {
     });
 }
 
+/// Builds the approval-facing request from a coordination session.
+///
+/// The label and the requester are carried across deliberately. FROST signs the
+/// 32 bytes verbatim, so a nostr event digest and a Bitcoin taproot sighash are
+/// byte-identical on the wire and the label is the only thing distinguishing
+/// them; the Android summary falls back to it when there is nothing else to
+/// show, so dropping it leaves the user approving an unlabelled hash. The
+/// requester identifies which peer asked, which is the other half of deciding
+/// whether a request is expected.
+///
+/// `metadata` stays empty. Its fields come from the session's structured
+/// payload, which needs decoding per message type before it can be trusted to
+/// populate an amount or a destination, and showing a wrong amount would be
+/// worse than showing none.
+fn sign_request_from_session(session: &keep_frost_net::SessionInfo) -> SignRequest {
+    SignRequest {
+        id: hex::encode(session.session_id),
+        session_id: session.session_id.to_vec(),
+        message_type: session.message_type.clone(),
+        message_preview: hex::encode(&session.message[..session.message.len().min(8)]),
+        from_peer: session.requester,
+        timestamp: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+        metadata: None,
+    }
+}
+
 const MAX_PENDING_REQUESTS: usize = 100;
 const SIGNING_RESPONSE_TIMEOUT: Duration = Duration::from_secs(60);
 const MAX_IMPORT_DATA_SIZE: usize = 64 * 1024;
@@ -3458,18 +3487,7 @@ impl KeepMobile {
                         continue;
                     }
                     guard.push(PendingRequest {
-                        info: SignRequest {
-                            id: hex::encode(session.session_id),
-                            session_id: session.session_id.to_vec(),
-                            message_type: String::new(),
-                            message_preview: hex::encode(&session.message[..session.message.len().min(8)]),
-                            from_peer: 0,
-                            timestamp: std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .unwrap_or_default()
-                                .as_secs(),
-                            metadata: None,
-                        },
+                        info: sign_request_from_session(&session),
                         response_tx,
                     });
                     drop(guard);
@@ -4520,5 +4538,55 @@ mod restore_backup_metadata_tests {
             "a true flag must survive too, or the fix would just invert the bug: {metadata_json}"
         );
         assert!(restored_share_meta(&storage).did_backup);
+    }
+}
+
+#[cfg(test)]
+mod sign_request_mapping_tests {
+    use super::*;
+
+    fn session(message_type: &str, requester: u16) -> keep_frost_net::SessionInfo {
+        keep_frost_net::SessionInfo {
+            session_id: [9u8; 32],
+            message: vec![0xab; 32],
+            threshold: 2,
+            participants: vec![1, 2, 3],
+            requester,
+            message_type: message_type.into(),
+            structured_payload: None,
+            derivation_path: vec![],
+        }
+    }
+
+    #[test]
+    fn the_label_reaches_the_approval_request() {
+        // Without this the Android summary falls back to an empty string and the
+        // user approves 32 bytes with nothing saying which domain they belong to.
+        let req = sign_request_from_session(&session("nostr-event", 3));
+        assert_eq!(req.message_type, "nostr-event");
+    }
+
+    #[test]
+    fn a_bitcoin_label_is_not_confused_with_a_nostr_one() {
+        // The two digests are byte-identical, so the label is the only thing
+        // carrying the difference through to the person approving.
+        let nostr = sign_request_from_session(&session("nostr-event", 1));
+        let bitcoin = sign_request_from_session(&session("bitcoin-sighash", 1));
+        assert_ne!(nostr.message_type, bitcoin.message_type);
+        assert_eq!(bitcoin.message_type, "bitcoin-sighash");
+    }
+
+    #[test]
+    fn the_requesting_peer_reaches_the_approval_request() {
+        let req = sign_request_from_session(&session("nostr-event", 4));
+        assert_eq!(req.from_peer, 4, "the approver needs to know who asked");
+    }
+
+    #[test]
+    fn the_preview_is_bounded_and_hex() {
+        let req = sign_request_from_session(&session("nostr-event", 1));
+        // Eight bytes rendered as hex, not the whole digest.
+        assert_eq!(req.message_preview.len(), 16);
+        assert!(req.message_preview.chars().all(|c| c.is_ascii_hexdigit()));
     }
 }

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -219,13 +219,25 @@ fn init_logging() {
 
 /// Builds the approval-facing request from a coordination session.
 ///
-/// The label and the requester are carried across deliberately. FROST signs the
-/// 32 bytes verbatim, so a nostr event digest and a Bitcoin taproot sighash are
-/// byte-identical on the wire and the label is the only thing distinguishing
-/// them; the Android summary falls back to it when there is nothing else to
-/// show, so dropping it leaves the user approving an unlabelled hash. The
-/// requester identifies which peer asked, which is the other half of deciding
-/// whether a request is expected.
+/// The label is carried across so the prompt is not an unlabelled hash, but it
+/// is **requester-supplied and not bound to the signed bytes**, so a peer can
+/// relabel a sighash as anything it likes. It is a hint about what the requester
+/// claims, never proof of what the bytes are, and nothing downstream may treat
+/// it as the domain discriminator. The hooks that would refuse a mislabelled
+/// request do not run here: installing hooks replaces the set rather than
+/// composing with it, so this crate's hooks are the only pre-sign policy on
+/// mobile.
+///
+/// Because it reaches a prompt and a notification, it goes through the same
+/// sanitizer every other adversary-authored prompt field in this codebase uses,
+/// which strips control characters and bidi overrides and caps the length. A
+/// newline here would otherwise render as extra lines in the notification body,
+/// and a right-to-left override would let the requester rewrite the text around
+/// it.
+///
+/// The requester index is authenticated: it is resolved from the signature-
+/// verified sender rather than taken from the payload, so a peer cannot claim
+/// another peer's index.
 ///
 /// `metadata` stays empty. Its fields come from the session's structured
 /// payload, which needs decoding per message type before it can be trusted to
@@ -235,7 +247,10 @@ fn sign_request_from_session(session: &keep_frost_net::SessionInfo) -> SignReque
     SignRequest {
         id: hex::encode(session.session_id),
         session_id: session.session_id.to_vec(),
-        message_type: session.message_type.clone(),
+        message_type: keep_nip46::handler::sanitize_prompt_field(
+            &session.message_type,
+            MESSAGE_TYPE_DISPLAY_MAX,
+        ),
         message_preview: hex::encode(&session.message[..session.message.len().min(8)]),
         from_peer: session.requester,
         timestamp: std::time::SystemTime::now()
@@ -245,6 +260,12 @@ fn sign_request_from_session(session: &keep_frost_net::SessionInfo) -> SignReque
         metadata: None,
     }
 }
+
+/// Display cap for the requester-supplied label, matching the method-name cap
+/// used for the other short prompt field in this codebase. The wire validator
+/// already bounds it, but that bound lives in another crate and does not apply
+/// to a session built by any other route.
+const MESSAGE_TYPE_DISPLAY_MAX: usize = 32;
 
 const MAX_PENDING_REQUESTS: usize = 100;
 const SIGNING_RESPONSE_TIMEOUT: Duration = Duration::from_secs(60);
@@ -4567,13 +4588,53 @@ mod sign_request_mapping_tests {
     }
 
     #[test]
-    fn a_bitcoin_label_is_not_confused_with_a_nostr_one() {
-        // The two digests are byte-identical, so the label is the only thing
-        // carrying the difference through to the person approving.
-        let nostr = sign_request_from_session(&session("nostr-event", 1));
-        let bitcoin = sign_request_from_session(&session("bitcoin-sighash", 1));
-        assert_ne!(nostr.message_type, bitcoin.message_type);
-        assert_eq!(bitcoin.message_type, "bitcoin-sighash");
+    fn a_newline_cannot_add_lines_to_the_prompt() {
+        // The notification renders the summary as multi-line text, so an
+        // embedded newline would let the requester append their own lines
+        // beneath the real one.
+        let req = sign_request_from_session(&session("nostr-event\nApproved by Keep", 1));
+        assert!(
+            !req.message_type.contains('\n'),
+            "got: {:?}",
+            req.message_type
+        );
+    }
+
+    #[test]
+    fn a_bidi_override_cannot_rewrite_the_text_around_it() {
+        let req = sign_request_from_session(&session("nostr\u{202E}drowssap", 1));
+        assert!(
+            !req.message_type.contains('\u{202E}'),
+            "got: {:?}",
+            req.message_type
+        );
+    }
+
+    #[test]
+    fn an_overlong_label_cannot_crowd_out_the_rest_of_the_prompt() {
+        let req = sign_request_from_session(&session(&"A".repeat(64), 1));
+        assert!(
+            req.message_type.chars().count() <= MESSAGE_TYPE_DISPLAY_MAX + 3,
+            "got {} chars",
+            req.message_type.chars().count()
+        );
+    }
+
+    #[test]
+    fn an_ordinary_label_survives_sanitizing_intact() {
+        // The stripping must not eat the normal case it exists to display.
+        let req = sign_request_from_session(&session("bitcoin-sighash", 1));
+        assert_eq!(req.message_type, "bitcoin-sighash");
+    }
+
+    #[test]
+    fn the_untouched_fields_are_untouched() {
+        // Pins the half of the extraction that was meant to be behaviour-preserving.
+        let s = session("nostr-event", 2);
+        let req = sign_request_from_session(&s);
+        assert_eq!(req.id, hex::encode(s.session_id));
+        assert_eq!(req.session_id, s.session_id.to_vec());
+        assert!(req.metadata.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The co-sign request handed to the approval screen was built with its label and its requester hardcoded empty, while the session carrying both was in scope at that line.

This matters more than a missing field. FROST signs the 32 bytes verbatim, so a nostr event digest and a Bitcoin taproot sighash are byte-identical on the wire, and the session type's own documentation says the label exists precisely to tell them apart. On the Android side the summary builder falls back to that label when there is nothing else to show, and its other inputs come from metadata that is also hardcoded empty. The result is that a co-sign prompt reduces to sixteen hex characters, with nothing indicating whether the user is approving a Bitcoin spend or a nostr event, and nothing saying which peer asked.

Both fields now carry across. The mapping is extracted into a function so it can be tested directly, since the original line sits inside the node's event loop and needs a running node to reach.

`metadata` deliberately stays empty. Its fields come from the session's structured payload, which has to be decoded per message type before it can be trusted to populate an amount or a destination, and a wrong amount on an approval prompt is worse than no amount. That is a larger change and is tracked separately.

## Test plan

Four tests on the extracted mapping: the label reaches the request, a Bitcoin label is not interchangeable with a nostr one, the requester reaches the request, and the preview stays bounded to eight bytes of hex rather than the whole digest.

Falsified rather than assumed: restoring the two hardcoded values fails three of the four. The fourth covers the preview bound and passes either way by design, which is why it is there.

`cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and the full `cargo test -p keep-mobile` suite are clean: 301 tests.

Part of #792.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Approval requests now display the correct message type and requester identity.
  * Message previews are shown as bounded hexadecimal text for improved readability.
  * Request identifiers are populated consistently, while unavailable metadata remains omitted.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->