### PR TITLE
Record refused sign requests in the audit log

### DIFF
--- a/keep-frost-net/src/audit.rs
+++ b/keep-frost-net/src/audit.rs
@@ -36,6 +36,20 @@ pub enum SigningOperation {
     SignatureShareSent,
     SignatureCompleted,
     SignatureReceived,
+    /// A sign request this node refused before taking part.
+    ///
+    /// Every other variant records something that happened. Without this one
+    /// the log answers "what did we sign" but not "what were we asked to sign
+    /// and declined", so a peer probing a co-signer leaves no durable trace:
+    /// the refusal path emits a warning and nothing else, and warnings are not
+    /// evidence a holder still has next week.
+    ///
+    /// Carries no reason. The message a policy returns is a formatted string
+    /// that a custom hook could build from requester-supplied content, and an
+    /// audit log is the wrong place to accept text an adversary influences.
+    /// The session id and message hash already identify which request was
+    /// refused; the reason stays in the log line.
+    SignRequestRefused,
 }
 
 impl SigningAuditEntry {
@@ -84,6 +98,12 @@ impl SigningAuditEntry {
 }
 
 impl SigningOperation {
+    /// Stable wire numbering for the entry HMAC.
+    ///
+    /// These values are covered by the HMAC, so they are append-only: renumber
+    /// one and every entry already written under the old numbering fails
+    /// verification, which reads as tampering rather than as a version skew.
+    /// New operations take the next unused value and nothing else moves.
     fn discriminant(&self) -> u8 {
         match self {
             SigningOperation::SignRequestInitiated => 0,
@@ -91,6 +111,7 @@ impl SigningOperation {
             SigningOperation::SignatureShareSent => 2,
             SigningOperation::SignatureCompleted => 3,
             SigningOperation::SignatureReceived => 4,
+            SigningOperation::SignRequestRefused => 5,
         }
     }
 }

--- a/keep-frost-net/src/audit.rs
+++ b/keep-frost-net/src/audit.rs
@@ -121,8 +121,22 @@ pub struct SigningAuditLog {
     hmac_key: [u8; 32],
     #[zeroize(skip)]
     entries: Arc<RwLock<VecDeque<SigningAuditEntry>>>,
+    /// Refusals live in their own ring so they cannot evict the entries above.
+    ///
+    /// The two streams have different bounds in practice. Accepted-path entries
+    /// are limited by how many sessions can be open at once, while a refusal
+    /// creates no session, so a peer can trigger one per request indefinitely.
+    /// Sharing a single queue means a flood of refusals walks the whole history
+    /// out of a FIFO, and it does that precisely on the node that has co-signing
+    /// switched off, which is the configuration whose history is worth keeping.
+    /// Recording refusals is only an improvement if it cannot destroy the record
+    /// it was added to strengthen.
+    #[zeroize(skip)]
+    refusals: Arc<RwLock<VecDeque<SigningAuditEntry>>>,
     #[zeroize(skip)]
     max_entries: usize,
+    #[zeroize(skip)]
+    max_refusals: usize,
 }
 
 impl SigningAuditLog {
@@ -130,13 +144,27 @@ impl SigningAuditLog {
         Self {
             hmac_key,
             entries: Arc::new(RwLock::new(VecDeque::new())),
+            refusals: Arc::new(RwLock::new(VecDeque::new())),
             max_entries: 10000,
+            // Enough to show a probe pattern and its shape over time; small
+            // enough that the refusal stream is a bounded annex rather than a
+            // second full-sized log.
+            max_refusals: 1000,
         }
     }
 
     pub fn with_max_entries(mut self, max: usize) -> Self {
         self.max_entries = max;
         self
+    }
+
+    pub fn with_max_refusals(mut self, max: usize) -> Self {
+        self.max_refusals = max;
+        self
+    }
+
+    fn is_refusal(operation: &SigningOperation) -> bool {
+        matches!(operation, SigningOperation::SignRequestRefused)
     }
 
     pub fn log_signing_operation(
@@ -189,28 +217,60 @@ impl SigningAuditLog {
             "Signing audit log entry"
         );
 
-        let mut entries = self.entries.write();
-        if entries.len() >= self.max_entries {
-            entries.pop_front();
+        let (ring, cap) = if Self::is_refusal(&entry.operation) {
+            (&self.refusals, self.max_refusals)
+        } else {
+            (&self.entries, self.max_entries)
+        };
+        let mut ring = ring.write();
+        if ring.len() >= cap {
+            ring.pop_front();
         }
-        entries.push_back(entry);
+        ring.push_back(entry);
     }
 
+    /// Both rings, oldest first.
+    ///
+    /// Merged on the recorded timestamp rather than concatenated, so a caller
+    /// reading the log still sees one chronological account. Splitting the
+    /// storage is a retention decision and should not change what the log reads
+    /// like.
     pub fn entries(&self) -> Vec<SigningAuditEntry> {
-        self.entries.read().iter().cloned().collect()
+        let mut all: Vec<SigningAuditEntry> = self
+            .entries
+            .read()
+            .iter()
+            .chain(self.refusals.read().iter())
+            .cloned()
+            .collect();
+        all.sort_by_key(|e| e.timestamp_ms);
+        all
+    }
+
+    /// Refusals only, oldest first.
+    pub fn refusals(&self) -> Vec<SigningAuditEntry> {
+        self.refusals.read().iter().cloned().collect()
     }
 
     pub fn verify_all(&self) -> bool {
-        self.entries.read().iter().all(|e| e.verify(&self.hmac_key))
-    }
-
-    pub fn get_entries_for_session(&self, session_id: &[u8; 32]) -> Vec<SigningAuditEntry> {
         self.entries
             .read()
             .iter()
+            .chain(self.refusals.read().iter())
+            .all(|e| e.verify(&self.hmac_key))
+    }
+
+    pub fn get_entries_for_session(&self, session_id: &[u8; 32]) -> Vec<SigningAuditEntry> {
+        let mut found: Vec<SigningAuditEntry> = self
+            .entries
+            .read()
+            .iter()
+            .chain(self.refusals.read().iter())
             .filter(|e| &e.session_id == session_id)
             .cloned()
-            .collect()
+            .collect();
+        found.sort_by_key(|e| e.timestamp_ms);
+        found
     }
 }
 
@@ -223,6 +283,81 @@ fn hash_bytes(data: &[u8]) -> [u8; 32] {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A flood of refusals must not walk accepted-path history out of the log.
+    ///
+    /// This is the property the separate ring exists for. Refusals create no
+    /// session, so a peer can trigger them without limit, while accepted-path
+    /// entries are bounded by how many sessions can be open. In one shared FIFO
+    /// the unbounded stream evicts the bounded one, and it does that on the
+    /// node that has co-signing switched off, whose history is the history most
+    /// worth having.
+    #[test]
+    fn refusals_cannot_evict_accepted_entries() {
+        let log = SigningAuditLog::new([7u8; 32])
+            .with_max_entries(8)
+            .with_max_refusals(4);
+
+        let kept = [1u8; 32];
+        log.log_signing_operation(
+            kept,
+            b"real",
+            None,
+            vec![1, 2],
+            1,
+            SigningOperation::CommitmentSent,
+        );
+
+        // Far past the refusal cap: under a shared queue this would evict the
+        // entry above several times over.
+        for i in 0..50u8 {
+            log.log_signing_operation(
+                [i; 32],
+                b"probe",
+                None,
+                vec![1, 2],
+                1,
+                SigningOperation::SignRequestRefused,
+            );
+        }
+
+        assert!(
+            log.get_entries_for_session(&kept)
+                .iter()
+                .any(|e| matches!(e.operation, SigningOperation::CommitmentSent)),
+            "the accepted entry must survive a refusal flood"
+        );
+        assert_eq!(
+            log.refusals().len(),
+            4,
+            "refusals stay inside their own bound"
+        );
+        assert!(log.verify_all(), "both rings must remain verifiable");
+    }
+
+    /// Operation discriminants feed the entry HMAC, so a collision would let a
+    /// swapped operation verify. Nothing else pins this: the log writes and
+    /// verifies through the same function, so it agrees with itself either way.
+    #[test]
+    fn operation_discriminants_are_distinct() {
+        let all = [
+            SigningOperation::SignRequestInitiated,
+            SigningOperation::CommitmentSent,
+            SigningOperation::SignatureShareSent,
+            SigningOperation::SignatureCompleted,
+            SigningOperation::SignatureReceived,
+            SigningOperation::SignRequestRefused,
+        ];
+        let mut seen = std::collections::HashSet::new();
+        for op in &all {
+            assert!(
+                seen.insert(op.discriminant()),
+                "discriminant {} is used twice; these are covered by the entry HMAC, \
+                 so a duplicate lets one operation verify as another",
+                op.discriminant()
+            );
+        }
+    }
 
     #[test]
     fn test_audit_entry_hmac_verification() {

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -381,6 +381,29 @@ impl KfpNode {
         Ok(())
     }
 
+    /// Record a refusal of `request` that the requester is being told about.
+    ///
+    /// Both notified refusal paths go through here so they cannot drift into
+    /// recording different things. A warning is not evidence: a holder asking
+    /// later whether anyone sent requests this node declined has nothing to
+    /// consult otherwise.
+    ///
+    /// Called before the notification is sent, deliberately. The fact recorded
+    /// is that we refused, which holds whether or not the peer could be told,
+    /// and a refusal that could not be delivered is the one most worth keeping.
+    /// That differs from the accept path, which logs after its send because
+    /// there the recorded fact is the send itself.
+    fn record_refusal(&self, request: &SignRequestPayload) {
+        self.audit_log.log_signing_operation(
+            request.session_id,
+            &request.message,
+            None,
+            request.participants.clone(),
+            self.share.metadata.identifier,
+            SigningOperation::SignRequestRefused,
+        );
+    }
+
     pub(crate) async fn handle_sign_request(
         &self,
         from: PublicKey,
@@ -499,21 +522,11 @@ impl KfpNode {
                     error = %e,
                     "Sign request refused: structured payload does not match digest"
                 );
-                // Audited for the same reason as the policy refusal below, and
-                // with more cause. This fires when a requester's structured body
-                // does not produce the digest it asked us to sign, which is an
-                // attempted cross-domain relabel rather than a configuration
-                // saying no. Both sit past peer admission, so both are a known
-                // member's behaviour and worth keeping; recording one and not
-                // the other would leave the sharper signal invisible.
-                self.audit_log.log_signing_operation(
-                    request.session_id,
-                    &request.message,
-                    None,
-                    request.participants.clone(),
-                    self.share.metadata.identifier,
-                    SigningOperation::SignRequestRefused,
-                );
+                // Audited with more cause than the policy refusal below: this
+                // fires when a requester's structured body does not produce the
+                // digest it asked us to sign, which is an attempted
+                // cross-domain relabel rather than a configuration saying no.
+                self.record_refusal(&request);
                 self.send_session_error(
                     &from,
                     "policy_violation",
@@ -534,25 +547,9 @@ impl KfpNode {
                 error = %e,
                 "Sign request refused by pre-sign policy; signaling requester"
             );
-            // Record the refusal durably. A warning is not evidence: a holder
-            // asking later whether anyone probed them with requests this node
-            // declined has nothing to consult otherwise. This also covers the
-            // kill switch and the desktop approval prompt, which refuse by
-            // returning an error from this same hook and would likewise have
-            // left no trace. The entry is written before the notification is
-            // sent, deliberately: the fact recorded is that we refused, which
-            // holds whether or not the peer could be told, and a refusal that
-            // could not be delivered is the one most worth keeping. That
-            // differs from the accept path below, which logs after its send
-            // because there the recorded fact is the send itself.
-            self.audit_log.log_signing_operation(
-                request.session_id,
-                &request.message,
-                None,
-                request.participants.clone(),
-                self.share.metadata.identifier,
-                SigningOperation::SignRequestRefused,
-            );
+            // Covers the kill switch and the desktop approval prompt too: both
+            // refuse by returning an error from this same hook.
+            self.record_refusal(&request);
             self.send_session_error(
                 &from,
                 "policy_violation",

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -518,6 +518,24 @@ impl KfpNode {
                 session_id = %hex::encode(request.session_id),
                 "Sign request refused by pre-sign policy; signaling requester"
             );
+            // Record the refusal durably. A warning is not evidence: a holder
+            // asking later whether anyone probed them with requests this node
+            // declined has nothing to consult otherwise. This also covers the
+            // kill switch, which refuses by returning an error from the same
+            // hook and would likewise have left no trace.
+            // Record the refusal durably. A warning is not evidence: a holder
+            // asking later whether anyone probed them with requests this node
+            // declined has nothing to consult otherwise. This also covers the
+            // kill switch, which refuses by returning an error from the same
+            // hook and would likewise have left no trace.
+            self.audit_log.log_signing_operation(
+                request.session_id,
+                &request.message,
+                None,
+                request.participants.clone(),
+                self.share.metadata.identifier,
+                SigningOperation::SignRequestRefused,
+            );
             self.send_session_error(
                 &from,
                 "policy_violation",
@@ -1949,6 +1967,41 @@ mod gate_tests {
         let from = Keys::generate().public_key();
         let req = SignRequestPayload::new([1u8; 32], [0xAA; 32], vec![0u8; 32], "test", vec![1]);
         assert!(node.handle_sign_request(from, req).await.is_ok());
+    }
+
+    /// A refused request leaves a durable record.
+    ///
+    /// Every other audit operation records something that happened, so before
+    /// this the log answered "what did we sign" but not "what were we asked to
+    /// sign and declined". A peer probing a co-signer left only a warning, and
+    /// a warning is not something a holder still has to consult later.
+    #[tokio::test]
+    async fn a_refused_sign_request_is_recorded_in_the_audit_log() {
+        let (node, _relay) = test_node().await;
+        node.set_hooks(std::sync::Arc::new(crate::RefuseRawSignatureHooks));
+
+        let peer = Keys::generate().public_key();
+        node.peers.write().add_peer(crate::peer::Peer::new(peer, 2));
+
+        let session_id = [0x33u8; 32];
+        let group = *node.group_pubkey();
+        let req = SignRequestPayload::new(session_id, group, vec![0u8; 32], "raw", vec![1, 2]);
+        node.handle_sign_request(peer, req)
+            .await
+            .expect("a refusal is reported to the requester, not surfaced as an error here");
+
+        let entries = node.audit_log().get_entries_for_session(&session_id);
+        assert!(
+            entries
+                .iter()
+                .any(|e| matches!(e.operation, SigningOperation::SignRequestRefused)),
+            "the refusal must be recorded; got {:?}",
+            entries.iter().map(|e| &e.operation).collect::<Vec<_>>()
+        );
+        assert!(
+            node.audit_log().verify_all(),
+            "the new operation must be covered by the entry HMAC like every other one"
+        );
     }
 
     /// A sign request whose participant set excludes our own identifier is

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -499,6 +499,21 @@ impl KfpNode {
                     error = %e,
                     "Sign request refused: structured payload does not match digest"
                 );
+                // Audited for the same reason as the policy refusal below, and
+                // with more cause. This fires when a requester's structured body
+                // does not produce the digest it asked us to sign, which is an
+                // attempted cross-domain relabel rather than a configuration
+                // saying no. Both sit past peer admission, so both are a known
+                // member's behaviour and worth keeping; recording one and not
+                // the other would leave the sharper signal invisible.
+                self.audit_log.log_signing_operation(
+                    request.session_id,
+                    &request.message,
+                    None,
+                    request.participants.clone(),
+                    self.share.metadata.identifier,
+                    SigningOperation::SignRequestRefused,
+                );
                 self.send_session_error(
                     &from,
                     "policy_violation",
@@ -516,18 +531,20 @@ impl KfpNode {
             // timeout/failover exhaustion, mirroring the stale-nonce path below.
             warn!(
                 session_id = %hex::encode(request.session_id),
+                error = %e,
                 "Sign request refused by pre-sign policy; signaling requester"
             );
             // Record the refusal durably. A warning is not evidence: a holder
             // asking later whether anyone probed them with requests this node
             // declined has nothing to consult otherwise. This also covers the
-            // kill switch, which refuses by returning an error from the same
-            // hook and would likewise have left no trace.
-            // Record the refusal durably. A warning is not evidence: a holder
-            // asking later whether anyone probed them with requests this node
-            // declined has nothing to consult otherwise. This also covers the
-            // kill switch, which refuses by returning an error from the same
-            // hook and would likewise have left no trace.
+            // kill switch and the desktop approval prompt, which refuse by
+            // returning an error from this same hook and would likewise have
+            // left no trace. The entry is written before the notification is
+            // sent, deliberately: the fact recorded is that we refused, which
+            // holds whether or not the peer could be told, and a refusal that
+            // could not be delivered is the one most worth keeping. That
+            // differs from the accept path below, which logs after its send
+            // because there the recorded fact is the send itself.
             self.audit_log.log_signing_operation(
                 request.session_id,
                 &request.message,


### PR DESCRIPTION
## Summary

Every audit operation records something that happened, so the log answered what this node signed but not what it was asked to sign and declined. A peer probing a co-signer left a warning and nothing else, and a warning is not something a holder still has to consult a week later. That matters more now that mobile refuses a class of requests it previously accepted.

Two refusals sit past peer admission and both are now recorded. The pre-sign policy refusal, which also covers the kill switch and the desktop approval prompt since they refuse by returning an error from the same hook. And the structured-payload mismatch, which fires when a requester's body does not produce the digest it asked us to sign. The second is the sharper signal of the two: a configuration saying no versus an attempted cross-domain relabel. Recording one without the other would have left the more alarming case invisible.

Refusals go in their own bounded ring rather than the shared queue, and that is the part worth reviewing. The two streams have different natural bounds: accepted-path entries are limited by how many sessions can be open at once, while a refusal creates no session, so a peer can trigger one per request indefinitely. Sharing a single FIFO means the unbounded stream walks the bounded one out of the log, and it does that precisely on a node with co-signing switched off, which is the configuration whose history is worth keeping. Recording refusals is only an improvement if it cannot destroy the record it was added to strengthen. Reads merge both rings on timestamp, so splitting the storage is a retention decision and does not change what the log reads like.

The new operation carries no reason. A policy returns a formatted string and a custom hook could build one from requester-supplied content; an audit log is the wrong place to accept text an adversary influences. The reason now genuinely does go to the log line, which the first version of this claimed while omitting the error from the warning.

The entry is written before the requester is notified, deliberately. The recorded fact is that we refused, which holds whether or not the peer could be told, and a refusal that could not be delivered is the one most worth keeping. That differs from the accept path, which logs after its send because there the recorded fact is the send itself; the divergence is now noted at both sites.

Discriminants are appended, never renumbered, and that is now documented and tested. The values are covered by the entry HMAC, so renumbering one would fail verification on every entry written under the old numbering, reading as tampering rather than a version skew.

## Test plan

Four tests. A real refusal driven end to end through a node with a refusing policy, a trusted peer and a raw-labelled request, asserting the entry exists for that session and that the whole log still verifies. A refusal flood against a small cap, asserting an accepted-path entry survives and that refusals stay inside their own bound. Discriminant distinctness, which nothing else pins, since the log writes and verifies through the same function and so agrees with itself either way. Plus the existing HMAC tests.

Falsified rather than assumed, twice. Removing the audit call makes the first fail with an empty entry list. Reverting the refusal ring to the shared queue makes the flood test fail on the surviving-entry assertion. Both restored and passing. 451 library tests pass, formatter and clippy clean.

Note for local runs: the crate's integration tests need the `testing` feature, so a bare `cargo test -p keep-frost-net` fails on unrelated unresolved imports first.
