### PR TITLE
nip55: expose nip55_max_batch_size() so the batch cap has a single source

### DIFF
--- a/keep-mobile/src/lib.rs
+++ b/keep-mobile/src/lib.rs
@@ -145,6 +145,11 @@ pub fn backup_min_passphrase_length() -> u32 {
 }
 
 #[uniffi::export]
+pub fn nip55_max_batch_size() -> u32 {
+    nip55::MAX_BATCH_SIZE as u32
+}
+
+#[uniffi::export]
 pub fn recover_nsec(
     share_data: Vec<String>,
     passphrases: Vec<String>,

--- a/keep-mobile/src/nip55.rs
+++ b/keep-mobile/src/nip55.rs
@@ -30,7 +30,7 @@ const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
 // alone is not a sufficient DoS guard.
 const MAX_REQUESTS_PER_WINDOW: u32 = 60;
 const MAX_BACKOFF: Duration = Duration::from_secs(300);
-const MAX_BATCH_SIZE: usize = 20;
+pub(crate) const MAX_BATCH_SIZE: usize = 20;
 const MAX_RATE_LIMIT_ENTRIES: usize = 1000;
 const MAX_PERMISSIONS_COUNT: usize = 32;
 const MAX_PERMISSIONS_JSON_BYTES: usize = 8 * 1024;


### PR DESCRIPTION
The NIP-55 batch cap (`MAX_BATCH_SIZE = 20`) is duplicated in the Rust `handle_batch_request` and the keep-android Kotlin accumulation loop, and must be kept in sync by hand.

keep-android does not call the bulk `handle_batch_request` — it runs a Kotlin loop so each `sign_event` can interleave a `preApproveNostrEvent` before signing — so the cap lives on both sides of the RMP boundary.

This makes Rust the single source of truth for the cap value: `MAX_BATCH_SIZE` becomes `pub(crate)` and is exposed via `nip55_max_batch_size()`, mirroring the existing `backup_min_passphrase_length()`. keep-android reads it instead of hardcoding `20` (companion keep-android PR).

Refs privkeyio/keep-android#327.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to the NIP-55 maximum batch size for mobile integrations.
  * The maximum supported batch size is 20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->