### PR TITLE
Make DKG pending share recoverable via a vault-protected stash

### DIFF
--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -320,7 +320,13 @@ const PROXY_CONFIG_STORAGE_KEY: &str = "__keep_proxy_config_v1";
 const STRICT_PIN_CONFIG_STORAGE_KEY: &str = "__keep_strict_pin_config_v1";
 const BUNKER_CONFIG_STORAGE_KEY: &str = "__keep_bunker_config_v1";
 const KILL_SWITCH_STORAGE_KEY: &str = "__keep_kill_switch_v1";
-const DKG_PENDING_SHARE_KEY: &str = "__keep_dkg_pending_v1";
+/// Non-sensitive pending-DKG marker (name/group/protection). Under the `__keep_`
+/// metadata namespace so it reads without a vault unlock.
+const DKG_PENDING_MARKER_KEY: &str = "__keep_dkg_pending_v1";
+/// Sensitive pending-DKG secret (share export + ephemeral passphrase). The
+/// platform routes this reserved key to a dedicated auth-gated (`requireUserAuth`)
+/// alias, so it is not app-uid-readable at rest and loading it costs a vault unlock.
+const DKG_PENDING_SECRET_KEY: &str = "__keep_dkg_secret_v1";
 const DESCRIPTOR_SESSION_TIMEOUT: Duration = Duration::from_secs(600);
 
 #[derive(uniffi::Record)]
@@ -1396,7 +1402,7 @@ impl KeepMobile {
         // here would overwrite an earlier unrecovered stash and lose that share
         // for good. Refuse to start until the prior share is recovered; fail
         // closed on a load error so a corrupt stash is never silently clobbered.
-        if persistence::load_pending_dkg_share(&self.storage, DKG_PENDING_SHARE_KEY)?.is_some() {
+        if persistence::load_pending_dkg_marker(&self.storage, DKG_PENDING_MARKER_KEY)?.is_some() {
             return Err(KeepMobileError::StorageError {
                 msg: "a completed DKG share is pending recovery; recover it before starting a new run"
                     .into(),
@@ -1462,39 +1468,53 @@ impl KeepMobile {
             // stored. A storage failure here still emits `Failed` and never
             // `Complete`, so the group never looks ready without a stored share.
             Ok(result) => {
-                // Stash the finalized (passphrase-encrypted) share export durably
-                // before import so a storage failure here doesn't silently drop a
-                // share the peers already treat as live. NOTE: this is only a
-                // partial step toward §8's "keep `share_export` recoverable" — on
-                // the DKG path the ceremony passphrase is ephemeral, so
-                // `recover_dkg_share` can't decrypt this stash and `import_share`
-                // below is its only real chance to land. The durable copy lets
-                // `pending_dkg_share`/`discard_pending_dkg_share` surface and clear
-                // it; true recoverability is deferred to the auth-gated-alias fix
-                // (keep-6ik). If the stash write itself fails there's nothing more
-                // we can do, but the import below still gets its chance.
-                let pending = persistence::PendingDkgShare {
+                // Stash the finalized share durably before import so a storage
+                // failure here doesn't silently drop a share the peers already
+                // treat as live, AND make it recoverable (§8): the ceremony
+                // passphrase is ephemeral, so it is stashed inside the auth-gated
+                // secret and the blob's at-rest protection is bound to the device
+                // vault, not the passphrase. `recover_dkg_share` then needs only a
+                // vault unlock. Write the auth-gated secret first, then the
+                // non-sensitive marker: the marker is what gates recovery, so a
+                // half-write that leaves a secret without a marker is the safe
+                // failure (invisible, overwritten by the next run) rather than a
+                // marker pointing at a secret that never landed. Best-effort — if
+                // the stash write fails the import below still gets its chance.
+                let secret = persistence::PendingDkgSecret {
+                    schema_version: persistence::DKG_STASH_SCHEMA_VERSION,
                     share_export: result.share_export.clone(),
+                    vault_passphrase: Some(passphrase.to_string()),
+                };
+                let marker = persistence::PendingDkgMarker {
+                    schema_version: persistence::DKG_STASH_SCHEMA_VERSION,
                     name: name.clone(),
                     group_pubkey_hex: result.group_pubkey.clone(),
+                    vault_protected: true,
                 };
-                if let Err(e) = persistence::persist_pending_dkg_share(
+                if let Err(e) = persistence::persist_pending_dkg_secret(
                     &self.storage,
-                    DKG_PENDING_SHARE_KEY,
-                    &pending,
+                    DKG_PENDING_SECRET_KEY,
+                    &secret,
                 ) {
-                    tracing::warn!("failed to stash pending DKG share before import: {e}");
+                    tracing::warn!("failed to stash pending DKG secret before import: {e}");
+                } else if let Err(e) = persistence::persist_pending_dkg_marker(
+                    &self.storage,
+                    DKG_PENDING_MARKER_KEY,
+                    &marker,
+                ) {
+                    tracing::warn!("failed to stash pending DKG marker before import: {e}");
                 }
 
                 match self.import_share(result.share_export, passphrase.to_string(), name) {
                     Ok(info) => {
                         // Import confirmed; clear the stash (best-effort — a stale
                         // stash is recovered idempotently, never lost).
-                        if let Err(e) = persistence::delete_pending_dkg_share(
+                        if let Err(e) = persistence::delete_pending_dkg_stash(
                             &self.storage,
-                            DKG_PENDING_SHARE_KEY,
+                            DKG_PENDING_MARKER_KEY,
+                            DKG_PENDING_SECRET_KEY,
                         ) {
-                            tracing::warn!("failed to clear pending DKG share after import: {e}");
+                            tracing::warn!("failed to clear pending DKG stash after import: {e}");
                         }
                         progress.on_progress(DkgProgressUpdate::Complete {
                             group_pubkey: result.group_pubkey,
@@ -1531,42 +1551,72 @@ impl KeepMobile {
     /// exact loss this feature exists to prevent — letting the app retry.
     pub fn pending_dkg_share(&self) -> Result<Option<PendingShareInfo>, KeepMobileError> {
         Ok(
-            persistence::load_pending_dkg_share(&self.storage, DKG_PENDING_SHARE_KEY)?.map(
-                |pending| PendingShareInfo {
-                    name: pending.name,
-                    group_pubkey: pending.group_pubkey_hex,
+            persistence::load_pending_dkg_marker(&self.storage, DKG_PENDING_MARKER_KEY)?.map(
+                |marker| PendingShareInfo {
+                    name: marker.name,
+                    group_pubkey: marker.group_pubkey_hex,
+                    vault_protected: marker.vault_protected,
                 },
             ),
         )
     }
 
     /// Finish importing a share stashed by `frost_run_dkg` after its ceremony
-    /// completed but its import failed. Re-runs the import with the supplied
-    /// passphrase (which decrypts `share_export` and so cannot be persisted) and
-    /// clears the stash on success. Errors if nothing is pending.
-    pub fn recover_dkg_share(&self, passphrase: String) -> Result<ShareInfo, KeepMobileError> {
-        let pending = persistence::load_pending_dkg_share(&self.storage, DKG_PENDING_SHARE_KEY)?
+    /// completed but its import failed. Loading the secret costs a vault unlock
+    /// on the DKG path (its alias is auth-gated). For a vault-protected stash the
+    /// ephemeral ceremony passphrase rides inside the secret, so `passphrase` is
+    /// ignored and recovery needs only that unlock; for a passphrase-protected
+    /// stash (manual QR import) the caller must supply the passphrase they know.
+    /// Clears the stash on success. Errors if nothing is pending.
+    pub fn recover_dkg_share(
+        &self,
+        passphrase: Option<String>,
+    ) -> Result<ShareInfo, KeepMobileError> {
+        let marker = persistence::load_pending_dkg_marker(&self.storage, DKG_PENDING_MARKER_KEY)?
             .ok_or_else(|| KeepMobileError::StorageError {
                 msg: "no pending DKG share to recover".into(),
             })?;
+        let secret = persistence::load_pending_dkg_secret(&self.storage, DKG_PENDING_SECRET_KEY)?
+            .ok_or_else(|| KeepMobileError::StorageError {
+                msg: "pending DKG marker has no matching secret to recover".into(),
+            })?;
 
-        let info = self.import_share(pending.share_export, passphrase, pending.name)?;
+        let passphrase = if marker.vault_protected {
+            secret
+                .vault_passphrase
+                .ok_or_else(|| KeepMobileError::StorageError {
+                    msg: "vault-protected stash is missing its ceremony passphrase".into(),
+                })?
+        } else {
+            passphrase.ok_or_else(|| KeepMobileError::StorageError {
+                msg: "a passphrase is required to recover this share".into(),
+            })?
+        };
 
-        if let Err(e) = persistence::delete_pending_dkg_share(&self.storage, DKG_PENDING_SHARE_KEY)
-        {
-            tracing::warn!("failed to clear pending DKG share after recovery: {e}");
+        let info = self.import_share(secret.share_export, passphrase, marker.name)?;
+
+        if let Err(e) = persistence::delete_pending_dkg_stash(
+            &self.storage,
+            DKG_PENDING_MARKER_KEY,
+            DKG_PENDING_SECRET_KEY,
+        ) {
+            tracing::warn!("failed to clear pending DKG stash after recovery: {e}");
         }
         Ok(info)
     }
 
     /// Abandon a pending DKG share, re-enabling `frost_run_dkg`. The pending
-    /// guard is fail-closed, so a stash that can't be recovered — its ceremony
-    /// passphrase is gone, or the record is corrupt — would otherwise refuse
-    /// every future run for good. This is the deliberate escape hatch: it
-    /// discards the share permanently, so callers must gate it behind an
-    /// explicit user confirmation. Idempotent; succeeds when nothing is pending.
+    /// guard is fail-closed, so a stash that can't be recovered — its record is
+    /// corrupt, or the vault can't be unlocked — would otherwise refuse every
+    /// future run for good. This is the deliberate escape hatch: it discards the
+    /// share permanently, so callers must gate it behind an explicit user
+    /// confirmation. Idempotent; succeeds when nothing is pending.
     pub fn discard_pending_dkg_share(&self) -> Result<(), KeepMobileError> {
-        persistence::delete_pending_dkg_share(&self.storage, DKG_PENDING_SHARE_KEY)
+        persistence::delete_pending_dkg_stash(
+            &self.storage,
+            DKG_PENDING_MARKER_KEY,
+            DKG_PENDING_SECRET_KEY,
+        )
     }
 
     pub fn import_policy(&self, bundle_hex: String) -> Result<PolicyInfo, KeepMobileError> {
@@ -5287,6 +5337,86 @@ mod dkg_pending_share_tests {
             .unwrap()
     }
 
+    /// Stash a share the manual-QR way: the user knows the passphrase, so the
+    /// secret carries none and the marker records `vault_protected = false`.
+    fn stash_passphrase_protected(
+        storage: &Arc<dyn SecureStorage>,
+        export: &str,
+        name: &str,
+        group: &str,
+    ) {
+        persistence::persist_pending_dkg_secret(
+            storage,
+            DKG_PENDING_SECRET_KEY,
+            &persistence::PendingDkgSecret {
+                schema_version: persistence::DKG_STASH_SCHEMA_VERSION,
+                share_export: export.into(),
+                vault_passphrase: None,
+            },
+        )
+        .unwrap();
+        persistence::persist_pending_dkg_marker(
+            storage,
+            DKG_PENDING_MARKER_KEY,
+            &persistence::PendingDkgMarker {
+                schema_version: persistence::DKG_STASH_SCHEMA_VERSION,
+                name: name.into(),
+                group_pubkey_hex: group.into(),
+                vault_protected: false,
+            },
+        )
+        .unwrap();
+    }
+
+    // The DKG path stashes its ephemeral passphrase inside the auth-gated secret
+    // and marks the stash vault-protected. Recovery must then complete from the
+    // vault alone — `recover_dkg_share(None)` — with no user-supplied passphrase,
+    // which is the whole point of keep-6ik (the ceremony passphrase is never
+    // shown or stored anywhere the user could re-enter it).
+    #[test]
+    fn vault_protected_stash_recovers_without_a_supplied_passphrase() {
+        let storage = Arc::new(FailingShareStorage::default());
+        let mobile = KeepMobile::new(storage.clone() as Arc<dyn SecureStorage>).unwrap();
+
+        let passphrase = "f00dbabe".repeat(8); // stand-in for the 256-bit ceremony secret
+        let name = "vault-share";
+        let export = share_export(&passphrase, name);
+
+        persistence::persist_pending_dkg_secret(
+            &(storage.clone() as Arc<dyn SecureStorage>),
+            DKG_PENDING_SECRET_KEY,
+            &persistence::PendingDkgSecret {
+                schema_version: persistence::DKG_STASH_SCHEMA_VERSION,
+                share_export: export,
+                vault_passphrase: Some(passphrase),
+            },
+        )
+        .unwrap();
+        persistence::persist_pending_dkg_marker(
+            &(storage.clone() as Arc<dyn SecureStorage>),
+            DKG_PENDING_MARKER_KEY,
+            &persistence::PendingDkgMarker {
+                schema_version: persistence::DKG_STASH_SCHEMA_VERSION,
+                name: name.into(),
+                group_pubkey_hex: "cafe".into(),
+                vault_protected: true,
+            },
+        )
+        .unwrap();
+
+        // The marker surfaces the protection mode without a vault unlock.
+        let pending = mobile.pending_dkg_share().unwrap().unwrap();
+        assert!(pending.vault_protected);
+
+        // No passphrase supplied: recovery draws it from the vault-decrypted secret.
+        let info = mobile
+            .recover_dkg_share(None)
+            .expect("vault-protected recovery must not need a supplied passphrase");
+        assert_eq!(info.name, name);
+        assert!(mobile.pending_dkg_share().unwrap().is_none());
+        assert!(mobile.get_active_share().is_some());
+    }
+
     // A storage failure during the post-ceremony import must leave the finalized
     // share export durably stashed (never silently dropped), and a later
     // `recover_dkg_share` must complete the import and clear the stash.
@@ -5302,16 +5432,12 @@ mod dkg_pending_share_tests {
         // Reproduce `frost_run_dkg`'s post-ceremony path: stash first, then let
         // the import fail the way a full store would.
         storage.fail_shares.store(true, Ordering::Relaxed);
-        persistence::persist_pending_dkg_share(
+        stash_passphrase_protected(
             &(storage.clone() as Arc<dyn SecureStorage>),
-            DKG_PENDING_SHARE_KEY,
-            &persistence::PendingDkgShare {
-                share_export: export.clone(),
-                name: name.into(),
-                group_pubkey_hex: "deadbeef".into(),
-            },
-        )
-        .unwrap();
+            &export,
+            name,
+            "deadbeef",
+        );
         let import = mobile.import_share(export, passphrase.into(), name.into());
         assert!(
             import.is_err(),
@@ -5330,7 +5456,7 @@ mod dkg_pending_share_tests {
         // stash so it is not replayed.
         storage.fail_shares.store(false, Ordering::Relaxed);
         let info = mobile
-            .recover_dkg_share(passphrase.into())
+            .recover_dkg_share(Some(passphrase.into()))
             .expect("recovery must complete the import once storage is healthy");
         assert_eq!(info.name, name);
         assert!(
@@ -5350,18 +5476,16 @@ mod dkg_pending_share_tests {
         let mobile = KeepMobile::new(storage.clone() as Arc<dyn SecureStorage>).unwrap();
 
         let export = share_export("right-pass", "share");
-        persistence::persist_pending_dkg_share(
+        stash_passphrase_protected(
             &(storage.clone() as Arc<dyn SecureStorage>),
-            DKG_PENDING_SHARE_KEY,
-            &persistence::PendingDkgShare {
-                share_export: export,
-                name: "share".into(),
-                group_pubkey_hex: "abc123".into(),
-            },
-        )
-        .unwrap();
+            &export,
+            "share",
+            "abc123",
+        );
 
-        assert!(mobile.recover_dkg_share("wrong-pass".into()).is_err());
+        assert!(mobile
+            .recover_dkg_share(Some("wrong-pass".into()))
+            .is_err());
         assert!(
             mobile.pending_dkg_share().unwrap().is_some(),
             "a failed recovery must keep the share recoverable"
@@ -5374,7 +5498,7 @@ mod dkg_pending_share_tests {
         let storage: Arc<dyn SecureStorage> = Arc::new(FailingShareStorage::default());
         let mobile = KeepMobile::new(storage).unwrap();
         assert!(mobile.pending_dkg_share().unwrap().is_none());
-        assert!(mobile.recover_dkg_share("pass".into()).is_err());
+        assert!(mobile.recover_dkg_share(Some("pass".into())).is_err());
     }
 
     // A new DKG run must refuse to start while an earlier share is still pending
@@ -5385,16 +5509,12 @@ mod dkg_pending_share_tests {
         let storage = Arc::new(FailingShareStorage::default());
         let mobile = KeepMobile::new(storage.clone() as Arc<dyn SecureStorage>).unwrap();
 
-        persistence::persist_pending_dkg_share(
+        stash_passphrase_protected(
             &(storage.clone() as Arc<dyn SecureStorage>),
-            DKG_PENDING_SHARE_KEY,
-            &persistence::PendingDkgShare {
-                share_export: share_export("pass", "prior"),
-                name: "prior".into(),
-                group_pubkey_hex: "abc123".into(),
-            },
-        )
-        .unwrap();
+            &share_export("pass", "prior"),
+            "prior",
+            "abc123",
+        );
 
         struct NoopProgress;
         impl dkg::DkgProgressCallback for NoopProgress {
@@ -5436,7 +5556,7 @@ mod dkg_pending_share_tests {
 
         storage
             .store_share_by_key(
-                DKG_PENDING_SHARE_KEY.into(),
+                DKG_PENDING_MARKER_KEY.into(),
                 b"not valid json".to_vec(),
                 ShareMetadataInfo {
                     name: "dkg_pending".into(),
@@ -5470,7 +5590,7 @@ mod dkg_pending_share_tests {
         // cannot be recovered; without discard the device is stuck here.
         storage
             .store_share_by_key(
-                DKG_PENDING_SHARE_KEY.into(),
+                DKG_PENDING_MARKER_KEY.into(),
                 b"not valid json".to_vec(),
                 ShareMetadataInfo {
                     name: "dkg_pending".into(),

--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -1482,8 +1482,8 @@ impl KeepMobile {
                 // the stash write fails the import below still gets its chance.
                 let secret = persistence::PendingDkgSecret {
                     schema_version: persistence::DKG_STASH_SCHEMA_VERSION,
-                    share_export: result.share_export.clone(),
-                    vault_passphrase: Some(passphrase.to_string()),
+                    share_export: Zeroizing::new(result.share_export.clone()),
+                    vault_passphrase: Some(passphrase.clone()),
                 };
                 let marker = persistence::PendingDkgMarker {
                     schema_version: persistence::DKG_STASH_SCHEMA_VERSION,
@@ -1574,12 +1574,12 @@ impl KeepMobile {
     ) -> Result<ShareInfo, KeepMobileError> {
         let marker = persistence::load_pending_dkg_marker(&self.storage, DKG_PENDING_MARKER_KEY)?
             .ok_or_else(|| KeepMobileError::StorageError {
-                msg: "no pending DKG share to recover".into(),
-            })?;
+            msg: "no pending DKG share to recover".into(),
+        })?;
         let secret = persistence::load_pending_dkg_secret(&self.storage, DKG_PENDING_SECRET_KEY)?
             .ok_or_else(|| KeepMobileError::StorageError {
-                msg: "pending DKG marker has no matching secret to recover".into(),
-            })?;
+            msg: "pending DKG marker has no matching secret to recover".into(),
+        })?;
 
         let passphrase = if marker.vault_protected {
             secret
@@ -1588,12 +1588,16 @@ impl KeepMobile {
                     msg: "vault-protected stash is missing its ceremony passphrase".into(),
                 })?
         } else {
-            passphrase.ok_or_else(|| KeepMobileError::StorageError {
+            Zeroizing::new(passphrase.ok_or_else(|| KeepMobileError::StorageError {
                 msg: "a passphrase is required to recover this share".into(),
-            })?
+            })?)
         };
 
-        let info = self.import_share(secret.share_export, passphrase, marker.name)?;
+        let info = self.import_share(
+            secret.share_export.to_string(),
+            passphrase.to_string(),
+            marker.name,
+        )?;
 
         if let Err(e) = persistence::delete_pending_dkg_stash(
             &self.storage,
@@ -5350,7 +5354,7 @@ mod dkg_pending_share_tests {
             DKG_PENDING_SECRET_KEY,
             &persistence::PendingDkgSecret {
                 schema_version: persistence::DKG_STASH_SCHEMA_VERSION,
-                share_export: export.into(),
+                share_export: Zeroizing::new(export.into()),
                 vault_passphrase: None,
             },
         )
@@ -5387,8 +5391,8 @@ mod dkg_pending_share_tests {
             DKG_PENDING_SECRET_KEY,
             &persistence::PendingDkgSecret {
                 schema_version: persistence::DKG_STASH_SCHEMA_VERSION,
-                share_export: export,
-                vault_passphrase: Some(passphrase),
+                share_export: Zeroizing::new(export),
+                vault_passphrase: Some(Zeroizing::new(passphrase)),
             },
         )
         .unwrap();
@@ -5483,9 +5487,7 @@ mod dkg_pending_share_tests {
             "abc123",
         );
 
-        assert!(mobile
-            .recover_dkg_share(Some("wrong-pass".into()))
-            .is_err());
+        assert!(mobile.recover_dkg_share(Some("wrong-pass".into())).is_err());
         assert!(
             mobile.pending_dkg_share().unwrap().is_some(),
             "a failed recovery must keep the share recoverable"

--- a/keep-mobile/src/persistence.rs
+++ b/keep-mobile/src/persistence.rs
@@ -753,51 +753,119 @@ pub(crate) fn persist_kill_switch(
     storage.store_share_by_key(key.into(), data, storage_metadata("kill_switch"))
 }
 
-/// A DKG share that finished the ceremony but whose import into share storage
-/// has not yet been confirmed. `share_export` is the passphrase-encrypted
-/// portable share, so the stash carries no plaintext key material. Persisted
-/// before import so a storage failure doesn't silently drop a share the peers
-/// already treat as live (§8), and recovered via `recover_dkg_share`.
+/// The current DKG stash schema. Bumped when the wire shape of the marker or
+/// secret changes so a reader can branch on format instead of guessing.
+pub(crate) const DKG_STASH_SCHEMA_VERSION: u8 = 1;
+
+/// The non-sensitive half of a pending DKG stash: enough to answer "is a share
+/// waiting to be recovered, and how?" without touching the auth-gated secret.
+/// Lives under the `__keep_` metadata namespace so `pending_dkg_share` and the
+/// `frost_run_dkg` pre-flight can read it with no biometric prompt. Every added
+/// field carries `#[serde(default)]` so widening the schema can never turn an
+/// older marker into a fail-closed brick.
 #[derive(Serialize, Deserialize)]
-pub(crate) struct PendingDkgShare {
-    pub(crate) share_export: String,
+pub(crate) struct PendingDkgMarker {
+    #[serde(default)]
+    pub(crate) schema_version: u8,
     pub(crate) name: String,
     pub(crate) group_pubkey_hex: String,
+    /// `true` for the on-device DKG path: the ceremony passphrase is ephemeral,
+    /// so the secret's at-rest protection is bound to the device vault
+    /// (auth-gated Keystore alias) and the passphrase is stashed inside it —
+    /// recovery needs only a vault unlock. `false` for the manual QR-import path,
+    /// where the user knows the passphrase and supplies it to `recover_dkg_share`.
+    #[serde(default)]
+    pub(crate) vault_protected: bool,
 }
 
-pub(crate) fn persist_pending_dkg_share(
+/// The sensitive half of a pending DKG stash: the passphrase-encrypted share
+/// export and, for the vault-protected DKG path, the ephemeral ceremony
+/// passphrase needed to decrypt it. Stored under a dedicated key the platform
+/// routes to an auth-gated (`requireUserAuth`) alias, so at rest it is not
+/// app-uid-readable and loading it costs a vault unlock. Read only by
+/// `recover_dkg_share`.
+#[derive(Serialize, Deserialize)]
+pub(crate) struct PendingDkgSecret {
+    #[serde(default)]
+    pub(crate) schema_version: u8,
+    pub(crate) share_export: String,
+    /// The ephemeral ceremony passphrase, present only for the vault-protected
+    /// DKG path. Absent for QR import, where the user supplies it. Never leaves
+    /// the auth-gated blob.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) vault_passphrase: Option<String>,
+}
+
+pub(crate) fn persist_pending_dkg_marker(
     storage: &Arc<dyn SecureStorage>,
     key: &str,
-    pending: &PendingDkgShare,
+    marker: &PendingDkgMarker,
 ) -> Result<(), KeepMobileError> {
-    let data = serde_json::to_vec(pending).map_err(|e| KeepMobileError::StorageError {
-        msg: format!("failed to serialize pending DKG share: {e}"),
+    let data = serde_json::to_vec(marker).map_err(|e| KeepMobileError::StorageError {
+        msg: format!("failed to serialize pending DKG marker: {e}"),
     })?;
     storage.store_share_by_key(key.into(), data, storage_metadata("dkg_pending"))
 }
 
-pub(crate) fn load_pending_dkg_share(
+pub(crate) fn load_pending_dkg_marker(
     storage: &Arc<dyn SecureStorage>,
     key: &str,
-) -> Result<Option<PendingDkgShare>, KeepMobileError> {
+) -> Result<Option<PendingDkgMarker>, KeepMobileError> {
     match storage.load_share_by_key(key.into()) {
         Ok(data) => {
-            let pending =
+            let marker =
                 serde_json::from_slice(&data).map_err(|e| KeepMobileError::StorageError {
-                    msg: format!("failed to deserialize pending DKG share: {e}"),
+                    msg: format!("failed to deserialize pending DKG marker: {e}"),
                 })?;
-            Ok(Some(pending))
+            Ok(Some(marker))
         }
         Err(KeepMobileError::StorageNotFound) => Ok(None),
         Err(e) => Err(e),
     }
 }
 
-pub(crate) fn delete_pending_dkg_share(
+pub(crate) fn persist_pending_dkg_secret(
     storage: &Arc<dyn SecureStorage>,
     key: &str,
+    secret: &PendingDkgSecret,
 ) -> Result<(), KeepMobileError> {
-    match storage.delete_share_by_key(key.into()) {
+    let data = serde_json::to_vec(secret).map_err(|e| KeepMobileError::StorageError {
+        msg: format!("failed to serialize pending DKG secret: {e}"),
+    })?;
+    storage.store_share_by_key(key.into(), data, storage_metadata("dkg_secret"))
+}
+
+pub(crate) fn load_pending_dkg_secret(
+    storage: &Arc<dyn SecureStorage>,
+    key: &str,
+) -> Result<Option<PendingDkgSecret>, KeepMobileError> {
+    match storage.load_share_by_key(key.into()) {
+        Ok(data) => {
+            let secret =
+                serde_json::from_slice(&data).map_err(|e| KeepMobileError::StorageError {
+                    msg: format!("failed to deserialize pending DKG secret: {e}"),
+                })?;
+            Ok(Some(secret))
+        }
+        Err(KeepMobileError::StorageNotFound) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+pub(crate) fn delete_pending_dkg_stash(
+    storage: &Arc<dyn SecureStorage>,
+    marker_key: &str,
+    secret_key: &str,
+) -> Result<(), KeepMobileError> {
+    // Delete the secret first: the marker is what gates "is anything pending?",
+    // so an orphaned secret (marker gone, secret left) is the safe failure — it
+    // is invisible and overwritten by the next run — whereas an orphaned marker
+    // would refuse new runs while pointing at a secret that is already gone.
+    match storage.delete_share_by_key(secret_key.into()) {
+        Ok(()) | Err(KeepMobileError::StorageNotFound) => {}
+        Err(e) => return Err(e),
+    }
+    match storage.delete_share_by_key(marker_key.into()) {
         Ok(()) | Err(KeepMobileError::StorageNotFound) => Ok(()),
         Err(e) => Err(e),
     }

--- a/keep-mobile/src/persistence.rs
+++ b/keep-mobile/src/persistence.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
 
 use crate::error::KeepMobileError;
 use crate::policy::{PolicyBundle, POLICY_PUBKEY_LEN};
@@ -788,12 +789,12 @@ pub(crate) struct PendingDkgMarker {
 pub(crate) struct PendingDkgSecret {
     #[serde(default)]
     pub(crate) schema_version: u8,
-    pub(crate) share_export: String,
+    pub(crate) share_export: Zeroizing<String>,
     /// The ephemeral ceremony passphrase, present only for the vault-protected
     /// DKG path. Absent for QR import, where the user supplies it. Never leaves
     /// the auth-gated blob.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(crate) vault_passphrase: Option<String>,
+    pub(crate) vault_passphrase: Option<Zeroizing<String>>,
 }
 
 pub(crate) fn persist_pending_dkg_marker(
@@ -829,10 +830,15 @@ pub(crate) fn persist_pending_dkg_secret(
     key: &str,
     secret: &PendingDkgSecret,
 ) -> Result<(), KeepMobileError> {
-    let data = serde_json::to_vec(secret).map_err(|e| KeepMobileError::StorageError {
-        msg: format!("failed to serialize pending DKG secret: {e}"),
-    })?;
-    storage.store_share_by_key(key.into(), data, storage_metadata("dkg_secret"))
+    // The serialized blob holds the plaintext share export and ceremony
+    // passphrase; scrub the local copy once storage has taken its own.
+    let data =
+        Zeroizing::new(
+            serde_json::to_vec(secret).map_err(|e| KeepMobileError::StorageError {
+                msg: format!("failed to serialize pending DKG secret: {e}"),
+            })?,
+        );
+    storage.store_share_by_key(key.into(), data.to_vec(), storage_metadata("dkg_secret"))
 }
 
 pub(crate) fn load_pending_dkg_secret(
@@ -841,6 +847,8 @@ pub(crate) fn load_pending_dkg_secret(
 ) -> Result<Option<PendingDkgSecret>, KeepMobileError> {
     match storage.load_share_by_key(key.into()) {
         Ok(data) => {
+            // The loaded blob is plaintext secret material; scrub it after parse.
+            let data = Zeroizing::new(data);
             let secret =
                 serde_json::from_slice(&data).map_err(|e| KeepMobileError::StorageError {
                     msg: format!("failed to deserialize pending DKG secret: {e}"),

--- a/keep-mobile/src/storage.rs
+++ b/keep-mobile/src/storage.rs
@@ -29,6 +29,10 @@ pub struct ShareInfo {
 pub struct PendingShareInfo {
     pub name: String,
     pub group_pubkey: String,
+    /// `true` when recovery needs only a device-vault unlock (the DKG path stashed
+    /// its ephemeral passphrase); `false` when the caller must supply the
+    /// passphrase (manual QR import). Lets the UI pick the right recovery prompt.
+    pub vault_protected: bool,
 }
 
 #[derive(uniffi::Record, Clone, Debug)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved recovery of pending key-generation shares with support for vault-protected and passphrase-protected recovery.
  * Pending recovery details now indicate whether an additional passphrase is required.
  * Added safer handling for interrupted, failed, or discarded recovery attempts.

* **Bug Fixes**
  * Sensitive recovery data is better protected and automatically cleared after successful import or discard.
  * Improved handling of missing or corrupted pending recovery data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->