### PR TITLE
Release v0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "keep-agent"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "chrono",
@@ -4526,7 +4526,7 @@ dependencies = [
 
 [[package]]
 name = "keep-bitcoin"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "bitcoin",
  "getrandom 0.4.3",
@@ -4545,7 +4545,7 @@ dependencies = [
 
 [[package]]
 name = "keep-cli"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "base64 0.23.0",
@@ -4596,7 +4596,7 @@ dependencies = [
 
 [[package]]
 name = "keep-core"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aes 0.9.1",
  "argon2",
@@ -4645,7 +4645,7 @@ dependencies = [
 
 [[package]]
 name = "keep-desktop"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "base64 0.23.0",
  "bitcoin",
@@ -4678,14 +4678,14 @@ dependencies = [
 
 [[package]]
 name = "keep-enclave"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "keep-enclave-host",
 ]
 
 [[package]]
 name = "keep-enclave-host"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aes-gcm",
  "base64 0.23.0",
@@ -4716,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "keep-frost-net"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "base64 0.23.0",
  "bitcoin",
@@ -4757,7 +4757,7 @@ dependencies = [
 
 [[package]]
 name = "keep-mobile"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "base64 0.23.0",
  "bitcoin",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "keep-nip46"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "base64 0.23.0",
  "bitflags 2.13.1",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "keep-web"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "axum",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps the workspace to 0.9.2 so the advisory fixes in #937 reach a published artifact. v0.9.1 shipped this morning with `nostr 0.44.6` and `nostr-relay-pool 0.44.2`, both since superseded.

## Why this is not optional

I traced reachability rather than assuming, because "upgrade available" and "we are exposed" are different claims. keep reaches **five of the eight** advisories:

| advisory | reached via | kind |
|---|---|---|
| **RUSTSEC-2026-0232** unverified relay events | `Client::new` x26, `.connect()` x32 | **integrity** |
| RUSTSEC-2026-0231 relay auth memory | `RelayPool` x25 | DoS |
| RUSTSEC-2026-0227 NIP-44 v2 decrypt | `nip44::decrypt` x17 | DoS |
| RUSTSEC-2026-0228 NIP-04 parsing | `nip04::decrypt` | DoS |
| RUSTSEC-2026-0229 NIP-98 auth parsing | nip98 | DoS |

0232 is the one that decides it. It is an integrity failure on untrusted input, not a denial of service, and it is reachable through the relay client this project uses throughout.

**Three are not reachable**, and saying so matters as much:

- **0225**, Debug exposure of NIP-46/NIP-60 credentials, needs the *nostr crate's* NIP-46 types. `NostrConnectRequest` in `keep-nip46/src/bunker.rs:35` is this project's own struct, and `Kind::NostrConnect` is an event-kind constant, not a credential-bearing type. No NIP-60 or Cashu usage anywhere.
- **0226**, wallet event parsers, is NIP-60. `keep-core/src/wallet.rs` is a Bitcoin wallet with no NIP-60 involvement.
- **0230**, empty NIP-50 search filters, has no NIP-50 usage to reach.

So the headline advisory, credential exposure, is the one that does not apply here. The one that does is quieter and worse.

## Contents

`Cargo.toml` and `Cargo.lock` only. The dependency fix itself is #937, already on main; this makes it releasable.

## Test plan

- [x] Version expression `release.yml` uses returns `0.9.2`
- [x] `cargo deny check advisories`: `advisories ok`
- [x] Confirmed v0.9.1's tagged `Cargo.lock` carries 0.44.6 / 0.44.2, so the published artifacts are genuinely affected rather than presumed to be
- [ ] Full CI

Tag on the merge commit, per the release order that release.yml enforces: it refuses to build when `Cargo.toml` does not match the tag, which is what caught the first v0.9.1 attempt.