### PR TITLE
Abandon in-flight sessions and discard pooled nonces when the RNG latch trips

### DIFF
--- a/keep-frost-net/src/node/mod.rs
+++ b/keep-frost-net/src/node/mod.rs
@@ -1526,10 +1526,20 @@ impl KfpNode {
         {
             return;
         }
+        // Refusing new work is not enough on its own. Detection lags the
+        // degradation by up to one probe interval, so anything already in
+        // flight may be holding nonces drawn inside that window, and a round
+        // that reaches round 2 emits a share over one. Both are torn down here
+        // rather than left to expire.
+        let abandoned = self.sessions.write().abandon_all();
+        self.nonce_pool.clear_own();
+
         error!(
-            "OS RNG HEALTH CHECK FAILED: refusing to sign. Nonces drawn from a \
-             degraded source can be reused, and a reused nonce recovers this \
-             node's signing share."
+            abandoned_sessions = abandoned,
+            "OS RNG HEALTH CHECK FAILED: refusing to sign, abandoning in-flight \
+             sessions and discarding pooled nonces. Nonces drawn from a degraded \
+             source can be reused, and a reused nonce recovers this node's \
+             signing share."
         );
         if self.event_tx.send(KfpNodeEvent::EntropyDegraded).is_err() {
             warn!("no subscriber for the entropy alert; the signing refusal still holds");

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -996,6 +996,20 @@ impl KfpNode {
     }
 
     pub(crate) async fn generate_and_send_share(&self, session_id: &[u8; 32]) -> Result<()> {
+        // The last check before a share exists, and the one that has to be here
+        // rather than only at the entry points.
+        //
+        // Every caller gates on entry, but time passes between that gate and
+        // this call: the requester path draws its nonce and then runs the
+        // pre-sign hook, which on desktop blocks on a human for up to a minute
+        // against a thirty-second probe. The latch can trip inside that window,
+        // the teardown can run, and this would still emit a share over a nonce
+        // drawn before detection. An entry gate cannot cover a wait it precedes.
+        if self.is_entropy_degraded() {
+            debug!("Refusing to produce a signature share: OS RNG degraded");
+            return Ok(());
+        }
+
         let (signing_package, nonces, derivation_path) = {
             let mut sessions = self.sessions.write();
             let session = match sessions.get_session_mut(session_id) {
@@ -1598,6 +1612,17 @@ impl KfpNode {
         };
         let hooks = self.hooks.read().clone();
         hooks.pre_sign(&session_info)?;
+
+        // Re-checked after the hook, not just before it. The hook can block on a
+        // human, so this is the point where the latch is most likely to have
+        // tripped underneath the round. Returning here leaves the reserved peer
+        // commitments to the still-armed reservation guard instead of building a
+        // session on top of a nonce drawn before detection.
+        if self.is_entropy_degraded() {
+            return Err(SigningRoundError::fatal(FrostNetError::PolicyViolation(
+                "OS RNG health check failed during approval; signing refused".into(),
+            )));
+        }
 
         {
             let mut sessions = self.sessions.write();
@@ -2309,6 +2334,48 @@ mod gate_tests {
         assert!(
             node.sessions.write().get_session_mut(&id).is_none(),
             "an in-flight session must be abandoned, not left to expire"
+        );
+    }
+
+    /// The share chokepoint refuses even when the session survived the teardown.
+    ///
+    /// Entry gates cannot cover the requester path: it draws its nonce, then
+    /// runs the pre-sign hook, which on desktop blocks on a human for up to a
+    /// minute against a thirty-second probe. A latch trip inside that window
+    /// tears down the pool and the sessions, and the round then builds a fresh
+    /// session and reaches this call anyway. Asserted against a session created
+    /// after the latch, which is the state that window produces.
+    #[tokio::test]
+    async fn share_generation_refuses_after_the_latch_even_for_a_live_session() {
+        let (node, _relay) = test_node().await;
+        let participants = vec![1u16, 2u16];
+        let message = vec![0u8; 32];
+        let id = crate::session::derive_session_id(&message, &participants, 2);
+
+        node.mark_entropy_degraded();
+
+        {
+            let mut sessions = node.sessions.write();
+            sessions
+                .create_session(id, message, 2, participants)
+                .expect("session fixture");
+        }
+
+        // Ok, not Err: the refusal is a no-op for the caller, and the property
+        // that matters is that no share was produced. A SessionNotFound error
+        // would mean it got past the gate and failed for an unrelated reason.
+        assert!(
+            node.generate_and_send_share(&id).await.is_ok(),
+            "the refusal must be a clean no-op"
+        );
+        assert!(
+            node.sessions
+                .write()
+                .get_session_mut(&id)
+                .expect("the fixture session is still present")
+                .take_our_nonces()
+                .is_none(),
+            "refusing must not have consumed nonce material"
         );
     }
 

--- a/keep-frost-net/src/node/signing.rs
+++ b/keep-frost-net/src/node/signing.rs
@@ -874,6 +874,15 @@ impl KfpNode {
         from: PublicKey,
         payload: CommitmentPayload,
     ) -> Result<()> {
+        // Gated as well as torn down. `mark_entropy_degraded` abandons active
+        // sessions, so this is normally unreachable, but it makes the property
+        // local: no commitment advances a round to round 2 while the latch
+        // holds, whatever raced with the teardown.
+        if self.is_entropy_degraded() {
+            debug!("Dropping commitment: OS RNG degraded");
+            return Ok(());
+        }
+
         self.verify_peer_share_index(from, payload.share_index)?;
 
         let commitment =
@@ -2260,6 +2269,47 @@ mod gate_tests {
             .send_nonce_pool_to(&Keys::generate().public_key())
             .await
             .is_ok());
+    }
+
+    /// Latching tears down what was already running, not just what arrives next.
+    ///
+    /// Detection lags the degradation by up to one probe interval, so a session
+    /// created before the latch may hold nonces drawn inside that window, and a
+    /// round that reaches round 2 emits a signature share over one. Refusing new
+    /// work while letting those finish would leave the exact shares this exists
+    /// to prevent.
+    #[tokio::test]
+    async fn latching_abandons_in_flight_sessions_and_pooled_nonces() {
+        let (node, _relay) = test_node().await;
+        let participants = vec![1u16, 2u16];
+        let message = vec![0u8; 32];
+
+        {
+            let mut sessions = node.sessions.write();
+            let id = crate::session::derive_session_id(&message, &participants, 2);
+            sessions
+                .create_session(id, message.clone(), 2, participants.clone())
+                .expect("session fixture");
+            assert!(sessions.get_session_mut(&id).is_some());
+        }
+        node.replenish_nonce_pool().await.expect("pool fixture");
+        assert!(
+            node.nonce_pool.own_available() > 0,
+            "the pool must hold nonces before the latch"
+        );
+
+        node.mark_entropy_degraded();
+
+        assert_eq!(
+            node.nonce_pool.own_available(),
+            0,
+            "pooled nonces drawn before detection must be discarded"
+        );
+        let id = crate::session::derive_session_id(&message, &participants, 2);
+        assert!(
+            node.sessions.write().get_session_mut(&id).is_none(),
+            "an in-flight session must be abandoned, not left to expire"
+        );
     }
 
     /// A stale sign request (created_at outside the replay window) is rejected.

--- a/keep-frost-net/src/nonce_pool.rs
+++ b/keep-frost-net/src/nonce_pool.rs
@@ -237,6 +237,12 @@ impl NoncePool {
     /// peer reports a stale pre-exchanged nonce, so other peers' pooled
     /// commitments are preserved and they need not fall back to interactive
     /// rounds.
+    pub fn clear_peer(&self, share_index: u16) {
+        let mut inner = self.inner.lock();
+        inner.peer.retain(|(idx, _), _| *idx != share_index);
+        inner.peer_order.retain(|(idx, _)| *idx != share_index);
+    }
+
     /// Discard every own nonce still held.
     ///
     /// For the case where the material itself is suspect rather than stale: a
@@ -248,12 +254,6 @@ impl NoncePool {
         let mut inner = self.inner.lock();
         inner.own.clear();
         inner.own_order.clear();
-    }
-
-    pub fn clear_peer(&self, share_index: u16) {
-        let mut inner = self.inner.lock();
-        inner.peer.retain(|(idx, _), _| *idx != share_index);
-        inner.peer_order.retain(|(idx, _)| *idx != share_index);
     }
 
     /// Reserve one available commitment per requested peer for a signing

--- a/keep-frost-net/src/nonce_pool.rs
+++ b/keep-frost-net/src/nonce_pool.rs
@@ -237,6 +237,19 @@ impl NoncePool {
     /// peer reports a stale pre-exchanged nonce, so other peers' pooled
     /// commitments are preserved and they need not fall back to interactive
     /// rounds.
+    /// Discard every own nonce still held.
+    ///
+    /// For the case where the material itself is suspect rather than stale: a
+    /// nonce drawn from a source later found to be degraded cannot be told
+    /// apart from a sound one, so the whole pool goes. Dropping the secret
+    /// nonces also makes the advertised commitments unusable, since round 2
+    /// cannot run without them.
+    pub fn clear_own(&self) {
+        let mut inner = self.inner.lock();
+        inner.own.clear();
+        inner.own_order.clear();
+    }
+
     pub fn clear_peer(&self, share_index: u16) {
         let mut inner = self.inner.lock();
         inner.peer.retain(|(idx, _), _| *idx != share_index);
@@ -297,6 +310,27 @@ mod tests {
         let secret = shares.into_values().next().unwrap();
         let kp = KeyPackage::try_from(secret).unwrap();
         frost_secp256k1_tr::round1::commit(kp.signing_share(), &mut OsRng)
+    }
+
+    /// Discarding own nonces makes the advertised commitments unusable too:
+    /// round 2 cannot run without the secret half, so a commitment already on
+    /// the wire cannot be turned into a share.
+    #[test]
+    fn clearing_own_nonces_leaves_nothing_consumable() {
+        let pool = NoncePool::new();
+        let (nonces, _commitment) = make_pair();
+        pool.store_own([9u8; 32], nonces);
+        assert_eq!(pool.own_available(), 1);
+
+        pool.clear_own();
+
+        assert_eq!(pool.own_available(), 0);
+        assert!(!pool.contains_own(&[9u8; 32]));
+        assert!(
+            pool.consume_own(&[9u8; 32]).is_none(),
+            "a discarded nonce must not be recoverable"
+        );
+        assert!(pool.own_commitments().is_empty());
     }
 
     #[test]

--- a/keep-frost-net/src/session.rs
+++ b/keep-frost-net/src/session.rs
@@ -824,6 +824,17 @@ impl SessionManager {
         self.active_sessions.remove(session_id);
     }
 
+    /// Abandon every active session, returning how many were dropped.
+    ///
+    /// Deliberately not routed through `complete_session`: these rounds did not
+    /// complete, and recording them as completed would enter their ids in the
+    /// replay history and mask a genuine later replay of the same request.
+    pub fn abandon_all(&mut self) -> usize {
+        let count = self.active_sessions.len();
+        self.active_sessions.clear();
+        count
+    }
+
     pub fn complete_session(&mut self, session_id: &[u8; 32]) {
         self.active_sessions.remove(session_id);
 

--- a/keep-frost-net/src/session.rs
+++ b/keep-frost-net/src/session.rs
@@ -826,9 +826,14 @@ impl SessionManager {
 
     /// Abandon every active session, returning how many were dropped.
     ///
-    /// Deliberately not routed through `complete_session`: these rounds did not
-    /// complete, and recording them as completed would enter their ids in the
-    /// replay history and mask a genuine later replay of the same request.
+    /// Deliberately not routed through `complete_session`. That history is a
+    /// refuse-list, so adding ids would tighten replay detection rather than
+    /// loosen it; the cost is that it is bounded and evicts oldest-first. Up to
+    /// `MAX_ACTIVE_SESSIONS` ids at once would push out that many genuine
+    /// completed ids, which is the way this could actually mask a later replay.
+    /// Nothing is given up by leaving them out: a session that got as far as
+    /// holding nonces already recorded its id in the nonce store, which is
+    /// durable across restarts where this history is not.
     pub fn abandon_all(&mut self) -> usize {
         let count = self.active_sessions.len();
         self.active_sessions.clear();
@@ -859,6 +864,11 @@ impl SessionManager {
 
     pub fn active_count(&self) -> usize {
         self.active_sessions.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn completed_len(&self) -> usize {
+        self.completed_sessions.len()
     }
 
     pub fn is_replay(&self, session_id: &[u8; 32]) -> bool {
@@ -1271,5 +1281,35 @@ mod tests {
         let cached = manager.cache_and_remove_session(&session_id).unwrap();
         assert!(cached.is_some());
         assert!(manager.get_session(&session_id).is_none());
+    }
+
+    /// Abandoning is not completing. The distinction is invisible through
+    /// `get_session` alone, since both remove the session, so it is asserted
+    /// through the replay history: rewriting `abandon_all` as a loop over
+    /// `complete_session` would remove the sessions just the same and push that
+    /// many genuine ids out of a bounded, oldest-first history.
+    #[test]
+    fn abandoning_sessions_does_not_enter_them_in_the_replay_history() {
+        let mut manager = SessionManager::new();
+        let message = vec![7u8; 32];
+        let participants = vec![1u16, 2u16];
+        let id = derive_session_id(&message, &participants, 2);
+        manager
+            .create_session(id, message, 2, participants)
+            .unwrap();
+
+        let before = manager.completed_len();
+        assert_eq!(manager.abandon_all(), 1);
+
+        assert!(manager.get_session(&id).is_none(), "the session is gone");
+        assert_eq!(
+            manager.completed_len(),
+            before,
+            "an abandoned round must not be recorded as completed"
+        );
+        assert!(
+            !manager.is_replay(&id),
+            "and must not read back as a replay"
+        );
     }
 }


### PR DESCRIPTION
## Summary

The RNG latch refuses new signing work. It did nothing about work already running, which is the half that matters most, because detection lags the degradation.

A node notices a degraded source on a probe tick or on a draw. Anything created before that may be holding nonces drawn inside the window, and a round that has already collected its commitments goes on to round 2 and emits a signature share over one of them. Up to a full pool of own-nonces from the same window also stayed live and consumable. So the gates stopped exactly the case that had not started yet, and let through the case that was already holding suspect material.

Latching now tears both down:

- Every active session is abandoned, deliberately not by way of the completion path. That history is a refuse-list, so recording ids would tighten replay detection rather than loosen it, but it is bounded and evicts oldest-first: adding up to the active-session cap in one go would push out that many genuine completed ids, which is how this could actually mask a later replay. Nothing is given up by leaving them out, because a session that got as far as holding nonces already recorded its id in the nonce store, which survives restarts where this history does not.
- Every own nonce is discarded. Dropping the secret half also makes the commitments already advertised unusable, since round 2 cannot run without it, so a commitment on the wire cannot be turned into a share afterwards.

The refusal also sits at the point where a share is actually produced, which is the part an entry gate cannot cover. Review of the first version found the hole: the requester path gates on entry, draws its nonce, and then runs the pre-sign hook, which on desktop blocks on a human for up to sixty seconds against a thirty-second probe. The latch can trip inside that wait and the teardown can run, and the round would then build a fresh session and emit a share over a nonce drawn before detection. The peer commitments it reserved are not own nonces, so purging the pool did not stop it. There is now a check immediately after the hook, which lets the reservation guard return those commitments, and one at the single call that produces a share, so no path reaches round 2 while the latch holds regardless of what raced with the teardown.

`handle_commitment` is gated too, which closes the responder route at its entry.

## Why not let them expire

Sessions expire on a cleanup tick, so leaving them would close the window eventually. Eventually is the wrong shape here. A round that already has its commitments needs one more message to produce a share, and that share is over a nonce this node can no longer vouch for. Two of those recover the key.

## Test plan

Five tests. At the pool: clearing own nonces leaves nothing consumable, including the advertised commitments, so a nonce already published cannot be turned into a share. At the session manager: abandoning does not enter ids in the replay history, which is the property that separates it from completing and is invisible through the session lookup alone. At the node: latching abandons a session created beforehand and empties a pool filled beforehand, and share generation refuses even for a session that exists after the latch, which is the state the approval window produces.

Falsified individually. Removing the pool purge and removing the session abandon each fail the node test on their own half, clearing only the ordering vector while leaving the map fails the pool test, removing the chokepoint gate fails the share test, and rewriting the abandon as a loop over the completion path fails the history test. All 469 library tests pass, workspace builds, formatter, clippy and the RNG hygiene guard clean.
