### PR TITLE
Self-test the RNG hygiene guard

### DIFF
--- a/.github/workflows/rng-hygiene.yml
+++ b/.github/workflows/rng-hygiene.yml
@@ -37,5 +37,12 @@ jobs:
           # this removes the token from the working tree entirely.
           persist-credentials: false
 
+      # Assert the guard's rules before trusting them. Sibling guards in
+      # keep-node, keep-esp32 and keep-android each had a split-token evasion
+      # that no test would have caught. This scanner already buffers across
+      # lines; these cases are what keeps that true.
+      - name: Self-test the RNG hygiene guard
+        run: ./scripts/test-rng-hygiene.sh
+
       - name: Check for silent RNG fallbacks
         run: ./scripts/check-rng-hygiene.sh

--- a/scripts/test-rng-hygiene.sh
+++ b/scripts/test-rng-hygiene.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Self-test for check-rng-hygiene.sh.
+#
+# This guard keeps unhandled RNG errors, swallowed RNG failures and seeded PRNGs
+# out of production Rust, and asserts the entropy health gate still runs. A
+# scanner that quietly stops scanning reports a clean tree exactly like a clean
+# tree does, so the rules are asserted rather than trusted.
+#
+# Probes go under keep-core/src: the guard skips tests, benches, examples,
+# vendor, target and fuzz, so a probe placed there passes and looks like a
+# bypass when it is only misplaced. The positive control catches that.
+#
+# Note the two-pattern rules. A bare fill_bytes() is legitimate; it is a finding
+# only together with a swallow such as .ok() or .unwrap_or_default(). Probes are
+# written to the real rule, not to a simpler one that would pass regardless.
+#
+# Each reject case requires the guard to NAME the probe file. Without that, a
+# guard aborting for an unrelated reason would be credited as a detection and
+# every case below would pass while detecting nothing.
+#
+# Probes are staged into a throwaway GIT_INDEX_FILE, so the real index is never
+# touched. The file itself must exist on disk while the guard runs, because the
+# scanner reads bytes; it is removed on every path including the EXIT trap.
+set -uo pipefail
+
+cd "$(dirname "$0")/.." || { echo "FAIL: cannot cd to the repo root"; exit 1; }
+GUARD=scripts/check-rng-hygiene.sh
+[ -x "$GUARD" ] || { echo "FAIL: $GUARD not found or not executable"; exit 1; }
+
+TMPD=$(mktemp -d)
+PROBE=""
+cleanup() { rm -rf "$TMPD"; [ -n "$PROBE" ] && rm -f "$PROBE"; }
+trap cleanup EXIT
+
+fails=0
+
+# run_probe <path> <content> <pass|fail> <description>
+run_probe() {
+    local name="$1" content="$2" expect="$3" desc="$4"
+
+    if [ -e "$name" ]; then
+        echo "  HARNESS BROKEN: $name exists; refusing to overwrite a real file"
+        fails=$((fails + 1)); return
+    fi
+    PROBE="$name"
+    printf '%s' "$content" > "$name"
+
+    rm -f "$TMPD/index"
+    GIT_INDEX_FILE="$TMPD/index" git read-tree HEAD 2>/dev/null
+    GIT_INDEX_FILE="$TMPD/index" git add -f "$name" 2>/dev/null
+
+    local staged
+    staged=$(GIT_INDEX_FILE="$TMPD/index" git ls-files | wc -l)
+    if [ "$staged" -lt 10 ]; then
+        echo "  HARNESS BROKEN: only $staged file(s) staged; the guard would scan almost nothing"
+        fails=$((fails + 1)); rm -f "$name"; PROBE=""; return
+    fi
+
+    local rc=0 out
+    out=$(GIT_INDEX_FILE="$TMPD/index" "$GUARD" 2>&1) || rc=$?
+    rm -f "$name"; PROBE=""
+
+    if [ "$expect" = fail ]; then
+        if [ "$rc" -eq 0 ]; then
+            echo "  BYPASS: $desc"; fails=$((fails + 1))
+        elif ! printf '%s' "$out" | grep -qF "$name"; then
+            echo "  WRONG REASON: $desc (guard failed without naming $name)"; fails=$((fails + 1))
+        else
+            echo "  ok: $desc"
+        fi
+    else
+        if [ "$rc" -ne 0 ]; then
+            echo "  FALSE POSITIVE: $desc"
+            printf '%s\n' "$out" | sed 's/^/      /' | head -4
+            fails=$((fails + 1))
+        else
+            echo "  ok: $desc"
+        fi
+    fi
+}
+
+echo "== rejects what it must reject =="
+
+SRC=keep-core/src
+
+run_probe $SRC/probe_ctl.rs 'fn f(){ let mut b=[0u8;32]; getrandom::getrandom(&mut b); }
+' fail "unhandled RNG error (positive control: if this passes, nothing below means anything)"
+
+run_probe $SRC/probe_swallow.rs 'fn f(){ let mut b=[0u8;32]; getrandom::getrandom(&mut b).ok(); }
+' fail "RNG failure collapsed with .ok()"
+
+# The evasion that defeated the guards in keep-node, keep-esp32 and keep-android:
+# splitting the tokens across lines. This scanner already buffers, and this case
+# is here so that stays true.
+run_probe $SRC/probe_split.rs 'fn f(){ let mut b=[0u8;32]; getrandom::getrandom(&mut b)
+    .ok(); }
+' fail "swallow split onto the next line"
+
+run_probe $SRC/probe_split2.rs 'fn f(){ let mut b=[0u8;32]; getrandom::getrandom(&mut b)
+    .unwrap_or_default(); }
+' fail "unwrap_or_default split onto the next line"
+
+run_probe $SRC/probe_seeded.rs 'fn f(){ let r = SmallRng::seed_from_u64(1); let _ = r; }
+' fail "seeded PRNG in production code"
+
+echo "== accepts what it must accept =="
+
+run_probe $SRC/probe_ok.rs 'fn f()->Result<(),getrandom::Error>{ let mut b=[0u8;32]; getrandom::getrandom(&mut b)?; Ok(()) }
+' pass "RNG error propagated with ?"
+
+run_probe $SRC/probe_comment.rs '// getrandom(&mut b).ok() named in prose only
+fn f(){ let x=1; let _=x; }
+' pass "a banned shape inside a comment is not code"
+
+run_probe $SRC/probe_cfgtest.rs '#[cfg(test)]
+mod t { fn f(){ let mut b=[0u8;32]; getrandom::getrandom(&mut b).ok(); } }
+' pass "test code is out of scope"
+
+echo
+if [ "$fails" -ne 0 ]; then
+    echo "FAIL: $fails case(s) did not behave as required"
+    exit 1
+fi
+echo "OK: check-rng-hygiene.sh rejects every known bypass and accepts sanctioned use"

--- a/scripts/test-rng-hygiene.sh
+++ b/scripts/test-rng-hygiene.sh
@@ -49,10 +49,18 @@ run_probe() {
     GIT_INDEX_FILE="$TMPD/index" git read-tree HEAD 2>/dev/null
     GIT_INDEX_FILE="$TMPD/index" git add -f "$name" 2>/dev/null
 
+    # Both that the tree is populated AND that this probe is in it. Discarding
+    # the git errors above means a failed `git add` would otherwise leave the
+    # guard scanning a probe-free tree, and the case would be judged on a file
+    # the guard never saw.
     local staged
     staged=$(GIT_INDEX_FILE="$TMPD/index" git ls-files | wc -l)
     if [ "$staged" -lt 10 ]; then
         echo "  HARNESS BROKEN: only $staged file(s) staged; the guard would scan almost nothing"
+        fails=$((fails + 1)); rm -f "$name"; PROBE=""; return
+    fi
+    if ! GIT_INDEX_FILE="$TMPD/index" git ls-files --error-unmatch "$name" >/dev/null 2>&1; then
+        echo "  HARNESS BROKEN: $name was not staged; the guard would never see it"
         fails=$((fails + 1)); rm -f "$name"; PROBE=""; return
     fi
 


### PR DESCRIPTION
## Summary

Adds `scripts/test-rng-hygiene.sh`, asserting five rejections and three acceptances, and runs it in CI ahead of the guard. No change to the guard itself: it was tested and found sound.

## Why

Sibling guards in three repositories each turned out to have a split-token evasion this week, and none had a test that would have caught it:

| repo | evasion | fixed in |
|---|---|---|
| keep-node | variable indirection, string concatenation, extension gate | #108 |
| keep-esp32 | C line continuation inside an identifier | #154 |
| keep-android | Kotlin member access after a trailing dot, reflection | #473 |

This scanner was probed for the same class and **already handles it**: `scan_rust` buffers across lines, so a swallow moved onto the next line is still caught. That is worth locking in rather than rediscovering.

## What the probes are written against

Two things had to be checked before the cases were meaningful, and both corrected a wrong first attempt:

**Scope.** The guard skips `tests`, `benches`, `examples`, `vendor`, `target` and `fuzz`. A probe placed in `fuzz/fuzz_targets` passed and looked like a bypass when it was only misplaced. Probes now live under `keep-core/src`, and the positive control is what caught the mistake.

**Rule shape.** Rule 2 is a two-pattern rule: `fill_bytes(...)` is a finding only *together* with a swallow such as `.ok()` or `.unwrap_or_default()`. A bare `rand::thread_rng().fill_bytes(&mut b)` is legitimate and correctly not flagged. Writing a probe against the simpler rule I first assumed would have produced a case that passes regardless of whether the guard works.

## The cases

Rejections: unhandled RNG error, failure collapsed with `.ok()`, the same swallow split onto the next line, `unwrap_or_default` split onto the next line, seeded PRNG.

Acceptances: error propagated with `?`, a banned shape inside a comment, a swallow inside `#[cfg(test)]`.

Reject cases require the guard to **name the probe file**, so a guard aborting for an unrelated reason is reported as `WRONG REASON` instead of being credited as a detection. The harness aborts if fewer than 10 files stage.

## Test plan

- [x] 8/8 on the current guard
- [x] **Regression control**: with rule 3 disabled it reports `BYPASS: seeded PRNG in production code` and exits 1, so it detects a weakened guard rather than passing regardless
- [x] Guard confirmed byte-identical to its committed state afterwards, no sabotage remnants
- [x] Probes stage into a throwaway `GIT_INDEX_FILE`; real index untouched
- [x] `bash -n` clean, workflow parses
- [ ] CI

All four repositories now have a self-tested RNG guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated self-tests covering valid and invalid random-number usage patterns.
  * Expanded validation for error handling, seeded generators, comments, multiline cases, and test-only code.

* **Chores**
  * Continuous integration now runs the hygiene self-tests before performing its standard checks, helping detect validation regressions earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->