### PR TITLE
Make the network nonce store's reader lock and corruption handling fail closed

### DIFF
--- a/keep-frost-net/src/nonce_store.rs
+++ b/keep-frost-net/src/nonce_store.rs
@@ -28,6 +28,25 @@ pub struct FileNonceStore {
 
 impl FileNonceStore {
     pub fn new(path: &Path) -> Result<Self> {
+        // The lock and temp siblings are derived by replacing the extension,
+        // so a store named `*.lock` or `*.tmp` derives a sibling equal to
+        // itself. Both writer paths open the lock with `truncate(true)`, so a
+        // `.lock` store would be zeroed on the next record and left holding
+        // only the entry that just arrived: every previously consumed id gone
+        // from disk, and the guard silently empty after the next restart.
+        // Refuse the name rather than let the collision erase the store.
+        let collides = path
+            .extension()
+            .map(|e| e.to_string_lossy().to_ascii_lowercase())
+            .is_some_and(|e| e == "lock" || e == "tmp");
+        if collides {
+            return Err(FrostNetError::Session(format!(
+                "Nonce store path {} must not end in .lock or .tmp: those \
+                 extensions collide with the store's own lock and temp files",
+                path.display()
+            )));
+        }
+
         let consumed = Arc::new(RwLock::new(HashSet::new()));
         let insertion_order = Arc::new(RwLock::new(VecDeque::new()));
 
@@ -420,6 +439,29 @@ mod tests {
     /// The lost record is the most recently consumed session, because a short
     /// entry is a partial append. Skipping it silently returned that session id
     /// to the available set, so the recovery path itself produced the replay
+    /// A store named like its own lock or temp sibling is refused.
+    ///
+    /// Not a style rule: both writer paths open the lock with `truncate(true)`,
+    /// so a `.lock` store is erased by its own first write and the guard comes
+    /// back empty after a restart.
+    #[test]
+    fn a_store_named_like_its_own_lock_is_refused() {
+        let dir = tempdir().unwrap();
+
+        for name in ["nonces.lock", "nonces.tmp", "nonces.LOCK"] {
+            let path = dir.path().join(name);
+            assert!(
+                FileNonceStore::new(&path).is_err(),
+                "{name} derives a sibling equal to itself and must be refused"
+            );
+        }
+
+        assert!(
+            FileNonceStore::new(&dir.path().join("nonces.locked")).is_ok(),
+            "a name that merely starts with the same letters is fine"
+        );
+    }
+
     /// this store exists to prevent, and the only signal was a warning nobody
     /// reads after a crash.
     #[test]

--- a/keep-frost-net/src/nonce_store.rs
+++ b/keep-frost-net/src/nonce_store.rs
@@ -32,11 +32,33 @@ impl FileNonceStore {
         let insertion_order = Arc::new(RwLock::new(VecDeque::new()));
 
         if path.exists() {
+            // Lock the same sibling the writers lock, not the store itself.
+            //
+            // Reading under a lock on the store while `record` and the rewrite
+            // path lock `<store>.lock` meant the reader and the writers took
+            // locks on different inodes and never contended: this lock excluded
+            // nothing at all. Loading the consumed set could therefore run
+            // against a file being appended to or replaced underneath it, and
+            // the guard would start life having missed entries.
+            let lock_path = path.with_extension("lock");
+            let lock_file = {
+                let mut opts = OpenOptions::new();
+                opts.create(true).write(true).truncate(false);
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::OpenOptionsExt;
+                    opts.mode(0o600);
+                }
+                opts.open(&lock_path).map_err(|e| {
+                    FrostNetError::Session(format!("Failed to open nonce lock: {e}"))
+                })?
+            };
+            lock_file
+                .lock_exclusive()
+                .map_err(|e| FrostNetError::Session(format!("Failed to lock nonce store: {e}")))?;
+
             let file = File::open(path)
                 .map_err(|e| FrostNetError::Session(format!("Failed to open nonce store: {e}")))?;
-
-            file.lock_exclusive()
-                .map_err(|e| FrostNetError::Session(format!("Failed to lock nonce store: {e}")))?;
 
             let reader = BufReader::new(&file);
 
@@ -55,8 +77,20 @@ impl FileNonceStore {
                 })?;
 
                 if bytes.len() != 32 {
-                    warn!(line = %line, "Skipping invalid entry in nonce store");
-                    continue;
+                    // Refuse to load rather than skip. A short entry is a
+                    // truncated append, so the record it lost is the most
+                    // recently consumed session, and skipping it silently
+                    // returns that session id to the available set: the exact
+                    // replay this store exists to prevent, produced by the
+                    // recovery path rather than by an attacker. An odd-length
+                    // truncation already fails hard a few lines above, so this
+                    // is the same corruption being answered the same way rather
+                    // than a new failure mode.
+                    return Err(FrostNetError::Session(format!(
+                        "Nonce store entry is {} bytes, expected 32: the store is \
+                         truncated or corrupt and cannot be trusted to prevent reuse",
+                        bytes.len()
+                    )));
                 }
 
                 let mut session_id = [0u8; 32];
@@ -363,5 +397,78 @@ mod tests {
         store.record(&session_id).unwrap();
 
         assert_eq!(store.count(), 1);
+    }
+
+    /// A truncated entry must refuse to load, not be skipped.
+    ///
+    /// The lost record is the most recently consumed session, because a short
+    /// entry is a partial append. Skipping it silently returned that session id
+    /// to the available set, so the recovery path itself produced the replay
+    /// this store exists to prevent, and the only signal was a warning nobody
+    /// reads after a crash.
+    #[test]
+    fn a_truncated_entry_refuses_to_load() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nonces");
+
+        // One good entry, then a short one: an append cut off mid-write that
+        // still happens to decode as hex.
+        std::fs::write(
+            &path,
+            format!("{}\n{}\n", hex::encode([7u8; 32]), hex::encode([9u8; 16])),
+        )
+        .unwrap();
+
+        let err = match FileNonceStore::new(&path) {
+            Err(e) => e,
+            Ok(_) => panic!("a store that cannot be trusted must not load"),
+        };
+        assert!(
+            format!("{err}").contains("truncated or corrupt"),
+            "the refusal should say why the store is untrustworthy, got: {err}"
+        );
+    }
+
+    /// The whole point of refusing: a session already consumed must not come
+    /// back as available because the record after it was cut short.
+    #[test]
+    fn a_truncated_store_does_not_resurrect_a_consumed_session() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nonces");
+        let consumed = [7u8; 32];
+
+        std::fs::write(
+            &path,
+            format!("{}\n{}\n", hex::encode(consumed), hex::encode([9u8; 16])),
+        )
+        .unwrap();
+
+        // Loading must fail rather than yield a store that answers "available"
+        // for a session id the file says was consumed.
+        assert!(
+            FileNonceStore::new(&path).is_err(),
+            "a store loaded past a truncated entry would report a consumed \
+             session as available"
+        );
+    }
+
+    /// The reader must take the same lock the writers take.
+    ///
+    /// It previously locked the store file while `record` and the rewrite path
+    /// locked a sibling, so the two never contended and the reader's lock
+    /// excluded nothing. Observable without threads: loading creates the lock
+    /// file the writers use.
+    #[test]
+    fn loading_takes_the_lock_the_writers_take() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nonces");
+        std::fs::write(&path, format!("{}\n", hex::encode([1u8; 32]))).unwrap();
+
+        let _store = FileNonceStore::new(&path).unwrap();
+
+        assert!(
+            path.with_extension("lock").exists(),
+            "the reader must lock the writers' sibling, not the store itself"
+        );
     }
 }

--- a/keep-frost-net/src/nonce_store.rs
+++ b/keep-frost-net/src/nonce_store.rs
@@ -31,15 +31,19 @@ impl FileNonceStore {
         let consumed = Arc::new(RwLock::new(HashSet::new()));
         let insertion_order = Arc::new(RwLock::new(VecDeque::new()));
 
-        if path.exists() {
-            // Lock the same sibling the writers lock, not the store itself.
+        {
+            // Lock the same sibling the writers lock, not the store itself,
+            // and take it before checking whether the store exists.
             //
             // Reading under a lock on the store while `record` and the rewrite
             // path lock `<store>.lock` meant the reader and the writers took
             // locks on different inodes and never contended: this lock excluded
             // nothing at all. Loading the consumed set could therefore run
             // against a file being appended to or replaced underneath it, and
-            // the guard would start life having missed entries.
+            // the guard would start life having missed entries. Checking
+            // existence outside the lock had the same shape of hole: a store
+            // created between the check and the load would be skipped, and the
+            // guard would start empty with every consumed id reading available.
             let lock_path = path.with_extension("lock");
             let lock_file = {
                 let mut opts = OpenOptions::new();
@@ -57,53 +61,64 @@ impl FileNonceStore {
                 .lock_exclusive()
                 .map_err(|e| FrostNetError::Session(format!("Failed to lock nonce store: {e}")))?;
 
-            let file = File::open(path)
-                .map_err(|e| FrostNetError::Session(format!("Failed to open nonce store: {e}")))?;
-
-            let reader = BufReader::new(&file);
-
-            let mut guard = consumed.write();
-            for line in reader.lines() {
-                let line = line.map_err(|e| {
-                    FrostNetError::Session(format!("Failed to read nonce store: {e}"))
-                })?;
-                let line = line.trim();
-                if line.is_empty() {
-                    continue;
-                }
-
-                let bytes = hex::decode(line).map_err(|e| {
-                    FrostNetError::Session(format!("Invalid hex in nonce store: {e}"))
-                })?;
-
-                if bytes.len() != 32 {
-                    // Refuse to load rather than skip. A short entry is a
-                    // truncated append, so the record it lost is the most
-                    // recently consumed session, and skipping it silently
-                    // returns that session id to the available set: the exact
-                    // replay this store exists to prevent, produced by the
-                    // recovery path rather than by an attacker. An odd-length
-                    // truncation already fails hard a few lines above, so this
-                    // is the same corruption being answered the same way rather
-                    // than a new failure mode.
+            let file = match File::open(path) {
+                Ok(f) => Some(f),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+                Err(e) => {
                     return Err(FrostNetError::Session(format!(
-                        "Nonce store entry is {} bytes, expected 32: the store is \
+                        "Failed to open nonce store: {e}"
+                    )))
+                }
+            };
+
+            if let Some(file) = file {
+                let reader = BufReader::new(&file);
+
+                let mut guard = consumed.write();
+                for line in reader.lines() {
+                    let line = line.map_err(|e| {
+                        FrostNetError::Session(format!("Failed to read nonce store: {e}"))
+                    })?;
+                    let line = line.trim();
+                    if line.is_empty() {
+                        continue;
+                    }
+
+                    let bytes = hex::decode(line).map_err(|e| {
+                        FrostNetError::Session(format!("Invalid hex in nonce store: {e}"))
+                    })?;
+
+                    if bytes.len() != 32 {
+                        // Refuse to load rather than skip. A short entry is a
+                        // truncated append, so the record it lost is the most
+                        // recently consumed session, and skipping it silently
+                        // returns that session id to the available set: the exact
+                        // replay this store exists to prevent, produced by the
+                        // recovery path rather than by an attacker. An odd-length
+                        // truncation already fails hard a few lines above, so this
+                        // is the same corruption being answered the same way rather
+                        // than a new failure mode.
+                        return Err(FrostNetError::Session(format!(
+                            "Nonce store entry is {} bytes, expected 32: the store is \
                          truncated or corrupt and cannot be trusted to prevent reuse",
-                        bytes.len()
-                    )));
-                }
+                            bytes.len()
+                        )));
+                    }
 
-                let mut session_id = [0u8; 32];
-                session_id.copy_from_slice(&bytes);
-                if guard.insert(session_id) {
-                    insertion_order.write().push_back(session_id);
+                    let mut session_id = [0u8; 32];
+                    session_id.copy_from_slice(&bytes);
+                    if guard.insert(session_id) {
+                        insertion_order.write().push_back(session_id);
+                    }
                 }
+                debug!(count = guard.len(), path = ?path, "Loaded consumed session IDs");
             }
-            debug!(count = guard.len(), path = ?path, "Loaded consumed session IDs");
 
-            FileExt::unlock(&file).map_err(|e| {
-                FrostNetError::Session(format!("Failed to unlock nonce store: {e}"))
-            })?;
+            // `lock_file` is declared before `file`, so it drops last: the lock
+            // is released after the read completes. No explicit unlock, which
+            // is what the error paths above already rely on. Unlocking `file`
+            // here would target a handle that was never locked: a silent no-op
+            // on Unix, and an error on Windows that would fail every load.
         }
 
         Ok(Self {
@@ -330,6 +345,7 @@ impl NonceStore for MemoryNonceStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
     use tempfile::tempdir;
 
     #[test]
@@ -459,16 +475,48 @@ mod tests {
     /// excluded nothing. Observable without threads: loading creates the lock
     /// file the writers use.
     #[test]
+    #[cfg_attr(windows, ignore = "file locking behaves differently on Windows")]
     fn loading_takes_the_lock_the_writers_take() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("nonces");
         std::fs::write(&path, format!("{}\n", hex::encode([1u8; 32]))).unwrap();
 
-        let _store = FileNonceStore::new(&path).unwrap();
+        // Assert the lock is HELD, not merely that the lock file exists: that
+        // file is created by `open`, so an existence check stays green even if
+        // the `lock_exclusive` call is deleted outright.
+        //
+        // flock follows the open file description, so a second handle on the
+        // same path contends even within a single process.
+        let held = {
+            let f = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(false)
+                .open(path.with_extension("lock"))
+                .unwrap();
+            f.lock_exclusive().unwrap();
+            f
+        };
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let load_path = path.clone();
+        let loader = std::thread::spawn(move || {
+            let result = FileNonceStore::new(&load_path);
+            tx.send(()).unwrap();
+            result
+        });
 
         assert!(
-            path.with_extension("lock").exists(),
-            "the reader must lock the writers' sibling, not the store itself"
+            rx.recv_timeout(Duration::from_millis(300)).is_err(),
+            "loading must block while a writer holds the lock"
         );
+
+        FileExt::unlock(&held).unwrap();
+
+        let store = loader
+            .join()
+            .unwrap()
+            .expect("loading must succeed once the lock is released");
+        assert!(store.is_consumed(&[1u8; 32]), "the entry must be loaded");
     }
 }


### PR DESCRIPTION
## Summary

Three problems in the same file, found while reviewing the equivalent fix in the CLI's store.

**The reader locked the wrong file.** Loading the consumed set took an exclusive lock on the store, while the append path and the rewrite path both lock a sibling. The reader and the writers therefore locked different inodes and never contended, so that lock excluded nothing: the set could be loaded while the file was being appended to or replaced underneath it, and the guard would begin life having missed entries. The existence check had the same shape of hole and is now inside the critical section, so a store created between the check and the load can no longer be skipped entirely.

**A truncated entry was skipped with a warning.** That is the fail-open direction for a replay guard, and the record it drops is the worst one to lose: a short entry is a partial append, so the missing record is the most recently consumed session, and skipping it returns that session id to the available set. The recovery path itself produced the reuse the store exists to prevent, and the only trace was a warning nobody reads after a crash. Loading now refuses.

Worth noting this was already inconsistent rather than merely permissive. A truncation leaving an odd number of hex characters fails the decode and errors hard a few lines above; only an even-length one was skipped. The same corruption had two opposite answers depending on where the write happened to stop, so this aligns them rather than introducing a new failure mode.

**The unlock targeted a handle that was never locked.** Moving the lock onto the sibling left the paired unlock on the store handle. On Unix that is a silent no-op, so nothing here observes it. On Windows `UnlockFile` on an unheld region reports an error, which would have made every load of an existing store fail, on a target whose build job does not run for pull requests. The explicit unlock is gone in favor of the drop order the error paths already rely on.

**A store named like its own lock was erased by its own writes.** The lock and temp siblings are derived by replacing the extension, so a store called `*.lock` derives a lock path equal to itself, and both writer paths open the lock with `truncate(true)`. Recording into such a store zeroed it and left only the entry that had just arrived, so every previously consumed id was gone from disk and the guard came back empty on the next start. Confirmed by observation rather than inspection: with the check removed, recording two ids and reloading finds the first one missing. Such a path is now refused, `.tmp` included, since it collides the same way.

## Scope

The guard decision still reads an in-memory set built once at construction, so two processes sharing a file each hold their own stale view. Locking the load correctly makes the read atomic; it does not make the store multi-process safe, and this change should not be read as claiming that. Whether that is a supported deployment is a question about how this is run rather than about this code, and the answer changes what the fix should be, so it is filed rather than guessed at.

Also filed rather than fixed here: eviction above the entry ceiling silently returns old session ids to the available set, and the corruption refusal names no path and no remedy, which matters because the obvious operator response to a node that will not start is to delete the store, forfeiting all replay protection rather than the one lost entry.

## Test plan

Four tests. A truncated entry refuses to load, with the refusal saying why. A session recorded before a truncated entry does not come back as available, which is the consequence that matters rather than the error itself. And loading blocks while another handle holds the writers' lock, then succeeds and returns the entry once it is released.

The lock test asserts the lock is held rather than that the lock file exists. An existence assertion passes even with the `lock_exclusive` call deleted outright, since the file is created by the open that precedes it; the contended version fails against that mutant.

A fourth covers the colliding name, including a mixed-case spelling and a near-miss (`nonces.locked`) that must still be accepted.

Falsified: restoring the skip fails the truncation tests, and deleting `lock_exclusive` fails the lock test, and removing the name check fails the collision test. The unlock fix has no test, deliberately and not for lack of trying: it is a no-op on Unix, so nothing running in this pipeline can observe it. All 459 library tests pass, workspace builds, formatter and clippy clean.
