### PR TITLE
Hold nostr-sdk at 0.44 until the 0.45 API migration is done

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,16 @@ updates:
       # is stable; do not ship a pre-release crate in the LUKS unlock path.
       - dependency-name: "vsss-rs"
         update-types: ["version-update:semver-major"]
+      # nostr-sdk 0.45 removed every per-NIP feature flag (nip03, nip04, nip06,
+      # nip44, nip47, nip49, nip57, nip59, nip96, nip98, all-nips) and reworked the
+      # API surface. Bumping it is a migration, not an update: a scoped attempt on
+      # 0.45.1 produced 236 compile errors, concentrated in keep-frost-net and
+      # keep-agent (TagKind, nip44::encrypt/decrypt, EventBuilder::sign_with_keys,
+      # Timestamp::tweaked, RelayPoolNotification). Dependabot cannot resolve it at
+      # all today because the workspace requests the removed nip04 feature, so the
+      # weekly cargo job fails on it. Tracked separately; unpin when that lands.
+      - dependency-name: "nostr-sdk"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
The weekly dependabot cargo job is failing on `main`, and has been since `nostr-sdk` 0.45 shipped. This stops the failure and records why, without pretending the underlying migration is done.

## What is failing

Dependabot cannot resolve the workspace at all:

```
failed to select a version for `nostr-sdk`
  ... required by package `keep-cli v0.9.2`
versions that meet the requirements `^0.45` are: 0.45.1
package `keep-cli` depends on `nostr-sdk` with feature `nip04` but `nostr-sdk` does not have that feature
```

Upstream removed every per-NIP feature flag in 0.45: `pow-multi-thread`, `all-nips`, `nip03`, `nip04`, `nip06`, `nip44`, `nip47`, `nip49`, `nip57`, `nip59`, `nip96`, `nip98`. NIP-04 support is not gone, the gating is, so the manifests requesting those features no longer resolve.

The job still creates other PRs, so this presents as a permanently red weekly run rather than a total outage. That is arguably worse, since a run that is always red stops being read.

## Why this is a migration, not a bump

I scoped it on a scratch branch: bumped to 0.45.1, dropped the removed feature flags from all six manifests that name them, and built the workspace. Result: **236 compile errors**.

By frequency, the API surface that moved:

| Symbol | Occurrences |
|---|---|
| `TagKind` | 69 |
| `nip44` | 57 |
| `EventBuilder` | 29 |
| `sign_with_keys` | 27 |
| `Timestamp` / `tweaked` | 26 each |
| `encrypt` / `decrypt` | 26 / 4 |
| `RelayPoolNotification` | 4 |

Concentrated in `keep-frost-net` and `keep-agent`. 0.45 also merged `nostr-relay-pool` into `nostr-sdk` and dropped `TimeSupplier`, `EventBuilder::build_with_ctx`, `Event::is_expired_with_supplier`, and `Timestamp::now_with_supplier`, so the relay-pool and timestamp paths need rework rather than renaming.

This touches the Nostr transport and the NIP-44 encryption path, so it wants to be its own reviewed change with tests, not a dependency PR.

## Change

Ignore minor and major updates for `nostr-sdk` only, with the reasoning inline. `nostr-sdk` is 0.x, so a minor bump is a breaking change and both need holding. Patch updates within 0.44 still flow, as does every other crate.

## Separately found, not fixed here

`cargo check --workspace --all-features` fails on `main` today, independent of this: `aws-nitro-enclaves-nsm-api@0.5.2 requires rustc 1.92` against the workspace MSRV of 1.89. CI does not currently exercise that combination, so it is latent rather than breaking anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated dependency updates for `nostr-sdk` now remain limited to compatible patch releases.
  * Added documentation explaining why larger updates are currently excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->