### PR TITLE
ci: Keep signs its own releases (before going into production)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Include ready_for_review so a draft->ready transition re-runs CI. The
+    # build/lint jobs are gated on `draft != true`; without this trigger their
+    # required checks stay skipped after undrafting and block the PR forever.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 # Least privilege: no job in this workflow writes to the repo, but every job runs
 # third-party actions (cargo-deny, setup-android, taiki-e/install-action, rust-cache).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - run: xcode-select --install || true
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo build --release --locked
       - run: |
           mv target/release/keep keep-macos-x86_64
@@ -81,7 +81,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: macos-arm
       - run: cargo build --release --locked --target aarch64-apple-darwin
@@ -100,7 +100,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo build --release --locked
       - run: |
           mv target/release/keep.exe keep-windows-x86_64.exe
@@ -118,6 +118,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
@@ -126,6 +129,16 @@ jobs:
         run: |
           cd artifacts
           sha256sum * > SHA256SUMS
+      # Ship the release-signing public key so users can verify the
+      # maintainer-signed SHA256SUMS.minisig once it is uploaded. Signing itself
+      # stays offline; see docs/RELEASE_SIGNING.md.
+      - name: Attach signing public key
+        run: |
+          if [ -f release-signing.pub ]; then
+            cp release-signing.pub artifacts/
+          else
+            echo "release-signing.pub not present; skipping (run the group ceremony to add it)"
+          fi
       - name: Create release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:

--- a/.github/workflows/verify-signature.yml
+++ b/.github/workflows/verify-signature.yml
@@ -42,18 +42,49 @@ jobs:
           if grep -qx SHA256SUMS.minisig <<<"$assets"; then
             gh release download "$TAG" --pattern SHA256SUMS.minisig --dir .
           fi
+          # Also pull the artifacts the manifest covers. Verifying the signature
+          # alone only proves a threshold signed *some* manifest; without the
+          # binaries we cannot tell whether the published assets are the ones it
+          # describes. Everything except the manifest, its signature and the
+          # public key is a covered artifact.
+          mkdir -p covered
+          while IFS= read -r name; do
+            case "$name" in
+              SHA256SUMS|SHA256SUMS.minisig|release-signing.pub) continue ;;
+            esac
+            gh release download "$TAG" --pattern "$name" --dir covered
+          done <<<"$assets"
+      # Warnings, not notices, for the pending states. A notice is invisible
+      # unless you open the run, so an unsigned release would show the same bare
+      # green tick as a fully verified one under a check called "Verify release
+      # signature". The step summary states which of the three outcomes applies
+      # so the distinction survives a glance at the checks list.
       - name: Verify signature
         run: |
+          summary() { echo "$1" >> "$GITHUB_STEP_SUMMARY"; }
           if [ ! -f release-signing.pub ]; then
-            echo "::notice::release-signing.pub not committed yet; skipping verification"
-            exit 0
-          fi
-          if [ ! -f SHA256SUMS.minisig ]; then
-            echo "::notice::SHA256SUMS.minisig not uploaded yet; signature pending"
+            echo "::warning::NOT VERIFIED: release signing is wired but not activated (no release-signing.pub)"
+            summary "**Release signing: not activated.** No \`release-signing.pub\` in the repo, so nothing was verified."
             exit 0
           fi
           if [ ! -f SHA256SUMS ]; then
-            echo "::notice::SHA256SUMS not uploaded yet; nothing to verify"
+            echo "::warning::NOT VERIFIED: SHA256SUMS is missing from the release"
+            summary "**Release signing: no manifest.** \`SHA256SUMS\` is not attached to this release."
+            exit 0
+          fi
+          if [ ! -f SHA256SUMS.minisig ]; then
+            echo "::warning::NOT VERIFIED: signature pending (no SHA256SUMS.minisig uploaded yet)"
+            summary "**Release signing: signature pending.** \`SHA256SUMS\` is present but unsigned."
             exit 0
           fi
           minisign -V -p release-signing.pub -m SHA256SUMS
+          # The signature covers the manifest, not the files. Without this an
+          # artifact swapped after signing verifies green: the manifest is
+          # untouched and its signature still checks out. Comparing the assets
+          # against the signed digests is what makes the green tick mean the
+          # published binaries are the ones the maintainers signed.
+          cd covered
+          sha256sum -c ../SHA256SUMS
+          cd ..
+          summary "**Release signing: verified.** Signature valid and all published artifacts match the signed digests."
+

--- a/.github/workflows/verify-signature.yml
+++ b/.github/workflows/verify-signature.yml
@@ -83,8 +83,21 @@ jobs:
           # untouched and its signature still checks out. Comparing the assets
           # against the signed digests is what makes the green tick mean the
           # published binaries are the ones the maintainers signed.
-          cd covered
-          sha256sum -c ../SHA256SUMS
-          cd ..
-          summary "**Release signing: verified.** Signature valid and all published artifacts match the signed digests."
+          (cd covered && sha256sum -c ../SHA256SUMS)
+          # `sha256sum -c` only checks names the manifest lists, so it ignores an
+          # asset added after signing. That asset would be unsigned but sit on the
+          # release looking official. Require the two name sets to match exactly:
+          # anything published but unsigned, or signed but missing, fails here.
+          awk '{ sub(/^\*/, "", $2); print $2 }' SHA256SUMS | sort > /tmp/signed.txt
+          (cd covered && ls -1) | sort > /tmp/published.txt
+          if ! diff -u /tmp/signed.txt /tmp/published.txt > /tmp/setdiff.txt; then
+            echo "::error::Published assets do not match the signed manifest"
+            cat /tmp/setdiff.txt
+            summary "**Release signing: MISMATCH.** Published assets differ from the signed manifest."
+            summary '```'
+            cat /tmp/setdiff.txt >> "$GITHUB_STEP_SUMMARY"
+            summary '```'
+            exit 1
+          fi
+          summary "**Release signing: verified.** Signature valid, every published artifact matches its signed digest, and no unsigned assets are present."
 

--- a/.github/workflows/verify-signature.yml
+++ b/.github/workflows/verify-signature.yml
@@ -7,6 +7,13 @@ name: Verify release signature
 on:
   release:
     types: [published, edited]
+  # Asset uploads (the .minisig) do not reliably fire release events, so allow a
+  # maintainer to re-run verification for a tag after uploading the signature.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to verify (e.g. v1.2.3)
+        required: true
 
 permissions:
   contents: read
@@ -23,10 +30,18 @@ jobs:
       - name: Download manifest and signature
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
-          gh release download "$TAG" --pattern SHA256SUMS --dir . || true
-          gh release download "$TAG" --pattern SHA256SUMS.minisig --dir . || true
+          # List assets once; a failure here (auth/network/API) aborts the step
+          # rather than masquerading as a missing file. Download only present
+          # assets, and let genuine download failures propagate.
+          assets=$(gh release view "$TAG" --json assets --jq '.assets[].name')
+          if grep -qx SHA256SUMS <<<"$assets"; then
+            gh release download "$TAG" --pattern SHA256SUMS --dir .
+          fi
+          if grep -qx SHA256SUMS.minisig <<<"$assets"; then
+            gh release download "$TAG" --pattern SHA256SUMS.minisig --dir .
+          fi
       - name: Verify signature
         run: |
           if [ ! -f release-signing.pub ]; then

--- a/.github/workflows/verify-signature.yml
+++ b/.github/workflows/verify-signature.yml
@@ -1,9 +1,9 @@
 name: Verify release signature
 
-# Non-blocking: surfaces whether a maintainer has uploaded a valid
-# SHA256SUMS.minisig for the release. Signing happens offline (a threshold of
-# maintainers), so this only verifies; it never signs. See
-# docs/RELEASE_SIGNING.md.
+# Surfaces whether a maintainer has uploaded a valid SHA256SUMS.minisig for the
+# release. Non-blocking on missing files (clean notice, green); fails only on an
+# invalid signature. Signing happens offline (a threshold of maintainers), so
+# this only verifies; it never signs. See docs/RELEASE_SIGNING.md.
 on:
   release:
     types: [published, edited]
@@ -35,6 +35,10 @@ jobs:
           fi
           if [ ! -f SHA256SUMS.minisig ]; then
             echo "::notice::SHA256SUMS.minisig not uploaded yet; signature pending"
+            exit 0
+          fi
+          if [ ! -f SHA256SUMS ]; then
+            echo "::notice::SHA256SUMS not uploaded yet; nothing to verify"
             exit 0
           fi
           minisign -V -p release-signing.pub -m SHA256SUMS

--- a/.github/workflows/verify-signature.yml
+++ b/.github/workflows/verify-signature.yml
@@ -1,0 +1,40 @@
+name: Verify release signature
+
+# Non-blocking: surfaces whether a maintainer has uploaded a valid
+# SHA256SUMS.minisig for the release. Signing happens offline (a threshold of
+# maintainers), so this only verifies; it never signs. See
+# docs/RELEASE_SIGNING.md.
+on:
+  release:
+    types: [published, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Install minisign
+        run: sudo apt-get update && sudo apt-get install -y minisign
+      - name: Download manifest and signature
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh release download "$TAG" --pattern SHA256SUMS --dir . || true
+          gh release download "$TAG" --pattern SHA256SUMS.minisig --dir . || true
+      - name: Verify signature
+        run: |
+          if [ ! -f release-signing.pub ]; then
+            echo "::notice::release-signing.pub not committed yet; skipping verification"
+            exit 0
+          fi
+          if [ ! -f SHA256SUMS.minisig ]; then
+            echo "::notice::SHA256SUMS.minisig not uploaded yet; signature pending"
+            exit 0
+          fi
+          minisign -V -p release-signing.pub -m SHA256SUMS

--- a/docs/RELEASE_SIGNING.md
+++ b/docs/RELEASE_SIGNING.md
@@ -8,13 +8,27 @@ holds the signing key. The output is minisign-compatible, so downstream users
 verify with the stock [`minisign`](https://jedisct1.github.io/minisign/) tool or
 with `keep verify`.
 
-This is a Keep capability you can adopt for your own project. Keep will sign its
-own releases with it: once the signing group is established, releases ship
-`release-signing.pub` alongside the binaries and `SHA256SUMS` manifest, a
-threshold of maintainers signs the manifest offline and uploads
-`SHA256SUMS.minisig`, and a non-blocking `Verify release signature` workflow
-checks the signature once it lands. The release workflows are wired for this
-today; they stay inert until the group public key is generated and committed.
+This is a Keep capability you can adopt for your own project.
+
+**Keep's own releases are not signed this way yet.** The workflows are wired for
+it but dormant: no signing group exists, `release-signing.pub` is not in this
+repository, and the `Verify release signature` check reports NOT VERIFIED on
+every release. Do not expect a `SHA256SUMS.minisig` on current releases, and do
+not treat that check's green tick as evidence of anything until activation.
+
+Once the group is established, releases will ship `release-signing.pub`
+alongside the binaries and the `SHA256SUMS` manifest, a threshold of maintainers
+will sign the manifest offline and upload `SHA256SUMS.minisig`, and the workflow
+will verify both the signature and that every published artifact matches its
+signed digest.
+
+### Where the trust anchor lives
+
+`release-signing.pub` is attached to releases for convenience only. Anyone who
+can publish a release can attach a public key to it, so verifying a release
+against a key downloaded from that same release proves nothing on its own. The
+anchor is the copy committed in this repository; fetch it from a source you
+already trust, pin it, and reuse it across releases.
 
 ## Establishing a signing group
 

--- a/docs/RELEASE_SIGNING.md
+++ b/docs/RELEASE_SIGNING.md
@@ -22,7 +22,7 @@ will sign the manifest offline and upload `SHA256SUMS.minisig`, and the workflow
 will verify both the signature and that every published artifact matches its
 signed digest.
 
-### Where the trust anchor lives
+## Where the trust anchor lives
 
 `release-signing.pub` is attached to releases for convenience only. Anyone who
 can publish a release can attach a public key to it, so verifying a release

--- a/docs/RELEASE_SIGNING.md
+++ b/docs/RELEASE_SIGNING.md
@@ -8,11 +8,13 @@ holds the signing key. The output is minisign-compatible, so downstream users
 verify with the stock [`minisign`](https://jedisct1.github.io/minisign/) tool or
 with `keep verify`.
 
-This is a Keep capability you can adopt for your own project. Keep uses it for
-its own releases: they ship `release-signing.pub` alongside the binaries and `SHA256SUMS`
-manifest, and a threshold of maintainers signs the manifest offline and uploads
-`SHA256SUMS.minisig`. A non-blocking `Verify release signature` workflow checks
-the signature once it lands.
+This is a Keep capability you can adopt for your own project. Keep will sign its
+own releases with it: once the signing group is established, releases ship
+`release-signing.pub` alongside the binaries and `SHA256SUMS` manifest, a
+threshold of maintainers signs the manifest offline and uploads
+`SHA256SUMS.minisig`, and a non-blocking `Verify release signature` workflow
+checks the signature once it lands. The release workflows are wired for this
+today; they stay inert until the group public key is generated and committed.
 
 ## Establishing a signing group
 

--- a/docs/RELEASE_SIGNING.md
+++ b/docs/RELEASE_SIGNING.md
@@ -8,8 +8,8 @@ holds the signing key. The output is minisign-compatible, so downstream users
 verify with the stock [`minisign`](https://jedisct1.github.io/minisign/) tool or
 with `keep verify`.
 
-This is a Keep capability you can adopt for your own project. Keep dogfoods it:
-its releases ship `release-signing.pub` alongside the binaries and `SHA256SUMS`
+This is a Keep capability you can adopt for your own project. Keep uses it for
+its own releases: they ship `release-signing.pub` alongside the binaries and `SHA256SUMS`
 manifest, and a threshold of maintainers signs the manifest offline and uploads
 `SHA256SUMS.minisig`. A non-blocking `Verify release signature` workflow checks
 the signature once it lands.

--- a/docs/RELEASE_SIGNING.md
+++ b/docs/RELEASE_SIGNING.md
@@ -8,8 +8,11 @@ holds the signing key. The output is minisign-compatible, so downstream users
 verify with the stock [`minisign`](https://jedisct1.github.io/minisign/) tool or
 with `keep verify`.
 
-This is a Keep capability you can adopt for your own project. Keep's own GitHub
-releases are not signed this way; they ship binaries and a `SHA256SUMS` manifest.
+This is a Keep capability you can adopt for your own project. Keep dogfoods it:
+its releases ship `release-signing.pub` alongside the binaries and `SHA256SUMS`
+manifest, and a threshold of maintainers signs the manifest offline and uploads
+`SHA256SUMS.minisig`. A non-blocking `Verify release signature` workflow checks
+the signature once it lands.
 
 ## Establishing a signing group
 


### PR DESCRIPTION
## What this does

> **Status:** pre-production plumbing. Merges inert (both workflows skip
> cleanly without the key). The group ceremony and going live are gated on a
> working `keep` / `keep-android` build to sign and test with.

Wires Keep's own releases into the threshold release-signing flow documented in
`docs/RELEASE_SIGNING.md`, so downstream users can verify our release manifests.

- **`release.yml`** — attaches `release-signing.pub` to every release (alongside the
  binaries and `SHA256SUMS`) so users have the trust anchor to verify against.
- **`verify-signature.yml`** — a non-blocking check that runs `minisign -V` on the
  release's `SHA256SUMS` once a maintainer uploads `SHA256SUMS.minisig`. It stays
  green when files are absent and fails **only** on an invalid signature. Signing
  never happens in CI (see below); this workflow only verifies.
- **`RELEASE_SIGNING.md`** — documents that Keep signs its own releases with this flow.

## Activation (one-time, offline — not part of this merge)

This plumbing is inert until the signing group exists. To turn it on:

1. Run the group ceremony to generate the key and shares:
   ```sh
   keep frost generate --ed25519 --threshold <t> --shares <n> \
     --name release-signing --pubkey-out release-signing.pub
   ```
2. Distribute each share to its holder (`keep frost export`). Shares never touch CI.
3. Commit `release-signing.pub` to the repo root — this flips both workflows from
   "skip" to active.

## Per release, going forward

After a release publishes, a maintainer signs offline and uploads the signature:

```sh
gh release download <tag> --pattern SHA256SUMS
keep sign SHA256SUMS --group <group-npub-or-hex> -t "release <tag>"
gh release upload <tag> SHA256SUMS.minisig
```

The verify check then goes green. If it doesn't re-fire on the asset upload, run it
manually: **Actions → Verify release signature → Run workflow → enter the tag**.

## Why signing stays offline

Putting a threshold of shares into CI secrets recreates the single point of failure
threshold signing exists to remove. CI builds and publishes; maintainers sign offline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated verification for release signatures and artifact checksums.
  * Verification runs for published or updated releases and supports manual runs.
  * Release artifacts include the public signing key when available.
  * Verification reports warnings when signing is inactive or required files are missing, and fails for invalid signatures or mismatched artifacts.

* **Documentation**
  * Clarified that current releases are not signed and may report `NOT VERIFIED`.
  * Documented the planned signing workflow and repository public key as the trust anchor.

* **Chores**
  * CI now reruns when draft pull requests become ready for review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->