### PR TITLE
Durably stash completed DKG share before import so storage failure can't lose it

### DIFF
--- a/keep-agent-py/Cargo.lock
+++ b/keep-agent-py/Cargo.lock
@@ -8,8 +8,18 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
+]
+
+[[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -19,8 +29,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
- "cpufeatures",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -40,7 +61,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -65,7 +86,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17453125d1e5c866b1f38bcccf7b9dd4a561f55930c68685ec8f188d01f71c8c"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "ascon-core",
  "subtle",
  "zeroize",
@@ -161,6 +182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +198,12 @@ name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "bech32"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbd3e1070bbdf4cd88a75264e18e8a26f7cb5c6949eadf0ceb85fb159cf08f8"
 
 [[package]]
 name = "bincode"
@@ -190,6 +223,7 @@ dependencies = [
  "bitcoin_hashes",
  "serde",
  "unicode-normalization",
+ "zeroize",
 ]
 
 [[package]]
@@ -200,12 +234,12 @@ checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
- "bech32",
+ "bech32 0.11.1",
  "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
  "bitcoin_hashes",
- "hex-conservative",
+ "hex-conservative 0.2.2",
  "hex_lit",
  "secp256k1",
  "serde",
@@ -243,7 +277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
 dependencies = [
  "bitcoin-io",
- "hex-conservative",
+ "hex-conservative 0.2.2",
  "serde",
 ]
 
@@ -259,7 +293,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -285,12 +319,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -341,7 +393,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -373,8 +434,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
- "cpufeatures",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.2",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -383,18 +456,30 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
- "aead",
- "chacha20",
- "cipher",
- "poly1305",
+ "aead 0.5.2",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
+ "poly1305 0.8.0",
  "zeroize",
 ]
 
 [[package]]
-name = "chrono"
-version = "0.4.42"
+name = "chacha20poly1305"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
+dependencies = [
+ "aead 0.6.1",
+ "chacha20 0.10.1",
+ "cipher 0.5.2",
+ "poly1305 0.9.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -410,10 +495,27 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
  "zeroize",
 ]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -437,6 +539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,10 +557,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -487,16 +610,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
-
-[[package]]
-name = "debugless-unwrap"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f400d0750c0c069e8493f2256cb4da6f604b6d2eeb69a0ca8863acde352f8400"
 
 [[package]]
 name = "der"
@@ -504,7 +641,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -525,31 +662,43 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
+name = "digest"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -579,7 +728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -600,11 +749,11 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -657,13 +806,12 @@ dependencies = [
 
 [[package]]
 name = "frost-core"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2619366c227233c0f817ae01156bd21b8cf74d2bd96cbe0889f4c2e266724e44"
+checksum = "81ef2787af391c7e8bedc037a3b9ea03dde803fbd93e778e6bb369547800e5cd"
 dependencies = [
  "byteorder",
  "const-crc32-nostd",
- "debugless-unwrap",
  "derive-getters",
  "document-features",
  "hex",
@@ -675,13 +823,14 @@ dependencies = [
  "thiserror 2.0.17",
  "visibility",
  "zeroize",
+ "zeroize_derive",
 ]
 
 [[package]]
 name = "frost-rerandomized"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c5eb1ea58c0250b7ce834337f7b19e0417686d14ffc7f626137dea9149762d4"
+checksum = "8f4c5cedd2426728adef2c0b1720f57676354c473836d1ccc50d0f0d1c91942b"
 dependencies = [
  "derive-getters",
  "document-features",
@@ -692,16 +841,26 @@ dependencies = [
 
 [[package]]
 name = "frost-secp256k1-tr"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8a25b14bfd5d25deba5edce61ec99c3afb752a1d26630a196bba4cb1c4ca5e"
+checksum = "c6fca4ca9f057cf22066f3eb5bbda59d2af51f429f2aac5982a11a8a841c0993"
 dependencies = [
  "document-features",
  "frost-core",
  "frost-rerandomized",
  "k256",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -801,8 +960,20 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -879,6 +1050,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,7 +1070,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -899,7 +1088,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -917,6 +1115,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1069,8 +1276,18 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
+ "block-padding 0.3.3",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding 0.4.2",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1120,33 +1337,34 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
 [[package]]
 name = "keep-agent"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "chrono",
  "hex",
  "keep-bitcoin",
  "keep-core",
  "nostr-sdk",
- "rand 0.8.5",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "subtle",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "urlencoding",
+ "uuid",
  "zeroize",
 ]
 
 [[package]]
 name = "keep-agent-py"
-version = "0.1.0"
+version = "0.1.4"
 dependencies = [
  "hex",
  "k256",
@@ -1157,45 +1375,62 @@ dependencies = [
  "pyo3",
  "serde_json",
  "tokio",
+ "zeroize",
 ]
 
 [[package]]
 name = "keep-bitcoin"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "bitcoin",
+ "getrandom 0.4.3",
  "hex",
  "keep-core",
+ "miniscript",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tracing",
  "zeroize",
 ]
 
 [[package]]
 name = "keep-core"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
+ "aes 0.9.2",
  "argon2",
- "bech32",
+ "base64 0.23.1",
+ "bech32 0.12.0",
  "bincode",
+ "bip39",
+ "bitcoin",
  "blake2",
- "chacha20poly1305",
+ "cbc 0.2.1",
+ "chacha20 0.10.1",
+ "chacha20poly1305 0.11.0",
  "chrono",
  "dirs",
  "frost-secp256k1-tr",
+ "fs2",
  "hex",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "k256",
+ "memsec 0.7.0",
  "memsecurity",
- "rand 0.9.2",
- "redb",
+ "rand 0.10.2",
+ "redb 2.6.3",
+ "redb 4.1.0",
+ "scrypt 0.12.0",
  "secrecy",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "subtle",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tracing",
+ "unicode-normalization",
  "zeroize",
 ]
 
@@ -1275,6 +1510,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "memsec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c797b9d6bb23aab2fc369c65f871be49214f5c759af65bde26ffaaa2b646b492"
+dependencies = [
+ "getrandom 0.2.16",
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "memsecurity"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,11 +1531,22 @@ dependencies = [
  "blake3",
  "borsh",
  "bytes",
- "memsec",
+ "memsec 0.6.3",
  "once_cell",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "zeroize",
+]
+
+[[package]]
+name = "miniscript"
+version = "13.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd35e2c377504e50159561884b03610711db6c2fec6c89f2b98d94016684726b"
+dependencies = [
+ "bech32 0.11.1",
+ "bitcoin",
+ "hex-conservative 1.2.0",
 ]
 
 [[package]]
@@ -1315,18 +1572,18 @@ version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa5e3b6a278ed061835fe1ee293b71641e6bf8b401cfe4e1834bbf4ef0a34e1"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "base64 0.22.1",
- "bech32",
+ "bech32 0.11.1",
  "bip39",
  "bitcoin_hashes",
- "cbc",
- "chacha20",
- "chacha20poly1305",
+ "cbc 0.1.2",
+ "chacha20 0.9.1",
+ "chacha20poly1305 0.10.1",
  "getrandom 0.2.16",
  "hex",
  "instant",
- "scrypt",
+ "scrypt 0.11.0",
  "secp256k1",
  "serde",
  "serde_json",
@@ -1454,8 +1711,18 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -1492,9 +1759,19 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -1631,6 +1908,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,6 +1932,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1690,10 +1984,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "redb"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "redb"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
 dependencies = [
  "libc",
 ]
@@ -1709,13 +2018,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1724,7 +2033,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -1803,7 +2112,17 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1819,9 +2138,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "password-hash",
- "pbkdf2",
- "salsa20",
- "sha2",
+ "pbkdf2 0.12.2",
+ "salsa20 0.10.2",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "scrypt"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
+dependencies = [
+ "cfg-if",
+ "pbkdf2 0.13.0",
+ "salsa20 0.11.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -1934,8 +2265,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1945,8 +2276,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1970,7 +2312,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2268,9 +2610,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -2299,8 +2641,18 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2338,6 +2690,17 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"
@@ -2458,6 +2821,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,15 +2912,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2574,21 +2950,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2632,12 +2993,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2656,12 +3011,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2677,12 +3026,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2716,12 +3059,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2737,12 +3074,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2764,12 +3095,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2785,12 +3110,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2895,6 +3214,7 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 

--- a/keep-agent-ts/Cargo.lock
+++ b/keep-agent-ts/Cargo.lock
@@ -8,8 +8,40 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
+]
+
+[[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -29,7 +61,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -54,7 +86,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17453125d1e5c866b1f38bcccf7b9dd4a561f55930c68685ec8f188d01f71c8c"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "ascon-core",
  "subtle",
  "zeroize",
@@ -150,6 +182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +198,12 @@ name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "bech32"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbd3e1070bbdf4cd88a75264e18e8a26f7cb5c6949eadf0ceb85fb159cf08f8"
 
 [[package]]
 name = "bincode"
@@ -179,6 +223,7 @@ dependencies = [
  "bitcoin_hashes",
  "serde",
  "unicode-normalization",
+ "zeroize",
 ]
 
 [[package]]
@@ -189,12 +234,12 @@ checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
- "bech32",
+ "bech32 0.11.1",
  "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
  "bitcoin_hashes",
- "hex-conservative",
+ "hex-conservative 0.2.2",
  "hex_lit",
  "secp256k1",
  "serde",
@@ -232,7 +277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
 dependencies = [
  "bitcoin-io",
- "hex-conservative",
+ "hex-conservative 0.2.2",
  "serde",
 ]
 
@@ -248,7 +293,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -274,12 +319,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -330,7 +393,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -362,8 +434,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
- "cpufeatures",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.2",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -372,18 +456,30 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
- "aead",
- "chacha20",
- "cipher",
- "poly1305",
+ "aead 0.5.2",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
+ "poly1305 0.8.0",
  "zeroize",
 ]
 
 [[package]]
-name = "chrono"
-version = "0.4.42"
+name = "chacha20poly1305"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
+dependencies = [
+ "aead 0.6.1",
+ "chacha20 0.10.1",
+ "cipher 0.5.2",
+ "poly1305 0.9.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -399,10 +495,27 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
  "zeroize",
 ]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -426,6 +539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,10 +566,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -485,6 +619,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "ctor"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,16 +646,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
-
-[[package]]
-name = "debugless-unwrap"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f400d0750c0c069e8493f2256cb4da6f604b6d2eeb69a0ca8863acde352f8400"
 
 [[package]]
 name = "der"
@@ -518,7 +666,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -539,31 +687,43 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
+name = "digest"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -608,7 +768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -629,11 +789,11 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -686,13 +846,12 @@ dependencies = [
 
 [[package]]
 name = "frost-core"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2619366c227233c0f817ae01156bd21b8cf74d2bd96cbe0889f4c2e266724e44"
+checksum = "81ef2787af391c7e8bedc037a3b9ea03dde803fbd93e778e6bb369547800e5cd"
 dependencies = [
  "byteorder",
  "const-crc32-nostd",
- "debugless-unwrap",
  "derive-getters",
  "document-features",
  "hex",
@@ -704,13 +863,14 @@ dependencies = [
  "thiserror 2.0.17",
  "visibility",
  "zeroize",
+ "zeroize_derive",
 ]
 
 [[package]]
 name = "frost-rerandomized"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c5eb1ea58c0250b7ce834337f7b19e0417686d14ffc7f626137dea9149762d4"
+checksum = "8f4c5cedd2426728adef2c0b1720f57676354c473836d1ccc50d0f0d1c91942b"
 dependencies = [
  "derive-getters",
  "document-features",
@@ -721,16 +881,26 @@ dependencies = [
 
 [[package]]
 name = "frost-secp256k1-tr"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8a25b14bfd5d25deba5edce61ec99c3afb752a1d26630a196bba4cb1c4ca5e"
+checksum = "c6fca4ca9f057cf22066f3eb5bbda59d2af51f429f2aac5982a11a8a841c0993"
 dependencies = [
  "document-features",
  "frost-core",
  "frost-rerandomized",
  "k256",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -854,8 +1024,20 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -926,6 +1108,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,7 +1128,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -946,7 +1146,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -964,6 +1173,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1107,8 +1325,18 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
+ "block-padding 0.3.3",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding 0.4.2",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1158,33 +1386,34 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
 [[package]]
 name = "keep-agent"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "chrono",
  "hex",
  "keep-bitcoin",
  "keep-core",
  "nostr-sdk",
- "rand 0.8.5",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "subtle",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "urlencoding",
+ "uuid",
  "zeroize",
 ]
 
 [[package]]
 name = "keep-agent-ts"
-version = "0.1.0"
+version = "0.1.4"
 dependencies = [
  "hex",
  "k256",
@@ -1197,45 +1426,62 @@ dependencies = [
  "nostr-sdk",
  "serde_json",
  "tokio",
+ "zeroize",
 ]
 
 [[package]]
 name = "keep-bitcoin"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
  "bitcoin",
+ "getrandom 0.4.3",
  "hex",
  "keep-core",
+ "miniscript",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tracing",
  "zeroize",
 ]
 
 [[package]]
 name = "keep-core"
-version = "0.1.0"
+version = "0.9.2"
 dependencies = [
+ "aes 0.9.2",
  "argon2",
- "bech32",
+ "base64 0.23.1",
+ "bech32 0.12.0",
  "bincode",
+ "bip39",
+ "bitcoin",
  "blake2",
- "chacha20poly1305",
+ "cbc 0.2.1",
+ "chacha20 0.10.1",
+ "chacha20poly1305 0.11.0",
  "chrono",
  "dirs",
  "frost-secp256k1-tr",
+ "fs2",
  "hex",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "k256",
+ "memsec 0.7.0",
  "memsecurity",
- "rand 0.9.2",
- "redb",
+ "rand 0.10.2",
+ "redb 2.6.3",
+ "redb 4.1.0",
+ "scrypt 0.12.0",
  "secrecy",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "subtle",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tracing",
+ "unicode-normalization",
  "zeroize",
 ]
 
@@ -1316,6 +1562,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "memsec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c797b9d6bb23aab2fc369c65f871be49214f5c759af65bde26ffaaa2b646b492"
+dependencies = [
+ "getrandom 0.2.16",
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "memsecurity"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,11 +1583,22 @@ dependencies = [
  "blake3",
  "borsh",
  "bytes",
- "memsec",
+ "memsec 0.6.3",
  "once_cell",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "zeroize",
+]
+
+[[package]]
+name = "miniscript"
+version = "13.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd35e2c377504e50159561884b03610711db6c2fec6c89f2b98d94016684726b"
+dependencies = [
+ "bech32 0.11.1",
+ "bitcoin",
+ "hex-conservative 1.2.0",
 ]
 
 [[package]]
@@ -1422,17 +1690,18 @@ version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa5e3b6a278ed061835fe1ee293b71641e6bf8b401cfe4e1834bbf4ef0a34e1"
 dependencies = [
+ "aes 0.8.4",
  "base64 0.22.1",
- "bech32",
+ "bech32 0.11.1",
  "bip39",
  "bitcoin_hashes",
- "cbc",
- "chacha20",
- "chacha20poly1305",
+ "cbc 0.1.2",
+ "chacha20 0.9.1",
+ "chacha20poly1305 0.10.1",
  "getrandom 0.2.16",
  "hex",
  "instant",
- "scrypt",
+ "scrypt 0.11.0",
  "secp256k1",
  "serde",
  "serde_json",
@@ -1560,8 +1829,18 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -1598,9 +1877,19 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -1668,6 +1957,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,6 +1981,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1727,10 +2033,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "redb"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "redb"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
 dependencies = [
  "libc",
 ]
@@ -1746,13 +2067,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1761,7 +2082,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -1846,7 +2167,17 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1862,9 +2193,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "password-hash",
- "pbkdf2",
- "salsa20",
- "sha2",
+ "pbkdf2 0.12.2",
+ "salsa20 0.10.2",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "scrypt"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
+dependencies = [
+ "cfg-if",
+ "pbkdf2 0.13.0",
+ "salsa20 0.11.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -1977,8 +2320,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1988,8 +2331,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2013,7 +2367,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2305,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -2336,8 +2690,18 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2375,6 +2739,17 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"
@@ -2495,6 +2870,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,15 +2961,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2611,21 +2999,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2669,12 +3042,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2693,12 +3060,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2714,12 +3075,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2753,12 +3108,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2774,12 +3123,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2801,12 +3144,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2822,12 +3159,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2932,6 +3263,7 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1552,6 +1552,16 @@ impl KeepMobile {
         Ok(info)
     }
 
+    /// Abandon a pending DKG share, re-enabling `frost_run_dkg`. The pending
+    /// guard is fail-closed, so a stash that can't be recovered — its ceremony
+    /// passphrase is gone, or the record is corrupt — would otherwise refuse
+    /// every future run for good. This is the deliberate escape hatch: it
+    /// discards the share permanently, so callers must gate it behind an
+    /// explicit user confirmation. Idempotent; succeeds when nothing is pending.
+    pub fn discard_pending_dkg_share(&self) -> Result<(), KeepMobileError> {
+        persistence::delete_pending_dkg_share(&self.storage, DKG_PENDING_SHARE_KEY)
+    }
+
     pub fn import_policy(&self, bundle_hex: String) -> Result<PolicyInfo, KeepMobileError> {
         const MAX_BUNDLE_HEX_LEN: usize = 8192;
         if bundle_hex.len() > MAX_BUNDLE_HEX_LEN {
@@ -5436,5 +5446,40 @@ mod dkg_pending_share_tests {
             mobile.pending_dkg_share().is_err(),
             "a corrupt stash must not be reported as nothing pending"
         );
+    }
+
+    // An unrecoverable stash (its ceremony passphrase is gone, or it is corrupt)
+    // must not brick group creation for good: discarding it clears the stash and
+    // lets the pending guard pass again. Discard is also idempotent.
+    #[test]
+    fn discard_clears_unrecoverable_stash() {
+        let storage = Arc::new(FailingShareStorage::default());
+        let mobile = KeepMobile::new(storage.clone() as Arc<dyn SecureStorage>).unwrap();
+
+        // Nothing pending: discard is a no-op that still succeeds.
+        mobile.discard_pending_dkg_share().unwrap();
+
+        // A corrupt stash refuses new runs (guard fails closed on load error) and
+        // cannot be recovered; without discard the device is stuck here.
+        storage
+            .store_share_by_key(
+                DKG_PENDING_SHARE_KEY.into(),
+                b"not valid json".to_vec(),
+                ShareMetadataInfo {
+                    name: "dkg_pending".into(),
+                    identifier: 0,
+                    threshold: 0,
+                    total_shares: 0,
+                    group_pubkey: Vec::new(),
+                    did_backup: false,
+                },
+            )
+            .unwrap();
+        assert!(mobile.pending_dkg_share().is_err());
+
+        mobile.discard_pending_dkg_share().unwrap();
+
+        // Stash gone: the guard reports nothing pending, so a new run is unblocked.
+        assert!(mobile.pending_dkg_share().unwrap().is_none());
     }
 }

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1345,7 +1345,7 @@ impl KeepMobile {
     /// device ever holds the whole key and mobile/CLI cannot drift. `progress`
     /// receives live state; a run that fails reports [`DkgProgressUpdate::Failed`]
     /// before returning the error, and `Complete` fires only after the share is
-    /// persisted (§6/§8).
+    /// persisted (§6).
     ///
     /// Returns the stored share on success. `timeout_secs` bounds each round
     /// (floored to 30s to tolerate slow peers and biometric prompts).
@@ -1458,16 +1458,21 @@ impl KeepMobile {
         ));
 
         match outcome {
-            // §6/§8: persist first, and surface `Complete` only once the share is
+            // §6: persist first, and surface `Complete` only once the share is
             // stored. A storage failure here still emits `Failed` and never
             // `Complete`, so the group never looks ready without a stored share.
             Ok(result) => {
-                // §8: stash the finalized (passphrase-encrypted) share export
-                // durably before import so a storage failure here doesn't
-                // silently drop a share the peers already treat as live. If the
-                // stash write itself fails there's nothing more we can do, but
-                // the import below still gets its chance; recovery is only lost
-                // when both writes fail.
+                // Stash the finalized (passphrase-encrypted) share export durably
+                // before import so a storage failure here doesn't silently drop a
+                // share the peers already treat as live. NOTE: this is only a
+                // partial step toward §8's "keep `share_export` recoverable" — on
+                // the DKG path the ceremony passphrase is ephemeral, so
+                // `recover_dkg_share` can't decrypt this stash and `import_share`
+                // below is its only real chance to land. The durable copy lets
+                // `pending_dkg_share`/`discard_pending_dkg_share` surface and clear
+                // it; true recoverability is deferred to the auth-gated-alias fix
+                // (keep-6ik). If the stash write itself fails there's nothing more
+                // we can do, but the import below still gets its chance.
                 let pending = persistence::PendingDkgShare {
                     share_export: result.share_export.clone(),
                     name: name.clone(),
@@ -1516,9 +1521,11 @@ impl KeepMobile {
     }
 
     /// A DKG share whose ceremony completed but whose import into share storage
-    /// was never confirmed (§8). Present after a storage failure during
-    /// `frost_run_dkg`; the app prompts for the passphrase and calls
-    /// `recover_dkg_share` to finish. `Ok(None)` when nothing is pending; a load
+    /// was never confirmed. Present after a storage failure during
+    /// `frost_run_dkg`. Recovering it via `recover_dkg_share` needs the ceremony
+    /// passphrase, which the manual-import path has but the DKG path does not
+    /// (it is ephemeral); when it is unavailable the app clears the stash with
+    /// `discard_pending_dkg_share`. `Ok(None)` when nothing is pending; a load
     /// error is surfaced rather than masked as `None` so a corrupt or
     /// momentarily-unreadable stash can't make a live share look absent — the
     /// exact loss this feature exists to prevent — letting the app retry.

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -47,9 +47,7 @@ pub use signing_policy::{
     SignPolicySelection, SigningAuthLevel, SigningRateLimiter, SigningRequestContext,
     SigningRiskAssessment, SigningRiskFactor, UsageStats,
 };
-pub use storage::{
-    PendingShareInfo, SecureStorage, ShareInfo, ShareMetadataInfo, StoredShareInfo,
-};
+pub use storage::{PendingShareInfo, SecureStorage, ShareInfo, ShareMetadataInfo, StoredShareInfo};
 pub use types::{
     AnnouncedXpubInfo, BackupInfo, ConnectionStatus, DescriptorProposal, DeviceRegistrationInfo,
     DkgConfig, DkgParticipant, DkgProgressUpdate, FrostGenerationResult, GeneratedShareInfo,
@@ -1509,19 +1507,19 @@ impl KeepMobile {
     /// A DKG share whose ceremony completed but whose import into share storage
     /// was never confirmed (§8). Present after a storage failure during
     /// `frost_run_dkg`; the app prompts for the passphrase and calls
-    /// `recover_dkg_share` to finish. `None` when nothing is pending.
-    pub fn pending_dkg_share(&self) -> Option<PendingShareInfo> {
-        match persistence::load_pending_dkg_share(&self.storage, DKG_PENDING_SHARE_KEY) {
-            Ok(Some(pending)) => Some(PendingShareInfo {
-                name: pending.name,
-                group_pubkey: pending.group_pubkey_hex,
-            }),
-            Ok(None) => None,
-            Err(e) => {
-                tracing::warn!("failed to load pending DKG share: {e}");
-                None
-            }
-        }
+    /// `recover_dkg_share` to finish. `Ok(None)` when nothing is pending; a load
+    /// error is surfaced rather than masked as `None` so a corrupt or
+    /// momentarily-unreadable stash can't make a live share look absent — the
+    /// exact loss this feature exists to prevent — letting the app retry.
+    pub fn pending_dkg_share(&self) -> Result<Option<PendingShareInfo>, KeepMobileError> {
+        Ok(
+            persistence::load_pending_dkg_share(&self.storage, DKG_PENDING_SHARE_KEY)?.map(
+                |pending| PendingShareInfo {
+                    name: pending.name,
+                    group_pubkey: pending.group_pubkey_hex,
+                },
+            ),
+        )
     }
 
     /// Finish importing a share stashed by `frost_run_dkg` after its ceremony
@@ -1536,7 +1534,8 @@ impl KeepMobile {
 
         let info = self.import_share(pending.share_export, passphrase, pending.name)?;
 
-        if let Err(e) = persistence::delete_pending_dkg_share(&self.storage, DKG_PENDING_SHARE_KEY) {
+        if let Err(e) = persistence::delete_pending_dkg_share(&self.storage, DKG_PENDING_SHARE_KEY)
+        {
             tracing::warn!("failed to clear pending DKG share after recovery: {e}");
         }
         Ok(info)
@@ -5286,11 +5285,15 @@ mod dkg_pending_share_tests {
         )
         .unwrap();
         let import = mobile.import_share(export, passphrase.into(), name.into());
-        assert!(import.is_err(), "import must fail under the simulated full store");
+        assert!(
+            import.is_err(),
+            "import must fail under the simulated full store"
+        );
 
         // The share is not lost: it is surfaced as pending for recovery.
         let pending = mobile
             .pending_dkg_share()
+            .expect("loading the stash must not error")
             .expect("a failed import must leave a recoverable stash");
         assert_eq!(pending.name, name);
         assert_eq!(pending.group_pubkey, "deadbeef");
@@ -5303,7 +5306,7 @@ mod dkg_pending_share_tests {
             .expect("recovery must complete the import once storage is healthy");
         assert_eq!(info.name, name);
         assert!(
-            mobile.pending_dkg_share().is_none(),
+            mobile.pending_dkg_share().unwrap().is_none(),
             "a completed recovery must clear the stash"
         );
         assert!(
@@ -5332,7 +5335,7 @@ mod dkg_pending_share_tests {
 
         assert!(mobile.recover_dkg_share("wrong-pass".into()).is_err());
         assert!(
-            mobile.pending_dkg_share().is_some(),
+            mobile.pending_dkg_share().unwrap().is_some(),
             "a failed recovery must keep the share recoverable"
         );
     }
@@ -5342,7 +5345,35 @@ mod dkg_pending_share_tests {
     fn recover_without_pending_share_errors() {
         let storage: Arc<dyn SecureStorage> = Arc::new(FailingShareStorage::default());
         let mobile = KeepMobile::new(storage).unwrap();
-        assert!(mobile.pending_dkg_share().is_none());
+        assert!(mobile.pending_dkg_share().unwrap().is_none());
         assert!(mobile.recover_dkg_share("pass".into()).is_err());
+    }
+
+    // A corrupt stash must surface as an error, not be masked as "nothing
+    // pending" — otherwise a live share would look absent and never recover.
+    #[test]
+    fn unreadable_stash_surfaces_as_error() {
+        let storage = Arc::new(FailingShareStorage::default());
+        let mobile = KeepMobile::new(storage.clone() as Arc<dyn SecureStorage>).unwrap();
+
+        storage
+            .store_share_by_key(
+                DKG_PENDING_SHARE_KEY.into(),
+                b"not valid json".to_vec(),
+                ShareMetadataInfo {
+                    name: "dkg_pending".into(),
+                    identifier: 0,
+                    threshold: 0,
+                    total_shares: 0,
+                    group_pubkey: Vec::new(),
+                    did_backup: false,
+                },
+            )
+            .unwrap();
+
+        assert!(
+            mobile.pending_dkg_share().is_err(),
+            "a corrupt stash must not be reported as nothing pending"
+        );
     }
 }

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -827,40 +827,6 @@ impl KeepMobile {
         self.store_share_package(&share)
     }
 
-    /// Import a completed DKG share, retrying a bounded number of times while the
-    /// ceremony passphrase is still live. The DKG passphrase is ephemeral (the
-    /// app generates it per run and wipes it), so `recover_dkg_share` cannot
-    /// finish an import that failed once the run returns; a transient storage
-    /// error must therefore be absorbed here or the share is only discardable.
-    /// The import is keyed by group pubkey, so a retry after a partial write
-    /// overwrites rather than duplicates. A persistent failure exhausts the
-    /// attempts and falls through to the retained stash unchanged.
-    fn import_share_retrying(
-        &self,
-        share_export: &str,
-        passphrase: &str,
-        name: &str,
-    ) -> Result<ShareInfo, KeepMobileError> {
-        const MAX_ATTEMPTS: u32 = 3;
-        let mut attempt = 1;
-        loop {
-            match self.import_share(
-                share_export.to_string(),
-                passphrase.to_string(),
-                name.to_string(),
-            ) {
-                Ok(info) => return Ok(info),
-                Err(e) if attempt < MAX_ATTEMPTS => {
-                    tracing::warn!(
-                        "import of completed DKG share failed (attempt {attempt}/{MAX_ATTEMPTS}), retrying: {e}"
-                    );
-                    attempt += 1;
-                }
-                Err(e) => return Err(e),
-            }
-        }
-    }
-
     pub fn import_nsec(&self, nsec: Vec<u8>, name: String) -> Result<ShareInfo, KeepMobileError> {
         use nostr_sdk::prelude::{FromBech32, SecretKey};
         // Accept the nsec as wipeable bytes (a Kotlin ByteArray) rather than an
@@ -1515,12 +1481,7 @@ impl KeepMobile {
                     tracing::warn!("failed to stash pending DKG share before import: {e}");
                 }
 
-                // Retry the import in-process while the passphrase is still live:
-                // it is ephemeral, so `recover_dkg_share` can't finish an import
-                // that failed after the run returns. This absorbs a transient
-                // storage error; a persistent one still falls through to the
-                // stash below.
-                match self.import_share_retrying(&result.share_export, &passphrase, &name) {
+                match self.import_share(result.share_export, passphrase.to_string(), name) {
                     Ok(info) => {
                         // Import confirmed; clear the stash (best-effort — a stale
                         // stash is recovered idempotently, never lost).
@@ -5237,20 +5198,17 @@ mod dkg_pending_share_tests {
     use super::*;
     use crate::storage::{SecureStorage, ShareMetadataInfo};
     use std::collections::HashMap;
-    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Mutex as StdMutex;
 
     /// Secure storage that can be told to fail writes for real share records
     /// (any key not using the reserved `__keep_` namespace), modelling the
     /// full-store / encrypted-write failure that drops a completed DKG share.
-    /// `fail_shares` fails every real-share write (a persistent failure);
-    /// `fail_next_share_writes` fails only the next N (a transient one).
     #[derive(Default)]
     struct FailingShareStorage {
         data: StdMutex<HashMap<String, Vec<u8>>>,
         active: StdMutex<Option<String>>,
         fail_shares: AtomicBool,
-        fail_next_share_writes: AtomicU32,
     }
 
     impl SecureStorage for FailingShareStorage {
@@ -5275,20 +5233,10 @@ mod dkg_pending_share_tests {
             data: Vec<u8>,
             _: ShareMetadataInfo,
         ) -> Result<(), KeepMobileError> {
-            if !key.starts_with("__keep_") {
-                if self.fail_shares.load(Ordering::Relaxed) {
-                    return Err(KeepMobileError::StorageError {
-                        msg: "simulated full store".into(),
-                    });
-                }
-                let remaining = self.fail_next_share_writes.load(Ordering::Relaxed);
-                if remaining > 0 {
-                    self.fail_next_share_writes
-                        .store(remaining - 1, Ordering::Relaxed);
-                    return Err(KeepMobileError::StorageError {
-                        msg: "simulated transient store failure".into(),
-                    });
-                }
+            if !key.starts_with("__keep_") && self.fail_shares.load(Ordering::Relaxed) {
+                return Err(KeepMobileError::StorageError {
+                    msg: "simulated full store".into(),
+                });
             }
             self.data.lock().unwrap().insert(key, data);
             Ok(())
@@ -5533,44 +5481,5 @@ mod dkg_pending_share_tests {
 
         // Stash gone: the guard reports nothing pending, so a new run is unblocked.
         assert!(mobile.pending_dkg_share().unwrap().is_none());
-    }
-
-    // A transient storage failure during the post-ceremony import must be
-    // absorbed in-process (the passphrase is still live), so a completed DKG
-    // share imports without needing the unreachable recovery path. A share that
-    // fails fewer times than the retry budget still lands.
-    #[test]
-    fn import_retry_absorbs_transient_storage_failure() {
-        let storage = Arc::new(FailingShareStorage::default());
-        let mobile = KeepMobile::new(storage.clone() as Arc<dyn SecureStorage>).unwrap();
-
-        let passphrase = "correct horse battery staple";
-        let name = "ceremony-share";
-        let export = share_export(passphrase, name);
-
-        // Fail the first two share writes, then succeed — within the 3-attempt
-        // budget.
-        storage.fail_next_share_writes.store(2, Ordering::Relaxed);
-        let info = mobile
-            .import_share_retrying(&export, passphrase, name)
-            .expect("a transient failure inside the retry budget must still import");
-        assert_eq!(info.name, name);
-        assert!(mobile.get_active_share().is_some());
-    }
-
-    // A persistent storage failure exhausts the retries and surfaces the error,
-    // leaving recovery to the retained stash rather than looping forever.
-    #[test]
-    fn import_retry_gives_up_on_persistent_failure() {
-        let storage = Arc::new(FailingShareStorage::default());
-        let mobile = KeepMobile::new(storage.clone() as Arc<dyn SecureStorage>).unwrap();
-
-        let passphrase = "correct horse battery staple";
-        let export = share_export(passphrase, "share");
-
-        storage.fail_shares.store(true, Ordering::Relaxed);
-        assert!(mobile
-            .import_share_retrying(&export, passphrase, "share")
-            .is_err());
     }
 }

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1392,6 +1392,17 @@ impl KeepMobile {
             });
         }
 
+        // The pending stash is a single global slot, so a run that completed
+        // here would overwrite an earlier unrecovered stash and lose that share
+        // for good. Refuse to start until the prior share is recovered; fail
+        // closed on a load error so a corrupt stash is never silently clobbered.
+        if persistence::load_pending_dkg_share(&self.storage, DKG_PENDING_SHARE_KEY)?.is_some() {
+            return Err(KeepMobileError::StorageError {
+                msg: "a completed DKG share is pending recovery; recover it before starting a new run"
+                    .into(),
+            });
+        }
+
         // Load this device's pending subkey (from `frost_dkg_begin`) and rebuild
         // its keypair. Fail before any network I/O if the two-call sequence was
         // skipped.
@@ -5347,6 +5358,56 @@ mod dkg_pending_share_tests {
         let mobile = KeepMobile::new(storage).unwrap();
         assert!(mobile.pending_dkg_share().unwrap().is_none());
         assert!(mobile.recover_dkg_share("pass".into()).is_err());
+    }
+
+    // A new DKG run must refuse to start while an earlier share is still pending
+    // recovery, so its completion can't overwrite the single-slot stash and lose
+    // the earlier share. The reject happens in pre-flight, before any network I/O.
+    #[test]
+    fn run_dkg_rejected_while_share_pending_recovery() {
+        let storage = Arc::new(FailingShareStorage::default());
+        let mobile = KeepMobile::new(storage.clone() as Arc<dyn SecureStorage>).unwrap();
+
+        persistence::persist_pending_dkg_share(
+            &(storage.clone() as Arc<dyn SecureStorage>),
+            DKG_PENDING_SHARE_KEY,
+            &persistence::PendingDkgShare {
+                share_export: share_export("pass", "prior"),
+                name: "prior".into(),
+                group_pubkey_hex: "abc123".into(),
+            },
+        )
+        .unwrap();
+
+        struct NoopProgress;
+        impl dkg::DkgProgressCallback for NoopProgress {
+            fn on_progress(&self, _: DkgProgressUpdate) {}
+        }
+
+        let config = DkgConfig {
+            group_name: "new-group".into(),
+            threshold: 2,
+            participants: 3,
+            our_index: 1,
+            relays: vec!["wss://relay.example".into()],
+            roster: Vec::new(),
+        };
+        let err = mobile
+            .frost_run_dkg(
+                config,
+                "new-share".into(),
+                "pass".into(),
+                30,
+                Arc::new(NoopProgress),
+            )
+            .expect_err("a new run must be refused while a share is pending recovery");
+        assert!(
+            matches!(err, KeepMobileError::StorageError { .. }),
+            "expected a storage error, got {err:?}"
+        );
+
+        // The prior stash is untouched and still recoverable.
+        assert!(mobile.pending_dkg_share().unwrap().is_some());
     }
 
     // A corrupt stash must surface as an error, not be masked as "nothing

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -47,7 +47,9 @@ pub use signing_policy::{
     SignPolicySelection, SigningAuthLevel, SigningRateLimiter, SigningRequestContext,
     SigningRiskAssessment, SigningRiskFactor, UsageStats,
 };
-pub use storage::{SecureStorage, ShareInfo, ShareMetadataInfo, StoredShareInfo};
+pub use storage::{
+    PendingShareInfo, SecureStorage, ShareInfo, ShareMetadataInfo, StoredShareInfo,
+};
 pub use types::{
     AnnouncedXpubInfo, BackupInfo, ConnectionStatus, DescriptorProposal, DeviceRegistrationInfo,
     DkgConfig, DkgParticipant, DkgProgressUpdate, FrostGenerationResult, GeneratedShareInfo,
@@ -320,6 +322,7 @@ const PROXY_CONFIG_STORAGE_KEY: &str = "__keep_proxy_config_v1";
 const STRICT_PIN_CONFIG_STORAGE_KEY: &str = "__keep_strict_pin_config_v1";
 const BUNKER_CONFIG_STORAGE_KEY: &str = "__keep_bunker_config_v1";
 const KILL_SWITCH_STORAGE_KEY: &str = "__keep_kill_switch_v1";
+const DKG_PENDING_SHARE_KEY: &str = "__keep_dkg_pending_v1";
 const DESCRIPTOR_SESSION_TIMEOUT: Duration = Duration::from_secs(600);
 
 #[derive(uniffi::Record)]
@@ -1450,14 +1453,43 @@ impl KeepMobile {
             // stored. A storage failure here still emits `Failed` and never
             // `Complete`, so the group never looks ready without a stored share.
             Ok(result) => {
+                // §8: stash the finalized (passphrase-encrypted) share export
+                // durably before import so a storage failure here doesn't
+                // silently drop a share the peers already treat as live. If the
+                // stash write itself fails there's nothing more we can do, but
+                // the import below still gets its chance; recovery is only lost
+                // when both writes fail.
+                let pending = persistence::PendingDkgShare {
+                    share_export: result.share_export.clone(),
+                    name: name.clone(),
+                    group_pubkey_hex: result.group_pubkey.clone(),
+                };
+                if let Err(e) = persistence::persist_pending_dkg_share(
+                    &self.storage,
+                    DKG_PENDING_SHARE_KEY,
+                    &pending,
+                ) {
+                    tracing::warn!("failed to stash pending DKG share before import: {e}");
+                }
+
                 match self.import_share(result.share_export, passphrase.to_string(), name) {
                     Ok(info) => {
+                        // Import confirmed; clear the stash (best-effort — a stale
+                        // stash is recovered idempotently, never lost).
+                        if let Err(e) = persistence::delete_pending_dkg_share(
+                            &self.storage,
+                            DKG_PENDING_SHARE_KEY,
+                        ) {
+                            tracing::warn!("failed to clear pending DKG share after import: {e}");
+                        }
                         progress.on_progress(DkgProgressUpdate::Complete {
                             group_pubkey: result.group_pubkey,
                         });
                         Ok(info)
                     }
                     Err(e) => {
+                        // Stash retained: `recover_dkg_share` can finish the
+                        // import on next launch. Never emit `Complete`.
                         progress.on_progress(DkgProgressUpdate::Failed {
                             reason: e.to_string(),
                         });
@@ -1472,6 +1504,42 @@ impl KeepMobile {
                 Err(e)
             }
         }
+    }
+
+    /// A DKG share whose ceremony completed but whose import into share storage
+    /// was never confirmed (§8). Present after a storage failure during
+    /// `frost_run_dkg`; the app prompts for the passphrase and calls
+    /// `recover_dkg_share` to finish. `None` when nothing is pending.
+    pub fn pending_dkg_share(&self) -> Option<PendingShareInfo> {
+        match persistence::load_pending_dkg_share(&self.storage, DKG_PENDING_SHARE_KEY) {
+            Ok(Some(pending)) => Some(PendingShareInfo {
+                name: pending.name,
+                group_pubkey: pending.group_pubkey_hex,
+            }),
+            Ok(None) => None,
+            Err(e) => {
+                tracing::warn!("failed to load pending DKG share: {e}");
+                None
+            }
+        }
+    }
+
+    /// Finish importing a share stashed by `frost_run_dkg` after its ceremony
+    /// completed but its import failed. Re-runs the import with the supplied
+    /// passphrase (which decrypts `share_export` and so cannot be persisted) and
+    /// clears the stash on success. Errors if nothing is pending.
+    pub fn recover_dkg_share(&self, passphrase: String) -> Result<ShareInfo, KeepMobileError> {
+        let pending = persistence::load_pending_dkg_share(&self.storage, DKG_PENDING_SHARE_KEY)?
+            .ok_or_else(|| KeepMobileError::StorageError {
+                msg: "no pending DKG share to recover".into(),
+            })?;
+
+        let info = self.import_share(pending.share_export, passphrase, pending.name)?;
+
+        if let Err(e) = persistence::delete_pending_dkg_share(&self.storage, DKG_PENDING_SHARE_KEY) {
+            tracing::warn!("failed to clear pending DKG share after recovery: {e}");
+        }
+        Ok(info)
     }
 
     pub fn import_policy(&self, bundle_hex: String) -> Result<PolicyInfo, KeepMobileError> {
@@ -5102,5 +5170,179 @@ mod baseline_presign_policy_tests {
                 message,
             ))
             .expect("a pre-approved request with an ordinary label must still pass");
+    }
+}
+
+#[cfg(test)]
+mod dkg_pending_share_tests {
+    use super::*;
+    use crate::storage::{SecureStorage, ShareMetadataInfo};
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Mutex as StdMutex;
+
+    /// Secure storage that can be told to fail writes for real share records
+    /// (any key not using the reserved `__keep_` namespace), modelling the
+    /// full-store / encrypted-write failure that drops a completed DKG share.
+    #[derive(Default)]
+    struct FailingShareStorage {
+        data: StdMutex<HashMap<String, Vec<u8>>>,
+        active: StdMutex<Option<String>>,
+        fail_shares: AtomicBool,
+    }
+
+    impl SecureStorage for FailingShareStorage {
+        fn store_share(&self, _: Vec<u8>, _: ShareMetadataInfo) -> Result<(), KeepMobileError> {
+            Ok(())
+        }
+        fn load_share(&self) -> Result<Vec<u8>, KeepMobileError> {
+            Err(KeepMobileError::StorageNotFound)
+        }
+        fn has_share(&self) -> bool {
+            false
+        }
+        fn get_share_metadata(&self) -> Option<ShareMetadataInfo> {
+            None
+        }
+        fn delete_share(&self) -> Result<(), KeepMobileError> {
+            Ok(())
+        }
+        fn store_share_by_key(
+            &self,
+            key: String,
+            data: Vec<u8>,
+            _: ShareMetadataInfo,
+        ) -> Result<(), KeepMobileError> {
+            if !key.starts_with("__keep_") && self.fail_shares.load(Ordering::Relaxed) {
+                return Err(KeepMobileError::StorageError {
+                    msg: "simulated full store".into(),
+                });
+            }
+            self.data.lock().unwrap().insert(key, data);
+            Ok(())
+        }
+        fn load_share_by_key(&self, key: String) -> Result<Vec<u8>, KeepMobileError> {
+            self.data
+                .lock()
+                .unwrap()
+                .get(&key)
+                .cloned()
+                .ok_or(KeepMobileError::StorageNotFound)
+        }
+        fn list_all_shares(&self) -> Vec<ShareMetadataInfo> {
+            Vec::new()
+        }
+        fn delete_share_by_key(&self, key: String) -> Result<(), KeepMobileError> {
+            self.data.lock().unwrap().remove(&key);
+            Ok(())
+        }
+        fn get_active_share_key(&self) -> Option<String> {
+            self.active.lock().unwrap().clone()
+        }
+        fn set_active_share_key(&self, key: Option<String>) -> Result<(), KeepMobileError> {
+            *self.active.lock().unwrap() = key;
+            Ok(())
+        }
+    }
+
+    /// Build a valid passphrase-encrypted share export string, as a completed
+    /// DKG would hand to `import_share`.
+    fn share_export(passphrase: &str, name: &str) -> String {
+        let key_bytes = Zeroizing::new(hex::decode("07".repeat(32)).unwrap());
+        let (key_package, pubkey_package, vk_bytes) =
+            KeepMobile::build_nsec_packages(&key_bytes).unwrap();
+        let group_pubkey: [u8; 32] = vk_bytes[1..33].try_into().unwrap();
+        let metadata = ShareMetadata::new(1, 1, 1, group_pubkey, name.into());
+        let share = SharePackage::new(metadata, &key_package, &pubkey_package).unwrap();
+        ShareExport::from_share(&share, passphrase)
+            .unwrap()
+            .to_json()
+            .unwrap()
+    }
+
+    // A storage failure during the post-ceremony import must leave the finalized
+    // share export durably stashed (never silently dropped), and a later
+    // `recover_dkg_share` must complete the import and clear the stash.
+    #[test]
+    fn stash_survives_import_failure_and_recovers() {
+        let storage = Arc::new(FailingShareStorage::default());
+        let mobile = KeepMobile::new(storage.clone() as Arc<dyn SecureStorage>).unwrap();
+
+        let passphrase = "correct horse battery staple";
+        let name = "ceremony-share";
+        let export = share_export(passphrase, name);
+
+        // Reproduce `frost_run_dkg`'s post-ceremony path: stash first, then let
+        // the import fail the way a full store would.
+        storage.fail_shares.store(true, Ordering::Relaxed);
+        persistence::persist_pending_dkg_share(
+            &(storage.clone() as Arc<dyn SecureStorage>),
+            DKG_PENDING_SHARE_KEY,
+            &persistence::PendingDkgShare {
+                share_export: export.clone(),
+                name: name.into(),
+                group_pubkey_hex: "deadbeef".into(),
+            },
+        )
+        .unwrap();
+        let import = mobile.import_share(export, passphrase.into(), name.into());
+        assert!(import.is_err(), "import must fail under the simulated full store");
+
+        // The share is not lost: it is surfaced as pending for recovery.
+        let pending = mobile
+            .pending_dkg_share()
+            .expect("a failed import must leave a recoverable stash");
+        assert_eq!(pending.name, name);
+        assert_eq!(pending.group_pubkey, "deadbeef");
+
+        // Storage recovers; finishing the import stores the share and clears the
+        // stash so it is not replayed.
+        storage.fail_shares.store(false, Ordering::Relaxed);
+        let info = mobile
+            .recover_dkg_share(passphrase.into())
+            .expect("recovery must complete the import once storage is healthy");
+        assert_eq!(info.name, name);
+        assert!(
+            mobile.pending_dkg_share().is_none(),
+            "a completed recovery must clear the stash"
+        );
+        assert!(
+            mobile.get_active_share().is_some(),
+            "the recovered share must be stored and active"
+        );
+    }
+
+    // A wrong passphrase must not clear the stash: the share stays recoverable.
+    #[test]
+    fn failed_recovery_retains_stash() {
+        let storage = Arc::new(FailingShareStorage::default());
+        let mobile = KeepMobile::new(storage.clone() as Arc<dyn SecureStorage>).unwrap();
+
+        let export = share_export("right-pass", "share");
+        persistence::persist_pending_dkg_share(
+            &(storage.clone() as Arc<dyn SecureStorage>),
+            DKG_PENDING_SHARE_KEY,
+            &persistence::PendingDkgShare {
+                share_export: export,
+                name: "share".into(),
+                group_pubkey_hex: "abc123".into(),
+            },
+        )
+        .unwrap();
+
+        assert!(mobile.recover_dkg_share("wrong-pass".into()).is_err());
+        assert!(
+            mobile.pending_dkg_share().is_some(),
+            "a failed recovery must keep the share recoverable"
+        );
+    }
+
+    // With nothing stashed, recovery reports there is nothing to do.
+    #[test]
+    fn recover_without_pending_share_errors() {
+        let storage: Arc<dyn SecureStorage> = Arc::new(FailingShareStorage::default());
+        let mobile = KeepMobile::new(storage).unwrap();
+        assert!(mobile.pending_dkg_share().is_none());
+        assert!(mobile.recover_dkg_share("pass".into()).is_err());
     }
 }

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -827,6 +827,40 @@ impl KeepMobile {
         self.store_share_package(&share)
     }
 
+    /// Import a completed DKG share, retrying a bounded number of times while the
+    /// ceremony passphrase is still live. The DKG passphrase is ephemeral (the
+    /// app generates it per run and wipes it), so `recover_dkg_share` cannot
+    /// finish an import that failed once the run returns; a transient storage
+    /// error must therefore be absorbed here or the share is only discardable.
+    /// The import is keyed by group pubkey, so a retry after a partial write
+    /// overwrites rather than duplicates. A persistent failure exhausts the
+    /// attempts and falls through to the retained stash unchanged.
+    fn import_share_retrying(
+        &self,
+        share_export: &str,
+        passphrase: &str,
+        name: &str,
+    ) -> Result<ShareInfo, KeepMobileError> {
+        const MAX_ATTEMPTS: u32 = 3;
+        let mut attempt = 1;
+        loop {
+            match self.import_share(
+                share_export.to_string(),
+                passphrase.to_string(),
+                name.to_string(),
+            ) {
+                Ok(info) => return Ok(info),
+                Err(e) if attempt < MAX_ATTEMPTS => {
+                    tracing::warn!(
+                        "import of completed DKG share failed (attempt {attempt}/{MAX_ATTEMPTS}), retrying: {e}"
+                    );
+                    attempt += 1;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
     pub fn import_nsec(&self, nsec: Vec<u8>, name: String) -> Result<ShareInfo, KeepMobileError> {
         use nostr_sdk::prelude::{FromBech32, SecretKey};
         // Accept the nsec as wipeable bytes (a Kotlin ByteArray) rather than an
@@ -1481,7 +1515,12 @@ impl KeepMobile {
                     tracing::warn!("failed to stash pending DKG share before import: {e}");
                 }
 
-                match self.import_share(result.share_export, passphrase.to_string(), name) {
+                // Retry the import in-process while the passphrase is still live:
+                // it is ephemeral, so `recover_dkg_share` can't finish an import
+                // that failed after the run returns. This absorbs a transient
+                // storage error; a persistent one still falls through to the
+                // stash below.
+                match self.import_share_retrying(&result.share_export, &passphrase, &name) {
                     Ok(info) => {
                         // Import confirmed; clear the stash (best-effort — a stale
                         // stash is recovered idempotently, never lost).
@@ -5198,17 +5237,20 @@ mod dkg_pending_share_tests {
     use super::*;
     use crate::storage::{SecureStorage, ShareMetadataInfo};
     use std::collections::HashMap;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
     use std::sync::Mutex as StdMutex;
 
     /// Secure storage that can be told to fail writes for real share records
     /// (any key not using the reserved `__keep_` namespace), modelling the
     /// full-store / encrypted-write failure that drops a completed DKG share.
+    /// `fail_shares` fails every real-share write (a persistent failure);
+    /// `fail_next_share_writes` fails only the next N (a transient one).
     #[derive(Default)]
     struct FailingShareStorage {
         data: StdMutex<HashMap<String, Vec<u8>>>,
         active: StdMutex<Option<String>>,
         fail_shares: AtomicBool,
+        fail_next_share_writes: AtomicU32,
     }
 
     impl SecureStorage for FailingShareStorage {
@@ -5233,10 +5275,20 @@ mod dkg_pending_share_tests {
             data: Vec<u8>,
             _: ShareMetadataInfo,
         ) -> Result<(), KeepMobileError> {
-            if !key.starts_with("__keep_") && self.fail_shares.load(Ordering::Relaxed) {
-                return Err(KeepMobileError::StorageError {
-                    msg: "simulated full store".into(),
-                });
+            if !key.starts_with("__keep_") {
+                if self.fail_shares.load(Ordering::Relaxed) {
+                    return Err(KeepMobileError::StorageError {
+                        msg: "simulated full store".into(),
+                    });
+                }
+                let remaining = self.fail_next_share_writes.load(Ordering::Relaxed);
+                if remaining > 0 {
+                    self.fail_next_share_writes
+                        .store(remaining - 1, Ordering::Relaxed);
+                    return Err(KeepMobileError::StorageError {
+                        msg: "simulated transient store failure".into(),
+                    });
+                }
             }
             self.data.lock().unwrap().insert(key, data);
             Ok(())
@@ -5481,5 +5533,44 @@ mod dkg_pending_share_tests {
 
         // Stash gone: the guard reports nothing pending, so a new run is unblocked.
         assert!(mobile.pending_dkg_share().unwrap().is_none());
+    }
+
+    // A transient storage failure during the post-ceremony import must be
+    // absorbed in-process (the passphrase is still live), so a completed DKG
+    // share imports without needing the unreachable recovery path. A share that
+    // fails fewer times than the retry budget still lands.
+    #[test]
+    fn import_retry_absorbs_transient_storage_failure() {
+        let storage = Arc::new(FailingShareStorage::default());
+        let mobile = KeepMobile::new(storage.clone() as Arc<dyn SecureStorage>).unwrap();
+
+        let passphrase = "correct horse battery staple";
+        let name = "ceremony-share";
+        let export = share_export(passphrase, name);
+
+        // Fail the first two share writes, then succeed — within the 3-attempt
+        // budget.
+        storage.fail_next_share_writes.store(2, Ordering::Relaxed);
+        let info = mobile
+            .import_share_retrying(&export, passphrase, name)
+            .expect("a transient failure inside the retry budget must still import");
+        assert_eq!(info.name, name);
+        assert!(mobile.get_active_share().is_some());
+    }
+
+    // A persistent storage failure exhausts the retries and surfaces the error,
+    // leaving recovery to the retained stash rather than looping forever.
+    #[test]
+    fn import_retry_gives_up_on_persistent_failure() {
+        let storage = Arc::new(FailingShareStorage::default());
+        let mobile = KeepMobile::new(storage.clone() as Arc<dyn SecureStorage>).unwrap();
+
+        let passphrase = "correct horse battery staple";
+        let export = share_export(passphrase, "share");
+
+        storage.fail_shares.store(true, Ordering::Relaxed);
+        assert!(mobile
+            .import_share_retrying(&export, passphrase, "share")
+            .is_err());
     }
 }

--- a/keep-mobile/src/persistence.rs
+++ b/keep-mobile/src/persistence.rs
@@ -752,3 +752,53 @@ pub(crate) fn persist_kill_switch(
     })?;
     storage.store_share_by_key(key.into(), data, storage_metadata("kill_switch"))
 }
+
+/// A DKG share that finished the ceremony but whose import into share storage
+/// has not yet been confirmed. `share_export` is the passphrase-encrypted
+/// portable share, so the stash carries no plaintext key material. Persisted
+/// before import so a storage failure doesn't silently drop a share the peers
+/// already treat as live (§8), and recovered via `recover_dkg_share`.
+#[derive(Serialize, Deserialize)]
+pub(crate) struct PendingDkgShare {
+    pub(crate) share_export: String,
+    pub(crate) name: String,
+    pub(crate) group_pubkey_hex: String,
+}
+
+pub(crate) fn persist_pending_dkg_share(
+    storage: &Arc<dyn SecureStorage>,
+    key: &str,
+    pending: &PendingDkgShare,
+) -> Result<(), KeepMobileError> {
+    let data = serde_json::to_vec(pending).map_err(|e| KeepMobileError::StorageError {
+        msg: format!("failed to serialize pending DKG share: {e}"),
+    })?;
+    storage.store_share_by_key(key.into(), data, storage_metadata("dkg_pending"))
+}
+
+pub(crate) fn load_pending_dkg_share(
+    storage: &Arc<dyn SecureStorage>,
+    key: &str,
+) -> Result<Option<PendingDkgShare>, KeepMobileError> {
+    match storage.load_share_by_key(key.into()) {
+        Ok(data) => {
+            let pending =
+                serde_json::from_slice(&data).map_err(|e| KeepMobileError::StorageError {
+                    msg: format!("failed to deserialize pending DKG share: {e}"),
+                })?;
+            Ok(Some(pending))
+        }
+        Err(KeepMobileError::StorageNotFound) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+pub(crate) fn delete_pending_dkg_share(
+    storage: &Arc<dyn SecureStorage>,
+    key: &str,
+) -> Result<(), KeepMobileError> {
+    match storage.delete_share_by_key(key.into()) {
+        Ok(()) | Err(KeepMobileError::StorageNotFound) => Ok(()),
+        Err(e) => Err(e),
+    }
+}

--- a/keep-mobile/src/storage.rs
+++ b/keep-mobile/src/storage.rs
@@ -22,6 +22,15 @@ pub struct ShareInfo {
     pub group_pubkey: String,
 }
 
+/// A DKG share that completed its ceremony but whose import has not yet been
+/// confirmed persisted. Surfaced after relaunch so the app can prompt for the
+/// passphrase and finish the import via `recover_dkg_share`.
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct PendingShareInfo {
+    pub name: String,
+    pub group_pubkey: String,
+}
+
 #[derive(uniffi::Record, Clone, Debug)]
 pub struct StoredShareInfo {
     pub group_pubkey: String,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added safeguards to prevent starting a new DKG process while a completed share is pending.
  - Pending shares are securely retained across app restarts and cleared after successful import.
  - Added options to view pending share details, recover shares using a passphrase, or discard them.
  - Added handling for missing or unavailable pending shares.
  - Pending shares are protected from being overwritten during recovery or import failures.
  - Added recovery support when importing a pending share fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->