### PR TITLE
Correct the README's unsafe-code claim and ignore the dev-only nostr-relay-builder advisory

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Minimum Supported Rust Version: **1.89**.
 
 ## Security
 
-Pure Rust. Crates set `#![forbid(unsafe_code)]` wherever the toolchain allows it. Two deny instead: `keep-core`, with two narrow audited exceptions (the `mlock`-backed secret buffers and the RDRAND entropy probe), and `keep-agent-ts`, because the `napi` macro expands to code that `forbid` rejects. Keys are derived with Argon2id, encrypted with XChaCha20-Poly1305, protected in RAM with Ascon-128a, and locked with mlock(2). FROST uses BIP-340 Schnorr signatures. See [`docs/SECURITY.md`](docs/SECURITY.md) for details.
+Pure Rust. Most crates set `#![forbid(unsafe_code)]`. Three deny it instead, each for a specific reason: `keep-core` (the `mlock`-backed secret buffers and the RDRAND entropy probe), `keep-cli` (Windows file-ACL calls), and `keep-agent-ts` (the `napi` macro expands to code that `forbid` rejects). Every unsafe block outside those three is a compile error. Keys are derived with Argon2id, encrypted with XChaCha20-Poly1305, protected in RAM with Ascon-128a, and locked with mlock(2). FROST uses BIP-340 Schnorr signatures. See [`docs/SECURITY.md`](docs/SECURITY.md) for details.
 
 Keep can threshold-sign software releases with a FROST-Ed25519 group (minisign-compatible), so no single maintainer holds the signing key. See [`docs/RELEASE_SIGNING.md`](docs/RELEASE_SIGNING.md).
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Minimum Supported Rust Version: **1.89**.
 
 ## Security
 
-Pure Rust with `#![forbid(unsafe_code)]`. Keys are derived with Argon2id, encrypted with XChaCha20-Poly1305, protected in RAM with Ascon-128a, and locked with mlock(2). FROST uses BIP-340 Schnorr signatures. See [`docs/SECURITY.md`](docs/SECURITY.md) for details.
+Pure Rust. Crates set `#![forbid(unsafe_code)]` wherever the toolchain allows it. Two deny instead: `keep-core`, with two narrow audited exceptions (the `mlock`-backed secret buffers and the RDRAND entropy probe), and `keep-agent-ts`, because the `napi` macro expands to code that `forbid` rejects. Keys are derived with Argon2id, encrypted with XChaCha20-Poly1305, protected in RAM with Ascon-128a, and locked with mlock(2). FROST uses BIP-340 Schnorr signatures. See [`docs/SECURITY.md`](docs/SECURITY.md) for details.
 
 Keep can threshold-sign software releases with a FROST-Ed25519 group (minisign-compatible), so no single maintainer holds the signing key. See [`docs/RELEASE_SIGNING.md`](docs/RELEASE_SIGNING.md).
 

--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,7 @@ ignore = [
     { id = "RUSTSEC-2024-0415", reason = "gtk3 bindings unmaintained; no migration path for tray-icon ecosystem" },
     { id = "RUSTSEC-2026-0194", reason = "quick-xml XML DoS; only reached via wayland-scanner (build-time protocol XML) and tauri-winrt-notification (self-generated Windows toast XML), never untrusted input; fix requires 0.41.0, unavailable at the pinned transitive minors" },
     { id = "RUSTSEC-2026-0195", reason = "quick-xml XML DoS; only reached via wayland-scanner (build-time protocol XML) and tauri-winrt-notification (self-generated Windows toast XML), never untrusted input; fix requires 0.41.0, unavailable at the pinned transitive minors" },
+    { id = "RUSTSEC-2026-0237", reason = "nostr-relay-builder unmaintained; dev-dependency only (test relay for keep-cli, keep-frost-net, keep-nip46 integration tests), never in a shipped artifact; unmaintained advisory with no fixed version to move to" },
 ]
 unmaintained = "workspace"
 

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2026 PrivKey LLC
 // SPDX-License-Identifier: MIT
 
-#![deny(unsafe_code)]
+#![forbid(unsafe_code)]
 
 mod cli;
 mod commands;

--- a/keep-cli/src/main.rs
+++ b/keep-cli/src/main.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2026 PrivKey LLC
 // SPDX-License-Identifier: MIT
 
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 mod cli;
 mod commands;


### PR DESCRIPTION
Two unrelated small fixes, both documentation or policy rather than code. No functional change.

## README unsafe-code claim was wrong

The Security section claimed the codebase is "Pure Rust with `#![forbid(unsafe_code)]`". That is the kind of claim a security-minded reader will check, and it does not hold. Three crates deny rather than forbid, each for a real reason:

- `keep-core` carries inner `#[allow(unsafe_code)]` at `crypto.rs:49` and `crypto.rs:61` plus a module-level allow in `entropy.rs`. The `MlockedBox`/`MlockedVec` secret buffers need `memsec::mlock`, `alloc_zeroed`, raw pointer access, and `unsafe impl Send`/`Sync`; the entropy health check needs the CPUID and RDRAND intrinsics.
- `keep-cli` pulls in `panic_windows.rs`, which sets `#![allow(unsafe_code)]` for Windows file-ACL calls under `#[cfg(windows)]`.
- `keep-agent-ts` cannot forbid because the `napi` attribute macro expands to `ctor_entry` code carrying `allow(unsafe_code)`, which `forbid` rejects with E0453.

The section now names those three and their reasons. Stating the two real unsafe surfaces is a stronger claim than a blanket assertion that turns out to be false.

I initially tried tightening `keep-cli` and `keep-agent-ts` to `forbid`. Both are dead ends, for the reasons above, and the `keep-cli` one is only visible when compiling for Windows.

## Ignore RUSTSEC-2026-0237

`cargo deny check advisories` began failing on every branch when this advisory was published; it is unrelated to any code change here. `nostr-relay-builder` is unmaintained, is a `[dev-dependencies]` edge only (the test relay used by `keep-cli`, `keep-frost-net`, and `keep-nip46` integration tests), and ships in no released artifact. It is an unmaintained advisory rather than a vulnerability, so there is no fixed version to move to.

Ignored with that rationale recorded inline. `cargo deny check advisories` passes locally with the entry. Replacing the test relay outright is the real fix and is worth doing separately.
