### PR TITLE
Run the baseline pre-sign policy before the pre-approval short-circuit

### DIFF
--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -432,6 +432,27 @@ impl SigningHooks for MobileSigningHooks {
                 "co-signing is disabled".into(),
             ));
         }
+        // Baseline pre-sign policy. Installing hooks replaces the set rather
+        // than composing with it, so the policies that refuse an unstructured
+        // request never run on this crate's node unless it invokes them
+        // itself. Without this, a phone co-signer accepts message_type="raw":
+        // 32 bytes with no claimed domain at all, which frost-secp256k1 signs
+        // verbatim and which is therefore indistinguishable from a Bitcoin
+        // sighash once signed.
+        //
+        // Placed before the pre-approval short-circuit for the same reason the
+        // kill switch is: an approval recorded earlier must not authorise a
+        // request the policy refuses now. Putting it after would let exactly
+        // the requests that skip the prompt also skip the policy.
+        //
+        // Refusing the raw label is unconditional because nothing legitimately
+        // sends it to a phone. Requiring a structured body on every request is
+        // the stronger policy and is deliberately not applied here: the
+        // payload is optional at the request site, so making it mandatory
+        // would refuse initiators that do not attach one, and a co-signer that
+        // cannot sign reads as broken rather than as protected.
+        keep_frost_net::RefuseRawSignatureHooks.pre_sign(session)?;
+
         if self.consume_pre_approval(&session.message) {
             return Ok(());
         }
@@ -4700,5 +4721,167 @@ mod sign_request_mapping_tests {
         // Eight bytes rendered as hex, not the whole digest.
         assert_eq!(req.message_preview.len(), 16);
         assert!(req.message_preview.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}
+
+#[cfg(test)]
+mod baseline_presign_policy_tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex as StdMutex;
+
+    /// Storage whose only job is to answer the kill-switch read. Seeded
+    /// directly rather than through `store_share_by_key`, which requires share
+    /// metadata that has nothing to do with a boolean.
+    struct KillSwitchOffStorage {
+        data: StdMutex<HashMap<String, Vec<u8>>>,
+    }
+
+    impl KillSwitchOffStorage {
+        fn with_switch_off() -> Self {
+            let mut data = HashMap::new();
+            data.insert(
+                KILL_SWITCH_STORAGE_KEY.to_string(),
+                serde_json::to_vec(&false).expect("bool serialises"),
+            );
+            Self {
+                data: StdMutex::new(data),
+            }
+        }
+    }
+
+    impl SecureStorage for KillSwitchOffStorage {
+        fn store_share(&self, _: Vec<u8>, _: ShareMetadataInfo) -> Result<(), KeepMobileError> {
+            Ok(())
+        }
+        fn load_share(&self) -> Result<Vec<u8>, KeepMobileError> {
+            Err(KeepMobileError::StorageNotFound)
+        }
+        fn has_share(&self) -> bool {
+            false
+        }
+        fn get_share_metadata(&self) -> Option<ShareMetadataInfo> {
+            None
+        }
+        fn delete_share(&self) -> Result<(), KeepMobileError> {
+            Ok(())
+        }
+        fn store_share_by_key(
+            &self,
+            key: String,
+            data: Vec<u8>,
+            _: ShareMetadataInfo,
+        ) -> Result<(), KeepMobileError> {
+            self.data.lock().unwrap().insert(key, data);
+            Ok(())
+        }
+        fn load_share_by_key(&self, key: String) -> Result<Vec<u8>, KeepMobileError> {
+            self.data
+                .lock()
+                .unwrap()
+                .get(&key)
+                .cloned()
+                .ok_or(KeepMobileError::StorageNotFound)
+        }
+        fn list_all_shares(&self) -> Vec<ShareMetadataInfo> {
+            Vec::new()
+        }
+        fn delete_share_by_key(&self, _: String) -> Result<(), KeepMobileError> {
+            Ok(())
+        }
+        fn get_active_share_key(&self) -> Option<String> {
+            None
+        }
+        fn set_active_share_key(&self, _: Option<String>) -> Result<(), KeepMobileError> {
+            Ok(())
+        }
+    }
+
+    fn session_with(message_type: &str, message: Vec<u8>) -> SessionInfo {
+        SessionInfo {
+            session_id: [9u8; 32],
+            message,
+            threshold: 2,
+            participants: vec![1, 2],
+            requester: 1,
+            message_type: message_type.to_string(),
+            structured_payload: None,
+            derivation_path: Vec::new(),
+        }
+    }
+
+    /// The baseline policy has to run before the pre-approval short-circuit, and
+    /// this is the case that tells the two placements apart. A pre-approval
+    /// records that the user accepted one specific set of bytes; it does not
+    /// record consent to sign an unstructured request, and a policy sitting
+    /// below the short-circuit would never be consulted for one. Move the
+    /// policy call after `consume_pre_approval` and this test fails, which is
+    /// the point of writing it this way round rather than testing an
+    /// unapproved request that would be refused at the prompt anyway.
+    #[test]
+    fn raw_label_is_refused_even_when_already_pre_approved() {
+        // An unreadable switch counts as engaged, so it has to be explicitly
+        // off or this passes for the wrong reason: every request refused, and
+        // nothing proven about the policy under test.
+        let storage = KillSwitchOffStorage::with_switch_off();
+
+        let message = vec![7u8; 32];
+        let pre_approved: PreApprovedHashes = Arc::new(StdMutex::new(HashMap::new()));
+        {
+            use sha2::{Digest, Sha256};
+            let hash: [u8; 32] = Sha256::digest(&message).into();
+            pre_approved
+                .lock()
+                .unwrap()
+                .insert(hash, std::time::Instant::now());
+        }
+
+        let (request_tx, _request_rx) = mpsc::channel(1);
+        let hooks = MobileSigningHooks {
+            request_tx,
+            pre_approved_hashes: pre_approved,
+            storage: Arc::new(storage),
+        };
+
+        let err = hooks
+            .pre_sign(&session_with("raw", message.clone()))
+            .expect_err("a raw request must be refused even with a pre-approval recorded");
+        assert!(
+            format!("{err}").contains("raw"),
+            "refusal should name the policy that fired, got: {err}"
+        );
+    }
+
+    /// The guard must not swallow the requests it exists to let through: a
+    /// pre-approved request carrying an ordinary label still short-circuits.
+    /// Without this, refusing everything would satisfy the test above.
+    #[test]
+    fn a_pre_approved_ordinary_request_still_passes() {
+        let storage = KillSwitchOffStorage::with_switch_off();
+
+        let message = vec![3u8; 32];
+        let pre_approved: PreApprovedHashes = Arc::new(StdMutex::new(HashMap::new()));
+        {
+            use sha2::{Digest, Sha256};
+            let hash: [u8; 32] = Sha256::digest(&message).into();
+            pre_approved
+                .lock()
+                .unwrap()
+                .insert(hash, std::time::Instant::now());
+        }
+
+        let (request_tx, _request_rx) = mpsc::channel(1);
+        let hooks = MobileSigningHooks {
+            request_tx,
+            pre_approved_hashes: pre_approved,
+            storage: Arc::new(storage),
+        };
+
+        hooks
+            .pre_sign(&session_with(
+                keep_frost_net::MSG_TYPE_BITCOIN_SIGHASH,
+                message,
+            ))
+            .expect("a pre-approved request with an ordinary label must still pass");
     }
 }

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -445,13 +445,46 @@ impl SigningHooks for MobileSigningHooks {
         // request the policy refuses now. Putting it after would let exactly
         // the requests that skip the prompt also skip the policy.
         //
-        // Refusing the raw label is unconditional because nothing legitimately
-        // sends it to a phone. Requiring a structured body on every request is
-        // the stronger policy and is deliberately not applied here: the
-        // payload is optional at the request site, so making it mandatory
-        // would refuse initiators that do not attach one, and a co-signer that
-        // cannot sign reads as broken rather than as protected.
+        // Requiring a structured body on every request is the stronger policy
+        // and is deliberately not applied here: the payload is optional at the
+        // request site, so making it mandatory would refuse initiators that do
+        // not attach one, and a co-signer that cannot sign reads as broken
+        // rather than as protected.
+        //
+        // The CLI's `frost network sign` does send the raw label, so this is
+        // not a label nothing produces. A refusal there is not fatal: the
+        // coordinator excludes the index and fails over, and only errors when
+        // this share is needed to reach threshold. A phone holding key material
+        // is the right place to be stricter than the default serve policy.
         keep_frost_net::RefuseRawSignatureHooks.pre_sign(session)?;
+
+        // Refuse anything whose *displayed* label is blank or raw, normalising
+        // exactly the way the prompt does before deciding.
+        //
+        // Two gaps close here, and both come from the check and the display
+        // disagreeing about what a label says. The policy above compares the
+        // untouched string, while the prompt strips zero-width characters, so
+        // a label of "raw\u{200b}" is not refused and still renders as "raw".
+        // And an empty label defeats a denylist outright while rendering worse
+        // than the label it evades: the surface drops a blank label entirely,
+        // taking the "claimed:" qualifier with it, so the request carrying no
+        // stated domain at all would show fewer warnings than one that says
+        // "raw". The most dangerous request must not be the least alarming.
+        let shown = keep_nip46::handler::sanitize_prompt_field(
+            &session.message_type,
+            MESSAGE_TYPE_DISPLAY_MAX,
+        );
+        let shown = shown.trim();
+        if shown.is_empty() || shown.eq_ignore_ascii_case(keep_frost_net::MSG_TYPE_RAW) {
+            return Err(keep_frost_net::FrostNetError::PolicyViolation(format!(
+                "co-signer refuses a request whose label displays as {}: \
+                 an approval prompt cannot describe what it is asking about. \
+                 session_id={}, requester=share {}",
+                if shown.is_empty() { "blank" } else { "raw" },
+                hex::encode(session.session_id),
+                session.requester
+            )));
+        }
 
         if self.consume_pre_approval(&session.message) {
             return Ok(());
@@ -4850,6 +4883,72 @@ mod baseline_presign_policy_tests {
             format!("{err}").contains("raw"),
             "refusal should name the policy that fired, got: {err}"
         );
+    }
+
+    /// The gap a denylist leaves. An empty label is not "raw", so the string
+    /// comparison misses it, and the approval surface drops a blank label
+    /// along with the "claimed:" qualifier that would have marked it
+    /// unverified. Before this guard the request carrying no stated domain at
+    /// all rendered with fewer warnings than one that admitted to being raw.
+    #[test]
+    fn a_label_that_would_display_as_blank_is_refused() {
+        for label in ["", "   ", "\u{200b}", " \u{200b} "] {
+            let storage = KillSwitchOffStorage::with_switch_off();
+            let (request_tx, _request_rx) = mpsc::channel(1);
+            let hooks = MobileSigningHooks {
+                request_tx,
+                pre_approved_hashes: Arc::new(StdMutex::new(HashMap::new())),
+                storage: Arc::new(storage),
+            };
+            let err = hooks
+                .pre_sign(&session_with(label, vec![1u8; 32]))
+                .expect_err("a label that displays as blank must be refused");
+            assert!(
+                format!("{err}").contains("blank"),
+                "expected the blank-label refusal for {label:?}, got: {err}"
+            );
+        }
+    }
+
+    /// The check and the display have to agree on what the label says. The
+    /// upstream policy compares the untouched string while the prompt strips
+    /// zero-width characters, so this value evades the comparison and still
+    /// renders as "raw".
+    #[test]
+    fn raw_with_a_zero_width_character_is_refused() {
+        let storage = KillSwitchOffStorage::with_switch_off();
+        let (request_tx, _request_rx) = mpsc::channel(1);
+        let hooks = MobileSigningHooks {
+            request_tx,
+            pre_approved_hashes: Arc::new(StdMutex::new(HashMap::new())),
+            storage: Arc::new(storage),
+        };
+        let err = hooks
+            .pre_sign(&session_with("raw\u{200b}", vec![2u8; 32]))
+            .expect_err("a label displaying as raw must be refused however it is spelled");
+        assert!(
+            format!("{err}").contains("raw"),
+            "refusal should name the policy that fired, got: {err}"
+        );
+    }
+
+    /// A raw request with no pre-approval. Less about coverage than about
+    /// failing fast: delete the policy and this path falls through to the
+    /// interactive prompt, where the send succeeds and the test then waits out
+    /// the full response timeout instead of failing. A regression that stalls
+    /// the suite is harder to read than one that fails.
+    #[test]
+    fn raw_without_a_pre_approval_is_refused_rather_than_prompted() {
+        let storage = KillSwitchOffStorage::with_switch_off();
+        let (request_tx, _request_rx) = mpsc::channel(1);
+        let hooks = MobileSigningHooks {
+            request_tx,
+            pre_approved_hashes: Arc::new(StdMutex::new(HashMap::new())),
+            storage: Arc::new(storage),
+        };
+        hooks
+            .pre_sign(&session_with("raw", vec![4u8; 32]))
+            .expect_err("a raw request must be refused without reaching the prompt");
     }
 
     /// The guard must not swallow the requests it exists to let through: a


### PR DESCRIPTION
## Summary

Installing hooks replaces the set rather than composing with it, so this crate's hooks are the entire pre-sign policy on mobile and the ones the crate provides never run here. Composing is one call, which is how the bundled combination in the same module is written. This invokes it, and then closes the gap that invoking it alone leaves.

Worth being accurate about what was broken, because the obvious reading overstates it. A raw request did not previously sign silently: absent a pre-approval it reached the human prompt and rendered as `claimed: raw`. The real gap was the pre-approved path, and the value here is defense in depth plus parity with the crate policy rather than closing a silent-signing hole.

Placement is the part worth reviewing. The policy goes above the pre-approval short-circuit, for the same reason the kill switch already sits there: an approval recorded earlier must not authorise a request the policy refuses now. Below the short-circuit, exactly the requests that skip the prompt would also skip the policy, which is the wrong half to exempt. That ordering also turns out to matter for a second reason: consuming a pre-approval removes it, so a policy running afterwards would let a peer burn a user's approval with a request that was never going to be signed.

A denylist on one string is not enough on its own, and review found the case that shows why. An empty label is not "raw", so the comparison misses it, and the approval surface drops a blank label along with the qualifier that marks a label unverified. The request carrying no stated domain at all therefore rendered with fewer warnings than one that admitted to being raw: the most dangerous request was the least alarming. The same divergence covers a label of `raw` followed by a zero-width character, which the comparison misses and the prompt renders as `raw`. So the second check refuses anything whose displayed label is blank or raw, normalising exactly the way the prompt does before deciding.

Requiring a structured body on every request is the stronger policy and is deliberately not applied. The payload is optional at the request site, so mandating it would refuse initiators that do not attach one, and a co-signer that cannot sign reads as broken rather than as protected.

One behavior change for release notes: the CLI's `frost network sign` does send the raw label, so a phone in that group now refuses it. That is not fatal. The coordinator excludes the index and fails over, erroring only when the phone's share is needed to reach threshold. Mobile enforcing this unconditionally while `serve --refuse-raw-sign` stays opt-in is a deliberate asymmetry: a phone holding key material is the right place to be stricter than a server default.

## Test plan

Five tests. The first stages a raw request that is already pre-approved, which is the case that distinguishes the two placements, since a pre-approval records that the user accepted one specific set of bytes rather than consent to sign an unstructured request. Two cover the displayed-label guard: a label that renders blank, across empty, whitespace and zero-width inputs, and `raw` spelled with a zero-width character. One covers a raw request with no pre-approval. The last checks a pre-approved request with an ordinary label still passes, so that refusing everything cannot satisfy any of the others.

Falsified rather than assumed, twice. Moving the policy below the short-circuit makes the first fail while the last still passes. Removing the displayed-label guard makes both of its tests fail while the other three pass. That second run also showed why the not-pre-approved case earns its place: without the guard those tests fall through to the prompt and wait out the full sixty-second response timeout instead of failing, and a regression that stalls the suite is harder to read than one that fails.

Formatter and clippy clean.
