### PR TITLE
Correct the approval-result contract now that refusals are remembered

### DIFF
--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -90,10 +90,19 @@ impl From<BunkerRememberDuration> for RememberDuration {
     }
 }
 
-/// Result of an approval prompt as returned by the native UI. `approved=false`
-/// always means reject and `remember` is ignored. `approved=true` plus a non-
-/// `JustThisTime` duration persists a per-(app, kind) grant in the bunker so
-/// subsequent requests within the window auto-approve without re-prompting.
+/// Result of an approval prompt as returned by the native UI.
+///
+/// `remember` is honoured on both answers, not only on approval. With
+/// `approved=true` and a non-`JustThisTime` duration, a per-(app, kind) grant
+/// is persisted and later requests skip the prompt. With `approved=false` and a
+/// duration, the refusal is remembered the same way and later requests are
+/// refused without prompting, which is what stops a client that retries from
+/// re-asking indefinitely.
+///
+/// A native surface must therefore send `JustThisTime` on rejection unless the
+/// user chose a duration for that answer. Passing through a value left over
+/// from an earlier interaction would silently create a block nobody asked for.
+/// Rejecting with `JustThisTime` records nothing.
 #[derive(uniffi::Record, Clone, Copy, Debug)]
 pub struct BunkerApprovalResult {
     pub approved: bool,

--- a/keep-nip46/src/types.rs
+++ b/keep-nip46/src/types.rs
@@ -81,10 +81,20 @@ impl RememberDuration {
     }
 }
 
-/// Result of a per-request approval prompt. `approved == false` always means
-/// reject (with `remember = JustThisTime`). `approved == true` plus a non-
-/// `JustThisTime` duration persists a per-app, per-kind grant so subsequent
-/// requests within the window auto-approve without re-prompting.
+/// Result of a per-request approval prompt.
+///
+/// `remember` applies to whichever answer was given, not only to approval. With
+/// `approved == true` and a non-`JustThisTime` duration, a per-app, per-kind
+/// grant is persisted and subsequent requests within the window skip the
+/// prompt. With `approved == false` and a duration, the refusal is remembered
+/// the same way and subsequent requests are refused without prompting.
+///
+/// Callers must therefore send `JustThisTime` on rejection unless the user
+/// deliberately chose a duration for *that* answer. Forwarding a value left
+/// over from an earlier interaction would create a block the user never asked
+/// for, which is the failure this field's symmetry makes possible. Rejecting
+/// with `JustThisTime` records nothing, which is the safe default and what
+/// `rejected()` and the `From<bool>` conversion both produce.
 #[derive(Debug, Clone, Copy)]
 pub struct ApprovalResult {
     pub approved: bool,


### PR DESCRIPTION
## Summary

Two doc comments describe behaviour that stopped being true when refusals became durable. Both state that the remember-duration is ignored on rejection. It is not: a rejection carrying a duration now records a refusal, and later requests are refused without prompting.

This matters more than a stale comment usually would, because the second one is a UniFFI contract and the Android surface is written to it. A consumer following it would forward whatever value the duration control happened to hold, on the stated understanding that rejection ignores it, and silently create a block the user never asked for. The comment is what the next implementer trusts.

No behaviour change. The conversion in keep-mobile already passes the duration through on both answers, and the boolean conversion in keep-nip46 already produces `JustThisTime` on rejection, which records nothing. What was missing was the contract saying so.

Both now state the rule the surfaces need: send `JustThisTime` on rejection unless the user deliberately chose a duration for that answer, because a leftover value becomes a lasting refusal.

The reason to make the field symmetric rather than reject-specific comes from a reference signer for the same protocol, which passes one shared remember control to both its accept and reject callbacks. The control means "remember my decision for this long", and the decision is whichever button was pressed. That is coherent, and it is what these comments now describe.

## Test plan

Documentation only. Both crates build. The behaviour these comments describe is covered by the tests added with the refusal work: a rejection carrying a duration refuses the next request without prompting, and a `JustThisTime` rejection records nothing so every request still asks.