### PR TITLE
Stop the rate-limit tests racing the derivation they trigger

### DIFF
--- a/keep-core/src/hidden/volume.rs
+++ b/keep-core/src/hidden/volume.rs
@@ -1273,15 +1273,25 @@ mod tests {
             assert!(!matches!(result, Err(KeepError::RateLimited(_))));
         }
 
-        // Attempts 6-8 on same instance for tight timing.
-        // After 5 failures, delay=1s. After 6, delay=2s. After 7, delay=4s.
-        // Three rapid attempts ensures we hit rate limiting even on very
-        // slow CI runners where individual Argon2 calls take >1s.
+        // Keep attempting until one is refused rather than asserting on a
+        // fixed attempt. The backoff is measured from the last failure and
+        // doubles past the free allowance (1s, 2s, 4s, ...), while an attempt
+        // costs a constant Argon2 derivation, so on a slow runner the window
+        // can expire before the next attempt arrives and no particular attempt
+        // is guaranteed to be refused. Because the delay grows exponentially
+        // and the derivation cost does not, it overtakes that cost within a few
+        // attempts. Bounded so a real regression fails here instead of looping.
         let mut storage = HiddenStorage::open(&path).unwrap();
-        let _ = storage.unlock_outer("wrong");
-        let _ = storage.unlock_outer("wrong");
-        let result = storage.unlock_outer("wrong");
-        assert!(matches!(result, Err(KeepError::RateLimited(_))));
+        let refused = (0..8).any(|_| {
+            matches!(
+                storage.unlock_outer("wrong"),
+                Err(KeepError::RateLimited(_))
+            )
+        });
+        assert!(
+            refused,
+            "rate limiting never engaged after repeated outer failures"
+        );
     }
 
     #[test]
@@ -1307,15 +1317,25 @@ mod tests {
             assert!(!matches!(result, Err(KeepError::RateLimited(_))));
         }
 
-        // Attempts 6-8 on same instance for tight timing.
-        // After 5 failures, delay=1s. After 6, delay=2s. After 7, delay=4s.
-        // Three rapid attempts ensures we hit rate limiting even on very
-        // slow CI runners where individual Argon2 calls take >1s.
+        // Keep attempting until one is refused rather than asserting on a
+        // fixed attempt. The backoff is measured from the last failure and
+        // doubles past the free allowance (1s, 2s, 4s, ...), while an attempt
+        // costs a constant Argon2 derivation, so on a slow runner the window
+        // can expire before the next attempt arrives and no particular attempt
+        // is guaranteed to be refused. Because the delay grows exponentially
+        // and the derivation cost does not, it overtakes that cost within a few
+        // attempts. Bounded so a real regression fails here instead of looping.
         let mut storage = HiddenStorage::open(&path).unwrap();
-        let _ = storage.unlock_hidden("wrong");
-        let _ = storage.unlock_hidden("wrong");
-        let result = storage.unlock_hidden("wrong");
-        assert!(matches!(result, Err(KeepError::RateLimited(_))));
+        let refused = (0..8).any(|_| {
+            matches!(
+                storage.unlock_hidden("wrong"),
+                Err(KeepError::RateLimited(_))
+            )
+        });
+        assert!(
+            refused,
+            "rate limiting never engaged after repeated hidden failures"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`build (macos-latest)` failed on main with `test_rate_limiting_outer` asserting that an unlock attempt was refused when it was not. The job does not run on pull requests, so this only appears after merge.

Not a regression from the commit it failed on, which touched only keep-mobile while this test lives in keep-core. It is a timing race the test has always had.

The backoff is measured from the last recorded failure and doubles past the free allowance, so one, two, four seconds and so on. Each attempt costs an Argon2 derivation, and that cost is constant. The test spent its five free attempts, then made three rapid ones and asserted the third was refused, at which point the required wait was four seconds. On a runner where a single derivation takes longer than that, the window has already elapsed by the time the next attempt arrives, every attempt is allowed, and the assertion fails. The existing comment anticipated exactly this and picked a fixed number of attempts, which cannot be enough for an arbitrarily slow machine.

Both affected tests now keep attempting until one is refused, bounded so a real regression fails rather than loops. This is not a weaker assertion: the delay grows exponentially while the derivation cost does not, so the backoff overtakes it within a couple of attempts on any machine. It removes the dependency on the runner being fast rather than papering over the failure.

The combined-unlock test in the same module shares the shape but asserts differently and was already passing; it is left alone rather than changed speculatively.

## Test plan

All three rate-limit tests pass locally, and the full `cargo test -p keep-core --lib` suite is clean at 386 tests. `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.

Falsified rather than assumed: with the rate-limit check stubbed to always allow, all three fail. So the loop still catches the defect the test exists for; it just no longer races the derivation.

The original failure cannot be reproduced on this machine, because reproducing it requires an Argon2 derivation slower than the four-second window. The mechanism is established from the backoff computation and the failing assertion rather than from a local repro, and the fix removes the dependency on that timing entirely rather than tuning it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved rate-limiting tests to avoid timing-dependent failures.
  * Added bounded repeated-attempt checks for both outer and hidden storage scenarios.
  * Clarified failure messages when rate limiting does not activate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->