### PR TITLE
Keep the job token out of a tree the PR author controls

### DIFF
--- a/.github/workflows/rng-hygiene.yml
+++ b/.github/workflows/rng-hygiene.yml
@@ -29,6 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # This job checks out a PR branch and then EXECUTES a script from it.
+          # actions/checkout persists GITHUB_TOKEN into .git/config by default,
+          # leaving it readable by PR-authored code. Nothing here needs git
+          # credentials; `permissions: contents: read` above bounds the scope,
+          # this removes the token from the working tree entirely.
+          persist-credentials: false
 
       - name: Check for silent RNG fallbacks
         run: ./scripts/check-rng-hygiene.sh


### PR DESCRIPTION
## Summary
Adds `persist-credentials: false` to the `rng-hygiene` workflow's checkout.

## Why

The job checks out a PR branch and then **executes a script from it** — `scripts/check-rng-hygiene.sh`, which any PR author can edit. `actions/checkout` writes `GITHUB_TOKEN` into `.git/config` by default, so that PR-authored script could read it.

`permissions: contents: read` (already set) bounds what the token can do; this removes it from the working tree entirely. The job performs no git operations that need credentials.

Found in a CodeRabbit comment on #932 that I merged past without reading. The same fix is going to keep-esp32 (two guard workflows) and keep-node.

## Test plan
- [x] Workflow file parses as YAML
- [x] `scripts/check-rng-hygiene.sh` still clean on the tree
- [ ] Takes effect on the next CI run of this workflow; not verifiable locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved repository security by preventing temporary authentication credentials from being stored during automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->