### PR TITLE
Remember a refusal so a retrying client cannot re-prompt indefinitely

### DIFF
--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -18,7 +18,9 @@ use keep_core::keyring::Keyring;
 
 use crate::audit::{AuditAction, AuditEntry, AuditLog};
 use crate::frost_signer::{FrostSigner, NetworkFrostSigner};
-use crate::permissions::{AppPermission, Permission, PermissionDuration, PermissionManager};
+use crate::permissions::{
+    AppPermission, ApprovalDecision, Permission, PermissionDuration, PermissionManager,
+};
 use crate::rate_limit::{RateLimitConfig, RateLimiter};
 use crate::types::{
     ApprovalRequest, ApprovalResult, ConnectAuthorization, HttpAuthDetails, RememberDuration,
@@ -517,13 +519,22 @@ impl SignerHandler {
         self.require_permission(&app_pubkey, Permission::SIGN_EVENT)
             .await?;
 
-        let needs_approval = self
-            .permissions
-            .lock()
-            .await
-            .needs_approval(&app_pubkey, kind);
+        // A refusal the user already gave is consulted before prompting. Without
+        // this, saying no decides one request and nothing more: a client that
+        // retries turns a single refusal into a prompt every retry interval,
+        // and the only way to stop it is revoking the app entirely, which is a
+        // far broader answer than the one the user gave.
+        let decision = self.permissions.lock().await.decide(&app_pubkey, kind);
+        if decision == ApprovalDecision::Deny {
+            self.audit.lock().await.log(
+                AuditEntry::new(AuditAction::UserRejected, app_pubkey)
+                    .with_event_kind(kind)
+                    .with_success(false),
+            );
+            return Err(KeepError::UserRejected);
+        }
 
-        if needs_approval {
+        if decision == ApprovalDecision::Ask {
             let result = self
                 .request_approval(ApprovalRequest {
                     app_pubkey,
@@ -544,6 +555,31 @@ impl SignerHandler {
                 .await;
 
             if !result.approved {
+                // The result already carried a duration; nothing read it on this
+                // branch, so "no, and stop asking for an hour" was
+                // indistinguishable from "no, this once". Recording it is what
+                // makes a refusal hold against a client that retries.
+                //
+                // Only bounded windows are remembered. `Forever` yields no
+                // duration here, and that is the right outcome rather than a
+                // gap: these refusals are in-memory, so a forever refusal would
+                // quietly disappear on the next restart, and promising forever
+                // while delivering until-restart is worse than not offering it.
+                // Revoking the app is the instrument for a permanent no.
+                //
+                // NIP-98 is clamped exactly as an approval is, so a refusal can
+                // never be remembered longer than an approval could.
+                let remember = if kind == NIP98_HTTP_AUTH {
+                    clamp_nip98_remember(result.remember)
+                } else {
+                    result.remember
+                };
+                if let Some(secs) = remember.as_seconds() {
+                    self.permissions
+                        .lock()
+                        .await
+                        .deny_kind_for(&app_pubkey, kind, secs);
+                }
                 self.audit.lock().await.log(
                     AuditEntry::new(AuditAction::UserRejected, app_pubkey)
                         .with_event_kind(kind)

--- a/keep-nip46/src/handler.rs
+++ b/keep-nip46/src/handler.rs
@@ -525,16 +525,27 @@ impl SignerHandler {
         // and the only way to stop it is revoking the app entirely, which is a
         // far broader answer than the one the user gave.
         let decision = self.permissions.lock().await.decide(&app_pubkey, kind);
-        if decision == ApprovalDecision::Deny {
-            self.audit.lock().await.log(
-                AuditEntry::new(AuditAction::UserRejected, app_pubkey)
-                    .with_event_kind(kind)
-                    .with_success(false),
-            );
-            return Err(KeepError::UserRejected);
-        }
+        // Matched exhaustively rather than compared. A fourth variant added
+        // later would match neither `== Deny` nor `== Ask` and fall through
+        // both blocks into signing, which is a fail-open at a signing boundary
+        // and precisely what this enum exists to prevent. A match makes that a
+        // compile error instead of a silent authorisation.
+        let ask = match decision {
+            ApprovalDecision::Deny => {
+                // Deliberately not audited. The user's refusal was recorded when
+                // they gave it; this is that answer being replayed, not a new
+                // decision. Auditing here would write one entry per retry at
+                // line rate into the same ring that carries signing history,
+                // which is the amplification a sibling crate had to undo one
+                // change earlier: an unbounded stream evicting the record it
+                // was added to strengthen.
+                return Err(KeepError::UserRejected);
+            }
+            ApprovalDecision::Ask => true,
+            ApprovalDecision::Allow => false,
+        };
 
-        if decision == ApprovalDecision::Ask {
+        if ask {
             let result = self
                 .request_approval(ApprovalRequest {
                     app_pubkey,
@@ -2025,6 +2036,112 @@ mod tests {
             }
         }
         fn on_connect(&self, _pubkey: &str, _name: &str, _authorization: ConnectAuthorization) {}
+    }
+
+    /// Rejects every request with a fixed `remember`, counting prompts.
+    struct RejectingCallbacks {
+        remember: RememberDuration,
+        sign_event_prompts: std::sync::atomic::AtomicUsize,
+    }
+    impl crate::types::ServerCallbacks for RejectingCallbacks {
+        fn on_log(&self, _event: crate::types::LogEvent) {}
+        fn request_approval(&self, request: ApprovalRequest) -> ApprovalResult {
+            // Only signing is refused. Rejecting the connect too would fail the
+            // handshake and the test would never reach the path under test.
+            if request.method != "sign_event" {
+                return ApprovalResult::approved_once();
+            }
+            self.sign_event_prompts
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            ApprovalResult {
+                approved: false,
+                remember: self.remember,
+            }
+        }
+        fn on_connect(&self, _pubkey: &str, _name: &str, _authorization: ConnectAuthorization) {}
+    }
+
+    async fn rejecting_handler(
+        remember: RememberDuration,
+    ) -> (SignerHandler, Arc<RejectingCallbacks>, PublicKey, PublicKey) {
+        let keyring = setup_keyring();
+        let permissions = Arc::new(Mutex::new(PermissionManager::new()));
+        let audit = Arc::new(Mutex::new(AuditLog::new(100)));
+        let cb = Arc::new(RejectingCallbacks {
+            remember,
+            sign_event_prompts: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let handler = SignerHandler::new(keyring, permissions, audit, Some(cb.clone()))
+            .with_connect_grant(Permission::GET_PUBLIC_KEY | Permission::SIGN_EVENT);
+        let app = Keys::generate().public_key();
+        handler.handle_connect(app, None, None, None).await.unwrap();
+        let signer_pk = handler.our_pubkey().await.unwrap();
+        (handler, cb, app, signer_pk)
+    }
+
+    /// The wiring, end to end through the handler rather than the permission
+    /// map. A refusal carrying a duration must stop the next request without
+    /// prompting a second time.
+    #[tokio::test]
+    async fn a_remembered_rejection_refuses_the_next_request_without_prompting() {
+        let (handler, cb, app, signer_pk) = rejecting_handler(RememberDuration::OneHour).await;
+
+        for body in ["one", "two", "three"] {
+            let ev = UnsignedEvent::new(signer_pk, Timestamp::now(), Kind::TextNote, vec![], body);
+            assert!(handler.handle_sign_event(app, ev).await.is_err());
+        }
+
+        assert_eq!(
+            cb.sign_event_prompts
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the user should be asked once; the refusal answers the retries"
+        );
+    }
+
+    /// The negative that matters most. A one-shot refusal must leave nothing
+    /// behind: if it recorded a window, every "no, this once" would become a
+    /// lasting silent block the user never asked for.
+    #[tokio::test]
+    async fn a_one_shot_rejection_records_nothing() {
+        let (handler, cb, app, signer_pk) = rejecting_handler(RememberDuration::JustThisTime).await;
+
+        for body in ["one", "two", "three"] {
+            let ev = UnsignedEvent::new(signer_pk, Timestamp::now(), Kind::TextNote, vec![], body);
+            assert!(handler.handle_sign_event(app, ev).await.is_err());
+        }
+
+        assert_eq!(
+            cb.sign_event_prompts
+                .load(std::sync::atomic::Ordering::SeqCst),
+            3,
+            "a one-shot refusal must not silently persist; every request should still ask"
+        );
+    }
+
+    /// A remembered refusal is scoped to the kind it was given for.
+    #[tokio::test]
+    async fn a_remembered_rejection_does_not_cover_other_kinds() {
+        let (handler, cb, app, signer_pk) = rejecting_handler(RememberDuration::OneHour).await;
+
+        let first = UnsignedEvent::new(signer_pk, Timestamp::now(), Kind::TextNote, vec![], "a");
+        assert!(handler.handle_sign_event(app, first).await.is_err());
+
+        let other = UnsignedEvent::new(
+            signer_pk,
+            Timestamp::now(),
+            Kind::from(30023u16),
+            vec![],
+            "b",
+        );
+        assert!(handler.handle_sign_event(app, other).await.is_err());
+
+        assert_eq!(
+            cb.sign_event_prompts
+                .load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "refusing one kind must not silently refuse a different one"
+        );
     }
 
     #[tokio::test]

--- a/keep-nip46/src/lib.rs
+++ b/keep-nip46/src/lib.rs
@@ -31,7 +31,9 @@ pub use frost_signer::{FrostSigner, NetworkFrostSigner};
 pub use handler::SignerHandler;
 #[cfg(unix)]
 pub use local_server::{LocalServer, LocalServerConfig};
-pub use permissions::{AppPermission, Permission, PermissionDuration, PermissionManager};
+pub use permissions::{
+    AppPermission, ApprovalDecision, Permission, PermissionDuration, PermissionManager,
+};
 pub use rate_limit::{RateLimitConfig, RateLimiter};
 pub use server::{PreGrantedApp, Server, ServerConfig};
 pub use types::{ApprovalRequest, LogEvent, ServerCallbacks, NIP98_HTTP_AUTH};

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -720,6 +720,15 @@ impl PermissionManager {
         // #575: NIP-98 (kind 27235) is never auto-approved.
         kinds.remove(&NIP98_HTTP_AUTH);
         if let Some(app) = self.apps.get_mut(pubkey) {
+            // Clear refusals for the kinds being granted. This is the only
+            // grant path that does not come from a prompt, and once a refusal
+            // stands the prompt never fires, so without this there is no route
+            // from refused back to allowed short of waiting out the window,
+            // restarting, or revoking the app: the broad answer this feature
+            // exists to avoid.
+            for kind in &kinds {
+                app.timed_kind_denials.remove(kind);
+            }
             // A user configuring auto-approve kinds is an explicit remember
             // decision, so gate persistence keeps it (and does not false-drop it
             // on restart). Clearing to empty leaves the flag untouched so a

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -382,11 +382,26 @@ impl PermissionManager {
                 return ApprovalDecision::Deny;
             }
         }
-        if self.needs_approval(pubkey, kind) {
+        if self.requires_prompt_ignoring_denials(pubkey, kind) {
             ApprovalDecision::Ask
         } else {
             ApprovalDecision::Allow
         }
+    }
+
+    /// Whether the caller must not proceed without further action.
+    ///
+    /// True for both a refusal and an unanswered request, because the only
+    /// answer that permits proceeding silently is an explicit grant. Kept as a
+    /// bool for the existing callers; prefer [`Self::decide`], which
+    /// distinguishes the two and lets a refusal short-circuit the prompt.
+    ///
+    /// Deliberately not `decide(..) == Ask`. That reads better and is unsafe:
+    /// it would return false for a refusal, so a caller writing
+    /// `if !needs_approval { proceed }` would treat a remembered no as a yes.
+    /// A signer must not have an API whose obvious misuse authorises signing.
+    pub fn needs_approval(&self, pubkey: &PublicKey, kind: Kind) -> bool {
+        self.decide(pubkey, kind) != ApprovalDecision::Allow
     }
 
     /// Record that the user refused `kind` for this app, for `secs`.
@@ -402,6 +417,15 @@ impl PermissionManager {
         let Some(app) = self.apps.get_mut(pubkey) else {
             return false;
         };
+        // Clamp NIP-98 here rather than trusting the caller. The handler
+        // already clamps its own path, but this is a public write API and the
+        // invariant is that a refusal can never be remembered for longer than
+        // an approval could; that has to hold at the point of writing.
+        let secs = if kind == NIP98_HTTP_AUTH {
+            secs.min(NIP98_MAX_REMEMBER_SECS)
+        } else {
+            secs
+        };
         let expiry = Timestamp::now().as_secs().saturating_add(secs);
         app.auto_approve_kinds.remove(&kind);
         app.timed_kind_grants.remove(&kind);
@@ -409,7 +433,11 @@ impl PermissionManager {
         true
     }
 
-    pub fn needs_approval(&self, pubkey: &PublicKey, kind: Kind) -> bool {
+    /// Whether a prompt is required, considering grants only.
+    ///
+    /// Private because it answers half the question. A remembered refusal is
+    /// resolved by [`Self::decide`], which consults this for the other half.
+    fn requires_prompt_ignoring_denials(&self, pubkey: &PublicKey, kind: Kind) -> bool {
         // #613: NIP-98 (kind 27235) is opt-in remembered only via an explicit,
         // short, unexpired per-app timed grant written by the approval path. It
         // is never covered by a forever (auto_approve) or global grant: those
@@ -1631,6 +1659,57 @@ mod tests {
             pm.decide(&pubkey, Kind::TextNote),
             ApprovalDecision::Deny,
             "refusal must win the tie"
+        );
+    }
+
+    /// The boolean API must not report "no approval needed" for a refusal.
+    ///
+    /// This is the one way remembering a refusal could make things worse than
+    /// not remembering it. A caller writing `if !needs_approval { proceed }` is
+    /// the obvious use of a boolean, so the boolean has to be false only when
+    /// proceeding is actually permitted.
+    #[test]
+    fn needs_approval_never_reports_a_refusal_as_permission_to_proceed() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "agent".into());
+
+        // Granted, so proceeding is permitted and the bool is false.
+        assert!(pm.grant_kind_for(&pubkey, Kind::from(9999u16), 3600));
+        assert!(!pm.needs_approval(&pubkey, Kind::from(9999u16)));
+
+        // Refused. The bool must go back to true: a refusal is not permission.
+        assert!(pm.deny_kind_for(&pubkey, Kind::from(9999u16), 3600));
+        assert_eq!(
+            pm.decide(&pubkey, Kind::from(9999u16)),
+            ApprovalDecision::Deny
+        );
+        assert!(
+            pm.needs_approval(&pubkey, Kind::from(9999u16)),
+            "a remembered refusal must never read as permission to proceed"
+        );
+    }
+
+    /// A refusal cannot be remembered for longer than an approval could.
+    #[test]
+    fn a_nip98_refusal_is_clamped_like_a_nip98_approval() {
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "agent".into());
+
+        let before = Timestamp::now().as_secs();
+        assert!(pm.deny_kind_for(&pubkey, NIP98_HTTP_AUTH, 30 * 24 * 3600));
+
+        let expiry = *pm
+            .apps
+            .get(&pubkey)
+            .expect("app")
+            .timed_kind_denials
+            .get(&NIP98_HTTP_AUTH)
+            .expect("denial recorded");
+        assert!(
+            expiry <= before + NIP98_MAX_REMEMBER_SECS + 2,
+            "a month-long NIP-98 refusal must be clamped to the same window an approval gets"
         );
     }
 }

--- a/keep-nip46/src/permissions.rs
+++ b/keep-nip46/src/permissions.rs
@@ -102,6 +102,21 @@ impl PermissionDuration {
     }
 }
 
+/// What to do with a request without asking the user.
+///
+/// A boolean cannot carry this. "Do not prompt" is two different answers,
+/// allow and refuse, and collapsing them is how a remembered refusal would
+/// turn into a silent approval.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApprovalDecision {
+    /// A live grant covers it; proceed without prompting.
+    Allow,
+    /// A live refusal covers it; reject without prompting.
+    Deny,
+    /// Nothing on record; ask.
+    Ask,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppPermission {
     pub pubkey: PublicKey,
@@ -123,6 +138,22 @@ pub struct AppPermission {
     /// or restored across a restart.
     #[serde(skip)]
     pub timed_kind_grants: HashMap<Kind, u64>,
+    /// Per-app, per-kind refusals with an explicit expiry (unix epoch seconds).
+    ///
+    /// The grant fields above answer "may this app do this without asking".
+    /// This answers "has the user already said no, recently enough that asking
+    /// again would be pestering them". Without it a rejection decides one
+    /// request and nothing more, which is fine for a person, who stops asking,
+    /// and wrong for an automated client, which retries: one refusal becomes a
+    /// prompt every retry interval, and the only way to stop it is revoking the
+    /// app outright, an answer far broader than the one being given.
+    ///
+    /// Not serialized, and deliberately not persisted in this change. A denial
+    /// that survives a restart is a stronger instrument than the problem needs:
+    /// within a session it stops the pestering completely, and after a restart
+    /// the client asks once more and is told no once more.
+    #[serde(skip)]
+    pub timed_kind_denials: HashMap<Kind, u64>,
     pub connected_at: Timestamp,
     pub last_used: Timestamp,
     pub request_count: u64,
@@ -150,6 +181,7 @@ impl AppPermission {
             permissions: Permission::DEFAULT,
             auto_approve_kinds: HashSet::from([Kind::Reaction]),
             timed_kind_grants: HashMap::new(),
+            timed_kind_denials: HashMap::new(),
             connected_at: Timestamp::now(),
             last_used: Timestamp::now(),
             request_count: 0,
@@ -165,6 +197,13 @@ impl AppPermission {
         self.timed_kind_grants
             .get(&kind)
             .is_some_and(|expiry| now_unix_secs() < *expiry)
+    }
+
+    /// Whether a live refusal covers `kind`.
+    pub fn has_unexpired_denial(&self, kind: Kind) -> bool {
+        self.timed_kind_denials
+            .get(&kind)
+            .is_some_and(|&expiry| Timestamp::now().as_secs() < expiry)
     }
 
     /// Whether the app currently holds a live remember-grant: a Forever per-kind
@@ -332,6 +371,44 @@ impl PermissionManager {
         self.apps.contains_key(pubkey)
     }
 
+    /// Decide a request without prompting, or say that prompting is needed.
+    ///
+    /// A live refusal wins over a live grant. The two should not coexist, since
+    /// recording either clears the other, but if they ever did, refusing is the
+    /// answer that cannot authorise something the user did not intend.
+    pub fn decide(&self, pubkey: &PublicKey, kind: Kind) -> ApprovalDecision {
+        if let Some(app) = self.apps.get(pubkey) {
+            if !app.duration.is_expired(app.connected_at) && app.has_unexpired_denial(kind) {
+                return ApprovalDecision::Deny;
+            }
+        }
+        if self.needs_approval(pubkey, kind) {
+            ApprovalDecision::Ask
+        } else {
+            ApprovalDecision::Allow
+        }
+    }
+
+    /// Record that the user refused `kind` for this app, for `secs`.
+    ///
+    /// Clears any grant for the same kind: a refusal that leaves an existing
+    /// grant standing would be overridden by it the moment the decision is next
+    /// taken, so the user's most recent answer has to be the one that holds.
+    /// Returns whether anything was written, so callers only audit real changes.
+    pub fn deny_kind_for(&mut self, pubkey: &PublicKey, kind: Kind, secs: u64) -> bool {
+        if secs == 0 {
+            return false;
+        }
+        let Some(app) = self.apps.get_mut(pubkey) else {
+            return false;
+        };
+        let expiry = Timestamp::now().as_secs().saturating_add(secs);
+        app.auto_approve_kinds.remove(&kind);
+        app.timed_kind_grants.remove(&kind);
+        app.timed_kind_denials.insert(kind, expiry);
+        true
+    }
+
     pub fn needs_approval(&self, pubkey: &PublicKey, kind: Kind) -> bool {
         // #613: NIP-98 (kind 27235) is opt-in remembered only via an explicit,
         // short, unexpired per-app timed grant written by the approval path. It
@@ -391,6 +468,10 @@ impl PermissionManager {
             app.auto_approve_kinds.insert(kind);
             // A Forever grant supersedes any timed grant for the same kind.
             app.timed_kind_grants.remove(&kind);
+            // ...and any refusal. The decision path refuses ahead of allowing,
+            // so a grant left sitting behind a live refusal would never take
+            // effect and the user would see their approval ignored.
+            app.timed_kind_denials.remove(&kind);
             app.last_used = Timestamp::now();
             // An explicit user remember-decision (vs a client-supplied connect
             // kind scope); gates cross-restart persistence.
@@ -444,6 +525,10 @@ impl PermissionManager {
             // a user can deliberately shrink an over-granted window.
             let expiry = now.saturating_add(secs);
             app.timed_kind_grants.insert(kind, expiry);
+            // Clear any refusal for the same kind. The decision path refuses
+            // ahead of allowing, so a grant left behind a live refusal would
+            // never take effect and the approval would appear to be ignored.
+            app.timed_kind_denials.remove(&kind);
             app.last_used = Timestamp::now();
             // An explicit user remember-decision; gates cross-restart persistence.
             app.explicitly_remembered = true;
@@ -1448,5 +1533,104 @@ mod tests {
             .timed_kind_grants
             .contains_key(&Kind::TextNote));
         assert!(pm.needs_approval(&pubkey, Kind::TextNote));
+    }
+
+    #[test]
+    fn a_refusal_decides_the_next_request_without_prompting() {
+        // The point of the change. Before it, a refusal decided one request:
+        // the next identical one prompted again, so a client that retries
+        // turned one "no" into an unbounded stream of prompts.
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "agent".into());
+
+        assert_eq!(
+            pm.decide(&pubkey, Kind::TextNote),
+            ApprovalDecision::Ask,
+            "nothing on record yet, so it must ask"
+        );
+
+        assert!(pm.deny_kind_for(&pubkey, Kind::TextNote, 3600));
+
+        assert_eq!(
+            pm.decide(&pubkey, Kind::TextNote),
+            ApprovalDecision::Deny,
+            "the refusal must hold without prompting again"
+        );
+        // Scoped to the kind that was refused, not the app. Uses a kind that
+        // genuinely asks: Reaction is auto-approved by default here, so it
+        // would have read as Allow and proven nothing about scoping.
+        assert_eq!(
+            pm.decide(&pubkey, Kind::from(9999u16)),
+            ApprovalDecision::Ask,
+            "refusing one kind must not silently refuse the others"
+        );
+    }
+
+    #[test]
+    fn an_expired_refusal_asks_again() {
+        // A refusal is a pause, not a revocation. If it never expired it would
+        // be a permanent block wearing a duration, and the user would have no
+        // way back other than revoking the app.
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "agent".into());
+
+        assert!(pm.deny_kind_for(&pubkey, Kind::TextNote, 1));
+        // Rewind the recorded expiry rather than sleeping.
+        if let Some(app) = pm.apps.get_mut(&pubkey) {
+            app.timed_kind_denials.insert(Kind::TextNote, 1);
+        }
+        assert_eq!(
+            pm.decide(&pubkey, Kind::TextNote),
+            ApprovalDecision::Ask,
+            "an elapsed refusal must stop applying"
+        );
+    }
+
+    #[test]
+    fn approving_clears_a_standing_refusal() {
+        // The decision path refuses ahead of allowing, so a grant written while
+        // a refusal still stood would never take effect: the user would approve
+        // and watch nothing change.
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "agent".into());
+
+        assert!(pm.deny_kind_for(&pubkey, Kind::TextNote, 3600));
+        assert_eq!(pm.decide(&pubkey, Kind::TextNote), ApprovalDecision::Deny);
+
+        assert!(pm.grant_kind_for(&pubkey, Kind::TextNote, 3600));
+        assert_eq!(
+            pm.decide(&pubkey, Kind::TextNote),
+            ApprovalDecision::Allow,
+            "an explicit approval must override the earlier refusal"
+        );
+
+        // And the same via a forever grant.
+        assert!(pm.deny_kind_for(&pubkey, Kind::Reaction, 3600));
+        assert!(pm.grant_kind_forever(&pubkey, Kind::Reaction));
+        assert_eq!(pm.decide(&pubkey, Kind::Reaction), ApprovalDecision::Allow);
+    }
+
+    #[test]
+    fn a_refusal_wins_over_a_grant_if_both_somehow_stand() {
+        // They should not coexist, since recording either clears the other.
+        // This pins the tie-break anyway: for a signer the answer that cannot
+        // authorise something unintended is the safe one.
+        let mut pm = PermissionManager::new();
+        let pubkey = Keys::generate().public_key();
+        pm.connect(pubkey, "agent".into());
+
+        assert!(pm.grant_kind_for(&pubkey, Kind::TextNote, 3600));
+        if let Some(app) = pm.apps.get_mut(&pubkey) {
+            let expiry = Timestamp::now().as_secs() + 3600;
+            app.timed_kind_denials.insert(Kind::TextNote, expiry);
+        }
+        assert_eq!(
+            pm.decide(&pubkey, Kind::TextNote),
+            ApprovalDecision::Deny,
+            "refusal must win the tie"
+        );
     }
 }


### PR DESCRIPTION
## Summary

**This is plumbing, and it does not change behaviour on any shipped surface yet.** Stating that first because the original version of this description did not, and the gap is the kind that gets recorded as a fix that never shipped. Every surface builds the approval result through the boolean conversion, which hardcodes a one-shot duration on both branches, and the Android reject path hardcodes it explicitly. A one-shot duration yields no seconds, so the recording call never fires today. Making the surfaces carry the duration on rejection is filed separately and blocks the umbrella this belongs to.

The gap being closed: the permission model remembers approvals and not refusals, so saying no decides one request and nothing more. That is fine for a person, who stops asking, and wrong for an automated client, which retries: one refusal becomes a prompt every retry interval, and the only way to stop it is revoking the app outright, an answer far broader than the one the user gave.

No new type crosses the boundary. `ApprovalResult` already carried a remember-duration and the rejection branch never read it, so "no, and stop asking for an hour" was indistinguishable from "no, this once".

The decision needed a third answer. A boolean cannot say "do not prompt" two different ways, allow and refuse, and collapsing them is how a remembered refusal turns into a silent approval. `decide` returns allow, deny or ask; the old predicate became a private helper under its original body and `needs_approval` now delegates to `decide`, so there is one source of truth rather than two predicates that can disagree.

`needs_approval` returns `!= Allow`, deliberately not `== Ask`. The latter reads better and is unsafe: it returns false for a refusal, so a caller writing `if !needs_approval { proceed }` would treat a remembered no as a yes. A signer must not ship an API whose obvious misuse authorises signing.

The handler matches the decision exhaustively rather than comparing it. A fourth variant added later would match neither `== Deny` nor `== Ask` and fall through into signing; a match makes that a compile error.

A replayed refusal is not audited. The user's decision was recorded when they made it, and writing an entry per retry would put an unbounded stream into the same ring that carries signing history, which is the amplification a sibling crate had to undo one change earlier.

Every path that grants now clears a standing refusal, including the permissions-UI path that does not come from a prompt. That one matters most: once a refusal stands the prompt never fires, so without it there is no route from refused back to allowed short of waiting out the window, restarting, or revoking.

Only bounded windows are remembered, and the clamp for NIP-98 is applied inside the write API rather than trusted to callers. Refusals are in-memory; persisting them across restarts is deliberately out of scope, since within a session this stops the pestering completely.

## Test plan

Nine tests. Four on the permission model: a refusal decides the next request and is scoped to the kind; an elapsed refusal asks again; approving clears a standing refusal on both grant paths; a refusal wins a tie. Two on the API contract: the boolean never reports a refusal as permission to proceed, and a NIP-98 refusal is clamped like a NIP-98 approval. Three drive the handler end to end with a callback that counts prompts: a remembered rejection answers the retries with one prompt, a one-shot rejection records nothing so all three requests still ask, and a remembered rejection does not cover a different kind.

Falsified rather than assumed, four ways. Removing the deny branch fails three of the model tests while the expiry test correctly still passes. Applying `== Ask` to the boolean fails the safety test with the message it was written for. Removing the NIP-98 clamp fails the clamp test. Deleting the handler wiring fails the prompt-count test while the other two correctly still pass.

That last one is the falsification the first round of this PR skipped: the original tests all sat in the permission model, so deleting the handler wiring left every one of them green. The tests reached the mechanism and not the thing that calls it.

189 unit tests plus the integration suites pass, workspace builds, formatter and clippy clean.
