### PR TITLE
Update nostr and nostr-relay-pool past eight advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -234,7 +234,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2358,7 +2358,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2575,7 +2575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5455,7 +5455,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.19",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5736,9 +5736,9 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "nostr"
-version = "0.44.6"
+version = "0.44.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e826dd648489de2c5b293920e20b92932ef820302007c1987c758d4d06eeb2cf"
+checksum = "c7d3d987ea7078dc36947cde532637c472a229426702e4331dd7667325378bd9"
 dependencies = [
  "aes 0.8.4",
  "base64 0.22.1",
@@ -5798,9 +5798,9 @@ dependencies = [
 
 [[package]]
 name = "nostr-relay-pool"
-version = "0.44.2"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb94d61a467a869a6790b907838a9bea82c813d567d9fcbac995f207be8cee4b"
+checksum = "c85c54d6ca9aae4ae2bf19a7663ba9db5f45f783f1d24aff55f006386b8b99a1"
 dependencies = [
  "async-utility",
  "async-wsocket",
@@ -5849,7 +5849,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7818,7 +7818,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8553,7 +8553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8828,7 +8828,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8850,7 +8850,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9488,7 +9488,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.19",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9594,7 +9594,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10585,7 +10585,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`nostr` 0.44.6 to 0.44.7 and `nostr-relay-pool` 0.44.2 to 0.44.3, clearing eight advisories published against the tree since v0.9.1 shipped.

## What was open

| advisory | issue |
|---|---|
| RUSTSEC-2026-0225 | **Debug output exposes NIP-46 and NIP-60 credentials** |
| RUSTSEC-2026-0226 | **Wallet event parsers accept unauthenticated events** |
| RUSTSEC-2026-0232 | Processing of unverified relay events |
| RUSTSEC-2026-0227 | NIP-44 v2 decryption permits resource exhaustion |
| RUSTSEC-2026-0228 | NIP-04 parsing amplifies malformed ciphertext memory use |
| RUSTSEC-2026-0229 | NIP-98 authorization parsing permits resource exhaustion |
| RUSTSEC-2026-0231 | Relay authentication challenges can exhaust memory |
| RUSTSEC-2026-0230 | Empty NIP-50 search filters can panic |

The first three are the ones that matter most here. NIP-46 is the remote-signer protocol this project implements, so credentials reaching debug output is a disclosure path in exactly the component that exists to hold them. Accepting unauthenticated wallet events and processing unverified relay events are both integrity failures on untrusted input, which is the threat model for anything that talks to a relay.

The remaining five are denial of service against parsers fed by untrusted peers. Lower ceiling, same untrusted-input surface.

## Two updates, not one

`cargo update -p nostr` alone left RUSTSEC-2026-0231 and RUSTSEC-2026-0232 open: those are fixed in `nostr-relay-pool >= 0.44.3`, reached through `nostr-sdk`. Verified by re-running `cargo deny` after the first update rather than assuming one bump covered all eight. `nostr-relay-pool` was last moved to 0.44.2 in #935 for RUSTSEC-2026-0224, so this is the second advisory against that crate in as many days.

## Scope

`Cargo.lock` only, 17 lines. No manifest edits, no API changes, both bumps within the existing semver ranges.

## Test plan

- [x] `cargo deny check advisories` reports `advisories ok` (was 8 errors)
- [x] `cargo check --workspace --all-targets --features testing` succeeds
- [x] `keep-core` entropy suite: 12 passed
- [x] `keep-cli` nonce store suite: 8 passed
- [ ] Full CI

## Release

v0.9.1 was published earlier today and its artifacts contain the vulnerable versions. Whether that warrants a v0.9.2 is a call worth making deliberately rather than by default: the disclosure paths above are real, but no keep code is known to reach them, and I have not traced the call graph to establish that either way. Flagging rather than deciding.

Found because `deny` failed on an unrelated PR (#936). That job is time-dependent by nature, and this is the second time today it has surfaced a genuine advisory on a run that had nothing to do with dependencies.