### PR TITLE
Record which peer asked for a signature in the audit log

### DIFF
--- a/keep-frost-net/src/audit.rs
+++ b/keep-frost-net/src/audit.rs
@@ -29,14 +29,25 @@ pub struct SigningAuditEntry {
     /// Which peer asked for this signature, by share index.
     ///
     /// Set on the entries written while handling an inbound request, where the
-    /// index has been resolved against the signature-verified peer list and is
-    /// therefore an identity rather than a claim. `None` elsewhere in the
-    /// session's lifecycle, and on requests this node initiated itself.
+    /// index has been resolved by looking the event's author up in the admitted
+    /// peer list. `None` on everything else: the mid-round entries, and
+    /// requests this node initiated itself.
     ///
-    /// Deliberately not copied onto every entry. The requester is a property of
-    /// the session, every entry already carries the session id, and duplicating
-    /// it would mean threading mutable state through the session layer to
-    /// restate something a join already answers.
+    /// Attributes the entry it sits on and nothing else. An earlier version of
+    /// this comment said the session id carried attribution to the rest of the
+    /// round; it does not. The session id is derived from the message, the
+    /// threshold and the sorted participant set, none of which mention the
+    /// requester, and participant selection does not depend on who asked, so
+    /// two peers requesting the same digest derive the same session id. A
+    /// duplicate request is also answered from the cached commitment before the
+    /// requester is ever resolved, so a second peer can drive a round whose
+    /// remaining entries would join back to the first. Carrying the requester
+    /// on the session is the fix for that and is filed separately.
+    ///
+    /// The index is as trustworthy as peer admission, which is a weaker
+    /// statement than it sounds: member transport keys are derived from the
+    /// group public key, so this identifies which member slot the request
+    /// arrived under rather than proving who sat in it.
     pub requester: Option<u16>,
     pub hmac: [u8; 32],
 }
@@ -83,18 +94,22 @@ impl SigningAuditEntry {
         mac.update(session_id);
         mac.update(message_hash);
         mac.update(signature_hash);
+        // Length-prefixed. Without this the run is unparseable: every field
+        // after it used to be fixed width, so total length still determined the
+        // split, but adding a variable-width field at the end broke that and
+        // made two different records hash identically. Concretely, participants
+        // [7,9] with our_index 5, operation 1 and requester Some(3) produced the
+        // same bytes as participants [7,9,5] with our_index 257, operation 3 and
+        // no requester.
+        mac.update(&(participant_indices.len() as u16).to_le_bytes());
         for idx in participant_indices {
             mac.update(&idx.to_le_bytes());
         }
         mac.update(&our_index.to_le_bytes());
         mac.update(&[operation.discriminant()]);
-        // Tagged rather than written only when present. With this field last,
-        // an untagged form is already unambiguous, since an absent requester
-        // contributes no bytes and share index 0 contributes two. The tag makes
-        // that independent of position: these fields are concatenated without
-        // delimiters, so appending anything after an untagged optional would
-        // let "nobody recorded" followed by the next field collide with "peer 0
-        // asked". Paying one byte now avoids a silent reattribution later.
+        // Tagged so the field is self-delimiting. On its own this does not make
+        // the preimage injective, which is what the length prefix above is for;
+        // it keeps this field parseable if another is ever appended after it.
         match requester {
             Some(idx) => {
                 mac.update(&[1u8]);
@@ -247,6 +262,7 @@ impl SigningAuditLog {
             signature_hash = %hex::encode(signature_hash),
             participants = ?participant_indices,
             our_index = our_index,
+            requester = ?requester,
             operation = ?operation,
             hmac = %hex::encode(hmac),
             "Signing audit log entry"
@@ -524,5 +540,50 @@ mod tests {
             !entry.verify(&key),
             "an unattributed entry must not verify as one attributed to peer 0"
         );
+    }
+
+    /// Two different records must not hash the same.
+    ///
+    /// The participant run is variable length. Every field after it used to be
+    /// fixed width, so the total length still determined where the run ended;
+    /// adding a variable-width field at the end removed that and made the
+    /// preimage ambiguous. These are the exact values that collided: the bytes
+    /// of two participants plus an index and a one-byte operation are also the
+    /// bytes of three participants plus a larger index and a different
+    /// operation. Without the length prefix one entry verifies as the other
+    /// with no knowledge of the key, which would let a record be rewritten into
+    /// a different one that still passes.
+    #[test]
+    fn distinct_records_do_not_share_an_hmac() {
+        let key = [5u8; 32];
+        let log = SigningAuditLog::new(key);
+        let session = [1u8; 32];
+
+        log.log_signing_operation(
+            session,
+            b"m",
+            None,
+            vec![7, 9],
+            5,
+            SigningOperation::CommitmentSent,
+            Some(3),
+        );
+        log.log_signing_operation(
+            session,
+            b"m",
+            None,
+            vec![7, 9, 5],
+            257,
+            SigningOperation::SignatureCompleted,
+            None,
+        );
+
+        let entries = log.entries();
+        assert_eq!(entries.len(), 2);
+        assert_ne!(
+            entries[0].hmac, entries[1].hmac,
+            "two different records must not produce the same authentication tag"
+        );
+        assert!(log.verify_all());
     }
 }

--- a/keep-frost-net/src/audit.rs
+++ b/keep-frost-net/src/audit.rs
@@ -26,6 +26,18 @@ pub struct SigningAuditEntry {
     pub participant_indices: Vec<u16>,
     pub our_index: u16,
     pub operation: SigningOperation,
+    /// Which peer asked for this signature, by share index.
+    ///
+    /// Set on the entries written while handling an inbound request, where the
+    /// index has been resolved against the signature-verified peer list and is
+    /// therefore an identity rather than a claim. `None` elsewhere in the
+    /// session's lifecycle, and on requests this node initiated itself.
+    ///
+    /// Deliberately not copied onto every entry. The requester is a property of
+    /// the session, every entry already carries the session id, and duplicating
+    /// it would mean threading mutable state through the session layer to
+    /// restate something a join already answers.
+    pub requester: Option<u16>,
     pub hmac: [u8; 32],
 }
 
@@ -63,6 +75,7 @@ impl SigningAuditEntry {
         participant_indices: &[u16],
         our_index: u16,
         operation: &SigningOperation,
+        requester: Option<u16>,
     ) -> [u8; 32] {
         let mut mac = HmacSha256::new_from_slice(hmac_key).expect("HMAC accepts any key length");
 
@@ -75,6 +88,20 @@ impl SigningAuditEntry {
         }
         mac.update(&our_index.to_le_bytes());
         mac.update(&[operation.discriminant()]);
+        // Tagged rather than written only when present. With this field last,
+        // an untagged form is already unambiguous, since an absent requester
+        // contributes no bytes and share index 0 contributes two. The tag makes
+        // that independent of position: these fields are concatenated without
+        // delimiters, so appending anything after an untagged optional would
+        // let "nobody recorded" followed by the next field collide with "peer 0
+        // asked". Paying one byte now avoids a silent reattribution later.
+        match requester {
+            Some(idx) => {
+                mac.update(&[1u8]);
+                mac.update(&idx.to_le_bytes());
+            }
+            None => mac.update(&[0u8]),
+        }
 
         let result = mac.finalize();
         let mut hmac_out = [0u8; 32];
@@ -92,6 +119,7 @@ impl SigningAuditEntry {
             &self.participant_indices,
             self.our_index,
             &self.operation,
+            self.requester,
         );
         bool::from(self.hmac.ct_eq(&expected))
     }
@@ -167,6 +195,10 @@ impl SigningAuditLog {
         matches!(operation, SigningOperation::SignRequestRefused)
     }
 
+    // Same reason as `compute_hmac` above: these are the fields of one audit
+    // record, and grouping them into a struct would add a type whose only
+    // purpose is to satisfy a lint about how they are passed.
+    #[allow(clippy::too_many_arguments)]
     pub fn log_signing_operation(
         &self,
         session_id: [u8; 32],
@@ -175,6 +207,7 @@ impl SigningAuditLog {
         participant_indices: Vec<u16>,
         our_index: u16,
         operation: SigningOperation,
+        requester: Option<u16>,
     ) {
         let timestamp_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -193,6 +226,7 @@ impl SigningAuditLog {
             &participant_indices,
             our_index,
             &operation,
+            requester,
         );
 
         let entry = SigningAuditEntry {
@@ -203,6 +237,7 @@ impl SigningAuditLog {
             participant_indices: participant_indices.clone(),
             our_index,
             operation: operation.clone(),
+            requester,
             hmac,
         };
 
@@ -306,6 +341,7 @@ mod tests {
             vec![1, 2],
             1,
             SigningOperation::CommitmentSent,
+            None,
         );
 
         // Far past the refusal cap: under a shared queue this would evict the
@@ -318,6 +354,7 @@ mod tests {
                 vec![1, 2],
                 1,
                 SigningOperation::SignRequestRefused,
+                None,
             );
         }
 
@@ -375,6 +412,7 @@ mod tests {
             vec![1, 2, 3],
             1,
             SigningOperation::SignatureCompleted,
+            None,
         );
 
         assert!(log.verify_all());
@@ -396,6 +434,7 @@ mod tests {
             vec![1, 2, 3],
             1,
             SigningOperation::SignatureCompleted,
+            None,
         );
 
         {
@@ -419,11 +458,71 @@ mod tests {
                 vec![1],
                 1,
                 SigningOperation::CommitmentSent,
+                None,
             );
         }
 
         let entries = log.entries();
         assert_eq!(entries.len(), 3);
         assert_eq!(entries[0].session_id[0], 2);
+    }
+
+    /// Reattributing an entry must break its HMAC.
+    ///
+    /// A field the HMAC does not cover is a field anyone with write access can
+    /// change, and "which peer asked for this" is exactly the claim an audit
+    /// log exists to make unforgeable. Storing it without binding it would look
+    /// identical in the API and mean nothing.
+    #[test]
+    fn the_requester_is_covered_by_the_entry_hmac() {
+        let key = [9u8; 32];
+        let log = SigningAuditLog::new(key);
+        log.log_signing_operation(
+            [1u8; 32],
+            b"m",
+            None,
+            vec![1, 2],
+            1,
+            SigningOperation::CommitmentSent,
+            Some(2),
+        );
+
+        let mut entry = log.entries().into_iter().next().expect("one entry");
+        assert!(entry.verify(&key), "as written it verifies");
+
+        entry.requester = Some(3);
+        assert!(
+            !entry.verify(&key),
+            "pointing the entry at a different peer must invalidate it"
+        );
+    }
+
+    /// An absent requester must not be interchangeable with share index 0.
+    ///
+    /// Pins the property rather than the encoding. It holds for the tagged form
+    /// in use and also for an untagged one while this field stays last, so this
+    /// test does not by itself justify the tag; it fails only if the requester
+    /// stops being covered at all. The tag is defence against a later field
+    /// being appended after it, which is a change no test here would catch.
+    #[test]
+    fn an_absent_requester_is_distinct_from_peer_zero() {
+        let key = [9u8; 32];
+        let log = SigningAuditLog::new(key);
+        log.log_signing_operation(
+            [1u8; 32],
+            b"m",
+            None,
+            vec![1],
+            1,
+            SigningOperation::CommitmentSent,
+            None,
+        );
+
+        let mut entry = log.entries().into_iter().next().expect("one entry");
+        entry.requester = Some(0);
+        assert!(
+            !entry.verify(&key),
+            "an unattributed entry must not verify as one attributed to peer 0"
+        );
     }
 }

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -393,7 +393,7 @@ impl KfpNode {
     /// and a refusal that could not be delivered is the one most worth keeping.
     /// That differs from the accept path, which logs after its send because
     /// there the recorded fact is the send itself.
-    fn record_refusal(&self, request: &SignRequestPayload) {
+    fn record_refusal(&self, request: &SignRequestPayload, requester: Option<u16>) {
         self.audit_log.log_signing_operation(
             request.session_id,
             &request.message,
@@ -401,6 +401,7 @@ impl KfpNode {
             request.participants.clone(),
             self.share.metadata.identifier,
             SigningOperation::SignRequestRefused,
+            requester,
         );
     }
 
@@ -526,7 +527,7 @@ impl KfpNode {
                 // fires when a requester's structured body does not produce the
                 // digest it asked us to sign, which is an attempted
                 // cross-domain relabel rather than a configuration saying no.
-                self.record_refusal(&request);
+                self.record_refusal(&request, None);
                 self.send_session_error(
                     &from,
                     "policy_violation",
@@ -549,7 +550,7 @@ impl KfpNode {
             );
             // Covers the kill switch and the desktop approval prompt too: both
             // refuse by returning an error from this same hook.
-            self.record_refusal(&request);
+            self.record_refusal(&request, Some(requester));
             self.send_session_error(
                 &from,
                 "policy_violation",
@@ -806,6 +807,7 @@ impl KfpNode {
             request.participants,
             self.share.metadata.identifier,
             SigningOperation::CommitmentSent,
+            Some(requester),
         );
 
         // With pre-exchange, the full commitment set arrived in this request, so
@@ -931,6 +933,7 @@ impl KfpNode {
                 session_participants,
                 self.share.metadata.identifier,
                 SigningOperation::SignatureCompleted,
+                None,
             );
 
             self.invoke_post_sign_hook(session_id, &sig);
@@ -1041,6 +1044,7 @@ impl KfpNode {
             session_participants,
             self.share.metadata.identifier,
             SigningOperation::SignatureShareSent,
+            None,
         );
 
         Ok(())
@@ -1127,6 +1131,7 @@ impl KfpNode {
             session_participants,
             self.share.metadata.identifier,
             SigningOperation::SignatureReceived,
+            None,
         );
 
         self.invoke_post_sign_hook(&payload.session_id, &payload.signature);
@@ -1451,6 +1456,7 @@ impl KfpNode {
             participants.clone(),
             self.share.metadata.identifier,
             SigningOperation::SignRequestInitiated,
+            None,
         );
 
         // #487 PR3: apply the composite BIP-32 tweak to our own key package

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -527,7 +527,7 @@ impl KfpNode {
                 // fires when a requester's structured body does not produce the
                 // digest it asked us to sign, which is an attempted
                 // cross-domain relabel rather than a configuration saying no.
-                self.record_refusal(&request, None);
+                self.record_refusal(&request, Some(requester));
                 self.send_session_error(
                     &from,
                     "policy_violation",
@@ -2021,6 +2021,54 @@ mod gate_tests {
         assert!(
             node.audit_log().verify_all(),
             "the new operation must be covered by the entry HMAC like every other one"
+        );
+        assert_eq!(
+            entries
+                .iter()
+                .find(|e| matches!(e.operation, SigningOperation::SignRequestRefused))
+                .and_then(|e| e.requester),
+            Some(2),
+            "the refusal must name the peer that sent it; without this the call \
+             site could pass None and nothing would fail"
+        );
+    }
+
+    /// The structured-payload refusal is attributed too.
+    ///
+    /// It fires when a requester's body does not produce the digest it asked us
+    /// to sign, which is the entry most worth attributing, and it was recorded
+    /// unattributed while the index sat in scope a few lines above.
+    #[tokio::test]
+    async fn a_structured_payload_mismatch_names_the_peer_that_sent_it() {
+        let (node, _relay) = test_node().await;
+
+        let peer = Keys::generate().public_key();
+        node.peers.write().add_peer(crate::peer::Peer::new(peer, 2));
+
+        let session_id = [0x44u8; 32];
+        let group = *node.group_pubkey();
+        // A body that cannot produce the digest being signed.
+        let req = SignRequestPayload::new(
+            session_id,
+            group,
+            vec![0u8; 32],
+            crate::MSG_TYPE_NOSTR_EVENT,
+            vec![1, 2],
+        )
+        .with_structured_payload(b"not a nostr event".to_vec());
+
+        node.handle_sign_request(peer, req)
+            .await
+            .expect("a refusal is reported to the requester, not surfaced here");
+
+        let entries = node.audit_log().get_entries_for_session(&session_id);
+        assert_eq!(
+            entries
+                .iter()
+                .find(|e| matches!(e.operation, SigningOperation::SignRequestRefused))
+                .and_then(|e| e.requester),
+            Some(2),
+            "a relabel attempt must record which peer attempted it"
         );
     }
 


### PR DESCRIPTION
## Summary

Entries recorded what this node signed but not who asked for it. For a single holder that is enough, since there is only one party who could have asked. It stops being enough the moment several principals share a signer, which is the shape an agent deployment takes: the first question about any entry is which agent produced it, and no field answered it.

Both entries written while handling an inbound request now carry the requester's share index: the policy refusal and the structured-payload mismatch. The second is the one most worth attributing, since it fires when a requester's body does not produce the digest it asked us to sign, which is an attempted relabel rather than a configuration saying no.

The field is covered by the entry HMAC, because a field the HMAC does not cover is one anyone with write access can change, and this is exactly the claim an audit log exists to make unforgeable. That is safe to add here only because nothing persists these entries: the log is an in-memory queue rebuilt on every start, read by one status endpoint. There are no stored entries whose verification could break. The vault's hash-chained audit log is a different type in a different crate and is untouched.

Adding a variable-width field at the end exposed an existing weakness in the preimage. The participant list is written without a length prefix; every field after it used to be fixed width, so the total length still determined where the list ended. A trailing optional removed that, and two different records began hashing identically: two participants plus an index and a one-byte operation are also the bytes of three participants plus a larger index and a different operation. The list is now length-prefixed.

Two claims from the first version of this change were wrong and are corrected rather than quietly dropped. The requester is not attribution for the whole round: the session id is derived from the message, threshold and sorted participants, none of which mention the requester, and participant selection does not depend on who asked, so two peers requesting the same digest derive the same session id. A duplicate request is also answered from the cached commitment before the requester is resolved, so a second peer can drive a round whose remaining entries would join back to the first. The field now documents that it attributes the entry it sits on and nothing more. And the index is only as trustworthy as peer admission, which is weaker than it sounds, because member transport keys are derived from the group public key; it identifies which member slot a request arrived under rather than proving who sat in it.

The value is now also emitted on the tracing line, alongside every sibling field.

## Test plan

Five tests. Reattributing an entry breaks its HMAC. An unattributed entry does not verify as one attributed to share index zero. Two different records do not share a tag, using the exact values that collided. And both inbound-request call sites assert the recorded peer, which nothing did before: the existing refusal test exercised the attributed path with peer 2 and asserted nothing about it, so either call site could have passed nothing and the suite would have stayed green.

Falsified rather than assumed, three ways. Unbinding the requester from the HMAC fails the first two. Removing the length prefix reproduces the collision exactly. Passing nothing at either call site fails both wiring tests.

One earlier claim was withdrawn because falsification refuted it: the tag byte distinguishing present from absent is not what prevents a collision with share index zero. Removing it leaves those tests passing. It stays to keep the field self-delimiting, and the comment no longer claims more than that.

455 library tests pass, workspace builds, formatter and clippy clean. Follow-ups filed rather than fixed here: carrying the requester on the session so downstream entries are attributed, and the transport-key derivation that bounds what any of this can prove.
