### PR TITLE
Run the macOS build on pull requests, not only after merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest", "macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        # macOS runs on pull requests too, not only on push. It is the one
+        # platform job that has caught a real failure, and it caught it after
+        # merge: a timing-sensitive test that passes on a fast runner and fails
+        # on a slow one turned main red from a pull request that was fully
+        # green. Finding that before merge costs runner minutes; finding it
+        # after costs a red main plus the work to bisect it.
+        #
+        # The packaging jobs below stay push-only deliberately. They verify how
+        # artifacts are assembled rather than how the code behaves, so they are
+        # far less likely to catch a logic change, and they are the expensive
+        # ones to run per pull request.
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install dependencies (Linux)


### PR DESCRIPTION
## Summary

The macOS build ran only on push, so a pull request could be fully green and still turn `main` red on merge. That is not hypothetical: it happened today. A timing-sensitive test that passes on a fast runner and fails on a slow one went in green and broke `main`, and the failure was only visible after the merge that caused it.

macOS now runs on pull requests as well. Finding that class of failure before merge costs runner minutes. Finding it after costs a red default branch plus the work to identify which of several merged changes caused it, which in this case was none of them, since the failing test lived in a crate the merge did not touch.

The packaging jobs are deliberately left push-only. Windows, Debian and the reproducibility check verify how artifacts are assembled rather than how the code behaves, so they are much less likely to catch a logic change, and they are the expensive ones to run per pull request. This is a targeted change rather than a blanket one.

Worth stating plainly since it is a recurring cost: macOS runners bill at a higher multiplier than Linux, so this does raise per-pull-request CI spend. Easy to revert by restoring the conditional if that trade is not worth it.

Two related gaps are documented rather than changed, because both are defensible as they stand. Draft pull requests skip the build entirely, which is reasonable for work in progress but means a draft's green checks say nothing; there is a long-lived draft in the Android repository where that is currently misleading. And the Android instrumented suite is likewise gated on draft status. Both are now recorded in the invariants doc so the incompleteness is at least written down.

## Test plan

The workflow parses. The matrix is now unconditional, so this pull request itself is the first to exercise it: a `build (macos-latest)` job appearing on this PR is the change working.