### PR TITLE
Propagate RNG failure instead of panicking in every caller that can return a Result

### DIFF
--- a/keep-core/src/crypto.rs
+++ b/keep-core/src/crypto.rs
@@ -530,8 +530,10 @@ pub fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
 /// Generate cryptographically secure random bytes.
 ///
 /// Panics if the RNG health check fails. Prefer [`try_random_bytes`] anywhere a
-/// `Result` can be returned: the panic is fail-closed but blunt, and across a
-/// uniffi boundary it aborts the host app rather than surfacing an error.
+/// `Result` can be returned: the panic is fail-closed but blunt. uniffi catches
+/// the unwind and surfaces it as an untyped internal exception, so a caller on
+/// that path loses the error's identity rather than the process, and a
+/// long-running signer takes the panic on whichever task happened to draw.
 pub fn random_bytes<const N: usize>() -> [u8; N] {
     // rng-hygiene: ok - this is the panicking primitive itself, not a caller
     entropy::random_bytes()

--- a/keep-core/src/crypto.rs
+++ b/keep-core/src/crypto.rs
@@ -528,7 +528,12 @@ pub fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
 }
 
 /// Generate cryptographically secure random bytes.
+///
+/// Panics if the RNG health check fails. Prefer [`try_random_bytes`] anywhere a
+/// `Result` can be returned: the panic is fail-closed but blunt, and across a
+/// uniffi boundary it aborts the host app rather than surfacing an error.
 pub fn random_bytes<const N: usize>() -> [u8; N] {
+    // rng-hygiene: ok - this is the panicking primitive itself, not a caller
     entropy::random_bytes()
 }
 

--- a/keep-desktop/src/nostrconnect.rs
+++ b/keep-desktop/src/nostrconnect.rs
@@ -213,8 +213,14 @@ async fn send_nostrconnect_response(
 ) -> Result<(), String> {
     let keys = Keys::new(server.transport_secret());
 
+    // Fallible rather than panicking: the RNG health check firing means the
+    // source is degraded, and aborting the process is a heavier answer than
+    // failing the one response that needed the id.
+    let response_id =
+        keep_core::crypto::try_random_bytes::<16>().map_err(|e| format!("response id: {e}"))?;
+
     let response = serde_json::json!({
-        "id": hex::encode(keep_core::crypto::random_bytes::<16>()),
+        "id": hex::encode(response_id),
         "result": request.secret,
     });
     let response_json =

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -221,7 +221,7 @@ impl KfpNode {
         let key_package = self.share.key_package()?;
         let mut fresh = Vec::with_capacity(deficit);
         for _ in 0..deficit {
-            let nonce_id: NonceId = keep_core::crypto::random_bytes::<32>();
+            let nonce_id: NonceId = keep_core::crypto::try_random_bytes::<32>()?;
             let (nonces, commitment) =
                 frost_secp256k1_tr::round1::commit(key_package.signing_share(), &mut OsRng);
             self.nonce_pool.store_own(nonce_id, nonces);

--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -1343,10 +1343,12 @@ pub struct PingPayload {
 impl PingPayload {
     pub fn new() -> Self {
         Self {
-            // rng-hygiene: ok - `Default` below delegates here and cannot return
-            // a Result, so making this fallible means removing a public trait
-            // impl. That is an API decision, not a mechanical migration, and the
-            // value is a liveness challenge rather than key material.
+            // rng-hygiene: ok - the challenge is never checked. `handle_pong`
+            // binds the payload and drops it; responsiveness is decided by
+            // comparing pong arrival instants, so a degraded challenge changes
+            // nothing here. Adding a fallible `try_new` for the one production
+            // caller is the fix, tracked separately, along with the question of
+            // whether an unverified challenge should exist at all.
             challenge: keep_core::crypto::random_bytes::<32>(),
             timestamp: Timestamp::now().as_secs(),
         }

--- a/keep-frost-net/src/protocol.rs
+++ b/keep-frost-net/src/protocol.rs
@@ -1343,6 +1343,10 @@ pub struct PingPayload {
 impl PingPayload {
     pub fn new() -> Self {
         Self {
+            // rng-hygiene: ok - `Default` below delegates here and cannot return
+            // a Result, so making this fallible means removing a public trait
+            // impl. That is an API decision, not a mechanical migration, and the
+            // value is a liveness challenge rather than key material.
             challenge: keep_core::crypto::random_bytes::<32>(),
             timestamp: Timestamp::now().as_secs(),
         }

--- a/keep-mobile/src/nip46.rs
+++ b/keep-mobile/src/nip46.rs
@@ -483,7 +483,7 @@ fn load_or_create_bunker_keys(
     {
         Some(bytes) => bytes,
         None => {
-            let bytes = Zeroizing::new(keep_core::crypto::random_bytes::<32>());
+            let bytes = Zeroizing::new(keep_core::crypto::try_random_bytes::<32>()?);
             stored.transport_secret = Some(hex::encode(&bytes[..]));
             dirty = true;
             bytes
@@ -493,7 +493,7 @@ fn load_or_create_bunker_keys(
     let connect_secret = match stored.connect_secret.as_deref() {
         Some(secret) if !secret.is_empty() => Zeroizing::new(secret.to_owned()),
         _ => {
-            let secret = Zeroizing::new(hex::encode(keep_core::crypto::random_bytes::<16>()));
+            let secret = Zeroizing::new(hex::encode(keep_core::crypto::try_random_bytes::<16>()?));
             stored.connect_secret = Some(secret.as_str().to_owned());
             dirty = true;
             secret

--- a/keep-mobile/src/nip55_caller.rs
+++ b/keep-mobile/src/nip55_caller.rs
@@ -115,6 +115,8 @@ impl Nip55NonceStore {
     /// minutes after `now_elapsed_ms` (an `elapsedRealtime` boot-time millis
     /// value). Evicts expired (then oldest) entries when the active set is full.
     pub fn generate(&self, package_name: String, now_elapsed_ms: u64) -> String {
+        // rng-hygiene: ok - uniffi-exported, so returning a Result changes the
+        // generated Kotlin signature and has to land with the Android caller.
         let nonce = hex::encode(keep_core::crypto::random_bytes::<32>());
         let mut nonces = self.nonces.lock().unwrap_or_else(|e| e.into_inner());
         nonces.insert(

--- a/keep-nip46/src/client.rs
+++ b/keep-nip46/src/client.rs
@@ -323,7 +323,7 @@ impl Nip46Client {
         if let Some(ref s) = self.secret {
             params.push(Zeroizing::new(s.as_str().to_string()));
         }
-        let id = new_request_id();
+        let id = new_request_id()?;
         let response = self.request(&id, "connect", params).await?;
         match (response.result.as_deref(), response.error.as_deref()) {
             (Some(_), None) => Ok(()),
@@ -347,7 +347,7 @@ impl Nip46Client {
     ) -> Result<RegisterWalletResponse> {
         validate_register_wallet_args(name, descriptor)?;
 
-        let id = new_request_id();
+        let id = new_request_id()?;
         let mut response = self
             .request_with_timeout(
                 &id,
@@ -405,7 +405,7 @@ impl Nip46Client {
     /// and fall back to user-supplied values rather than aborting wallet
     /// registration.
     pub async fn get_device_info(&self) -> Result<DeviceInfo> {
-        let id = new_request_id();
+        let id = new_request_id()?;
         let response = self
             .request_with_timeout(&id, "get_device_info", Vec::new(), GET_DEVICE_INFO_TIMEOUT)
             .await?;
@@ -500,7 +500,7 @@ impl Nip46Client {
             )));
         }
 
-        let id = new_request_id();
+        let id = new_request_id()?;
         let mut response = self
             .request_with_timeout(
                 &id,
@@ -679,8 +679,8 @@ impl Nip46Client {
     }
 }
 
-fn new_request_id() -> String {
-    hex::encode(keep_core::crypto::random_bytes::<16>())
+fn new_request_id() -> Result<String> {
+    Ok(hex::encode(keep_core::crypto::try_random_bytes::<16>()?))
 }
 
 /// JSON-escape `value` and append the quoted result to `buf`. The intermediate
@@ -822,8 +822,8 @@ mod tests {
 
     #[test]
     fn test_new_request_id_is_unique() {
-        let a = new_request_id();
-        let b = new_request_id();
+        let a = new_request_id().unwrap();
+        let b = new_request_id().unwrap();
         assert_ne!(a, b);
         assert_eq!(a.len(), 32);
     }

--- a/keep-nip46/src/server.rs
+++ b/keep-nip46/src/server.rs
@@ -206,7 +206,7 @@ fn finalize_handler(
     mut handler: SignerHandler,
     config: &ServerConfig,
     relay_urls: &[String],
-) -> (SignerHandler, Option<Zeroizing<String>>) {
+) -> Result<(SignerHandler, Option<Zeroizing<String>>)> {
     handler = handler.with_relay_urls(relay_urls.to_vec());
     if let Some(ref rl_config) = config.rate_limit {
         handler = handler.with_rate_limit(rl_config.clone());
@@ -215,7 +215,7 @@ fn finalize_handler(
         handler = handler.with_kill_switch(ks.clone());
     }
     let bunker_secret = if config.auto_approve && config.expected_secret.is_none() {
-        let secret = hex::encode(keep_core::crypto::random_bytes::<16>());
+        let secret = hex::encode(keep_core::crypto::try_random_bytes::<16>()?);
         warn!("headless mode: bunker secret required for authentication");
         handler = handler.with_expected_secret(secret.clone());
         Some(Zeroizing::new(secret))
@@ -227,7 +227,7 @@ fn finalize_handler(
     } else {
         None
     };
-    (handler, bunker_secret)
+    Ok((handler, bunker_secret))
 }
 
 impl Server {
@@ -369,7 +369,7 @@ impl Server {
         if let Some(frost) = frost_signer {
             handler = handler.with_frost_signer(frost);
         }
-        let (handler, bunker_secret) = finalize_handler(handler, &config, relay_urls);
+        let (handler, bunker_secret) = finalize_handler(handler, &config, relay_urls)?;
 
         Ok(Self::build(
             keys,
@@ -492,7 +492,7 @@ impl Server {
             .with_connect_grant(config.connect_grant)
             .with_connect_auto_approve_kinds(config.connect_auto_approve_kinds.clone())
             .with_transport_pubkey(keys.public_key());
-        let (handler, bunker_secret) = finalize_handler(handler, &config, relay_urls);
+        let (handler, bunker_secret) = finalize_handler(handler, &config, relay_urls)?;
 
         Ok(Self::build(
             keys,
@@ -921,7 +921,7 @@ mod tests {
         };
 
         let (_handler, bunker_secret) =
-            finalize_handler(handler, &config, &["wss://relay.example.com".to_string()]);
+            finalize_handler(handler, &config, &["wss://relay.example.com".to_string()]).unwrap();
 
         let secret = bunker_secret.expect("expected_secret should surface as bunker secret");
         assert_eq!(secret.as_str(), "my-secret");
@@ -1202,7 +1202,7 @@ mod tests {
             ..ServerConfig::default()
         };
         let (_h, sec) =
-            finalize_handler(handler, &config, &["wss://relay.example.com".to_string()]);
+            finalize_handler(handler, &config, &["wss://relay.example.com".to_string()]).unwrap();
         let generated = sec.expect("headless without explicit secret must generate one");
         assert!(
             !generated.is_empty(),
@@ -1220,7 +1220,7 @@ mod tests {
             ..ServerConfig::default()
         };
         let (_h, sec) =
-            finalize_handler(handler, &config, &["wss://relay.example.com".to_string()]);
+            finalize_handler(handler, &config, &["wss://relay.example.com".to_string()]).unwrap();
         assert!(
             sec.is_none(),
             "interactive mode without explicit secret must NOT generate one"
@@ -1241,7 +1241,7 @@ mod tests {
             ..ServerConfig::default()
         };
         let (_h, sec) =
-            finalize_handler(handler, &config, &["wss://relay.example.com".to_string()]);
+            finalize_handler(handler, &config, &["wss://relay.example.com".to_string()]).unwrap();
         assert_eq!(
             sec.expect("explicit secret should surface").as_str(),
             "operator-supplied"

--- a/scripts/check-rng-hygiene.sh
+++ b/scripts/check-rng-hygiene.sh
@@ -19,6 +19,12 @@
 #      `unwrap_or_default()` -- which for a `[u8; N]` means all zeros.
 #   3. A seeded, reproducible PRNG (`seed_from_u64`, `from_seed`, `SmallRng`)
 #      standing in for the OS RNG. Fine in tests, never in production.
+#   5. The panicking draw (`crypto::random_bytes`) used where the caller could
+#      have propagated instead. It aborts the process on a health-check failure,
+#      which is fail-closed but ungraceful: across a uniffi boundary it becomes
+#      an app abort, and in a long-running signer it kills the service. Prefer
+#      `try_random_bytes`; opt out where the signature genuinely cannot carry a
+#      `Result`.
 #   4. keep-core's entropy gate. `random_bytes_mixed_internal()` mixes OS
 #      randomness with timing jitter and process context, so its output looks
 #      random even when a source has degraded -- the health check is what makes
@@ -349,7 +355,31 @@ else
   fi
 fi
 
+# --------------------------------------------- 5. the panicking draw ---------
+# `random_bytes` is `try_random_bytes().expect(..)`. Panicking on a degraded RNG
+# is the right direction -- it refuses to hand out a key rather than hand out a
+# predictable one -- but it is the blunt version of it. Across uniffi a panic
+# becomes an app abort, and in the bunker it takes down a running signer, so a
+# caller that can return an error should.
+#
+# Single-pattern like rule 3: there is no "handled" spelling of this call, only
+# the fallible sibling or a deliberate opt-out. `crypto::try_random_bytes` does
+# not contain the literal `crypto::random_bytes`, so the fallible form is not
+# matched.
+#
+# The optional `::` is load-bearing. Nearly every call here is a turbofish
+# (`random_bytes::<32>()`), where the next character after the name is a colon,
+# so without it this rule matched only the bare-parenthesis spelling and sailed
+# straight past the sites it exists to find.
+panicking_bad=$(scan_rust '(crypto|entropy)::random_bytes(::)?[ \t]*[(<]') || {
+  fail "the scanner itself failed; refusing to report a clean tree"
+  exit 1
+}
+report "$panicking_bad" "panicking RNG draw where the error could have propagated:" \
+  'use keep_core::crypto::try_random_bytes::<N>()? and let the caller decide' \
+  "or, where the signature cannot carry a Result: // $OPT_OUT - <reason>"
+
 if [ "$status" -eq 0 ]; then
-  echo "RNG hygiene: OK (getrandom errors handled, no swallowed failures, no seeded PRNGs, entropy gate intact on $gate_ok entry points)"
+  echo "RNG hygiene: OK (getrandom errors handled, no swallowed failures, no seeded PRNGs, no unpropagated panicking draws, entropy gate intact on $gate_ok entry points)"
 fi
 exit "$status"

--- a/scripts/check-rng-hygiene.sh
+++ b/scripts/check-rng-hygiene.sh
@@ -21,8 +21,9 @@
 #      standing in for the OS RNG. Fine in tests, never in production.
 #   5. The panicking draw (`crypto::random_bytes`) used where the caller could
 #      have propagated instead. It aborts the process on a health-check failure,
-#      which is fail-closed but ungraceful: across a uniffi boundary it becomes
-#      an app abort, and in a long-running signer it kills the service. Prefer
+#      which is fail-closed but ungraceful: uniffi catches the unwind and
+#      surfaces an untyped internal exception, losing the error's identity, and
+#      in a long-running signer it takes down whichever task drew. Prefer
 #      `try_random_bytes`; opt out where the signature genuinely cannot carry a
 #      `Result`.
 #   4. keep-core's entropy gate. `random_bytes_mixed_internal()` mixes OS
@@ -381,9 +382,9 @@ fi
 # --------------------------------------------- 5. the panicking draw ---------
 # `random_bytes` is `try_random_bytes().expect(..)`. Panicking on a degraded RNG
 # is the right direction -- it refuses to hand out a key rather than hand out a
-# predictable one -- but it is the blunt version of it. Across uniffi a panic
-# becomes an app abort, and in the bunker it takes down a running signer, so a
-# caller that can return an error should.
+# predictable one -- but it is the blunt version of it. uniffi catches the
+# unwind and reports an untyped internal exception, and in the bunker the panic
+# lands on whichever task drew, so a caller that can return an error should.
 #
 # Single-pattern like rule 3: there is no "handled" spelling of this call, only
 # the fallible sibling or a deliberate opt-out. `crypto::try_random_bytes` does

--- a/scripts/check-rng-hygiene.sh
+++ b/scripts/check-rng-hygiene.sh
@@ -152,7 +152,9 @@ scan_rust() { # $1 = call-site ERE, $2 = optional verdict ERE for the whole stat
           } else if (inerr && is_exit(c)) {
             seen = 1
           }
-          d += count(L[i], "{") - count(L[i], "}")
+          # Stripped text, not raw: a brace inside a string literal would end the
+          # block early and the exit search would stop before the real handler.
+          d += count(c, "{") - count(c, "}")
           if (i > from && d <= 0) break
         }
         return seen
@@ -232,7 +234,14 @@ scan_rust() { # $1 = call-site ERE, $2 = optional verdict ERE for the whole stat
             else if (line !~ /^#\[/ && line != "") { pending = 0 }
           }
           if (line ~ /^#\[cfg\(test\)\]/) pending = 1
-          depth += count(raw, "{") - count(raw, "}")
+          # Stripped text, not raw. An unbalanced brace inside a string literal
+          # in a test block left `testdepth` armed to end-of-file, so every rule
+          # silently stopped scanning the rest of that file and still reported a
+          # clean tree. `write_store(dir.path(), "{ this is not json")` in
+          # keep-desktop is exactly this shape, harmless only because its test
+          # module ends the file. Fourteen files have production code after a
+          # mid-file test block, so the next one would be a total miss.
+          depth += count(code, "{") - count(code, "}")
           if (testdepth >= 0) {
             if (depth <= testdepth) testdepth = -1
             continue
@@ -275,9 +284,18 @@ scan_rust() { # $1 = call-site ERE, $2 = optional verdict ERE for the whole stat
           if (index(buf, ";") || (ctrl && index(raw, "{"))) { judge(buf, i, i, ctrl) }
           else { instmt = 1; start = i }
         }
+        # Fail closed if the test-block tracker never disarmed: the brace
+        # accounting lost sync, so an unknown tail of this file went unscanned.
+        # Reporting that clean is the one outcome this guard must never produce.
+        # Goes to stderr so it survives the command substitution the caller reads.
+        if (testdepth >= 0) print "rng-hygiene: brace tracking stuck in " fname > "/dev/stderr"
+        if (testdepth >= 0) print "SCANNER-STUCK"
       }
     ' "$f") || rc=2
-    [ -n "$out" ] && printf '%s\n' "$out"
+    case $out in
+      *SCANNER-STUCK*) rc=2 ;;
+      *) [ -n "$out" ] && printf '%s\n' "$out" ;;
+    esac
   done
   return "$rc"
 }

--- a/scripts/check-rng-hygiene.sh
+++ b/scripts/check-rng-hygiene.sh
@@ -284,6 +284,11 @@ scan_rust() { # $1 = call-site ERE, $2 = optional verdict ERE for the whole stat
           if (index(buf, ";") || (ctrl && index(raw, "{"))) { judge(buf, i, i, ctrl) }
           else { instmt = 1; start = i }
         }
+        # A statement still being assembled at end of file was never judged.
+        # `pub fn x() -> T { draw() }` as the last line has no semicolon and no
+        # following `}` line to terminate it, so the buffer was simply dropped
+        # and the call inside it never scanned.
+        if (instmt) judge(buf, start, start, ctrl)
         # Fail closed if the test-block tracker never disarmed: the brace
         # accounting lost sync, so an unknown tail of this file went unscanned.
         # Reporting that clean is the one outcome this guard must never produce.

--- a/scripts/check-rng-hygiene.sh
+++ b/scripts/check-rng-hygiene.sh
@@ -99,11 +99,11 @@ fi
 # One awk per file, and its exit status is checked -- an earlier version piped
 # awk's stderr to /dev/null behind `|| true`, which meant a broken awk reported a
 # clean tree.
-scan_rust() { # $1 = call-site ERE, $2 = optional verdict ERE for the whole statement
+scan_rust() { # $1 = call-site ERE, $2 = optional verdict ERE, $3 = strict (no ?/expect suppression)
   local f rc out
   rc=0
   for f in $SOURCES; do
-    out=$(awk -v pat="$1" -v vpat="${2:-}" -v optout="$OPT_OUT" -v fname="$f" '
+    out=$(awk -v pat="$1" -v vpat="${2:-}" -v strict="${3:-}" -v optout="$OPT_OUT" -v fname="$f" '
       function count(s, ch,   i, n) {
         # Literal character count: gsub()/split() would treat ch as a regex,
         # and "(" alone is not a valid one -- BSD awk aborts on it.
@@ -176,7 +176,13 @@ scan_rust() { # $1 = call-site ERE, $2 = optional verdict ERE for the whole stat
         # The `?` / expect / unwrap has to belong to THIS call, not to something
         # nested inside its arguments: `let _ = rng(&mut k).map_err(|e| f(n)?);`
         # discards the RNG result while carrying a `?`, and used to pass.
-        if (outer(t) ~ /\?/ || t ~ /\)[ \t]*\.expect\(/ || t ~ /\)[ \t]*\.unwrap\(/) return
+        # Strict rules skip this. The suppression below reads a `?` or an
+        # `.expect(..)` as "the error was handled", which is the right reading
+        # for a call that returns a Result. A panicking draw returns an array,
+        # so a `?` in the same statement belongs to something else entirely and
+        # says nothing about the draw. Without this gate,
+        # `f(crypto::random_bytes::<32>())?` was silently skipped.
+        if (strict == "" && (outer(t) ~ /\?/ || t ~ /\)[ \t]*\.expect\(/ || t ~ /\)[ \t]*\.unwrap\(/)) return
         if (isctrl && block_exits(blockstart)) return
         printf "%s:%d:%s\n", fname, where, t
       }
@@ -394,8 +400,12 @@ fi
 # The optional `::` is load-bearing. Nearly every call here is a turbofish
 # (`random_bytes::<32>()`), where the next character after the name is a colon,
 # so without it this rule matched only the bare-parenthesis spelling and sailed
-# straight past the sites it exists to find.
-panicking_bad=$(scan_rust '(crypto|entropy)::random_bytes(::)?[ \t]*[(<]') || {
+# straight past the sites it exists to find. The left identifier boundary keeps
+# a module merely ending in those names (`not_crypto::random_bytes`) from being
+# reported, and `strict` turns off the shared `?`/`.expect` suppression, which
+# would otherwise excuse the draw because of error handling belonging to another
+# call in the same statement.
+panicking_bad=$(scan_rust '(^|[^A-Za-z0-9_])(crypto|entropy)::random_bytes(::)?[ \t]*[(<]' '' strict) || {
   fail "the scanner itself failed; refusing to report a clean tree"
   exit 1
 }

--- a/scripts/test-rng-hygiene.sh
+++ b/scripts/test-rng-hygiene.sh
@@ -111,6 +111,20 @@ run_probe $SRC/probe_split2.rs 'fn f(){ let mut b=[0u8;32]; getrandom::getrandom
 run_probe $SRC/probe_seeded.rs 'fn f(){ let r = SmallRng::seed_from_u64(1); let _ = r; }
 ' fail "seeded PRNG in production code"
 
+run_probe $SRC/probe_panicking.rs 'fn f()->[u8;32]{ keep_core::crypto::random_bytes::<32>() }
+' fail "panicking draw where the caller could have propagated"
+
+run_probe $SRC/probe_panicking_turbofish.rs 'fn f()->Result<[u8;32],()>{ let b = keep_core::crypto::random_bytes::<32>(); Ok(b) }
+' fail "turbofish spelling of the panicking draw"
+
+run_probe $SRC/probe_stuck.rs '#[cfg(test)]
+mod t { fn g(){ let s = "unbalanced {"; let _ = s; } }
+
+pub fn f()->[u8;32]{
+    keep_core::crypto::random_bytes::<32>()
+}
+' fail "a brace in a test string must not hide the production code after it"
+
 echo "== accepts what it must accept =="
 
 run_probe $SRC/probe_ok.rs 'fn f()->Result<(),getrandom::Error>{ let mut b=[0u8;32]; getrandom::getrandom(&mut b)?; Ok(()) }
@@ -123,6 +137,15 @@ fn f(){ let x=1; let _=x; }
 run_probe $SRC/probe_cfgtest.rs '#[cfg(test)]
 mod t { fn f(){ let mut b=[0u8;32]; getrandom::getrandom(&mut b).ok(); } }
 ' pass "test code is out of scope"
+
+run_probe $SRC/probe_try.rs 'fn f()->keep_core::Result<[u8;32]>{ Ok(keep_core::crypto::try_random_bytes::<32>()?) }
+' pass "the fallible draw is not the panicking one"
+
+run_probe $SRC/probe_optout.rs 'fn f()->[u8;32]{
+    // rng-hygiene: ok - signature cannot carry a Result
+    keep_core::crypto::random_bytes::<32>()
+}
+' pass "a panicking draw with a stated reason"
 
 echo
 if [ "$fails" -ne 0 ]; then

--- a/scripts/test-rng-hygiene.sh
+++ b/scripts/test-rng-hygiene.sh
@@ -125,6 +125,12 @@ pub fn f()->[u8;32]{
 }
 ' fail "a brace in a test string must not hide the production code after it"
 
+run_probe $SRC/probe_panicking_outer_q.rs 'fn f()->Result<[u8;32],()>{ let k = g(keep_core::crypto::random_bytes::<32>())?; Ok(k) }
+' fail "a ? belonging to another call must not excuse the draw"
+
+run_probe $SRC/probe_panicking_expect.rs 'fn f()->[u8;32]{ keep_core::crypto::random_bytes::<32>().expect("x") }
+' fail "a trailing .expect must not excuse the draw"
+
 echo "== accepts what it must accept =="
 
 run_probe $SRC/probe_ok.rs 'fn f()->Result<(),getrandom::Error>{ let mut b=[0u8;32]; getrandom::getrandom(&mut b)?; Ok(()) }
@@ -137,6 +143,9 @@ fn f(){ let x=1; let _=x; }
 run_probe $SRC/probe_cfgtest.rs '#[cfg(test)]
 mod t { fn f(){ let mut b=[0u8;32]; getrandom::getrandom(&mut b).ok(); } }
 ' pass "test code is out of scope"
+
+run_probe $SRC/probe_notcrypto.rs 'fn f()->[u8;32]{ let x = not_crypto::random_bytes::<32>(); x }
+' pass "a module merely ending in crypto is a different path"
 
 run_probe $SRC/probe_try.rs 'fn f()->keep_core::Result<[u8;32]>{ Ok(keep_core::crypto::try_random_bytes::<32>()?) }
 ' pass "the fallible draw is not the panicking one"


### PR DESCRIPTION
## Summary

`crypto::random_bytes` is `try_random_bytes().expect(..)`, so a failed RNG health check aborts the process. That direction is right, refusing to hand out a key beats handing out a predictable one, but it is the blunt version of it: across a uniffi boundary the panic becomes a host app abort, and in the bunker it takes down a running signer. Six production callers could have returned an error instead and did not.

Migrated, none of which changes a public signature:

- FROST nonce id in the pool replenish path, already `Result<()>`
- the bunker transport secret and connect secret in the mobile path, already `Result<_, KeepMobileError>`
- the nostrconnect response id, already `Result<(), String>`
- the headless bunker secret in `finalize_handler`, private, both callers already `Result<Self>`
- the JSON-RPC request id in `new_request_id`, private, all four production callers already `Result`

The last two took a return type change; both functions are private and every caller was already fallible, so the change stops at the crate boundary.

## What is deliberately not migrated

`PingPayload::new` is delegated to by a public `Default` impl, which cannot return a `Result`. Making the constructor fallible therefore means removing a public trait impl, which is an API decision rather than a mechanical migration, and the value is a liveness challenge rather than key material.

`Nip55NonceStore::generate` is uniffi-exported, so a `Result` changes the generated Kotlin signature and has to land together with the Android caller.

Both are annotated in place with the reason, and both are filed.

## Keeping it migrated

There is no seam to force a health-check failure, so there is no runtime test that a caller propagates rather than aborts. Rather than assert that in a comment, this adds a fifth rule to the existing RNG hygiene guard: a production call to the panicking draw is a finding unless it carries an opt-out naming why. The two exceptions above are the only opted-out callers, so the migration cannot quietly regress.

Worth recording that the rule was wrong when first written. It matched `random_bytes(` but not `random_bytes::<32>()`, which is how nearly every call in this workspace is spelled, because the character after the name is a colon. It reported a clean tree while missing the sites it existed to find. The optional `::` is why it now catches them.

## Two scanner faults fixed alongside

Review of this change surfaced a fault in the guard that predates it and is worth more than the migration. `scan_rust` counted braces on raw lines rather than on comment- and string-stripped code, so a single unbalanced brace inside a string literal in a test block left the test-depth tracker armed to end of file. Every rule then stopped scanning the rest of that file and still reported clean. `write_store(dir.path(), "{ this is not json")` in keep-desktop is exactly this shape, harmless only because its test module ends the file; fourteen files have production code after a mid-file test block. Braces are now counted on stripped code, and the scanner reports rather than passes if the tracker never disarms.

Isolating that one exposed a second: a statement still being assembled at end of file was dropped instead of judged, so `pub fn x() -> T { draw() }` as the last line of a file was never scanned at all. Both are fixed and both now have probes.

## Test plan

Full workspace builds, all library tests pass, formatter and clippy clean, and the guard reports OK.

Falsified in every direction that matters. Reintroducing a panicking caller in the signing path is reported. Reverting the pattern to its first version and reintroducing that caller reports nothing, which is what makes the pattern fix load-bearing rather than cosmetic. Reverting the brace fix while a stray brace is present hides a production caller entirely and now trips the stuck-scanner check instead.

The guard's own probe suite gains five cases: the two spellings of the panicking draw, the brace-in-test-string hiding production code, and the two shapes that must still pass, the fallible sibling and an opted-out call. Rule 5 was the only rule with no probe, which is the gap that let its first version ship matching almost nothing.

Corrected two rationale comments that were wrong as written: uniffi catches the unwind and raises an untyped internal exception rather than aborting the host app, and `PingPayload::new` does not need its `Default` impl removed, since a `try_new` for its single production caller is enough. The ping challenge is never checked on receipt, which is filed separately.
