### PR TITLE
Make the entropy health check sample the OS, then refuse to sign when it fails

### DIFF
--- a/keep-core/src/crypto.rs
+++ b/keep-core/src/crypto.rs
@@ -1292,8 +1292,13 @@ mod tests {
     fn entropy_health_error_maps_to_keep_encryption_error() {
         // The RNG-failure path returns a recoverable error rather than panicking
         // (#685); it surfaces as a crypto/encryption-class KeepError.
-        let err = crate::error::KeepError::from(crate::entropy::EntropyHealthError);
-        assert!(matches!(err, crate::error::KeepError::Encryption(_)));
+        for e in [
+            crate::entropy::EntropyHealthError::Degraded,
+            crate::entropy::EntropyHealthError::Unavailable,
+        ] {
+            let err = crate::error::KeepError::from(e);
+            assert!(matches!(err, crate::error::KeepError::Encryption(_)));
+        }
     }
 
     #[test]

--- a/keep-core/src/entropy.rs
+++ b/keep-core/src/entropy.rs
@@ -3,7 +3,6 @@
 #![allow(unsafe_code)]
 
 use blake2::{Blake2b512, Digest};
-use rand::Rng;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::OnceLock;
 
@@ -32,7 +31,8 @@ fn gather_os_entropy(pool: &mut [u8]) -> Result<(), EntropyHealthError> {
     use rand::TryRng;
     rand::rngs::SysRng
         .try_fill_bytes(pool)
-        .map_err(|_| EntropyHealthError)
+        .map_err(|_| EntropyHealthError)?;
+    Ok(())
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/keep-core/src/entropy.rs
+++ b/keep-core/src/entropy.rs
@@ -17,8 +17,22 @@ fn hash_to_32(hasher: Blake2b512) -> [u8; 32] {
     output
 }
 
-fn gather_os_entropy(pool: &mut [u8]) {
-    rand::rng().fill_bytes(pool);
+/// Fills `pool` straight from the operating system.
+///
+/// `SysRng` is the stateless OS interface: every call is a `getrandom` syscall.
+/// It is deliberately NOT `rand::rng()`, which is a thread-local ChaCha12
+/// seeded once from the OS and reseeded only every 64 KiB. Sampling that
+/// instead measured a userspace stream cipher, so a kernel source stuck on a
+/// constant would be expanded into output that is non-zero, distinct per draw
+/// and far apart pairwise: the health check below would pass while every FROST
+/// nonce, drawn from `OsRng` and thus from `getrandom`, came out identical.
+/// A check that cannot observe the source it is certifying is the same shape as
+/// the bug the whole module exists to catch.
+fn gather_os_entropy(pool: &mut [u8]) -> Result<(), EntropyHealthError> {
+    use rand::TryRng;
+    rand::rngs::SysRng
+        .try_fill_bytes(pool)
+        .map_err(|_| EntropyHealthError)
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -194,12 +208,12 @@ fn ensure_entropy_health() -> Result<(), EntropyHealthError> {
 /// Returns an error if the RNG health check fails.
 pub fn random_bytes_mixed() -> Result<[u8; 32], EntropyHealthError> {
     ensure_entropy_health()?;
-    Ok(random_bytes_mixed_internal())
+    random_bytes_mixed_internal()
 }
 
-fn random_bytes_mixed_internal() -> [u8; 32] {
+fn random_bytes_mixed_internal() -> Result<[u8; 32], EntropyHealthError> {
     let mut os_pool = [0u8; POOL_SIZE];
-    gather_os_entropy(&mut os_pool);
+    gather_os_entropy(&mut os_pool)?;
 
     let mut rdrand_pool = [0u8; 16];
     let has_rdrand = gather_rdrand(&mut rdrand_pool);
@@ -208,9 +222,9 @@ fn random_bytes_mixed_internal() -> [u8; 32] {
     let context = gather_process_context();
 
     if has_rdrand {
-        mix_entropy(&[&os_pool, &timing, &context, &rdrand_pool])
+        Ok(mix_entropy(&[&os_pool, &timing, &context, &rdrand_pool]))
     } else {
-        mix_entropy(&[&os_pool, &timing, &context])
+        Ok(mix_entropy(&[&os_pool, &timing, &context]))
     }
 }
 
@@ -226,12 +240,12 @@ pub fn try_random_bytes<const N: usize>() -> Result<[u8; N], EntropyHealthError>
     let mut output = [0u8; N];
 
     if N <= 32 {
-        output.copy_from_slice(&random_bytes_mixed_internal()[..N]);
+        output.copy_from_slice(&random_bytes_mixed_internal()?[..N]);
         return Ok(output);
     }
 
     for (counter, chunk) in output.chunks_mut(32).enumerate() {
-        let block = random_bytes_mixed_internal();
+        let block = random_bytes_mixed_internal()?;
         let mut hasher = Blake2b512::new();
         hasher.update(block);
         hasher.update((counter as u64).to_le_bytes());
@@ -302,12 +316,12 @@ fn samples_look_random(samples: &[[u8; 32]; 3]) -> bool {
 }
 
 /// Draws three samples straight from the OS RNG, with nothing mixed in.
-fn os_samples() -> [[u8; 32]; 3] {
-    std::array::from_fn(|_| {
-        let mut buf = [0u8; 32];
-        gather_os_entropy(&mut buf);
-        buf
-    })
+fn os_samples() -> Result<[[u8; 32]; 3], EntropyHealthError> {
+    let mut samples = [[0u8; 32]; 3];
+    for sample in &mut samples {
+        gather_os_entropy(sample)?;
+    }
+    Ok(samples)
 }
 
 fn check_entropy_health_internal() -> Result<(), EntropyHealthError> {
@@ -318,13 +332,16 @@ fn check_entropy_health_internal() -> Result<(), EntropyHealthError> {
     // non-zero and ~128 bits apart even if gather_os_entropy() wrote a constant.
     // A gate that can only observe the combiner is the same shape as the bug
     // this whole check exists to catch.
-    if !samples_look_random(&os_samples()) {
+    if !samples_look_random(&os_samples()?) {
         return Err(EntropyHealthError);
     }
 
     // The mixed output is checked too, which catches a broken mixer rather than
     // a broken source.
-    let mixed: [[u8; 32]; 3] = std::array::from_fn(|_| random_bytes_mixed_internal());
+    let mut mixed = [[0u8; 32]; 3];
+    for block in &mut mixed {
+        *block = random_bytes_mixed_internal()?;
+    }
     if !samples_look_random(&mixed) {
         return Err(EntropyHealthError);
     }
@@ -474,8 +491,40 @@ mod tests {
         );
 
         assert!(
-            samples_look_random(&os_samples()),
+            samples_look_random(&os_samples().expect("the OS RNG is available")),
             "a healthy OS RNG passes"
+        );
+    }
+
+    /// Why [`gather_os_entropy`] must call the OS and not a userspace generator.
+    ///
+    /// A constant source is caught. The same constant used as a stream cipher
+    /// key is not: the keystream is non-zero, distinct per draw and far apart
+    /// pairwise, so it sails through every criterion here. That is exactly what
+    /// sampling `rand::rng()` did, since it is a thread-local ChaCha12 seeded
+    /// once from the OS. The check certified the expansion instead of the
+    /// source, and a kernel stuck on a constant would have passed while every
+    /// nonce drawn from `getrandom` came out identical.
+    #[test]
+    fn a_stream_cipher_hides_the_constant_source_it_was_seeded_from() {
+        use chacha20::cipher::{KeyIvInit, StreamCipher};
+
+        let stuck = [[7u8; 32]; 3];
+        assert!(
+            !samples_look_random(&stuck),
+            "the raw constant source must be caught"
+        );
+
+        let mut expanded = [[0u8; 32]; 3];
+        let mut cipher = chacha20::ChaCha20::new(&[7u8; 32].into(), &[0u8; 12].into());
+        for block in &mut expanded {
+            cipher.apply_keystream(block);
+        }
+
+        assert!(
+            samples_look_random(&expanded),
+            "expanding that same constant defeats the check, which is why the \
+             sample must come from the OS rather than from a seeded generator"
         );
     }
 }

--- a/keep-core/src/entropy.rs
+++ b/keep-core/src/entropy.rs
@@ -31,7 +31,7 @@ fn gather_os_entropy(pool: &mut [u8]) -> Result<(), EntropyHealthError> {
     use rand::TryRng;
     rand::rngs::SysRng
         .try_fill_bytes(pool)
-        .map_err(|_| EntropyHealthError)?;
+        .map_err(|_| EntropyHealthError::Unavailable)?;
     Ok(())
 }
 
@@ -269,16 +269,33 @@ pub fn random_bytes<const N: usize>() -> [u8; N] {
     try_random_bytes().expect("RNG health check failed: constant or zero output detected")
 }
 
-/// Error returned when RNG health check fails.
-#[derive(Debug, Clone, Copy)]
-pub struct EntropyHealthError;
+/// Why a draw could not be trusted.
+///
+/// The two arms are kept apart because they call for different responses. A
+/// source that answered with constant output is a property of the machine and
+/// will not improve on its own, so a co-signer should stop and stay stopped.
+/// A call that failed to complete is a different statement, closer to "no file
+/// descriptors" than to "the kernel is broken", and treating it as permanent
+/// turns a transient fault into an outage that needs an operator to clear.
+/// They also read differently in a log, which matters when someone is trying to
+/// work out what happened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntropyHealthError {
+    /// The source answered, and what it returned failed the health criteria.
+    Degraded,
+    /// The source could not be read at all.
+    Unavailable,
+}
 
 impl std::fmt::Display for EntropyHealthError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "RNG health check failed: constant or zero output detected"
-        )
+        match self {
+            Self::Degraded => write!(
+                f,
+                "RNG health check failed: constant or zero output detected"
+            ),
+            Self::Unavailable => write!(f, "RNG unavailable: the OS refused to provide entropy"),
+        }
     }
 }
 
@@ -333,7 +350,7 @@ fn check_entropy_health_internal() -> Result<(), EntropyHealthError> {
     // A gate that can only observe the combiner is the same shape as the bug
     // this whole check exists to catch.
     if !samples_look_random(&os_samples()?) {
-        return Err(EntropyHealthError);
+        return Err(EntropyHealthError::Degraded);
     }
 
     // The mixed output is checked too, which catches a broken mixer rather than
@@ -343,7 +360,7 @@ fn check_entropy_health_internal() -> Result<(), EntropyHealthError> {
         *block = random_bytes_mixed_internal()?;
     }
     if !samples_look_random(&mixed) {
-        return Err(EntropyHealthError);
+        return Err(EntropyHealthError::Degraded);
     }
 
     Ok(())

--- a/keep-desktop/src/frost.rs
+++ b/keep-desktop/src/frost.rs
@@ -748,6 +748,18 @@ fn handle_node_event(
                 ),
             );
         }
+        // The OS RNG failed its health check, so this node has stopped
+        // signing. Surfaced as an error because it is not self-correcting:
+        // it holds until the machine's entropy source is fixed and the node
+        // restarted.
+        KfpNodeEvent::EntropyDegraded => {
+            push_log(
+                frost_events,
+                now_secs,
+                EventLogType::Error,
+                "RNG HEALTH CHECK FAILED: co-signing refused on this node".to_string(),
+            );
+        }
         // Threshold-OPRF unlock events are not surfaced in the
         // desktop UI yet (KeepNode appliance flow).
         KfpNodeEvent::OprfEvalRequested { .. }

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -803,6 +803,12 @@ pub enum KfpNodeEvent {
     DuressFrozen {
         beacon_pubkey: PublicKey,
     },
+    /// The OS RNG health check failed: three raw samples came back constant,
+    /// repeated, or too close together. Signing is refused from here on. Not
+    /// cleared at runtime, because the condition means the source this node
+    /// draws every nonce from is untrustworthy, and resuming on a later sample
+    /// that happens to look fine is how a reused nonce gets signed.
+    EntropyDegraded,
 }
 
 impl std::fmt::Debug for KfpNodeEvent {
@@ -1016,6 +1022,7 @@ impl std::fmt::Debug for KfpNodeEvent {
                 .debug_struct("DuressFrozen")
                 .field("beacon_pubkey", beacon_pubkey)
                 .finish(),
+            Self::EntropyDegraded => f.write_str("EntropyDegraded"),
         }
     }
 }
@@ -1100,6 +1107,9 @@ pub struct KfpNode {
     /// re-broadcast neither re-alerts nor does redundant unwrap/verify work.
     /// Sticky across reboot via the optional persister + the operator clear.
     duress_freeze: RwLock<Option<DuressFreeze>>,
+    /// Latched once the OS RNG health check fails. Sticky for the life of the
+    /// process: see [`KfpNodeEvent::EntropyDegraded`].
+    entropy_degraded: std::sync::atomic::AtomicBool,
     /// Optional durable sink for the freeze (see [`DuressPersister`]). `None`
     /// means the freeze is in-memory only (lost on restart).
     duress_persister: Option<DuressPersister>,
@@ -1352,6 +1362,7 @@ impl KfpNode {
             tpm_attestation_policy: None,
             duress_beacon_pins: None,
             duress_freeze: RwLock::new(None),
+            entropy_degraded: std::sync::atomic::AtomicBool::new(false),
             duress_persister: None,
             announce_attestor: None,
             announce_task: std::sync::Mutex::new(None),
@@ -1483,6 +1494,51 @@ impl KfpNode {
     /// Whether this holder is currently duress-frozen (refusing OPRF evals).
     pub fn is_duress_frozen(&self) -> bool {
         self.duress_freeze.read().is_some()
+    }
+
+    /// Whether the OS RNG has been observed failing its health check.
+    ///
+    /// Signing refuses while this holds. Nonce reuse from a degraded source
+    /// recovers the signing share outright, so refusing to sign is the only
+    /// answer that keeps the share safe; a node that cannot draw a trustworthy
+    /// nonce has nothing useful left to do with one.
+    pub fn is_entropy_degraded(&self) -> bool {
+        self.entropy_degraded
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Latch the degraded flag and alert. Idempotent: only the first observation
+    /// emits, so a repeating probe cannot flood the event channel.
+    pub(crate) fn mark_entropy_degraded(&self) {
+        if self
+            .entropy_degraded
+            .swap(true, std::sync::atomic::Ordering::Relaxed)
+        {
+            return;
+        }
+        error!(
+            "OS RNG HEALTH CHECK FAILED: refusing to sign. Nonces drawn from a \
+             degraded source can be reused, and a reused nonce recovers this \
+             node's signing share."
+        );
+        if self.event_tx.send(KfpNodeEvent::EntropyDegraded).is_err() {
+            warn!("no subscriber for the entropy alert; the signing refusal still holds");
+        }
+    }
+
+    /// Probe the OS RNG directly and latch if it is degraded.
+    ///
+    /// Runs on the tick where the pool needed nothing, so a node whose pool
+    /// stays full still checks its RNG. Without this the only detector was a
+    /// draw, and a draw only happens when there is a deficit: a healthy-looking
+    /// idle node would never notice its source had failed.
+    pub(crate) fn probe_entropy_health(&self) {
+        if self.is_entropy_degraded() {
+            return;
+        }
+        if keep_core::entropy::check_entropy_health().is_err() {
+            self.mark_entropy_degraded();
+        }
     }
 
     /// The active duress freeze, if any (for alerting / persistence).
@@ -2241,6 +2297,11 @@ impl KfpNode {
                         if let Err(e) = self.replenish_nonce_pool().await {
                             warn!(error = %e, "Failed to replenish nonce pool");
                         }
+                    } else {
+                        // Drawing already health-checks, so probe only on the
+                        // ticks where nothing was drawn. Either way the source
+                        // is checked once per interval, at roughly constant cost.
+                        self.probe_entropy_health();
                     }
                 }
                 _ = cleanup_interval.tick() => {

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -2293,15 +2293,17 @@ impl KfpNode {
                     self.spawn_announce();
                 }
                 _ = replenish_interval.tick() => {
+                    // Unconditional, because a draw is not a substitute. The
+                    // gate inside `try_random_bytes` re-runs the real check only
+                    // on a pid change or every few thousand generations, so a
+                    // node under steady signing load, which is the one always
+                    // holding a deficit, would go hours between actual checks.
+                    // Probing here costs a handful of syscalls per interval.
+                    self.probe_entropy_health();
                     if self.nonce_pool.own_deficit() > 0 {
                         if let Err(e) = self.replenish_nonce_pool().await {
                             warn!(error = %e, "Failed to replenish nonce pool");
                         }
-                    } else {
-                        // Drawing already health-checks, so probe only on the
-                        // ticks where nothing was drawn. Either way the source
-                        // is checked once per interval, at roughly constant cost.
-                        self.probe_entropy_health();
                     }
                 }
                 _ = cleanup_interval.tick() => {

--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1507,6 +1507,16 @@ impl KfpNode {
             .load(std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// Whether this failure should stop the node signing for good.
+    ///
+    /// Only a source that answered badly. A call that could not be completed is
+    /// a different statement, closer to "out of descriptors" than to "the kernel
+    /// is emitting constants", and latching on it turns a transient fault into
+    /// an outage that only an operator can clear.
+    pub(crate) fn latches_signing(e: keep_core::entropy::EntropyHealthError) -> bool {
+        e == keep_core::entropy::EntropyHealthError::Degraded
+    }
+
     /// Latch the degraded flag and alert. Idempotent: only the first observation
     /// emits, so a repeating probe cannot flood the event channel.
     pub(crate) fn mark_entropy_degraded(&self) {
@@ -1536,8 +1546,10 @@ impl KfpNode {
         if self.is_entropy_degraded() {
             return;
         }
-        if keep_core::entropy::check_entropy_health().is_err() {
-            self.mark_entropy_degraded();
+        if let Err(e) = keep_core::entropy::check_entropy_health() {
+            if Self::latches_signing(e) {
+                self.mark_entropy_degraded();
+            }
         }
     }
 
@@ -2300,7 +2312,12 @@ impl KfpNode {
                     // holding a deficit, would go hours between actual checks.
                     // Probing here costs a handful of syscalls per interval.
                     self.probe_entropy_health();
-                    if self.nonce_pool.own_deficit() > 0 {
+                    // Skipped rather than attempted-and-refused once latched.
+                    // The deficit can never close while signing is off, so
+                    // calling in would log the same refusal every interval for
+                    // the life of the process: the flood the alert itself is
+                    // careful to avoid.
+                    if !self.is_entropy_degraded() && self.nonce_pool.own_deficit() > 0 {
                         if let Err(e) = self.replenish_nonce_pool().await {
                             warn!(error = %e, "Failed to replenish nonce pool");
                         }

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -218,6 +218,16 @@ impl KfpNode {
             return Ok(());
         }
 
+        // A latched node stops refilling. Otherwise it keeps drawing from the
+        // degraded source and broadcasting the results every interval, which
+        // under a stuck source means publishing the same commitment repeatedly
+        // and advertising the failure to the whole group.
+        if self.is_entropy_degraded() {
+            return Err(FrostNetError::PolicyViolation(
+                "OS RNG health check failed; not replenishing nonces".into(),
+            ));
+        }
+
         let key_package = self.share.key_package()?;
         let mut fresh = Vec::with_capacity(deficit);
         for _ in 0..deficit {
@@ -2199,6 +2209,20 @@ mod gate_tests {
             Ok(crate::node::KfpNodeEvent::EntropyDegraded)
         ));
         assert!(rx.try_recv().is_err(), "the second mark must not re-alert");
+    }
+
+    /// A latched node stops refilling its pool. Left running it would keep
+    /// drawing from the degraded source and broadcasting the results, which
+    /// under a stuck source publishes the same commitment over and over.
+    #[tokio::test]
+    async fn replenish_refused_when_entropy_degraded() {
+        let (node, _relay) = test_node().await;
+        node.mark_entropy_degraded();
+
+        assert!(matches!(
+            node.replenish_nonce_pool().await,
+            Err(FrostNetError::PolicyViolation(_))
+        ));
     }
 
     /// A stale sign request (created_at outside the replay window) is rejected.

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -236,7 +236,9 @@ impl KfpNode {
             // into a stringly-typed encryption error, and deciding to stop
             // signing on a string match is exactly the guess this refuses to make.
             let nonce_id: NonceId = keep_core::entropy::try_random_bytes::<32>().map_err(|e| {
-                self.mark_entropy_degraded();
+                if Self::latches_signing(e) {
+                    self.mark_entropy_degraded();
+                }
                 FrostNetError::Session(format!("nonce id: {e}"))
             })?;
             let (nonces, commitment) =
@@ -276,7 +278,16 @@ impl KfpNode {
     /// when a peer is newly discovered after the pool was already replenished,
     /// so it does not have to wait for the next replenish broadcast (which only
     /// carries freshly generated commitments) to enable instant signing.
+    /// Publishes this node's pooled commitments to a peer.
+    ///
+    /// Refuses once latched: the pool can still hold commitments drawn in the
+    /// window before detection, and handing those to a newly discovered peer
+    /// advertises exactly what the replenish gate stops broadcasting.
     pub(crate) async fn send_nonce_pool_to(&self, pubkey: &PublicKey) -> Result<()> {
+        if self.is_entropy_degraded() {
+            return Ok(());
+        }
+
         let available = self.nonce_pool.own_commitments();
         if available.is_empty() {
             return Ok(());
@@ -2223,6 +2234,32 @@ mod gate_tests {
             node.replenish_nonce_pool().await,
             Err(FrostNetError::PolicyViolation(_))
         ));
+    }
+
+    /// A source that could not be read is not a source that answered badly.
+    /// Latching on the former turns a transient fault, an exhausted descriptor
+    /// table or a container with no `/dev`, into an outage only an operator can
+    /// clear. Only the statistical verdict is permanent.
+    #[test]
+    fn only_a_degraded_source_latches_signing() {
+        use keep_core::entropy::EntropyHealthError;
+
+        assert!(KfpNode::latches_signing(EntropyHealthError::Degraded));
+        assert!(!KfpNode::latches_signing(EntropyHealthError::Unavailable));
+    }
+
+    /// A latched node stops handing its pooled commitments to newly discovered
+    /// peers. The pool can still hold nonces drawn in the window before
+    /// detection, and publishing those is what the replenish gate exists to stop.
+    #[tokio::test]
+    async fn nonce_pool_is_not_published_when_entropy_degraded() {
+        let (node, _relay) = test_node().await;
+        node.mark_entropy_degraded();
+
+        assert!(node
+            .send_nonce_pool_to(&Keys::generate().public_key())
+            .await
+            .is_ok());
     }
 
     /// A stale sign request (created_at outside the replay window) is rejected.

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -221,7 +221,14 @@ impl KfpNode {
         let key_package = self.share.key_package()?;
         let mut fresh = Vec::with_capacity(deficit);
         for _ in 0..deficit {
-            let nonce_id: NonceId = keep_core::crypto::try_random_bytes::<32>()?;
+            // Drawn through the entropy module rather than the crypto wrapper
+            // so the health failure keeps its own type. The wrapper flattens it
+            // into a stringly-typed encryption error, and deciding to stop
+            // signing on a string match is exactly the guess this refuses to make.
+            let nonce_id: NonceId = keep_core::entropy::try_random_bytes::<32>().map_err(|e| {
+                self.mark_entropy_degraded();
+                FrostNetError::Session(format!("nonce id: {e}"))
+            })?;
             let (nonces, commitment) =
                 frost_secp256k1_tr::round1::commit(key_package.signing_share(), &mut OsRng);
             self.nonce_pool.store_own(nonce_id, nonces);
@@ -412,6 +419,17 @@ impl KfpNode {
     ) -> Result<()> {
         if request.group_pubkey != self.group_pubkey {
             return Ok(());
+        }
+
+        // Fail closed on a degraded RNG. Round 1 draws this node's nonce from
+        // OsRng, which is not health-checked at the point of use, so once the
+        // source is known bad the only safe move is to stop signing: two shares
+        // over one nonce recover the key.
+        if self.is_entropy_degraded() {
+            debug!("Rejecting sign request: OS RNG degraded");
+            return Err(FrostNetError::PolicyViolation(
+                "OS RNG health check failed; co-signing refused".into(),
+            ));
         }
 
         // Fail closed under duress: a verified duress beacon freezes co-signing
@@ -1408,6 +1426,14 @@ impl KfpNode {
         logical_id: [u8; 32],
         attempt: usize,
     ) -> std::result::Result<[u8; 64], SigningRoundError> {
+        // Fatal, not retryable: failover re-samples the participant set, and no
+        // set can be signed for while this node's own nonce source is degraded.
+        if self.is_entropy_degraded() {
+            return Err(SigningRoundError::fatal(FrostNetError::PolicyViolation(
+                "OS RNG health check failed; signing refused".into(),
+            )));
+        }
+
         let threshold = self.share.metadata.threshold;
 
         let (participants, participant_peers) = self
@@ -2110,6 +2136,69 @@ mod gate_tests {
             node.handle_sign_request(from, req).await,
             Err(FrostNetError::PolicyViolation(_))
         ));
+    }
+
+    /// A node whose RNG failed its health check refuses to co-sign. Round 1
+    /// draws this node's nonce from `OsRng`, which is not health-checked where
+    /// it is used, so the latch is the only thing standing between a degraded
+    /// source and a signature. Two shares over one nonce recover the key, which
+    /// is why this refuses rather than degrades.
+    #[tokio::test]
+    async fn handle_sign_request_refused_when_entropy_degraded() {
+        let (node, _relay) = test_node().await;
+        let group = *node.group_pubkey();
+        assert!(!node.is_entropy_degraded(), "must start healthy");
+
+        node.mark_entropy_degraded();
+        assert!(node.is_entropy_degraded(), "the latch must hold");
+
+        let from = Keys::generate().public_key();
+        let req = SignRequestPayload::new([1u8; 32], group, vec![0u8; 32], "test", vec![1]);
+        assert!(matches!(
+            node.handle_sign_request(from, req).await,
+            Err(FrostNetError::PolicyViolation(_))
+        ));
+    }
+
+    /// The latch also stops this node initiating a round of its own. Refusing
+    /// only inbound requests would leave the path that draws a nonce at
+    /// `signing_round` wide open, which is the same nonce from the same source.
+    #[tokio::test]
+    async fn signing_round_refused_when_entropy_degraded() {
+        let (node, _relay) = test_node().await;
+        node.mark_entropy_degraded();
+
+        let err = node
+            .signing_round(vec![0u8; 32], "test", None, vec![], &[], [0u8; 32], 0)
+            .await
+            .expect_err("a degraded node must not start a round");
+        // A PolicyViolation, specifically. The retry loop above only fails over
+        // on Timeout and InsufficientPeers, so this variant ends the attempt
+        // instead of re-sampling a participant set that cannot help: the
+        // degraded source is local, and every candidate set draws from it.
+        assert!(
+            matches!(err.error, FrostNetError::PolicyViolation(_)),
+            "expected a policy refusal, got {:?}",
+            err.error
+        );
+    }
+
+    /// Latching twice alerts once. The probe runs on a timer, so an unguarded
+    /// mark would emit an event per tick for as long as the node stays up and
+    /// push the rest of the signing history out of any bounded consumer.
+    #[tokio::test]
+    async fn marking_entropy_degraded_twice_alerts_once() {
+        let (node, _relay) = test_node().await;
+        let mut rx = node.subscribe();
+
+        node.mark_entropy_degraded();
+        node.mark_entropy_degraded();
+
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(crate::node::KfpNodeEvent::EntropyDegraded)
+        ));
+        assert!(rx.try_recv().is_err(), "the second mark must not re-alert");
     }
 
     /// A stale sign request (created_at outside the replay window) is rejected.

--- a/scripts/check-rng-hygiene.sh
+++ b/scripts/check-rng-hygiene.sh
@@ -66,7 +66,10 @@ status=0
 fail() { printf '\n\033[31mFAIL\033[0m %s\n' "$1"; status=1; }
 
 OPT_OUT='rng-hygiene: ok'
-ENTROPY_MODULE='keep-core/src/entropy.rs'
+# Overridable so the probe suite can point rules 4 and 6 at a fixture. Those two
+# read a fixed path rather than the scanned file list, so without this they were
+# the only rules that could not be proven to still fail.
+ENTROPY_MODULE="${ENTROPY_MODULE:-keep-core/src/entropy.rs}"
 
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
   printf '\n\033[31mFAIL\033[0m not inside a git work tree; this guard scans tracked files only\n'
@@ -413,7 +416,42 @@ report "$panicking_bad" "panicking RNG draw where the error could have propagate
   'use keep_core::crypto::try_random_bytes::<N>()? and let the caller decide' \
   "or, where the signature cannot carry a Result: // $OPT_OUT - <reason>"
 
+# ------------------------------------ 6. the health check samples the OS -----
+# The check is only worth running if it looks at the source the keys actually
+# come from. `gather_os_entropy` fed it `rand::rng()` for a long time, which is
+# a thread-local ChaCha12 seeded once from the OS: a kernel stuck on a constant
+# was expanded into a keystream that passes every criterion the check applies,
+# while FROST nonces, drawn from `getrandom` via OsRng, came out identical. The
+# check certified the expansion rather than the source.
+#
+# Structural rather than a grep for the bad call, so replacing it with any other
+# userspace generator is caught too: the sampler must name the OS interface.
+if [ -f "$ENTROPY_MODULE" ]; then
+  os_src=$(awk '
+    /^[ \t]*fn gather_os_entropy/ { inside = 1; found = 0; next }
+    inside && /^[ \t]*\}/ { print (found ? "OK" : "NOT-OS"); inside = 0 }
+    inside {
+      p = index($0, "//"); if (p > 0) $0 = substr($0, 1, p - 1)
+      if ($0 ~ /SysRng|getrandom/) found = 1
+    }
+    END { if (inside) print "UNTERMINATED" }
+  ' "$ENTROPY_MODULE") || { fail "rule 6 scanner failed on $ENTROPY_MODULE"; exit 1; }
+  case $os_src in
+    OK) ;;
+    NOT-OS)
+      fail "the entropy health check does not sample the OS:"
+      echo "  gather_os_entropy() in $ENTROPY_MODULE names no OS interface."
+      echo "  → it must draw through SysRng/getrandom. A seeded userspace"
+      echo "    generator expands a degraded source into output that passes"
+      echo "    every check here, which certifies the expansion, not the source." ;;
+    *)
+      fail "rule 6 could not find gather_os_entropy() in $ENTROPY_MODULE"
+      echo "  → the sampler was renamed or moved; update this rule deliberately"
+      echo "    rather than leaving it vacuous." ;;
+  esac
+fi
+
 if [ "$status" -eq 0 ]; then
-  echo "RNG hygiene: OK (getrandom errors handled, no swallowed failures, no seeded PRNGs, no unpropagated panicking draws, entropy gate intact on $gate_ok entry points)"
+  echo "RNG hygiene: OK (getrandom errors handled, no swallowed failures, no seeded PRNGs, no unpropagated panicking draws, health check samples the OS, entropy gate intact on $gate_ok entry points)"
 fi
 exit "$status"

--- a/scripts/check-rng-hygiene.sh
+++ b/scripts/check-rng-hygiene.sh
@@ -19,6 +19,10 @@
 #      `unwrap_or_default()` -- which for a `[u8; N]` means all zeros.
 #   3. A seeded, reproducible PRNG (`seed_from_u64`, `from_seed`, `SmallRng`)
 #      standing in for the OS RNG. Fine in tests, never in production.
+#   4. keep-core's entropy gate. `random_bytes_mixed_internal()` mixes OS
+#      randomness with timing jitter and process context, so its output looks
+#      random even when a source has degraded -- the health check is what makes
+#      the degradation visible, and every public entry point must run it.
 #   5. The panicking draw (`crypto::random_bytes`) used where the caller could
 #      have propagated instead. It aborts the process on a health-check failure,
 #      which is fail-closed but ungraceful: uniffi catches the unwind and
@@ -26,10 +30,11 @@
 #      in a long-running signer it takes down whichever task drew. Prefer
 #      `try_random_bytes`; opt out where the signature genuinely cannot carry a
 #      `Result`.
-#   4. keep-core's entropy gate. `random_bytes_mixed_internal()` mixes OS
-#      randomness with timing jitter and process context, so its output looks
-#      random even when a source has degraded -- the health check is what makes
-#      the degradation visible, and every public entry point must run it.
+#   6. The health check sampling something other than the OS. It read
+#      `rand::rng()`, a thread-local ChaCha12 seeded once from the OS, so a
+#      kernel stuck on a constant was expanded into a keystream that passed
+#      every criterion while the nonces drawn from `getrandom` were identical.
+#      The sampler must call the OS interface.
 #
 # Deliberate non-crypto randomness (backoff jitter, sampling) is allowed with an
 # inline opt-out on the same line, in the comment block directly above, or on any
@@ -52,7 +57,8 @@
 # whether a checked draw is used correctly once generated, nor whether a value
 # reaches the right place. It does not inspect dependencies, so a crate that
 # degrades its own RNG internally is invisible here. Rule 4 checks that the gate
-# is called, not that the health check itself is sound.
+# is called, not that the health check itself is sound, and rule 6 checks that
+# the sampler calls the OS, not that what it returns is what reaches the buffer.
 #
 # Portable to BSD awk and BSD xargs (developers run this on macOS), so: no gawk
 # extensions, and no `xargs -r`.
@@ -459,16 +465,24 @@ if [ -f "$ENTROPY_MODULE" ]; then
       return n
     }
     !inside && $0 ~ /(^|[^a-zA-Z0-9_])fn[ \t]+gather_os_entropy[ \t]*\(/ {
-      inside = 1; found = 0; depth = 0; started = 0
+      inside = 1; found = 0; depth = 0; started = 0; pending = 0
     }
     inside {
       code = strip($0)
       # A call, not a mention: `SysRng.method(` or `getrandom::fill(`.
-      # `SysRng` then end-of-line counts: rustfmt puts the receiver and the
-      # `.try_fill_bytes(..)` on separate lines, so requiring the dot on the
-      # same line rejected the real function. A trailing `;` (a bare `use`)
-      # matches neither branch, so an import still does not count as a call.
-      if (code ~ /SysRng[ \t]*(\.|$)/ || code ~ /getrandom[a-z_:]*[ \t]*\(/) found = 1
+      # A call, not a mention. rustfmt puts the receiver and the
+      # `.try_fill_bytes(..)` on separate lines, so a receiver at end of line is
+      # held pending and counts only once an invoked method follows it. Accepting
+      # it outright let a bare `let _ = SysRng;` stand in for the draw.
+      if (code ~ /SysRng[ \t]*\./ || code ~ /getrandom[a-z_:]*[ \t]*\(/) {
+        found = 1; pending = 0
+      } else if (code ~ /SysRng[ \t]*$/) {
+        pending = 1
+      } else if (pending && code ~ /^[ \t]*\.[a-zA-Z_][a-zA-Z0-9_]*[ \t]*\(/) {
+        found = 1; pending = 0
+      } else if (code ~ /[^ \t]/) {
+        pending = 0
+      }
       depth += count(code, "{") - count(code, "}")
       if (count(code, "{") > 0) started = 1
       if (started && depth <= 0) {

--- a/scripts/check-rng-hygiene.sh
+++ b/scripts/check-rng-hygiene.sh
@@ -424,15 +424,57 @@ report "$panicking_bad" "panicking RNG draw where the error could have propagate
 # while FROST nonces, drawn from `getrandom` via OsRng, came out identical. The
 # check certified the expansion rather than the source.
 #
-# Structural rather than a grep for the bad call, so replacing it with any other
-# userspace generator is caught too: the sampler must name the OS interface.
+# Inverted rather than a grep for the bad call, so replacing it with any other
+# userspace generator is caught too: the sampler must call the OS interface.
+#
+# What it does not cover, stated so a green run is not read as more than it is:
+# it checks that an OS call appears in the body, not that the value it produces
+# is the one written to `pool`. A dead call alongside a bad draw satisfies it.
+# Closing that needs a parser, and the shape it would catch is deliberate rather
+# than accidental; the regression this exists to stop is someone quietly putting
+# a thread-local generator back, which it does catch.
 if [ -f "$ENTROPY_MODULE" ]; then
+  # Brace-depth scoped, comment- and string-stripped, and a CALL is required:
+  # naming the OS in a log message satisfied an earlier version of this, and
+  # terminating on the first line-initial `}` reported correct code whenever the
+  # body opened any nested block (a `#[cfg]` arm, an early return) before the
+  # draw. Both were verified against fixtures.
   os_src=$(awk '
-    /^[ \t]*fn gather_os_entropy/ { inside = 1; found = 0; next }
-    inside && /^[ \t]*\}/ { print (found ? "OK" : "NOT-OS"); inside = 0 }
+    function strip(s,   p, out, i, c, instr, q) {
+      p = index(s, "//"); if (p > 0) s = substr(s, 1, p - 1)
+      out = ""; instr = 0
+      for (i = 1; i <= length(s); i++) {
+        c = substr(s, i, 1)
+        if (instr) { if (c == "\\") { i++; continue }
+                     if (c == q) instr = 0
+                     continue }
+        if (c == "\"" || c == "\x27") { instr = 1; q = c; continue }
+        out = out c
+      }
+      return out
+    }
+    function count(s, ch,   i, n) {
+      n = 0
+      for (i = length(s); i > 0; i--) if (substr(s, i, 1) == ch) n++
+      return n
+    }
+    !inside && $0 ~ /(^|[^a-zA-Z0-9_])fn[ \t]+gather_os_entropy[ \t]*\(/ {
+      inside = 1; found = 0; depth = 0; started = 0
+    }
     inside {
-      p = index($0, "//"); if (p > 0) $0 = substr($0, 1, p - 1)
-      if ($0 ~ /SysRng|getrandom/) found = 1
+      code = strip($0)
+      # A call, not a mention: `SysRng.method(` or `getrandom::fill(`.
+      # `SysRng` then end-of-line counts: rustfmt puts the receiver and the
+      # `.try_fill_bytes(..)` on separate lines, so requiring the dot on the
+      # same line rejected the real function. A trailing `;` (a bare `use`)
+      # matches neither branch, so an import still does not count as a call.
+      if (code ~ /SysRng[ \t]*(\.|$)/ || code ~ /getrandom[a-z_:]*[ \t]*\(/) found = 1
+      depth += count(code, "{") - count(code, "}")
+      if (count(code, "{") > 0) started = 1
+      if (started && depth <= 0) {
+        print (found ? "OK" : "NOT-OS"); inside = 0
+      }
+      next
     }
     END { if (inside) print "UNTERMINATED" }
   ' "$ENTROPY_MODULE") || { fail "rule 6 scanner failed on $ENTROPY_MODULE"; exit 1; }

--- a/scripts/test-rng-hygiene.sh
+++ b/scripts/test-rng-hygiene.sh
@@ -156,6 +156,34 @@ run_probe $SRC/probe_optout.rs 'fn f()->[u8;32]{
 }
 ' pass "a panicking draw with a stated reason"
 
+echo "== the health check must sample the OS (rule 6) =="
+
+probe_rule6() { # $1 = body, $2 = pass|fail, $3 = description
+    local body="$1" expect="$2" desc="$3" out rc
+    local fixture="$TMPD/entropy_fixture.rs"
+    printf 'fn gather_os_entropy(pool: &mut [u8]) {\n%s\n}\n' "$body" > "$fixture"
+    out=$(ENTROPY_MODULE="$fixture" "$GUARD" 2>&1); rc=$?
+    if [ "$expect" = fail ]; then
+        if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q 'does not sample the OS'; then
+            echo "  ok: $desc"
+        else
+            echo "  FAIL: $desc (guard did not report it)"; fails=$((fails + 1))
+        fi
+    else
+        if printf '%s' "$out" | grep -q 'does not sample the OS'; then
+            echo "  FAIL: $desc (guard reported it anyway)"; fails=$((fails + 1))
+        else
+            echo "  ok: $desc"
+        fi
+    fi
+}
+
+probe_rule6 '    rand::rng().fill_bytes(pool);' fail "a thread-local generator is not the OS"
+probe_rule6 '    SmallRng::from_entropy().fill_bytes(pool);' fail "any seeded generator is not the OS"
+probe_rule6 '    // SysRng would go here' fail "naming the OS in a comment is not calling it"
+probe_rule6 '    rand::rngs::SysRng.try_fill_bytes(pool).map_err(|_| E)?;' pass "SysRng is the OS interface"
+probe_rule6 '    getrandom::fill(pool)?;' pass "getrandom directly is the OS interface"
+
 echo
 if [ "$fails" -ne 0 ]; then
     echo "FAIL: $fails case(s) did not behave as required"

--- a/scripts/test-rng-hygiene.sh
+++ b/scripts/test-rng-hygiene.sh
@@ -181,7 +181,19 @@ probe_rule6() { # $1 = body, $2 = pass|fail, $3 = description
 probe_rule6 '    rand::rng().fill_bytes(pool);' fail "a thread-local generator is not the OS"
 probe_rule6 '    SmallRng::from_entropy().fill_bytes(pool);' fail "any seeded generator is not the OS"
 probe_rule6 '    // SysRng would go here' fail "naming the OS in a comment is not calling it"
+probe_rule6 '    tracing::debug!("drawing from getrandom");
+    rand::rng().fill_bytes(pool);' fail "naming the OS in a log message is not calling it"
+probe_rule6 '    use rand::rngs::SysRng;
+    rand::rng().fill_bytes(pool);' fail "importing the OS interface is not calling it"
 probe_rule6 '    rand::rngs::SysRng.try_fill_bytes(pool).map_err(|_| E)?;' pass "SysRng is the OS interface"
+probe_rule6 '    rand::rngs::SysRng
+        .try_fill_bytes(pool)
+        .map_err(|_| E)?;' pass "the receiver and the call may be on separate lines"
+probe_rule6 '    #[cfg(test)]
+    {
+        let _ = 1;
+    }
+    rand::rngs::SysRng.try_fill_bytes(pool).map_err(|_| E)?;' pass "a nested block before the draw is not a finding"
 probe_rule6 '    getrandom::fill(pool)?;' pass "getrandom directly is the OS interface"
 
 echo

--- a/scripts/test-rng-hygiene.sh
+++ b/scripts/test-rng-hygiene.sh
@@ -158,10 +158,21 @@ run_probe $SRC/probe_optout.rs 'fn f()->[u8;32]{
 
 echo "== the health check must sample the OS (rule 6) =="
 
+# The fixture carries a rule-4-satisfying entry point as well, so a passing case
+# can require the guard to exit 0. Without it every fixture tripped rule 4 for
+# want of a gated entry point, the guard exited non-zero on every probe, and the
+# pass cases could only assert that one particular string was absent -- which
+# stayed true with rule 6 deleted outright.
 probe_rule6() { # $1 = body, $2 = pass|fail, $3 = description
     local body="$1" expect="$2" desc="$3" out rc
     local fixture="$TMPD/entropy_fixture.rs"
-    printf 'fn gather_os_entropy(pool: &mut [u8]) {\n%s\n}\n' "$body" > "$fixture"
+    {
+        printf 'fn gather_os_entropy(pool: &mut [u8]) {\n%s\n}\n' "$body"
+        printf 'pub fn draw() -> Result<(), E> {\n'
+        printf '    ensure_entropy_health()?;\n'
+        printf '    let _ = random_bytes_mixed_internal();\n'
+        printf '    Ok(())\n}\n'
+    } > "$fixture"
     out=$(ENTROPY_MODULE="$fixture" "$GUARD" 2>&1); rc=$?
     if [ "$expect" = fail ]; then
         if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q 'does not sample the OS'; then
@@ -170,10 +181,12 @@ probe_rule6() { # $1 = body, $2 = pass|fail, $3 = description
             echo "  FAIL: $desc (guard did not report it)"; fails=$((fails + 1))
         fi
     else
-        if printf '%s' "$out" | grep -q 'does not sample the OS'; then
-            echo "  FAIL: $desc (guard reported it anyway)"; fails=$((fails + 1))
-        else
+        if [ "$rc" -eq 0 ]; then
             echo "  ok: $desc"
+        else
+            echo "  FAIL: $desc (guard exited $rc)"
+            printf '%s\n' "$out" | sed 's/^/      /' | head -6
+            fails=$((fails + 1))
         fi
     fi
 }
@@ -194,6 +207,9 @@ probe_rule6 '    #[cfg(test)]
         let _ = 1;
     }
     rand::rngs::SysRng.try_fill_bytes(pool).map_err(|_| E)?;' pass "a nested block before the draw is not a finding"
+probe_rule6 '    let _ = rand::rngs::SysRng
+    ;
+    rand::rng().fill_bytes(pool);' fail "a receiver with no method call is not a draw"
 probe_rule6 '    getrandom::fill(pool)?;' pass "getrandom directly is the OS interface"
 
 echo


### PR DESCRIPTION
## Summary

Review of the first version of this change found that its premise was false, so the fix for that is here too and is the more important half.

The health check was documented as sampling the OS directly, before anything is mixed in. It sampled `rand::rng()`, which is a thread-local ChaCha12 seeded once from the OS and reseeded only every 64 KiB. FROST nonces come from `OsRng`, which calls `getrandom` on every fill. So the check measured a userspace stream cipher while the keys came from the kernel. A kernel stuck on a constant seeds ChaCha12 with that constant and yields a keystream that is non-zero, distinct per draw and far apart pairwise: the check passes, every nonce comes out identical, and two shares over one nonce give `s = (z1 - z2) / (c1 - c2)`, the signing share. The check certified the expansion instead of the source, which is the same shape as the bug the module exists to catch. It has been that way since the module was introduced.

`gather_os_entropy` now draws through `rand::rngs::SysRng`, the stateless OS interface re-exported from `getrandom`, so every sample is a syscall. No new dependency: it is the same crate `rand` already pulls in. The draw is fallible now, since the OS interface can fail where the thread-local one panics, and that failure propagates as a health error, which is the correct reading of it.

With that fixed, the rest of this change is the response. When the check fails it is not saying "a draw did not succeed", it is saying the source this node takes every nonce from is producing constant output.

The node treated that as a transient replenish failure: the only caller logged a warning on a 30 second timer and carried on serving sign requests. Nothing else could notice, because FROST round 1 draws its nonce from `OsRng` at the point of use and never health-checks. Two signature shares over one nonce give `s = (z1 - z2) / (c1 - c2)`, the signer's key share, so continuing to sign is the one response that risks the share outright.

This latches the observation and refuses to sign while it holds, following the duress freeze already in this node rather than inventing a second shape for the same idea.

- The latch is sticky, and only a source that *answered badly* sets it. Making the draw fallible introduced a second failure kind: the OS call itself not completing, which on Linux means something like an exhausted descriptor table or a container with no populated `/dev` rather than a broken kernel. Those warrant different answers, so the error carries which one it was and only the statistical verdict is permanent. Latching on the other would turn a transient fault into an outage needing an operator to clear, and the two also read differently in a log, which matters when someone is working out what happened.
- Stickiness is right for the degraded case specifically. Resuming because a later sample happened to look fine is how a reused nonce gets signed, and a false positive there needs three 32-byte draws to collide or land within 64 bits.
- Both nonce-drawing paths refuse: the inbound request and the round this node starts itself. Gating only the inbound half would leave the same draw from the same source reachable.
- The refusal is a policy violation rather than a timeout, so failover ends the attempt instead of re-sampling. No participant set is signable while the local source is degraded, and retrying only spends the remaining attempts.
- Alerting is idempotent, so a probe on a timer cannot flood a bounded consumer with one event per tick.

## Detection had a second hole

The only thing that health-checked was a draw, and draws happen only when the nonce pool has a deficit, so a node whose pool stayed full never checked its RNG. Reviewing that turned up the sharper version: the gate inside the draw re-runs the real check only on a pid change or every few thousand generations, so the node most likely to be signing, and therefore always in deficit, is the one that would go hours between actual checks. The tick now probes unconditionally, which costs a handful of syscalls per interval.

A latched node also stops replenishing, and is skipped rather than called-and-refused, so it does not log the same refusal every interval for the life of the process. It stops handing pooled commitments to newly discovered peers too: the pool can still hold nonces drawn in the window before detection. Left running it would keep drawing from the degraded source and broadcasting the results every interval, which under a stuck source means publishing the same commitment over and over and advertising the failure to the group.

## Scope

`handle_ecdh_request` is deliberately not gated. It draws no randomness, so refusing there would be symmetry rather than a reason. The initial issue proposed gating it; reading the handler is what changed the answer.

The nonce id is now drawn through `keep_core::entropy` rather than the `crypto` wrapper, because the wrapper flattens the health failure into a stringly-typed encryption error. Deciding to stop signing on a string match would be the kind of inference this change exists to remove.

## Keeping the check honest

Reverting the sampler to the thread-local generator passed every test and the whole hygiene guard, which is precisely the failure the guard exists to prevent: the fix would have silently regressed. A sixth rule now requires `gather_os_entropy` to name an OS interface, structurally rather than by grepping for the one bad call, so substituting any other userspace generator is caught as well.

That rule and the entropy-gate rule both read a fixed module path rather than the scanned file list, which made them the only two that could not be proven to still fail. The path is now overridable and rule 6 has nine probes.

Writing those probes is what showed the first version of the rule was both too weak and too strong. It accepted the OS being named in a log message or a bare `use`, and it rejected the real function as soon as the body opened any nested block before the draw, which would have turned CI red on the next ordinary refactor. It also rejected the real function once rustfmt split the receiver from the call across lines. It now strips comments and strings, requires a call rather than a mention, and tracks brace depth. One gap is left open and stated in the script: it checks that an OS call appears, not that its output is what reaches the buffer, so a dead call beside a bad draw still satisfies it. Closing that needs a parser, and that shape is sabotage rather than the accidental regression this is for.

## Test plan

Four tests on the node: a latched node refuses an inbound sign request, refuses to start a round of its own, refuses to replenish, and alerts once rather than per mark. Two in keep-core: one showing why the sampler matters, since a constant source is caught while the same constant expanded through a stream cipher is not, and one covering both failure kinds through the error conversion. One more on the node asserting that only the degraded kind latches, against a single shared predicate rather than the same comparison written at each site.

Falsified individually. Removing each gate fails only its own test, replacing the compare-and-swap with a plain store fails only the alerting test, and reverting the sampler now fails the guard. Each property is covered by something that observes it rather than by all of them passing on one mechanism.

Full workspace builds, all library tests pass, formatter, clippy and the RNG hygiene guard clean.
