### PR TITLE
Hold vsss-rs at 5.x until voprf 0.6 is stable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,15 @@ updates:
       minor-and-patch:
         update-types: ["minor", "patch"]
     open-pull-requests-limit: 5
+    ignore:
+      # vsss-rs 6.x requires elliptic-curve 0.14, but the oprf feature reaches it
+      # through voprf 0.5 -> k256 0.13 -> elliptic-curve 0.13. Bumping vsss-rs alone
+      # puts two elliptic-curve majors in the tree and k256::Scalar stops satisfying
+      # vsss_rs::elliptic_curve::PrimeField. Adopting 6.x needs k256 0.14, which needs
+      # voprf >= 0.6, and voprf has only published 0.6.0-pre.1. Revisit when voprf 0.6
+      # is stable; do not ship a pre-release crate in the LUKS unlock path.
+      - dependency-name: "vsss-rs"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Dependabot proposed bumping `vsss-rs` 5.4.0 to 6.0.1. That bump cannot be taken yet, and without an ignore rule it will be reopened every week.

## Why it breaks

`vsss-rs` is used in `keep-core/src/oprf.rs` for the Shamir split behind the `oprf` feature, which is the threshold-OPRF path that reconstructs the LUKS disk-encryption key at boot.

`vsss-rs` 6.x moved to `elliptic-curve` 0.14. The `oprf` feature reaches `elliptic-curve` 0.13 through `voprf` 0.5 and `k256` 0.13. Taking the bump alone puts both majors in the tree, so `k256::Scalar` no longer satisfies `vsss_rs::elliptic_curve::PrimeField` and `ProjectivePoint` no longer satisfies `Group`/`GroupEncoding`.

Verified by building the branch:

```
cargo check -p keep-core --features oprf
error[E0277]: the trait bound `k256::Scalar: vsss_rs::elliptic_curve::PrimeField` is not satisfied
error[E0277]: the trait bound `ProjectivePoint: vsss_rs::elliptic_curve::Group` is not satisfied
error[E0599]: the method `value` exists for reference `&DefaultShare<...>`, but its trait bounds were not satisfied
```

The lockfile on that branch carries `elliptic-curve` 0.13.8 and 0.14.1 simultaneously, which is the direct cause. There is also a `rand_core` 0.6 vs `rand` 0.9 mismatch in the same build.

## Why it cannot be fixed by upgrading further

Adopting 6.x requires `k256` 0.14, which requires `voprf` to support `elliptic-curve` 0.14. `k256` 0.14.0 is published and stable, but `voprf`'s newest release is `0.6.0-pre.1`, a pre-release.

Shipping a pre-release crate in the path that unlocks an encrypted disk is not a trade worth making for a dependency bump.

## Change

Ignore major-version updates for `vsss-rs` only, with the reasoning recorded inline so the next person does not rediscover it. Minor and patch updates still flow normally, as do all other crates.

Revisit when `voprf` 0.6 ships stable; at that point `k256` 0.14, `voprf` 0.6, and `vsss-rs` 6.x should be upgraded together as one reviewed change.

Closes the standing failure on the `vsss-rs` bump PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated upgrade management settings to defer potentially disruptive major-version changes until broader compatibility is available.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->